### PR TITLE
Support runtime/dynamic DataTypes in Server

### DIFF
--- a/milo-examples/server-examples/src/main/java/org/eclipse/milo/examples/server/ExampleNamespace.java
+++ b/milo-examples/server-examples/src/main/java/org/eclipse/milo/examples/server/ExampleNamespace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 the Eclipse Milo Authors
+ * Copyright (c) 2025 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -938,7 +938,7 @@ public class ExampleNamespace extends ManagedNamespaceWithLifecycle {
     // Register Codecs for each supported encoding with DataTypeManager
     getNodeContext()
         .getServer()
-        .getDataTypeManager()
+        .getStaticDataTypeManager()
         .registerType(dataTypeId, new CustomStructType.Codec(), binaryEncodingId, null, null);
 
     // Prior to OPC UA 1.04, clients that needed to interpret custom types read the
@@ -1010,7 +1010,7 @@ public class ExampleNamespace extends ManagedNamespaceWithLifecycle {
     // Register Codecs for each supported encoding with DataTypeManager
     getNodeContext()
         .getServer()
-        .getDataTypeManager()
+        .getStaticDataTypeManager()
         .registerType(dataTypeId, new CustomUnionType.Codec(), binaryEncodingId, null, null);
 
     StructureDescription description =
@@ -1189,7 +1189,7 @@ public class ExampleNamespace extends ManagedNamespaceWithLifecycle {
 
     ExtensionObject xo =
         ExtensionObject.encodeDefaultBinary(
-            getServer().getEncodingContext(), value, binaryEncodingId);
+            getServer().getStaticEncodingContext(), value, binaryEncodingId);
 
     customStructTypeVariable.setValue(new DataValue(new Variant(xo)));
 
@@ -1226,7 +1226,7 @@ public class ExampleNamespace extends ManagedNamespaceWithLifecycle {
 
     ExtensionObject xo =
         ExtensionObject.encodeDefaultBinary(
-            getServer().getEncodingContext(), value, binaryEncodingId);
+            getServer().getStaticEncodingContext(), value, binaryEncodingId);
 
     customUnionTypeVariable.setValue(new DataValue(new Variant(xo)));
 
@@ -1243,10 +1243,6 @@ public class ExampleNamespace extends ManagedNamespaceWithLifecycle {
   private void addDynamicStructTypeVariable(UaFolderNode rootFolder, DataType dataType)
       throws Exception {
 
-    NodeId dataTypeId =
-        ExpandedNodeId.parse("nsu=%s;s=DataType.DynamicStructType".formatted(NAMESPACE_URI))
-            .toNodeIdOrThrow(getServer().getNamespaceTable());
-
     UaVariableNode dynamicStructTypeVariable =
         UaVariableNode.build(
             getNodeContext(),
@@ -1256,7 +1252,7 @@ public class ExampleNamespace extends ManagedNamespaceWithLifecycle {
                     .setUserAccessLevel(AccessLevel.READ_WRITE)
                     .setBrowseName(newQualifiedName("DynamicStructTypeVariable"))
                     .setDisplayName(LocalizedText.english("DynamicStructTypeVariable"))
-                    .setDataType(dataTypeId)
+                    .setDataType(dataType.getNodeId())
                     .setTypeDefinition(NodeIds.BaseDataVariableType)
                     .build());
 

--- a/opc-ua-sdk/dtd-manager/src/main/java/org/eclipse/milo/opcua/sdk/server/dtd/BinaryDataTypeDictionaryManager.java
+++ b/opc-ua-sdk/dtd-manager/src/main/java/org/eclipse/milo/opcua/sdk/server/dtd/BinaryDataTypeDictionaryManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 the Eclipse Milo Authors
+ * Copyright (c) 2025 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -124,7 +124,7 @@ public class BinaryDataTypeDictionaryManager implements Lifecycle {
 
   @Override
   public void startup() {
-    context.getServer().getDataTypeManager().registerTypeDictionary(dataTypeDictionary);
+    context.getServer().getStaticDataTypeManager().registerTypeDictionary(dataTypeDictionary);
 
     // Add a DataTypeDictionary Node...
     dictionaryNode =
@@ -321,7 +321,7 @@ public class BinaryDataTypeDictionaryManager implements Lifecycle {
 
     context
         .getServer()
-        .getDataTypeManager()
+        .getStaticDataTypeManager()
         .registerType(dataTypeId, codec, binaryEncodingId, null, null);
   }
 

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/test/TestNamespace.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/test/TestNamespace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 the Eclipse Milo Authors
+ * Copyright (c) 2025 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -583,7 +583,7 @@ public class TestNamespace extends ManagedNamespaceWithLifecycle {
     // Register Codecs for each supported encoding with DataTypeManager
     getNodeContext()
         .getServer()
-        .getDataTypeManager()
+        .getStaticDataTypeManager()
         .registerType(
             dataTypeId, new MatrixTestType.Codec(), binaryEncodingId, null, jsonEncodingId);
   }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/AttributeReader.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/AttributeReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 the Eclipse Milo Authors
+ * Copyright (c) 2025 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -231,7 +231,7 @@ public class AttributeReader {
 
     if (newEncodingId != null) {
       return xo.transcode(
-          node.getNodeContext().getServer().getEncodingContext(), newEncodingId, newEncoding);
+          node.getNodeContext().getServer().getStaticEncodingContext(), newEncodingId, newEncoding);
     } else {
       return xo;
     }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServer.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 the Eclipse Milo Authors
+ * Copyright (c) 2025 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -128,7 +128,7 @@ public class OpcUaServer extends AbstractServiceHandler {
   private final Lazy<DataTypeTree> dataTypeTree = new Lazy<>();
   private final Lazy<ReferenceTypeTree> referenceTypeTree = new Lazy<>();
 
-  private final DataTypeManager dataTypeManager =
+  private final DataTypeManager staticDataTypeManager =
       DefaultDataTypeManager.createAndInitialize(namespaceTable);
 
   private final DataTypeManager dynamicDataTypeManager =
@@ -153,7 +153,7 @@ public class OpcUaServer extends AbstractServiceHandler {
   private final EventFactory eventFactory = new EventFactory(this);
   private final EventNotifier eventNotifier = new ServerEventNotifier();
 
-  private final EncodingContext encodingContext;
+  private final EncodingContext staticEncodingContext;
   private final EncodingContext dynamicEncodingContext;
 
   private final OpcUaNamespace opcUaNamespace;
@@ -171,11 +171,11 @@ public class OpcUaServer extends AbstractServiceHandler {
 
     applicationContext = new ServerApplicationContextImpl();
 
-    encodingContext =
+    staticEncodingContext =
         new EncodingContext() {
           @Override
           public DataTypeManager getDataTypeManager() {
-            return dataTypeManager;
+            return staticDataTypeManager;
           }
 
           @Override
@@ -351,16 +351,24 @@ public class OpcUaServer extends AbstractServiceHandler {
     return serverNamespace;
   }
 
-  public DataTypeManager getDataTypeManager() {
-    return dataTypeManager;
+  public EncodingManager getEncodingManager() {
+    return encodingManager;
+  }
+
+  public DataTypeManager getStaticDataTypeManager() {
+    return staticDataTypeManager;
   }
 
   public DataTypeManager getDynamicDataTypeManager() {
     return dynamicDataTypeManager;
   }
 
-  public EncodingManager getEncodingManager() {
-    return encodingManager;
+  public EncodingContext getStaticEncodingContext() {
+    return staticEncodingContext;
+  }
+
+  public EncodingContext getDynamicEncodingContext() {
+    return dynamicEncodingContext;
   }
 
   public NamespaceTable getNamespaceTable() {
@@ -369,14 +377,6 @@ public class OpcUaServer extends AbstractServiceHandler {
 
   public ServerTable getServerTable() {
     return serverTable;
-  }
-
-  public EncodingContext getEncodingContext() {
-    return encodingContext;
-  }
-
-  public EncodingContext getDynamicEncodingContext() {
-    return dynamicEncodingContext;
   }
 
   public ServerDiagnosticsSummary getDiagnosticsSummary() {
@@ -509,7 +509,7 @@ public class OpcUaServer extends AbstractServiceHandler {
 
     @Override
     public EncodingContext getEncodingContext() {
-      return encodingContext;
+      return staticEncodingContext;
     }
 
     @Override

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServer.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServer.java
@@ -131,6 +131,9 @@ public class OpcUaServer extends AbstractServiceHandler {
   private final DataTypeManager dataTypeManager =
       DefaultDataTypeManager.createAndInitialize(namespaceTable);
 
+  private final DataTypeManager dynamicDataTypeManager =
+      DefaultDataTypeManager.createAndInitialize(namespaceTable);
+
   private final Set<NodeId> registeredViews = Sets.newConcurrentHashSet();
 
   private final ServerDiagnosticsSummary diagnosticsSummary = new ServerDiagnosticsSummary(this);
@@ -151,6 +154,7 @@ public class OpcUaServer extends AbstractServiceHandler {
   private final EventNotifier eventNotifier = new ServerEventNotifier();
 
   private final EncodingContext encodingContext;
+  private final EncodingContext dynamicEncodingContext;
 
   private final OpcUaNamespace opcUaNamespace;
   private final ServerNamespace serverNamespace;
@@ -172,6 +176,34 @@ public class OpcUaServer extends AbstractServiceHandler {
           @Override
           public DataTypeManager getDataTypeManager() {
             return dataTypeManager;
+          }
+
+          @Override
+          public EncodingManager getEncodingManager() {
+            return encodingManager;
+          }
+
+          @Override
+          public EncodingLimits getEncodingLimits() {
+            return config.getEncodingLimits();
+          }
+
+          @Override
+          public NamespaceTable getNamespaceTable() {
+            return namespaceTable;
+          }
+
+          @Override
+          public ServerTable getServerTable() {
+            return serverTable;
+          }
+        };
+
+    dynamicEncodingContext =
+        new EncodingContext() {
+          @Override
+          public DataTypeManager getDataTypeManager() {
+            return dynamicDataTypeManager;
           }
 
           @Override
@@ -323,6 +355,10 @@ public class OpcUaServer extends AbstractServiceHandler {
     return dataTypeManager;
   }
 
+  public DataTypeManager getDynamicDataTypeManager() {
+    return dynamicDataTypeManager;
+  }
+
   public EncodingManager getEncodingManager() {
     return encodingManager;
   }
@@ -337,6 +373,10 @@ public class OpcUaServer extends AbstractServiceHandler {
 
   public EncodingContext getEncodingContext() {
     return encodingContext;
+  }
+
+  public EncodingContext getDynamicEncodingContext() {
+    return dynamicEncodingContext;
   }
 
   public ServerDiagnosticsSummary getDiagnosticsSummary() {

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/SessionManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/SessionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 the Eclipse Milo Authors
+ * Copyright (c) 2025 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -687,7 +687,7 @@ public class SessionManager {
       @Nullable ExtensionObject identityTokenXo, @Nullable UserTokenPolicy[] tokenPolicies) {
 
     if (identityTokenXo != null && !identityTokenXo.isNull()) {
-      Object identityToken = identityTokenXo.decodeOrNull(server.getEncodingContext());
+      Object identityToken = identityTokenXo.decodeOrNull(server.getStaticEncodingContext());
 
       if (identityToken instanceof UserIdentityToken) {
         return (UserIdentityToken) identityToken;

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/ServerDiagnosticsSummaryVariable.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/ServerDiagnosticsSummaryVariable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 the Eclipse Milo Authors
+ * Copyright (c) 2025 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -74,7 +74,7 @@ public class ServerDiagnosticsSummaryVariable extends AbstractLifecycle {
                 ctx -> {
                   ExtensionObject xo =
                       ExtensionObject.encode(
-                          server.getEncodingContext(),
+                          server.getStaticEncodingContext(),
                           server.getDiagnosticsSummary().getServerDiagnosticsSummaryDataType());
                   return new DataValue(new Variant(xo));
                 }));

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/SessionDiagnosticsVariable.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/SessionDiagnosticsVariable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 the Eclipse Milo Authors
+ * Copyright (c) 2025 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -88,7 +88,7 @@ public class SessionDiagnosticsVariable extends AbstractLifecycle {
                 ctx -> {
                   ExtensionObject xo =
                       ExtensionObject.encode(
-                          server.getEncodingContext(),
+                          server.getStaticEncodingContext(),
                           session.getSessionDiagnostics().getSessionDiagnosticsDataType());
                   return new DataValue(new Variant(xo));
                 }));
@@ -119,7 +119,7 @@ public class SessionDiagnosticsVariable extends AbstractLifecycle {
                 ctx -> {
                   ExtensionObject value =
                       ExtensionObject.encode(
-                          server.getEncodingContext(),
+                          server.getStaticEncodingContext(),
                           session.getSessionDiagnostics().getClientDescription());
                   return new DataValue(new Variant(value));
                 }));
@@ -222,7 +222,7 @@ public class SessionDiagnosticsVariable extends AbstractLifecycle {
                 ctx -> {
                   ExtensionObject value =
                       ExtensionObject.encode(
-                          server.getEncodingContext(),
+                          server.getStaticEncodingContext(),
                           session
                               .getSessionDiagnostics()
                               .getTotalRequestCount()
@@ -251,7 +251,7 @@ public class SessionDiagnosticsVariable extends AbstractLifecycle {
                 ctx -> {
                   ExtensionObject value =
                       ExtensionObject.encode(
-                          server.getEncodingContext(),
+                          server.getStaticEncodingContext(),
                           session.getSessionDiagnostics().getReadCount().getServiceCounter());
                   return new DataValue(new Variant(value));
                 }));
@@ -263,7 +263,7 @@ public class SessionDiagnosticsVariable extends AbstractLifecycle {
                 ctx -> {
                   ExtensionObject value =
                       ExtensionObject.encode(
-                          server.getEncodingContext(),
+                          server.getStaticEncodingContext(),
                           session
                               .getSessionDiagnostics()
                               .getHistoryReadCount()
@@ -278,7 +278,7 @@ public class SessionDiagnosticsVariable extends AbstractLifecycle {
                 ctx -> {
                   ExtensionObject value =
                       ExtensionObject.encode(
-                          server.getEncodingContext(),
+                          server.getStaticEncodingContext(),
                           session.getSessionDiagnostics().getWriteCount().getServiceCounter());
                   return new DataValue(new Variant(value));
                 }));
@@ -290,7 +290,7 @@ public class SessionDiagnosticsVariable extends AbstractLifecycle {
                 ctx -> {
                   ExtensionObject value =
                       ExtensionObject.encode(
-                          server.getEncodingContext(),
+                          server.getStaticEncodingContext(),
                           session
                               .getSessionDiagnostics()
                               .getHistoryUpdateCount()
@@ -305,7 +305,7 @@ public class SessionDiagnosticsVariable extends AbstractLifecycle {
                 ctx -> {
                   ExtensionObject value =
                       ExtensionObject.encode(
-                          server.getEncodingContext(),
+                          server.getStaticEncodingContext(),
                           session.getSessionDiagnostics().getCallCount().getServiceCounter());
                   return new DataValue(new Variant(value));
                 }));
@@ -317,7 +317,7 @@ public class SessionDiagnosticsVariable extends AbstractLifecycle {
                 ctx -> {
                   ExtensionObject value =
                       ExtensionObject.encode(
-                          server.getEncodingContext(),
+                          server.getStaticEncodingContext(),
                           session
                               .getSessionDiagnostics()
                               .getCreateMonitoredItemsCount()
@@ -332,7 +332,7 @@ public class SessionDiagnosticsVariable extends AbstractLifecycle {
                 ctx -> {
                   ExtensionObject value =
                       ExtensionObject.encode(
-                          server.getEncodingContext(),
+                          server.getStaticEncodingContext(),
                           session
                               .getSessionDiagnostics()
                               .getModifyMonitoredItemsCount()
@@ -347,7 +347,7 @@ public class SessionDiagnosticsVariable extends AbstractLifecycle {
                 ctx -> {
                   ExtensionObject value =
                       ExtensionObject.encode(
-                          server.getEncodingContext(),
+                          server.getStaticEncodingContext(),
                           session
                               .getSessionDiagnostics()
                               .getSetMonitoringModeCount()
@@ -362,7 +362,7 @@ public class SessionDiagnosticsVariable extends AbstractLifecycle {
                 ctx -> {
                   ExtensionObject value =
                       ExtensionObject.encode(
-                          server.getEncodingContext(),
+                          server.getStaticEncodingContext(),
                           session
                               .getSessionDiagnostics()
                               .getSetTriggeringCount()
@@ -377,7 +377,7 @@ public class SessionDiagnosticsVariable extends AbstractLifecycle {
                 ctx -> {
                   ExtensionObject value =
                       ExtensionObject.encode(
-                          server.getEncodingContext(),
+                          server.getStaticEncodingContext(),
                           session
                               .getSessionDiagnostics()
                               .getDeleteMonitoredItemsCount()
@@ -392,7 +392,7 @@ public class SessionDiagnosticsVariable extends AbstractLifecycle {
                 ctx -> {
                   ExtensionObject value =
                       ExtensionObject.encode(
-                          server.getEncodingContext(),
+                          server.getStaticEncodingContext(),
                           session
                               .getSessionDiagnostics()
                               .getCreateSubscriptionCount()
@@ -407,7 +407,7 @@ public class SessionDiagnosticsVariable extends AbstractLifecycle {
                 ctx -> {
                   ExtensionObject value =
                       ExtensionObject.encode(
-                          server.getEncodingContext(),
+                          server.getStaticEncodingContext(),
                           session
                               .getSessionDiagnostics()
                               .getModifySubscriptionCount()
@@ -422,7 +422,7 @@ public class SessionDiagnosticsVariable extends AbstractLifecycle {
                 ctx -> {
                   ExtensionObject value =
                       ExtensionObject.encode(
-                          server.getEncodingContext(),
+                          server.getStaticEncodingContext(),
                           session
                               .getSessionDiagnostics()
                               .getSetPublishingModeCount()
@@ -437,7 +437,7 @@ public class SessionDiagnosticsVariable extends AbstractLifecycle {
                 ctx -> {
                   ExtensionObject value =
                       ExtensionObject.encode(
-                          server.getEncodingContext(),
+                          server.getStaticEncodingContext(),
                           session.getSessionDiagnostics().getPublishCount().getServiceCounter());
                   return new DataValue(new Variant(value));
                 }));
@@ -449,7 +449,7 @@ public class SessionDiagnosticsVariable extends AbstractLifecycle {
                 ctx -> {
                   ExtensionObject value =
                       ExtensionObject.encode(
-                          server.getEncodingContext(),
+                          server.getStaticEncodingContext(),
                           session.getSessionDiagnostics().getRepublishCount().getServiceCounter());
                   return new DataValue(new Variant(value));
                 }));
@@ -461,7 +461,7 @@ public class SessionDiagnosticsVariable extends AbstractLifecycle {
                 ctx -> {
                   ExtensionObject value =
                       ExtensionObject.encode(
-                          server.getEncodingContext(),
+                          server.getStaticEncodingContext(),
                           session
                               .getSessionDiagnostics()
                               .getTransferSubscriptionsCount()
@@ -476,7 +476,7 @@ public class SessionDiagnosticsVariable extends AbstractLifecycle {
                 ctx -> {
                   ExtensionObject value =
                       ExtensionObject.encode(
-                          server.getEncodingContext(),
+                          server.getStaticEncodingContext(),
                           session
                               .getSessionDiagnostics()
                               .getDeleteSubscriptionsCount()
@@ -491,7 +491,7 @@ public class SessionDiagnosticsVariable extends AbstractLifecycle {
                 ctx -> {
                   ExtensionObject value =
                       ExtensionObject.encode(
-                          server.getEncodingContext(),
+                          server.getStaticEncodingContext(),
                           session.getSessionDiagnostics().getAddNodesCount().getServiceCounter());
                   return new DataValue(new Variant(value));
                 }));
@@ -503,7 +503,7 @@ public class SessionDiagnosticsVariable extends AbstractLifecycle {
                 ctx -> {
                   ExtensionObject value =
                       ExtensionObject.encode(
-                          server.getEncodingContext(),
+                          server.getStaticEncodingContext(),
                           session
                               .getSessionDiagnostics()
                               .getAddReferencesCount()
@@ -518,7 +518,7 @@ public class SessionDiagnosticsVariable extends AbstractLifecycle {
                 ctx -> {
                   ExtensionObject value =
                       ExtensionObject.encode(
-                          server.getEncodingContext(),
+                          server.getStaticEncodingContext(),
                           session
                               .getSessionDiagnostics()
                               .getDeleteNodesCount()
@@ -533,7 +533,7 @@ public class SessionDiagnosticsVariable extends AbstractLifecycle {
                 ctx -> {
                   ExtensionObject value =
                       ExtensionObject.encode(
-                          server.getEncodingContext(),
+                          server.getStaticEncodingContext(),
                           session
                               .getSessionDiagnostics()
                               .getDeleteReferencesCount()
@@ -548,7 +548,7 @@ public class SessionDiagnosticsVariable extends AbstractLifecycle {
                 ctx -> {
                   ExtensionObject value =
                       ExtensionObject.encode(
-                          server.getEncodingContext(),
+                          server.getStaticEncodingContext(),
                           session.getSessionDiagnostics().getBrowseCount().getServiceCounter());
                   return new DataValue(new Variant(value));
                 }));
@@ -560,7 +560,7 @@ public class SessionDiagnosticsVariable extends AbstractLifecycle {
                 ctx -> {
                   ExtensionObject value =
                       ExtensionObject.encode(
-                          server.getEncodingContext(),
+                          server.getStaticEncodingContext(),
                           session.getSessionDiagnostics().getBrowseNextCount().getServiceCounter());
                   return new DataValue(new Variant(value));
                 }));
@@ -572,7 +572,7 @@ public class SessionDiagnosticsVariable extends AbstractLifecycle {
                 ctx -> {
                   ExtensionObject value =
                       ExtensionObject.encode(
-                          server.getEncodingContext(),
+                          server.getStaticEncodingContext(),
                           session
                               .getSessionDiagnostics()
                               .getTranslateBrowsePathsToNodeIdsCount()
@@ -587,7 +587,7 @@ public class SessionDiagnosticsVariable extends AbstractLifecycle {
                 ctx -> {
                   ExtensionObject value =
                       ExtensionObject.encode(
-                          server.getEncodingContext(),
+                          server.getStaticEncodingContext(),
                           session.getSessionDiagnostics().getQueryFirstCount().getServiceCounter());
                   return new DataValue(new Variant(value));
                 }));
@@ -599,7 +599,7 @@ public class SessionDiagnosticsVariable extends AbstractLifecycle {
                 ctx -> {
                   ExtensionObject value =
                       ExtensionObject.encode(
-                          server.getEncodingContext(),
+                          server.getStaticEncodingContext(),
                           session.getSessionDiagnostics().getQueryNextCount().getServiceCounter());
                   return new DataValue(new Variant(value));
                 }));
@@ -611,7 +611,7 @@ public class SessionDiagnosticsVariable extends AbstractLifecycle {
                 ctx -> {
                   ExtensionObject value =
                       ExtensionObject.encode(
-                          server.getEncodingContext(),
+                          server.getStaticEncodingContext(),
                           session
                               .getSessionDiagnostics()
                               .getRegisterNodesCount()
@@ -626,7 +626,7 @@ public class SessionDiagnosticsVariable extends AbstractLifecycle {
                 ctx -> {
                   ExtensionObject value =
                       ExtensionObject.encode(
-                          server.getEncodingContext(),
+                          server.getStaticEncodingContext(),
                           session
                               .getSessionDiagnostics()
                               .getUnregisterNodesCount()

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/SessionDiagnosticsVariableArray.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/SessionDiagnosticsVariableArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 the Eclipse Milo Authors
+ * Copyright (c) 2025 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -143,7 +143,7 @@ public class SessionDiagnosticsVariableArray extends AbstractLifecycle {
                 ctx -> {
                   ExtensionObject[] xos =
                       ExtensionObject.encodeArray(
-                          server.getEncodingContext(),
+                          server.getStaticEncodingContext(),
                           server.getSessionManager().getAllSessions().stream()
                               .map(s -> s.getSessionDiagnostics().getSessionDiagnosticsDataType())
                               .toArray(SessionDiagnosticsDataType[]::new));

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/SessionSecurityDiagnosticsVariable.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/SessionSecurityDiagnosticsVariable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 the Eclipse Milo Authors
+ * Copyright (c) 2025 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -88,7 +88,7 @@ public class SessionSecurityDiagnosticsVariable extends AbstractLifecycle {
                 ctx -> {
                   ExtensionObject xo =
                       ExtensionObject.encode(
-                          server.getEncodingContext(),
+                          server.getStaticEncodingContext(),
                           session
                               .getSessionSecurityDiagnostics()
                               .getSessionSecurityDiagnosticsDataType());

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/SessionSecurityDiagnosticsVariableArray.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/SessionSecurityDiagnosticsVariableArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 the Eclipse Milo Authors
+ * Copyright (c) 2025 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -143,7 +143,7 @@ public class SessionSecurityDiagnosticsVariableArray extends AbstractLifecycle {
                 ctx -> {
                   ExtensionObject[] xos =
                       ExtensionObject.encodeArray(
-                          server.getEncodingContext(),
+                          server.getStaticEncodingContext(),
                           server.getSessionManager().getAllSessions().stream()
                               .map(
                                   s ->

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/SubscriptionDiagnosticsVariable.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/SubscriptionDiagnosticsVariable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 the Eclipse Milo Authors
+ * Copyright (c) 2025 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -88,7 +88,7 @@ public class SubscriptionDiagnosticsVariable extends AbstractLifecycle {
                 ctx -> {
                   ExtensionObject xo =
                       ExtensionObject.encode(
-                          server.getEncodingContext(),
+                          server.getStaticEncodingContext(),
                           subscriptionDiagnostics.getSubscriptionDiagnosticsDataType());
                   return new DataValue(new Variant(xo));
                 }));

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/SubscriptionDiagnosticsVariableArray.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/SubscriptionDiagnosticsVariableArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 the Eclipse Milo Authors
+ * Copyright (c) 2025 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -143,7 +143,7 @@ public abstract class SubscriptionDiagnosticsVariableArray extends AbstractLifec
                 ctx -> {
                   ExtensionObject[] xos =
                       ExtensionObject.encodeArray(
-                          server.getEncodingContext(),
+                          server.getStaticEncodingContext(),
                           getSubscriptions().stream()
                               .map(
                                   s ->

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/EventContentFilter.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/EventContentFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 the Eclipse Milo Authors
+ * Copyright (c) 2025 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -234,7 +234,7 @@ public class EventContentFilter {
     StatusCode[] operandStatusCodes = new StatusCode[xos.length];
 
     for (int i = 0; i < xos.length; i++) {
-      Object operand = xos[i].decodeOrNull(context.getServer().getEncodingContext());
+      Object operand = xos[i].decodeOrNull(context.getServer().getStaticEncodingContext());
 
       if (operand instanceof FilterOperand) {
         operands[i] = (FilterOperand) operand;
@@ -328,7 +328,7 @@ public class EventContentFilter {
     }
 
     FilterOperand[] filterOperands =
-        decodeOperands(context.getServer().getEncodingContext(), element.getFilterOperands());
+        decodeOperands(context.getServer().getStaticEncodingContext(), element.getFilterOperands());
 
     Operator<?> operator = getOperator(filterOperator);
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/items/MonitoredEventItem.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/items/MonitoredEventItem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 the Eclipse Milo Authors
+ * Copyright (c) 2025 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -221,7 +221,7 @@ public class MonitoredEventItem extends BaseMonitoredItem<Variant[]> implements 
 
   @Override
   public ExtensionObject getFilterResult() {
-    return ExtensionObject.encode(server.getEncodingContext(), filterResult);
+    return ExtensionObject.encode(server.getStaticEncodingContext(), filterResult);
   }
 
   @Override

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/methods/AbstractMethodInvocationHandler.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/methods/AbstractMethodInvocationHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 the Eclipse Milo Authors
+ * Copyright (c) 2025 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -91,7 +91,8 @@ public abstract class AbstractMethodInvocationHandler implements MethodInvocatio
 
             if (dataTypeTree.isStructType(argDataTypeId)) {
               ExtensionObject xo = (ExtensionObject) value;
-              Object decoded = xo.decode(node.getNodeContext().getServer().getEncodingContext());
+              Object decoded =
+                  xo.decode(node.getNodeContext().getServer().getStaticEncodingContext());
 
               if (decoded instanceof UaStructuredType structuredType) {
                 valueDataTypeId =

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/namespaces/OpcUaNamespace.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/namespaces/OpcUaNamespace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 the Eclipse Milo Authors
+ * Copyright (c) 2025 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -215,7 +215,7 @@ public class OpcUaNamespace extends ManagedNamespaceWithLifecycle {
 
                   ExtensionObject xo =
                       ExtensionObject.encode(
-                          server.getEncodingContext(),
+                          server.getStaticEncodingContext(),
                           new ServerStatusDataType(
                               serverStatusNode.getStartTime(),
                               DateTime.now(),

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/servicesets/impl/DefaultAttributeServiceSet.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/servicesets/impl/DefaultAttributeServiceSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 the Eclipse Milo Authors
+ * Copyright (c) 2025 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -222,7 +222,7 @@ public class DefaultAttributeServiceSet extends AbstractServiceSet implements At
             request.getRequestHeader().getAdditionalHeader());
 
     ExtensionObject xo = request.getHistoryReadDetails();
-    HistoryReadDetails details = (HistoryReadDetails) xo.decode(server.getEncodingContext());
+    HistoryReadDetails details = (HistoryReadDetails) xo.decode(server.getStaticEncodingContext());
 
     List<HistoryReadResult> results =
         server
@@ -289,7 +289,7 @@ public class DefaultAttributeServiceSet extends AbstractServiceSet implements At
 
     List<HistoryUpdateDetails> historyUpdateDetailsList =
         Stream.of(historyUpdateDetails)
-            .map(xo -> (HistoryUpdateDetails) xo.decode(server.getEncodingContext()))
+            .map(xo -> (HistoryUpdateDetails) xo.decode(server.getStaticEncodingContext()))
             .collect(Collectors.toList());
 
     if (historyUpdateDetailsList.isEmpty()) {

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/subscriptions/Subscription.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/subscriptions/Subscription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 the Eclipse Milo Authors
+ * Copyright (c) 2025 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -123,7 +123,7 @@ public class Subscription {
 
     subscriptionDiagnostics = new SubscriptionDiagnostics(this);
 
-    encodingContext = subscriptionManager.getServer().getEncodingContext();
+    encodingContext = subscriptionManager.getServer().getStaticEncodingContext();
 
     setPublishingInterval(publishingInterval);
     setMaxKeepAliveCount(maxKeepAliveCount);

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/subscriptions/SubscriptionManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/subscriptions/SubscriptionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 the Eclipse Milo Authors
+ * Copyright (c) 2025 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -477,7 +477,7 @@ public class SubscriptionManager {
       }
 
       Object filterObject =
-          request.getRequestedParameters().getFilter().decode(server.getEncodingContext());
+          request.getRequestedParameters().getFilter().decode(server.getStaticEncodingContext());
 
       MonitoringFilter filter = validateEventItemFilter(filterObject, attributes);
 
@@ -532,7 +532,7 @@ public class SubscriptionManager {
         ExtensionObject filterXo = request.getRequestedParameters().getFilter();
 
         if (filterXo != null && !filterXo.isNull()) {
-          Object filterObject = filterXo.decode(server.getEncodingContext());
+          Object filterObject = filterXo.decode(server.getStaticEncodingContext());
 
           filter = validateDataItemFilter(filterObject, attributeId, attributes);
         }
@@ -750,7 +750,7 @@ public class SubscriptionManager {
 
     if (attributeId == AttributeId.EventNotifier) {
       Object filterObject =
-          request.getRequestedParameters().getFilter().decode(server.getEncodingContext());
+          request.getRequestedParameters().getFilter().decode(server.getStaticEncodingContext());
 
       MonitoringFilter filter = validateEventItemFilter(filterObject, monitoringAttributes);
 
@@ -779,7 +779,7 @@ public class SubscriptionManager {
         ExtensionObject filterXo = request.getRequestedParameters().getFilter();
 
         if (filterXo != null && !filterXo.isNull()) {
-          Object filterObject = filterXo.decode(server.getEncodingContext());
+          Object filterObject = filterXo.decode(server.getStaticEncodingContext());
 
           filter = validateDataItemFilter(filterObject, attributeId, monitoringAttributes);
         }

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/UaNodeTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/UaNodeTest.java
@@ -57,7 +57,7 @@ public class UaNodeTest {
     Mockito.when(server.getAddressSpaceManager()).thenReturn(addressSpaceManager);
     Mockito.when(server.getObjectTypeManager()).thenReturn(objectTypeManager);
     Mockito.when(server.getVariableTypeManager()).thenReturn(variableTypeManager);
-    Mockito.when(server.getEncodingContext()).thenReturn(DefaultEncodingContext.INSTANCE);
+    Mockito.when(server.getStaticEncodingContext()).thenReturn(DefaultEncodingContext.INSTANCE);
     Mockito.when(server.getEncodingManager()).thenReturn(OpcUaEncodingManager.getInstance());
 
     UaNodeManager nodeManager = new UaNodeManager();

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/factories/NodeFactoryTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/factories/NodeFactoryTest.java
@@ -83,7 +83,7 @@ public class NodeFactoryTest {
 
     Mockito.when(server.getAddressSpaceManager()).thenReturn(addressSpaceManager);
 
-    Mockito.when(server.getEncodingContext()).thenReturn(DefaultEncodingContext.INSTANCE);
+    Mockito.when(server.getStaticEncodingContext()).thenReturn(DefaultEncodingContext.INSTANCE);
 
     Mockito.when(server.getEncodingManager()).thenReturn(OpcUaEncodingManager.getInstance());
 


### PR DESCRIPTION
Adds separate "dynamic" `DataTypeManager` and `EncodingContext` to `OpcUaServer` and updates the example namespace/server to register a type at runtime and expose it.

fixes #1371
