### PR TITLE
Allow sequenceNumber to wrap from UInt32.MAX to 0

### DIFF
--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/channel/ChunkDecoder.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/channel/ChunkDecoder.java
@@ -537,7 +537,7 @@ public final class ChunkDecoder {
                 return sequenceNumber < 1024 || sequenceNumber == lastSequenceNumber + 1;
             } else if (lastSequenceNumber == UInteger.MAX_VALUE) {
                 // must wrap at this point
-                return sequenceNumber > 0 && sequenceNumber < 1024;
+                return sequenceNumber >= 0 && sequenceNumber < 1024;
             } else {
                 return sequenceNumber == lastSequenceNumber + 1;
             }

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/channel/ChunkDecoderTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/channel/ChunkDecoderTest.java
@@ -32,6 +32,11 @@ public class ChunkDecoderTest {
             assertTrue(validateSequenceNumber(UInteger.MAX_VALUE - 1024, i));
         }
 
+        // wrapping around to anything < 1024 is allowed, from UInteger.MAX_VALUE
+        for (int i = 0; i < 1024; i++) {
+            assertTrue(validateSequenceNumber(UInteger.MAX_VALUE, i));
+        }
+
         // wrapping around to >= 1024 is not allowed
         for (int i = 1024; i < 2048; i++) {
             assertFalse(validateSequenceNumber(UInteger.MAX_VALUE - 1024, i));


### PR DESCRIPTION
fixes #1346