### PR TITLE
Fix exceptions during shutdown of SpringBootTest classes

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/SessionDiagnosticsVariableArray.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/SessionDiagnosticsVariableArray.java
@@ -214,11 +214,9 @@ public class SessionDiagnosticsVariableArray extends AbstractLifecycle {
     protected void onShutdown() {
         AttributeObserver observer = attributeObserver;
         if (observer != null) {
-            ServerDiagnosticsTypeNode diagnosticsNode = (ServerDiagnosticsTypeNode) server.getAddressSpaceManager()
-                .getManagedNode(Identifiers.Server_ServerDiagnostics)
-                .orElseThrow(() -> new NoSuchElementException("NodeId: " + Identifiers.Server_ServerDiagnostics));
-
-            diagnosticsNode.getEnabledFlagNode().removeAttributeObserver(observer);
+            server.getAddressSpaceManager().getManagedNode(Identifiers.Server_ServerDiagnostics)
+                    .map(ServerDiagnosticsTypeNode.class::cast).map(ServerDiagnosticsTypeNode::getEnabledFlagNode)
+                    .ifPresent(enabledFlagNode -> enabledFlagNode.removeAttributeObserver(observer));
             attributeObserver = null;
         }
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/SessionSecurityDiagnosticsVariableArray.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/SessionSecurityDiagnosticsVariableArray.java
@@ -214,11 +214,9 @@ public class SessionSecurityDiagnosticsVariableArray extends AbstractLifecycle {
     protected void onShutdown() {
         AttributeObserver observer = attributeObserver;
         if (observer != null) {
-            ServerDiagnosticsTypeNode diagnosticsNode = (ServerDiagnosticsTypeNode) server.getAddressSpaceManager()
-                .getManagedNode(Identifiers.Server_ServerDiagnostics)
-                .orElseThrow(() -> new NoSuchElementException("NodeId: " + Identifiers.Server_ServerDiagnostics));
-
-            diagnosticsNode.getEnabledFlagNode().removeAttributeObserver(observer);
+            server.getAddressSpaceManager().getManagedNode(Identifiers.Server_ServerDiagnostics)
+                    .map(ServerDiagnosticsTypeNode.class::cast).map(ServerDiagnosticsTypeNode::getEnabledFlagNode)
+                    .ifPresent(enabledFlagNode -> enabledFlagNode.removeAttributeObserver(observer));
             attributeObserver = null;
         }
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/SubscriptionDiagnosticsVariableArray.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/SubscriptionDiagnosticsVariableArray.java
@@ -153,11 +153,9 @@ public abstract class SubscriptionDiagnosticsVariableArray extends AbstractLifec
     protected void onShutdown() {
         AttributeObserver observer = attributeObserver;
         if (observer != null) {
-            ServerDiagnosticsTypeNode diagnosticsNode = (ServerDiagnosticsTypeNode) server.getAddressSpaceManager()
-                .getManagedNode(Identifiers.Server_ServerDiagnostics)
-                .orElseThrow(() -> new NoSuchElementException("NodeId: " + Identifiers.Server_ServerDiagnostics));
-
-            diagnosticsNode.getEnabledFlagNode().removeAttributeObserver(observer);
+            server.getAddressSpaceManager().getManagedNode(Identifiers.Server_ServerDiagnostics)
+                    .map(ServerDiagnosticsTypeNode.class::cast).map(ServerDiagnosticsTypeNode::getEnabledFlagNode)
+                    .ifPresent(enabledFlagNode -> enabledFlagNode.removeAttributeObserver(observer));
             attributeObserver = null;
         }
 


### PR DESCRIPTION
I got some exceptions when my OPC UA Server was shutting down in a SpringBootTest environment.
The commit fixes the NullPointerExceptions.

Sorry, I can not acknowledge all options below, because the project can't be fully imported from me right now.

```Exception in thread "ShutdownHook" java.lang.NullPointerException: Cannot invoke "org.eclipse.milo.opcua.sdk.server.model.nodes.variables.PropertyTypeNode.removeAttributeObserver(org.eclipse.milo.opcua.sdk.server.nodes.AttributeObserver)" because the return value of "org.eclipse.milo.opcua.sdk.server.model.nodes.objects.ServerDiagnosticsTypeNode.getEnabledFlagNode()" is null
	at org.eclipse.milo.opcua.sdk.server.diagnostics.variables.SessionDiagnosticsVariableArray.onShutdown(SessionDiagnosticsVariableArray.java:221)
	at org.eclipse.milo.opcua.sdk.server.AbstractLifecycle.shutdown(AbstractLifecycle.java:53)
	at org.eclipse.milo.opcua.sdk.server.diagnostics.objects.SessionsDiagnosticsSummaryObject.onShutdown(SessionsDiagnosticsSummaryObject.java:151)
	at org.eclipse.milo.opcua.sdk.server.AbstractLifecycle.shutdown(AbstractLifecycle.java:53)
	at org.eclipse.milo.opcua.sdk.server.diagnostics.objects.ServerDiagnosticsObject.onShutdown(ServerDiagnosticsObject.java:66)
	at org.eclipse.milo.opcua.sdk.server.AbstractLifecycle.shutdown(AbstractLifecycle.java:53)
	at java.base/java.util.concurrent.CopyOnWriteArrayList.forEach(CopyOnWriteArrayList.java:891)
	at org.eclipse.milo.opcua.sdk.server.LifecycleManager.onShutdown(LifecycleManager.java:55)
	at org.eclipse.milo.opcua.sdk.server.AbstractLifecycle.shutdown(AbstractLifecycle.java:53)
	at org.eclipse.milo.opcua.sdk.server.api.ManagedAddressSpaceFragmentWithLifecycle.shutdown(ManagedAddressSpaceFragmentWithLifecycle.java:118)
	at java.base/java.util.concurrent.CopyOnWriteArrayList.forEach(CopyOnWriteArrayList.java:891)
	at org.eclipse.milo.opcua.sdk.server.LifecycleManager.onShutdown(LifecycleManager.java:55)
	at org.eclipse.milo.opcua.sdk.server.AbstractLifecycle.shutdown(AbstractLifecycle.java:53)
	at org.eclipse.milo.opcua.sdk.server.namespaces.ServerNamespace.shutdown(ServerNamespace.java:72)
	at org.eclipse.milo.opcua.sdk.server.OpcUaServer.shutdown(OpcUaServer.java:153)
	...
```


Before you submit a pull request please acknowledge the following:
- [X] You have signed an Eclipse Contributor Agreement and are committing using the same email address
- [ ] Your code contains any tests relevant to the problem you are solving
- [ ] All new and existing tests passed
- [ ] Code follows the style guidelines and Checkstyle passes

See [CONTRIBUTING](https://github.com/eclipse/milo/blob/master/CONTRIBUTING.md) for more information.
