### PR TITLE
Notify SessionActivityListeners using client executor

### DIFF
--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmFactory.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmFactory.java
@@ -593,8 +593,11 @@ public class SessionFsmFactory {
                 SessionFsm.SessionActivityListeners sessionActivityListeners =
                     KEY_SESSION_ACTIVITY_LISTENERS.get(ctx);
 
-                sessionActivityListeners.sessionActivityListeners
-                    .forEach(listener -> listener.onSessionActive(session));
+                client.getConfig().getExecutor().execute(
+                    () ->
+                        sessionActivityListeners.sessionActivityListeners
+                            .forEach(listener -> listener.onSessionActive(session))
+                );
             });
 
         // onSessionInactive() callbacks
@@ -607,8 +610,11 @@ public class SessionFsmFactory {
                 SessionFsm.SessionActivityListeners sessionActivityListeners =
                     KEY_SESSION_ACTIVITY_LISTENERS.get(ctx);
 
-                sessionActivityListeners.sessionActivityListeners
-                    .forEach(listener -> listener.onSessionInactive(session));
+                client.getConfig().getExecutor().execute(
+                    () ->
+                        sessionActivityListeners.sessionActivityListeners
+                            .forEach(listener -> listener.onSessionInactive(session))
+                );
             });
 
 


### PR DESCRIPTION
This avoids deadlock when the user makes a blocking call that requires the Session from the SessionFsm from inside the callback.

fixes #1300
