### PR TITLE
Rename BuiltinDataType to OpcUaDataType

### DIFF
--- a/milo-examples/server-examples/src/main/java/org/eclipse/milo/examples/server/ExampleNamespace.java
+++ b/milo-examples/server-examples/src/main/java/org/eclipse/milo/examples/server/ExampleNamespace.java
@@ -50,8 +50,8 @@ import org.eclipse.milo.opcua.sdk.server.nodes.factories.NodeFactory;
 import org.eclipse.milo.opcua.sdk.server.nodes.filters.AttributeFilters;
 import org.eclipse.milo.opcua.sdk.server.util.SubscriptionModel;
 import org.eclipse.milo.opcua.stack.core.AttributeId;
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
@@ -853,7 +853,7 @@ public class ExampleNamespace extends ManagedNamespaceWithLifecycle {
             dataTypeId,
             new QualifiedName(getNamespaceIndex(), "CustomEnumType"),
             definition,
-            ubyte(BuiltinDataType.Int32.getTypeId()));
+            ubyte(OpcUaDataType.Int32.getTypeId()));
 
     dictionaryManager.registerEnum(description);
   }

--- a/opc-ua-sdk/codec-json/src/main/java/org/eclipse/milo/sdk/core/types/json/JsonConversions.java
+++ b/opc-ua-sdk/codec-json/src/main/java/org/eclipse/milo/sdk/core/types/json/JsonConversions.java
@@ -20,7 +20,7 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.HexFormat;
 import java.util.UUID;
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
@@ -47,16 +47,16 @@ public class JsonConversions {
   // region OPC UA to JSON Conversions
 
   /**
-   * Convert an OPC UA value of some {@link BuiltinDataType} to a {@link JsonElement}.
+   * Convert an OPC UA value of some {@link OpcUaDataType} to a {@link JsonElement}.
    *
-   * <p>Converting from values of type {@link BuiltinDataType#DiagnosticInfo} is not supported.
+   * <p>Converting from values of type {@link OpcUaDataType#DiagnosticInfo} is not supported.
    *
    * @param value the OPC UA value to convert.
-   * @param dataType the OPC UA {@link BuiltinDataType} of the value.
+   * @param dataType the OPC UA {@link OpcUaDataType} of the value.
    * @return the converted {@link JsonElement}.
-   * @throws IllegalArgumentException if the {@link BuiltinDataType} is not supported.
+   * @throws IllegalArgumentException if the {@link OpcUaDataType} is not supported.
    */
-  public static JsonElement from(Object value, BuiltinDataType dataType) {
+  public static JsonElement from(Object value, OpcUaDataType dataType) {
     return switch (dataType) {
       case Boolean -> fromBoolean((Boolean) value);
       case SByte -> fromSByte((Byte) value);
@@ -242,7 +242,7 @@ public class JsonConversions {
 
     var jsonObject = new JsonObject();
 
-    BuiltinDataType dataType = value.getBuiltinDataType().orElseThrow();
+    OpcUaDataType dataType = value.getBuiltinDataType().orElseThrow();
     jsonObject.addProperty("Type", dataType.getTypeId());
 
     if (valueObject.getClass().isArray()) {
@@ -279,16 +279,16 @@ public class JsonConversions {
   // region JSON to OPC UA Conversions
 
   /**
-   * Convert a {@link JsonElement} to a value of some OPC UA {@link BuiltinDataType}.
+   * Convert a {@link JsonElement} to a value of some OPC UA {@link OpcUaDataType}.
    *
-   * <p>Converting to values of type {@link BuiltinDataType#DiagnosticInfo} is not supported.
+   * <p>Converting to values of type {@link OpcUaDataType#DiagnosticInfo} is not supported.
    *
    * @param element the {@link JsonElement} to convert.
-   * @param dataType the OPC UA {@link BuiltinDataType} to convert to.
+   * @param dataType the OPC UA {@link OpcUaDataType} to convert to.
    * @return the converted value.
-   * @throws IllegalArgumentException if the {@link BuiltinDataType} is not supported.
+   * @throws IllegalArgumentException if the {@link OpcUaDataType} is not supported.
    */
-  public static Object to(JsonElement element, BuiltinDataType dataType) {
+  public static Object to(JsonElement element, OpcUaDataType dataType) {
     return switch (dataType) {
       case Boolean -> toBoolean(element);
       case SByte -> toSByte(element);
@@ -510,7 +510,7 @@ public class JsonConversions {
     int typeId = jsonObject.get("Type").getAsInt();
     JsonElement bodyElement = jsonObject.get("Body");
 
-    BuiltinDataType dataType = BuiltinDataType.fromTypeId(typeId);
+    OpcUaDataType dataType = OpcUaDataType.fromTypeId(typeId);
     if (dataType == null) {
       throw new IllegalArgumentException("unknown type: " + typeId);
     }

--- a/opc-ua-sdk/codec-json/src/main/java/org/eclipse/milo/sdk/core/types/json/JsonConversions.java
+++ b/opc-ua-sdk/codec-json/src/main/java/org/eclipse/milo/sdk/core/types/json/JsonConversions.java
@@ -242,7 +242,7 @@ public class JsonConversions {
 
     var jsonObject = new JsonObject();
 
-    OpcUaDataType dataType = value.getBuiltinDataType().orElseThrow();
+    OpcUaDataType dataType = value.getDataType().orElseThrow();
     jsonObject.addProperty("Type", dataType.getTypeId());
 
     if (valueObject.getClass().isArray()) {

--- a/opc-ua-sdk/codec-json/src/main/java/org/eclipse/milo/sdk/core/types/json/JsonStructCodec.java
+++ b/opc-ua-sdk/codec-json/src/main/java/org/eclipse/milo/sdk/core/types/json/JsonStructCodec.java
@@ -29,8 +29,8 @@ import java.util.StringJoiner;
 import java.util.UUID;
 import org.eclipse.milo.opcua.sdk.core.typetree.DataType;
 import org.eclipse.milo.opcua.sdk.core.typetree.DataTypeTree;
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaSerializationException;
 import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
@@ -165,8 +165,8 @@ public class JsonStructCodec extends GenericDataTypeCodec<JsonStruct> {
 
     if (field.getValueRank() == -1) {
       Object hint = getHint(field);
-      if (hint instanceof BuiltinDataType) {
-        return decodeBuiltinDataType(decoder, fieldName, (BuiltinDataType) hint);
+      if (hint instanceof OpcUaDataType) {
+        return decodeBuiltinDataType(decoder, fieldName, (OpcUaDataType) hint);
       } else if (hint instanceof EnumHint) {
         int enumValue = decoder.decodeEnum(fieldName);
 
@@ -187,8 +187,8 @@ public class JsonStructCodec extends GenericDataTypeCodec<JsonStruct> {
       }
     } else if (field.getValueRank() == 1) {
       Object hint = getHint(field);
-      if (hint instanceof BuiltinDataType) {
-        return decodeBuiltinDataTypeArray(decoder, fieldName, (BuiltinDataType) hint);
+      if (hint instanceof OpcUaDataType) {
+        return decodeBuiltinDataTypeArray(decoder, fieldName, (OpcUaDataType) hint);
       } else if (hint instanceof EnumHint) {
         var array = new JsonArray();
         for (int value : decoder.decodeEnumArray(fieldName)) {
@@ -215,8 +215,8 @@ public class JsonStructCodec extends GenericDataTypeCodec<JsonStruct> {
       }
     } else if (field.getValueRank() > 1) {
       Object hint = getHint(field);
-      if (hint instanceof BuiltinDataType) {
-        Matrix matrix = decoder.decodeMatrix(fieldName, (BuiltinDataType) hint);
+      if (hint instanceof OpcUaDataType) {
+        Matrix matrix = decoder.decodeMatrix(fieldName, (OpcUaDataType) hint);
 
         return decodeBuiltinDataTypeMatrix(matrix);
       } else if (hint instanceof EnumHint) {
@@ -225,7 +225,7 @@ public class JsonStructCodec extends GenericDataTypeCodec<JsonStruct> {
         return decodeEnumMatrix(matrix);
       } else if (hint instanceof StructHint) {
         if (dataTypeId.equals(NodeIds.Structure) || fieldAllowsSubtyping(field)) {
-          Matrix matrix = decoder.decodeMatrix(fieldName, BuiltinDataType.ExtensionObject);
+          Matrix matrix = decoder.decodeMatrix(fieldName, OpcUaDataType.ExtensionObject);
 
           return decodeStructMatrix(decoder.getEncodingContext(), matrix, true);
         } else {
@@ -256,7 +256,7 @@ public class JsonStructCodec extends GenericDataTypeCodec<JsonStruct> {
   }
 
   private static JsonElement decodeBuiltinDataType(
-      UaDecoder decoder, String fieldName, BuiltinDataType dataType) {
+      UaDecoder decoder, String fieldName, OpcUaDataType dataType) {
     return switch (dataType) {
       case Boolean -> JsonConversions.fromBoolean(decoder.decodeBoolean(fieldName));
       case SByte -> JsonConversions.fromSByte(decoder.decodeSByte(fieldName));
@@ -291,7 +291,7 @@ public class JsonStructCodec extends GenericDataTypeCodec<JsonStruct> {
   }
 
   private static JsonElement decodeBuiltinDataTypeArray(
-      UaDecoder decoder, String fieldName, BuiltinDataType dataType) {
+      UaDecoder decoder, String fieldName, OpcUaDataType dataType) {
     switch (dataType) {
       case Boolean:
         {
@@ -501,7 +501,7 @@ public class JsonStructCodec extends GenericDataTypeCodec<JsonStruct> {
   }
 
   private static JsonElement decodeBuiltinDataTypeMatrix(
-      Object flatArray, BuiltinDataType dataType, int[] dimensions, int offset) {
+      Object flatArray, OpcUaDataType dataType, int[] dimensions, int offset) {
     var jsonArray = new JsonArray();
 
     if (dimensions.length == 1) {
@@ -527,7 +527,7 @@ public class JsonStructCodec extends GenericDataTypeCodec<JsonStruct> {
 
   static JsonElement decodeEnumMatrix(Matrix matrix) {
     return decodeBuiltinDataTypeMatrix(
-        matrix.getElements(), BuiltinDataType.Int32, matrix.getDimensions(), 0);
+        matrix.getElements(), OpcUaDataType.Int32, matrix.getDimensions(), 0);
   }
 
   static JsonElement decodeStructMatrix(EncodingContext context, Matrix matrix, boolean subtyped) {
@@ -656,8 +656,8 @@ public class JsonStructCodec extends GenericDataTypeCodec<JsonStruct> {
 
     if (field.getValueRank() == -1) {
       Object hint = getHint(field);
-      if (hint instanceof BuiltinDataType) {
-        encodeBuiltinDataType(encoder, fieldName, (BuiltinDataType) hint, value);
+      if (hint instanceof OpcUaDataType) {
+        encodeBuiltinDataType(encoder, fieldName, (OpcUaDataType) hint, value);
       } else if (hint instanceof EnumHint) {
         encoder.encodeEnum(fieldName, new JsonEnumWrapper(value.getAsInt(), dataTypeId.expanded()));
       } else if (hint instanceof StructHint) {
@@ -681,8 +681,8 @@ public class JsonStructCodec extends GenericDataTypeCodec<JsonStruct> {
       JsonArray jsonArray = value.getAsJsonArray();
 
       Object hint = getHint(field);
-      if (hint instanceof BuiltinDataType) {
-        encodeBuiltinDataTypeArray(encoder, fieldName, (BuiltinDataType) hint, jsonArray);
+      if (hint instanceof OpcUaDataType) {
+        encodeBuiltinDataTypeArray(encoder, fieldName, (OpcUaDataType) hint, jsonArray);
       } else if (hint instanceof EnumHint) {
         JsonEnumWrapper[] enumValues = new JsonEnumWrapper[jsonArray.size()];
         for (int i = 0; i < jsonArray.size(); i++) {
@@ -724,26 +724,26 @@ public class JsonStructCodec extends GenericDataTypeCodec<JsonStruct> {
       JsonArray jsonArray = value.getAsJsonArray();
 
       Object hint = getHint(field);
-      if (hint instanceof BuiltinDataType) {
-        Object[] flatArray = encodeBuiltinDataTypeMatrix((BuiltinDataType) hint, jsonArray);
-        var matrix = new Matrix(flatArray, getDimensions(jsonArray), (BuiltinDataType) hint);
+      if (hint instanceof OpcUaDataType) {
+        Object[] flatArray = encodeBuiltinDataTypeMatrix((OpcUaDataType) hint, jsonArray);
+        var matrix = new Matrix(flatArray, getDimensions(jsonArray), (OpcUaDataType) hint);
         encoder.encodeMatrix(fieldName, matrix);
       } else if (hint instanceof EnumHint) {
         Object[] flatArray = encodeEnumMatrix(dataTypeId.expanded(), jsonArray);
-        var matrix = new Matrix(flatArray, getDimensions(jsonArray), BuiltinDataType.Int32);
+        var matrix = new Matrix(flatArray, getDimensions(jsonArray), OpcUaDataType.Int32);
         encoder.encodeEnumMatrix(fieldName, matrix);
       } else if (hint instanceof StructHint) {
         if (dataTypeId.equals(NodeIds.Structure) || fieldAllowsSubtyping(field)) {
           Object[] flatArray =
               encodeStructMatrix(encoder.getEncodingContext(), dataTypeTree, jsonArray, true);
           var matrix =
-              new Matrix(flatArray, getDimensions(jsonArray), BuiltinDataType.ExtensionObject);
+              new Matrix(flatArray, getDimensions(jsonArray), OpcUaDataType.ExtensionObject);
           encoder.encodeMatrix(fieldName, matrix);
         } else {
           Object[] flatArray =
               encodeStructMatrix(encoder.getEncodingContext(), dataTypeTree, jsonArray, false);
           var matrix =
-              new Matrix(flatArray, getDimensions(jsonArray), BuiltinDataType.ExtensionObject);
+              new Matrix(flatArray, getDimensions(jsonArray), OpcUaDataType.ExtensionObject);
           encoder.encodeStructMatrix(fieldName, matrix, dataTypeId);
         }
       } else {
@@ -755,7 +755,7 @@ public class JsonStructCodec extends GenericDataTypeCodec<JsonStruct> {
   }
 
   private void encodeBuiltinDataType(
-      UaEncoder encoder, String fieldName, BuiltinDataType dataType, JsonElement value) {
+      UaEncoder encoder, String fieldName, OpcUaDataType dataType, JsonElement value) {
     switch (dataType) {
       case Boolean:
         encoder.encodeBoolean(fieldName, JsonConversions.toBoolean(value));
@@ -837,7 +837,7 @@ public class JsonStructCodec extends GenericDataTypeCodec<JsonStruct> {
   }
 
   private void encodeBuiltinDataTypeArray(
-      UaEncoder encoder, String fieldName, BuiltinDataType dataType, JsonArray value) {
+      UaEncoder encoder, String fieldName, OpcUaDataType dataType, JsonArray value) {
     switch (dataType) {
       case Boolean:
         {
@@ -1062,7 +1062,7 @@ public class JsonStructCodec extends GenericDataTypeCodec<JsonStruct> {
     }
   }
 
-  static Object[] encodeBuiltinDataTypeMatrix(BuiltinDataType dataType, JsonArray jsonArray) {
+  static Object[] encodeBuiltinDataTypeMatrix(OpcUaDataType dataType, JsonArray jsonArray) {
     var elements = new ArrayList<>();
 
     for (int i = 0; i < jsonArray.size(); i++) {
@@ -1155,8 +1155,8 @@ public class JsonStructCodec extends GenericDataTypeCodec<JsonStruct> {
 
               for (StructureField f : fields) {
                 NodeId dataTypeId = f.getDataType();
-                if (BuiltinDataType.isBuiltin(dataTypeId)) {
-                  map.put(f, BuiltinDataType.fromNodeId(dataTypeId));
+                if (OpcUaDataType.isBuiltin(dataTypeId)) {
+                  map.put(f, OpcUaDataType.fromNodeId(dataTypeId));
                 } else if (dataTypeTree.isEnumType(dataTypeId)) {
                   map.put(f, new EnumHint());
                 } else if (dataTypeTree.isStructType(dataTypeId)) {

--- a/opc-ua-sdk/codec-json/src/main/java/org/eclipse/milo/sdk/core/types/json/JsonStructCodec.java
+++ b/opc-ua-sdk/codec-json/src/main/java/org/eclipse/milo/sdk/core/types/json/JsonStructCodec.java
@@ -492,7 +492,7 @@ public class JsonStructCodec extends GenericDataTypeCodec<JsonStruct> {
 
   static JsonElement decodeBuiltinDataTypeMatrix(Matrix matrix) {
     return matrix
-        .getBuiltinDataType()
+        .getDataType()
         .map(
             dataType ->
                 decodeBuiltinDataTypeMatrix(

--- a/opc-ua-sdk/codec-json/src/test/java/org/eclipse/milo/opcua/test/types/StructWithAbstractMatrixFields.java
+++ b/opc-ua-sdk/codec-json/src/test/java/org/eclipse/milo/opcua/test/types/StructWithAbstractMatrixFields.java
@@ -11,8 +11,8 @@
 package org.eclipse.milo.opcua.test.types;
 
 import java.util.StringJoiner;
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
 import org.eclipse.milo.opcua.stack.core.NamespaceTable;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
 import org.eclipse.milo.opcua.stack.core.encoding.GenericDataTypeCodec;
 import org.eclipse.milo.opcua.stack.core.encoding.UaDecoder;
@@ -174,15 +174,15 @@ public class StructWithAbstractMatrixFields extends Structure implements UaStruc
       final Matrix att1;
       final Matrix att2;
       {
-        Matrix matrix = decoder.decodeMatrix("Number", BuiltinDataType.Variant);
+        Matrix matrix = decoder.decodeMatrix("Number", OpcUaDataType.Variant);
         number = matrix.transform(v -> ((Variant) v).getValue());
       }
       {
-        Matrix matrix = decoder.decodeMatrix("ATT1", BuiltinDataType.ExtensionObject);
+        Matrix matrix = decoder.decodeMatrix("ATT1", OpcUaDataType.ExtensionObject);
         att1 = matrix.transform(v -> ((ExtensionObject) v).decode(context));
       }
       {
-        Matrix matrix = decoder.decodeMatrix("ATT2", BuiltinDataType.ExtensionObject);
+        Matrix matrix = decoder.decodeMatrix("ATT2", OpcUaDataType.ExtensionObject);
         att2 = matrix.transform(v -> ((ExtensionObject) v).decode(context));
       }
       return new StructWithAbstractMatrixFields(number, att1, att2);

--- a/opc-ua-sdk/codec-json/src/test/java/org/eclipse/milo/opcua/test/types/StructWithBuiltinMatrixFields.java
+++ b/opc-ua-sdk/codec-json/src/test/java/org/eclipse/milo/opcua/test/types/StructWithBuiltinMatrixFields.java
@@ -11,8 +11,8 @@
 package org.eclipse.milo.opcua.test.types;
 
 import java.util.StringJoiner;
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
 import org.eclipse.milo.opcua.stack.core.NamespaceTable;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
 import org.eclipse.milo.opcua.stack.core.encoding.GenericDataTypeCodec;
 import org.eclipse.milo.opcua.stack.core.encoding.UaDecoder;
@@ -569,29 +569,29 @@ public class StructWithBuiltinMatrixFields extends Structure implements UaStruct
       final Matrix localizedText;
       final Matrix dataValue;
       final Matrix variant;
-      _boolean = decoder.decodeMatrix("Boolean", BuiltinDataType.Boolean);
-      sByte = decoder.decodeMatrix("SByte", BuiltinDataType.SByte);
-      _byte = decoder.decodeMatrix("Byte", BuiltinDataType.Byte);
-      int16 = decoder.decodeMatrix("Int16", BuiltinDataType.Int16);
-      uInt16 = decoder.decodeMatrix("UInt16", BuiltinDataType.UInt16);
-      int32 = decoder.decodeMatrix("Int32", BuiltinDataType.Int32);
-      uInt32 = decoder.decodeMatrix("UInt32", BuiltinDataType.UInt32);
-      int64 = decoder.decodeMatrix("Int64", BuiltinDataType.Int64);
-      uInt64 = decoder.decodeMatrix("UInt64", BuiltinDataType.UInt64);
-      _float = decoder.decodeMatrix("Float", BuiltinDataType.Float);
-      _double = decoder.decodeMatrix("Double", BuiltinDataType.Double);
-      string = decoder.decodeMatrix("String", BuiltinDataType.String);
-      dateTime = decoder.decodeMatrix("DateTime", BuiltinDataType.DateTime);
-      guid = decoder.decodeMatrix("Guid", BuiltinDataType.Guid);
-      byteString = decoder.decodeMatrix("ByteString", BuiltinDataType.ByteString);
-      xmlElement = decoder.decodeMatrix("XmlElement", BuiltinDataType.XmlElement);
-      nodeId = decoder.decodeMatrix("NodeId", BuiltinDataType.NodeId);
-      expandedNodeId = decoder.decodeMatrix("ExpandedNodeId", BuiltinDataType.ExpandedNodeId);
-      statusCode = decoder.decodeMatrix("StatusCode", BuiltinDataType.StatusCode);
-      qualifiedName = decoder.decodeMatrix("QualifiedName", BuiltinDataType.QualifiedName);
-      localizedText = decoder.decodeMatrix("LocalizedText", BuiltinDataType.LocalizedText);
-      dataValue = decoder.decodeMatrix("DataValue", BuiltinDataType.DataValue);
-      variant = decoder.decodeMatrix("Variant", BuiltinDataType.Variant);
+      _boolean = decoder.decodeMatrix("Boolean", OpcUaDataType.Boolean);
+      sByte = decoder.decodeMatrix("SByte", OpcUaDataType.SByte);
+      _byte = decoder.decodeMatrix("Byte", OpcUaDataType.Byte);
+      int16 = decoder.decodeMatrix("Int16", OpcUaDataType.Int16);
+      uInt16 = decoder.decodeMatrix("UInt16", OpcUaDataType.UInt16);
+      int32 = decoder.decodeMatrix("Int32", OpcUaDataType.Int32);
+      uInt32 = decoder.decodeMatrix("UInt32", OpcUaDataType.UInt32);
+      int64 = decoder.decodeMatrix("Int64", OpcUaDataType.Int64);
+      uInt64 = decoder.decodeMatrix("UInt64", OpcUaDataType.UInt64);
+      _float = decoder.decodeMatrix("Float", OpcUaDataType.Float);
+      _double = decoder.decodeMatrix("Double", OpcUaDataType.Double);
+      string = decoder.decodeMatrix("String", OpcUaDataType.String);
+      dateTime = decoder.decodeMatrix("DateTime", OpcUaDataType.DateTime);
+      guid = decoder.decodeMatrix("Guid", OpcUaDataType.Guid);
+      byteString = decoder.decodeMatrix("ByteString", OpcUaDataType.ByteString);
+      xmlElement = decoder.decodeMatrix("XmlElement", OpcUaDataType.XmlElement);
+      nodeId = decoder.decodeMatrix("NodeId", OpcUaDataType.NodeId);
+      expandedNodeId = decoder.decodeMatrix("ExpandedNodeId", OpcUaDataType.ExpandedNodeId);
+      statusCode = decoder.decodeMatrix("StatusCode", OpcUaDataType.StatusCode);
+      qualifiedName = decoder.decodeMatrix("QualifiedName", OpcUaDataType.QualifiedName);
+      localizedText = decoder.decodeMatrix("LocalizedText", OpcUaDataType.LocalizedText);
+      dataValue = decoder.decodeMatrix("DataValue", OpcUaDataType.DataValue);
+      variant = decoder.decodeMatrix("Variant", OpcUaDataType.Variant);
       return new StructWithBuiltinMatrixFields(
           _boolean,
           sByte,

--- a/opc-ua-sdk/codec-json/src/test/java/org/eclipse/milo/opcua/test/types/StructWithBuiltinMatrixFieldsEx.java
+++ b/opc-ua-sdk/codec-json/src/test/java/org/eclipse/milo/opcua/test/types/StructWithBuiltinMatrixFieldsEx.java
@@ -11,8 +11,8 @@
 package org.eclipse.milo.opcua.test.types;
 
 import java.util.StringJoiner;
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
 import org.eclipse.milo.opcua.stack.core.NamespaceTable;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
 import org.eclipse.milo.opcua.stack.core.encoding.GenericDataTypeCodec;
 import org.eclipse.milo.opcua.stack.core.encoding.UaDecoder;
@@ -600,30 +600,30 @@ public class StructWithBuiltinMatrixFieldsEx extends StructWithBuiltinMatrixFiel
       final Matrix optionSetUi16;
       final Matrix optionSetUi32;
       final Matrix optionSetUi64;
-      _boolean = decoder.decodeMatrix("Boolean", BuiltinDataType.Boolean);
-      sByte = decoder.decodeMatrix("SByte", BuiltinDataType.SByte);
-      _byte = decoder.decodeMatrix("Byte", BuiltinDataType.Byte);
-      int16 = decoder.decodeMatrix("Int16", BuiltinDataType.Int16);
-      uInt16 = decoder.decodeMatrix("UInt16", BuiltinDataType.UInt16);
-      int32 = decoder.decodeMatrix("Int32", BuiltinDataType.Int32);
-      uInt32 = decoder.decodeMatrix("UInt32", BuiltinDataType.UInt32);
-      int64 = decoder.decodeMatrix("Int64", BuiltinDataType.Int64);
-      uInt64 = decoder.decodeMatrix("UInt64", BuiltinDataType.UInt64);
-      _float = decoder.decodeMatrix("Float", BuiltinDataType.Float);
-      _double = decoder.decodeMatrix("Double", BuiltinDataType.Double);
-      string = decoder.decodeMatrix("String", BuiltinDataType.String);
-      dateTime = decoder.decodeMatrix("DateTime", BuiltinDataType.DateTime);
-      guid = decoder.decodeMatrix("Guid", BuiltinDataType.Guid);
-      byteString = decoder.decodeMatrix("ByteString", BuiltinDataType.ByteString);
-      xmlElement = decoder.decodeMatrix("XmlElement", BuiltinDataType.XmlElement);
-      nodeId = decoder.decodeMatrix("NodeId", BuiltinDataType.NodeId);
-      expandedNodeId = decoder.decodeMatrix("ExpandedNodeId", BuiltinDataType.ExpandedNodeId);
-      statusCode = decoder.decodeMatrix("StatusCode", BuiltinDataType.StatusCode);
-      qualifiedName = decoder.decodeMatrix("QualifiedName", BuiltinDataType.QualifiedName);
-      localizedText = decoder.decodeMatrix("LocalizedText", BuiltinDataType.LocalizedText);
-      dataValue = decoder.decodeMatrix("DataValue", BuiltinDataType.DataValue);
-      variant = decoder.decodeMatrix("Variant", BuiltinDataType.Variant);
-      duration = decoder.decodeMatrix("Duration", BuiltinDataType.Double);
+      _boolean = decoder.decodeMatrix("Boolean", OpcUaDataType.Boolean);
+      sByte = decoder.decodeMatrix("SByte", OpcUaDataType.SByte);
+      _byte = decoder.decodeMatrix("Byte", OpcUaDataType.Byte);
+      int16 = decoder.decodeMatrix("Int16", OpcUaDataType.Int16);
+      uInt16 = decoder.decodeMatrix("UInt16", OpcUaDataType.UInt16);
+      int32 = decoder.decodeMatrix("Int32", OpcUaDataType.Int32);
+      uInt32 = decoder.decodeMatrix("UInt32", OpcUaDataType.UInt32);
+      int64 = decoder.decodeMatrix("Int64", OpcUaDataType.Int64);
+      uInt64 = decoder.decodeMatrix("UInt64", OpcUaDataType.UInt64);
+      _float = decoder.decodeMatrix("Float", OpcUaDataType.Float);
+      _double = decoder.decodeMatrix("Double", OpcUaDataType.Double);
+      string = decoder.decodeMatrix("String", OpcUaDataType.String);
+      dateTime = decoder.decodeMatrix("DateTime", OpcUaDataType.DateTime);
+      guid = decoder.decodeMatrix("Guid", OpcUaDataType.Guid);
+      byteString = decoder.decodeMatrix("ByteString", OpcUaDataType.ByteString);
+      xmlElement = decoder.decodeMatrix("XmlElement", OpcUaDataType.XmlElement);
+      nodeId = decoder.decodeMatrix("NodeId", OpcUaDataType.NodeId);
+      expandedNodeId = decoder.decodeMatrix("ExpandedNodeId", OpcUaDataType.ExpandedNodeId);
+      statusCode = decoder.decodeMatrix("StatusCode", OpcUaDataType.StatusCode);
+      qualifiedName = decoder.decodeMatrix("QualifiedName", OpcUaDataType.QualifiedName);
+      localizedText = decoder.decodeMatrix("LocalizedText", OpcUaDataType.LocalizedText);
+      dataValue = decoder.decodeMatrix("DataValue", OpcUaDataType.DataValue);
+      variant = decoder.decodeMatrix("Variant", OpcUaDataType.Variant);
+      duration = decoder.decodeMatrix("Duration", OpcUaDataType.Double);
       {
         Matrix matrix = decoder.decodeEnumMatrix("ApplicationType");
         applicationType = matrix.transform(i -> ApplicationType.from((Integer) i));
@@ -638,18 +638,18 @@ public class StructWithBuiltinMatrixFieldsEx extends StructWithBuiltinMatrixFiel
       unionOfScalar = (Matrix) decoder.decodeStructMatrix("UnionOfScalar", UnionOfScalar.TYPE_ID);
       unionOfArray = (Matrix) decoder.decodeStructMatrix("UnionOfArray", UnionOfArray.TYPE_ID);
       {
-        Matrix matrix = decoder.decodeMatrix("OptionSetUI8", BuiltinDataType.Byte);
+        Matrix matrix = decoder.decodeMatrix("OptionSetUI8", OpcUaDataType.Byte);
         optionSetUi8 = matrix.transform(i -> new AccessLevelType((UByte) i));
       }
       {
-        Matrix matrix = decoder.decodeMatrix("OptionSetUI16", BuiltinDataType.UInt16);
+        Matrix matrix = decoder.decodeMatrix("OptionSetUI16", OpcUaDataType.UInt16);
         optionSetUi16 = matrix.transform(i -> new AccessRestrictionType((UShort) i));
       }
       {
-        Matrix matrix = decoder.decodeMatrix("OptionSetUI32", BuiltinDataType.UInt32);
+        Matrix matrix = decoder.decodeMatrix("OptionSetUI32", OpcUaDataType.UInt32);
         optionSetUi32 = matrix.transform(i -> new AccessLevelExType((UInteger) i));
       }
-      optionSetUi64 = decoder.decodeMatrix("OptionSetUI64", BuiltinDataType.UInt64);
+      optionSetUi64 = decoder.decodeMatrix("OptionSetUI64", OpcUaDataType.UInt64);
       return new StructWithBuiltinMatrixFieldsEx(
           _boolean,
           sByte,

--- a/opc-ua-sdk/codec-json/src/test/java/org/eclipse/milo/opcua/test/types/StructWithOptionalMatrixFields.java
+++ b/opc-ua-sdk/codec-json/src/test/java/org/eclipse/milo/opcua/test/types/StructWithOptionalMatrixFields.java
@@ -11,8 +11,8 @@
 package org.eclipse.milo.opcua.test.types;
 
 import java.util.StringJoiner;
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
 import org.eclipse.milo.opcua.stack.core.NamespaceTable;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
 import org.eclipse.milo.opcua.stack.core.encoding.GenericDataTypeCodec;
 import org.eclipse.milo.opcua.stack.core.encoding.UaDecoder;
@@ -275,21 +275,21 @@ public class StructWithOptionalMatrixFields extends Structure implements UaStruc
       final Matrix concreteTestType;
       final Matrix optionalConcreteTestType;
       final long encodingMask = decoder.decodeUInt32("EncodingMask").longValue();
-      int32 = decoder.decodeMatrix("Int32", BuiltinDataType.Int32);
+      int32 = decoder.decodeMatrix("Int32", OpcUaDataType.Int32);
       if ((encodingMask & (1L << 0)) != 0) {
-        optionalInt32 = decoder.decodeMatrix("OptionalInt32", BuiltinDataType.Int32);
+        optionalInt32 = decoder.decodeMatrix("OptionalInt32", OpcUaDataType.Int32);
       } else {
         optionalInt32 = null;
       }
-      string = decoder.decodeMatrix("String", BuiltinDataType.String);
+      string = decoder.decodeMatrix("String", OpcUaDataType.String);
       if ((encodingMask & (1L << 1)) != 0) {
-        optionalString = decoder.decodeMatrix("OptionalString", BuiltinDataType.String);
+        optionalString = decoder.decodeMatrix("OptionalString", OpcUaDataType.String);
       } else {
         optionalString = null;
       }
-      duration = decoder.decodeMatrix("Duration", BuiltinDataType.Double);
+      duration = decoder.decodeMatrix("Duration", OpcUaDataType.Double);
       if ((encodingMask & (1L << 2)) != 0) {
-        optionalDuration = decoder.decodeMatrix("OptionalDuration", BuiltinDataType.Double);
+        optionalDuration = decoder.decodeMatrix("OptionalDuration", OpcUaDataType.Double);
       } else {
         optionalDuration = null;
       }

--- a/opc-ua-sdk/codec-json/src/test/java/org/eclipse/milo/opcua/test/types/StructWithStructureMatrixFields.java
+++ b/opc-ua-sdk/codec-json/src/test/java/org/eclipse/milo/opcua/test/types/StructWithStructureMatrixFields.java
@@ -11,8 +11,8 @@
 package org.eclipse.milo.opcua.test.types;
 
 import java.util.StringJoiner;
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
 import org.eclipse.milo.opcua.stack.core.NamespaceTable;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
 import org.eclipse.milo.opcua.stack.core.encoding.GenericDataTypeCodec;
 import org.eclipse.milo.opcua.stack.core.encoding.UaDecoder;
@@ -167,9 +167,9 @@ public class StructWithStructureMatrixFields extends Structure implements UaStru
       final Matrix struct1;
       final Matrix struct2;
       final Matrix struct3;
-      struct1 = decoder.decodeMatrix("Struct1", BuiltinDataType.ExtensionObject);
-      struct2 = decoder.decodeMatrix("Struct2", BuiltinDataType.ExtensionObject);
-      struct3 = decoder.decodeMatrix("Struct3", BuiltinDataType.ExtensionObject);
+      struct1 = decoder.decodeMatrix("Struct1", OpcUaDataType.ExtensionObject);
+      struct2 = decoder.decodeMatrix("Struct2", OpcUaDataType.ExtensionObject);
+      struct3 = decoder.decodeMatrix("Struct3", OpcUaDataType.ExtensionObject);
       return new StructWithStructureMatrixFields(struct1, struct2, struct3);
     }
 

--- a/opc-ua-sdk/codec-json/src/test/java/org/eclipse/milo/opcua/test/types/UnionOfMatrix.java
+++ b/opc-ua-sdk/codec-json/src/test/java/org/eclipse/milo/opcua/test/types/UnionOfMatrix.java
@@ -11,8 +11,8 @@
 package org.eclipse.milo.opcua.test.types;
 
 import java.util.StringJoiner;
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
 import org.eclipse.milo.opcua.stack.core.NamespaceTable;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaSerializationException;
 import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
@@ -186,19 +186,19 @@ public class UnionOfMatrix extends Union {
         case 1:
           {
             final Matrix _boolean;
-            _boolean = decoder.decodeMatrix("Boolean", BuiltinDataType.Boolean);
+            _boolean = decoder.decodeMatrix("Boolean", OpcUaDataType.Boolean);
             return UnionOfMatrix.ofBoolean(_boolean);
           }
         case 2:
           {
             final Matrix sByte;
-            sByte = decoder.decodeMatrix("SByte", BuiltinDataType.SByte);
+            sByte = decoder.decodeMatrix("SByte", OpcUaDataType.SByte);
             return UnionOfMatrix.ofSByte(sByte);
           }
         case 3:
           {
             final Matrix _byte;
-            _byte = decoder.decodeMatrix("Byte", BuiltinDataType.Byte);
+            _byte = decoder.decodeMatrix("Byte", OpcUaDataType.Byte);
             return UnionOfMatrix.ofByte(_byte);
           }
         default:

--- a/opc-ua-sdk/codec-json/src/test/java/org/eclipse/milo/sdk/core/types/json/util/AbstractEncodingContext.java
+++ b/opc-ua-sdk/codec-json/src/test/java/org/eclipse/milo/sdk/core/types/json/util/AbstractEncodingContext.java
@@ -12,9 +12,9 @@ package org.eclipse.milo.sdk.core.types.json.util;
 
 import org.eclipse.milo.opcua.sdk.core.typetree.DataType;
 import org.eclipse.milo.opcua.sdk.core.typetree.DataTypeTree;
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
 import org.eclipse.milo.opcua.stack.core.NamespaceTable;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.ServerTable;
 import org.eclipse.milo.opcua.stack.core.channel.EncodingLimits;
 import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingManager;
@@ -327,7 +327,7 @@ public abstract class AbstractEncodingContext implements EncodingContext {
         };
 
     Mockito.when(dataTypeTree.getDataType(typeId)).thenReturn(dataType);
-    Mockito.when(dataTypeTree.getBuiltinType(NodeIds.Duration)).thenReturn(BuiltinDataType.Double);
+    Mockito.when(dataTypeTree.getBuiltinType(NodeIds.Duration)).thenReturn(OpcUaDataType.Double);
     Mockito.when(dataTypeTree.isEnumType(NodeIds.ApplicationType)).thenReturn(true);
     Mockito.when(
             dataTypeTree.isEnumType(
@@ -336,13 +336,13 @@ public abstract class AbstractEncodingContext implements EncodingContext {
     Mockito.when(dataTypeTree.isStructType(NodeIds.XVType)).thenReturn(true);
 
     Mockito.when(dataTypeTree.getBuiltinType(NodeIds.AccessLevelType))
-        .thenReturn(BuiltinDataType.Byte);
+        .thenReturn(OpcUaDataType.Byte);
     Mockito.when(dataTypeTree.getBuiltinType(NodeIds.AccessRestrictionType))
-        .thenReturn(BuiltinDataType.UInt16);
+        .thenReturn(OpcUaDataType.UInt16);
     Mockito.when(dataTypeTree.getBuiltinType(NodeIds.AccessLevelExType))
-        .thenReturn(BuiltinDataType.UInt32);
+        .thenReturn(OpcUaDataType.UInt32);
     Mockito.when(dataTypeTree.getBuiltinType(NodeIds.BitFieldMaskDataType))
-        .thenReturn(BuiltinDataType.UInt64);
+        .thenReturn(OpcUaDataType.UInt64);
 
     return dataType;
   }
@@ -457,7 +457,7 @@ public abstract class AbstractEncodingContext implements EncodingContext {
         };
 
     Mockito.when(dataTypeTree.getDataType(typeId)).thenReturn(dataType);
-    Mockito.when(dataTypeTree.getBuiltinType(NodeIds.Number)).thenReturn(BuiltinDataType.Variant);
+    Mockito.when(dataTypeTree.getBuiltinType(NodeIds.Number)).thenReturn(OpcUaDataType.Variant);
     Mockito.when(dataTypeTree.isStructType(typeId)).thenReturn(true);
 
     return dataType;
@@ -497,7 +497,7 @@ public abstract class AbstractEncodingContext implements EncodingContext {
         };
 
     Mockito.when(dataTypeTree.getDataType(typeId)).thenReturn(dataType);
-    Mockito.when(dataTypeTree.getBuiltinType(NodeIds.Number)).thenReturn(BuiltinDataType.Variant);
+    Mockito.when(dataTypeTree.getBuiltinType(NodeIds.Number)).thenReturn(OpcUaDataType.Variant);
     Mockito.when(dataTypeTree.isStructType(typeId)).thenReturn(true);
 
     return dataType;

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/nodes/AttributeTestHelper.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/nodes/AttributeTestHelper.java
@@ -26,8 +26,8 @@ import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableTypeNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaViewNode;
 import org.eclipse.milo.opcua.sdk.test.TestNamespace;
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
@@ -210,7 +210,7 @@ class AttributeTestHelper {
                   USER_ROLE_PERMISSIONS,
                   ACCESS_RESTRICTIONS,
                   new DataValue(new Variant(42)),
-                  BuiltinDataType.Int32.getNodeId(),
+                  OpcUaDataType.Int32.getNodeId(),
                   -1,
                   null,
                   AccessLevel.toValue(AccessLevel.READ_WRITE),
@@ -239,7 +239,7 @@ class AttributeTestHelper {
                   USER_ROLE_PERMISSIONS,
                   ACCESS_RESTRICTIONS,
                   new DataValue(new Variant(42)),
-                  BuiltinDataType.Int32.getNodeId(),
+                  OpcUaDataType.Int32.getNodeId(),
                   -1,
                   null,
                   false);

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/nodes/UaVariableNodeAttributeTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/nodes/UaVariableNodeAttributeTest.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.eclipse.milo.opcua.sdk.core.AccessLevel;
 import org.eclipse.milo.opcua.sdk.test.AbstractClientServerTest;
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
@@ -46,7 +46,7 @@ public class UaVariableNodeAttributeTest extends AbstractClientServerTest {
     assertEquals(AttributeTestHelper.ACCESS_RESTRICTIONS, variableNode.getAccessRestrictions());
 
     assertEquals(new Variant(42), variableNode.getValue().getValue());
-    assertEquals(BuiltinDataType.Int32.getNodeId(), variableNode.getDataType());
+    assertEquals(OpcUaDataType.Int32.getNodeId(), variableNode.getDataType());
     assertEquals(-1, variableNode.getValueRank());
     assertNull(variableNode.getArrayDimensions());
     assertEquals(AccessLevel.toValue(AccessLevel.READ_WRITE), variableNode.getAccessLevel());
@@ -73,7 +73,7 @@ public class UaVariableNodeAttributeTest extends AbstractClientServerTest {
     assertEquals(AttributeTestHelper.ACCESS_RESTRICTIONS, variableNode.readAccessRestrictions());
 
     assertEquals(new Variant(42), variableNode.readValue().getValue());
-    assertEquals(BuiltinDataType.Int32.getNodeId(), variableNode.readDataType());
+    assertEquals(OpcUaDataType.Int32.getNodeId(), variableNode.readDataType());
     assertEquals(-1, variableNode.readValueRank());
     assertNull(variableNode.readArrayDimensions());
     assertEquals(AccessLevel.toValue(AccessLevel.READ_WRITE), variableNode.readAccessLevel());

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/nodes/UaVariableTypeNodeAttributeTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/nodes/UaVariableTypeNodeAttributeTest.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.eclipse.milo.opcua.sdk.test.AbstractClientServerTest;
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
@@ -46,7 +46,7 @@ public class UaVariableTypeNodeAttributeTest extends AbstractClientServerTest {
     assertEquals(AttributeTestHelper.ACCESS_RESTRICTIONS, variableTypeNode.getAccessRestrictions());
 
     assertEquals(new Variant(42), variableTypeNode.getValue().getValue());
-    assertEquals(BuiltinDataType.Int32.getNodeId(), variableTypeNode.getDataType());
+    assertEquals(OpcUaDataType.Int32.getNodeId(), variableTypeNode.getDataType());
     assertEquals(-1, variableTypeNode.getValueRank());
     assertNull(variableTypeNode.getArrayDimensions());
     assertFalse(variableTypeNode.getIsAbstract());
@@ -72,7 +72,7 @@ public class UaVariableTypeNodeAttributeTest extends AbstractClientServerTest {
         AttributeTestHelper.ACCESS_RESTRICTIONS, variableTypeNode.readAccessRestrictions());
 
     assertEquals(new Variant(42), variableTypeNode.readValue().getValue());
-    assertEquals(BuiltinDataType.Int32.getNodeId(), variableTypeNode.readDataType());
+    assertEquals(OpcUaDataType.Int32.getNodeId(), variableTypeNode.readDataType());
     assertEquals(-1, variableTypeNode.readValueRank());
     assertNull(variableTypeNode.readArrayDimensions());
     assertFalse(variableTypeNode.readIsAbstract());

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/core/typetree/AbstractDataTypeTreeTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/core/typetree/AbstractDataTypeTreeTest.java
@@ -19,8 +19,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Comparator;
 import java.util.Objects;
 import org.eclipse.milo.opcua.sdk.test.AbstractClientServerTest;
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
@@ -109,26 +109,26 @@ public abstract class AbstractDataTypeTreeTest extends AbstractClientServerTest 
   @Test
   public void testGetBuiltinType() {
     // Check all the builtin types
-    for (BuiltinDataType expectedType : BuiltinDataType.values()) {
-      BuiltinDataType builtinType = dataTypeTree.getBuiltinType(expectedType.getNodeId());
+    for (OpcUaDataType expectedType : OpcUaDataType.values()) {
+      OpcUaDataType builtinType = dataTypeTree.getBuiltinType(expectedType.getNodeId());
 
       assertEquals(expectedType, builtinType);
     }
 
     // Check that subtypes resolve to their builtin types
-    assertEquals(BuiltinDataType.String, dataTypeTree.getBuiltinType(NodeIds.NumericRange));
-    assertEquals(BuiltinDataType.DateTime, dataTypeTree.getBuiltinType(NodeIds.DateTime));
-    assertEquals(BuiltinDataType.ByteString, dataTypeTree.getBuiltinType(NodeIds.Image));
-    assertEquals(BuiltinDataType.ByteString, dataTypeTree.getBuiltinType(NodeIds.ImageBMP));
+    assertEquals(OpcUaDataType.String, dataTypeTree.getBuiltinType(NodeIds.NumericRange));
+    assertEquals(OpcUaDataType.DateTime, dataTypeTree.getBuiltinType(NodeIds.DateTime));
+    assertEquals(OpcUaDataType.ByteString, dataTypeTree.getBuiltinType(NodeIds.Image));
+    assertEquals(OpcUaDataType.ByteString, dataTypeTree.getBuiltinType(NodeIds.ImageBMP));
     assertEquals(
-        BuiltinDataType.NodeId, dataTypeTree.getBuiltinType(NodeIds.SessionAuthenticationToken));
+        OpcUaDataType.NodeId, dataTypeTree.getBuiltinType(NodeIds.SessionAuthenticationToken));
     assertEquals(
-        BuiltinDataType.ExtensionObject, dataTypeTree.getBuiltinType(NodeIds.TrustListDataType));
-    assertEquals(BuiltinDataType.Double, dataTypeTree.getBuiltinType(NodeIds.Duration));
-    assertEquals(BuiltinDataType.UInt32, dataTypeTree.getBuiltinType(NodeIds.IntegerId));
-    assertEquals(BuiltinDataType.UInt64, dataTypeTree.getBuiltinType(NodeIds.BitFieldMaskDataType));
+        OpcUaDataType.ExtensionObject, dataTypeTree.getBuiltinType(NodeIds.TrustListDataType));
+    assertEquals(OpcUaDataType.Double, dataTypeTree.getBuiltinType(NodeIds.Duration));
+    assertEquals(OpcUaDataType.UInt32, dataTypeTree.getBuiltinType(NodeIds.IntegerId));
+    assertEquals(OpcUaDataType.UInt64, dataTypeTree.getBuiltinType(NodeIds.BitFieldMaskDataType));
     // note: enumerations resolve to BaseDataType aka Variant
-    assertEquals(BuiltinDataType.Variant, dataTypeTree.getBuiltinType(NodeIds.NamingRuleType));
+    assertEquals(OpcUaDataType.Variant, dataTypeTree.getBuiltinType(NodeIds.NamingRuleType));
   }
 
   @Test

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/test/MatrixTestType.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/test/MatrixTestType.java
@@ -11,7 +11,7 @@
 package org.eclipse.milo.opcua.sdk.test;
 
 import java.util.Arrays;
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.UaSerializationException;
 import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
 import org.eclipse.milo.opcua.stack.core.encoding.GenericDataTypeCodec;
@@ -112,7 +112,7 @@ public class MatrixTestType implements UaStructuredType {
         throws UaSerializationException {
       Integer[][] builtinMatrix =
           (Integer[][])
-              decoder.decodeMatrix("BuiltinMatrix", BuiltinDataType.Int32).nestedArrayValue();
+              decoder.decodeMatrix("BuiltinMatrix", OpcUaDataType.Int32).nestedArrayValue();
       ApplicationType[][] enumMatrix =
           (ApplicationType[][])
               decoder

--- a/opc-ua-sdk/sdk-core/src/main/java/org/eclipse/milo/opcua/sdk/core/types/codec/FieldUtil.java
+++ b/opc-ua-sdk/sdk-core/src/main/java/org/eclipse/milo/opcua/sdk/core/types/codec/FieldUtil.java
@@ -21,8 +21,8 @@ import org.eclipse.milo.opcua.sdk.core.types.DynamicEnumType;
 import org.eclipse.milo.opcua.sdk.core.types.DynamicStructType;
 import org.eclipse.milo.opcua.sdk.core.typetree.DataType;
 import org.eclipse.milo.opcua.sdk.core.typetree.DataTypeTree;
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaSerializationException;
 import org.eclipse.milo.opcua.stack.core.encoding.UaDecoder;
@@ -117,7 +117,7 @@ class FieldUtil {
         return matrix.transform(v -> new DynamicEnumType(hint.dataType, (Integer) v));
       } else if (fieldHint instanceof FieldHint.Struct) {
         if (dataTypeId.equals(NodeIds.Structure) || fieldAllowsSubtyping(definition, field)) {
-          Matrix matrix = decoder.decodeMatrix(fieldName, BuiltinDataType.ExtensionObject);
+          Matrix matrix = decoder.decodeMatrix(fieldName, OpcUaDataType.ExtensionObject);
 
           return matrix.transform(
               o -> {
@@ -242,8 +242,8 @@ class FieldUtil {
       NodeId dataTypeId = field.getDataType();
 
       FieldHint hint;
-      if (BuiltinDataType.isBuiltin(dataTypeId)) {
-        BuiltinDataType dataType = requireNonNull(BuiltinDataType.fromNodeId(dataTypeId));
+      if (OpcUaDataType.isBuiltin(dataTypeId)) {
+        OpcUaDataType dataType = requireNonNull(OpcUaDataType.fromNodeId(dataTypeId));
         hint = new FieldHint.Builtin(dataType);
       } else if (dataTypeTree.isEnumType(dataTypeId)) {
         DataType dataType = requireNonNull(dataTypeTree.getDataType(dataTypeId));
@@ -261,9 +261,9 @@ class FieldUtil {
   }
 
   private static Object decodeBuiltinDataType(
-      UaDecoder decoder, String fieldName, BuiltinDataType builtinDataType) {
+      UaDecoder decoder, String fieldName, OpcUaDataType dataType) {
 
-    return switch (builtinDataType) {
+    return switch (dataType) {
       case Boolean -> decoder.decodeBoolean(fieldName);
       case SByte -> decoder.decodeSByte(fieldName);
       case Byte -> decoder.decodeByte(fieldName);
@@ -293,9 +293,9 @@ class FieldUtil {
   }
 
   private static Object decodeBuiltinDataTypeArray(
-      UaDecoder decoder, String fieldName, BuiltinDataType builtinDataType) {
+      UaDecoder decoder, String fieldName, OpcUaDataType dataType) {
 
-    return switch (builtinDataType) {
+    return switch (dataType) {
       case Boolean -> decoder.decodeBooleanArray(fieldName);
       case SByte -> decoder.decodeSByteArray(fieldName);
       case Byte -> decoder.decodeByteArray(fieldName);
@@ -325,9 +325,9 @@ class FieldUtil {
   }
 
   private static void encodeBuiltinDataType(
-      UaEncoder encoder, String fieldName, BuiltinDataType builtinDataType, Object value) {
+      UaEncoder encoder, String fieldName, OpcUaDataType dataType, Object value) {
 
-    switch (builtinDataType) {
+    switch (dataType) {
       case Boolean:
         encoder.encodeBoolean(fieldName, (Boolean) value);
         break;
@@ -405,14 +405,14 @@ class FieldUtil {
         break;
       default:
         // Shouldn't happen
-        throw new RuntimeException("unhandled BuiltinDataType: " + builtinDataType);
+        throw new RuntimeException("unhandled BuiltinDataType: " + dataType);
     }
   }
 
   private static void encodeBuiltinDataTypeArray(
-      UaEncoder encoder, String fieldName, BuiltinDataType builtinDataType, Object value) {
+      UaEncoder encoder, String fieldName, OpcUaDataType dataType, Object value) {
 
-    switch (builtinDataType) {
+    switch (dataType) {
       case Boolean:
         encoder.encodeBooleanArray(fieldName, (Boolean[]) value);
         break;
@@ -490,13 +490,13 @@ class FieldUtil {
         break;
       default:
         // Shouldn't happen
-        throw new RuntimeException("unhandled BuiltinDataType: " + builtinDataType);
+        throw new RuntimeException("unhandled BuiltinDataType: " + dataType);
     }
   }
 
   sealed interface FieldHint permits FieldHint.Builtin, FieldHint.Enum, FieldHint.Struct {
 
-    record Builtin(BuiltinDataType dataType) implements FieldHint {}
+    record Builtin(OpcUaDataType dataType) implements FieldHint {}
 
     record Enum(DataType dataType) implements FieldHint {}
 

--- a/opc-ua-sdk/sdk-core/src/main/java/org/eclipse/milo/opcua/sdk/core/typetree/DataTypeTree.java
+++ b/opc-ua-sdk/sdk-core/src/main/java/org/eclipse/milo/opcua/sdk/core/typetree/DataTypeTree.java
@@ -10,8 +10,8 @@
 
 package org.eclipse.milo.opcua.sdk.core.typetree;
 
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
@@ -53,12 +53,12 @@ public class DataTypeTree extends TypeTree<DataType> {
    *
    * @param dataTypeId the {@link NodeId} of a DataType Node.
    * @return the backing Class a value of DataType {@code dataTypeId} would have.
-   * @see BuiltinDataType
-   * @see BuiltinDataType#getBackingClass()
+   * @see OpcUaDataType
+   * @see OpcUaDataType#getBackingClass()
    */
   public Class<?> getBackingClass(NodeId dataTypeId) {
-    if (BuiltinDataType.isBuiltin(dataTypeId)) {
-      return BuiltinDataType.getBackingClass(dataTypeId);
+    if (OpcUaDataType.isBuiltin(dataTypeId)) {
+      return OpcUaDataType.getBackingClass(dataTypeId);
     } else {
       if (NodeIds.Enumeration.equals(dataTypeId)) {
         return Integer.class;
@@ -82,15 +82,15 @@ public class DataTypeTree extends TypeTree<DataType> {
   }
 
   /**
-   * Get the {@link BuiltinDataType} {@code dataTypeId} inherits from, following references to the
-   * parent as necessary until a {@link BuiltinDataType} is found.
+   * Get the {@link OpcUaDataType} {@code dataTypeId} inherits from, following references to the
+   * parent as necessary until a {@link OpcUaDataType} is found.
    *
    * @param dataTypeId the {@link NodeId} of a DataType Node.
-   * @return the {@link BuiltinDataType} this DataType inherits from.
+   * @return the {@link OpcUaDataType} this DataType inherits from.
    */
-  public BuiltinDataType getBuiltinType(NodeId dataTypeId) {
-    if (BuiltinDataType.isBuiltin(dataTypeId)) {
-      return BuiltinDataType.fromNodeId(dataTypeId);
+  public OpcUaDataType getBuiltinType(NodeId dataTypeId) {
+    if (OpcUaDataType.isBuiltin(dataTypeId)) {
+      return OpcUaDataType.fromNodeId(dataTypeId);
     } else {
       Tree<DataType> node = types.get(dataTypeId);
       Tree<DataType> parent = node != null ? node.getParent() : null;
@@ -98,7 +98,7 @@ public class DataTypeTree extends TypeTree<DataType> {
       if (parent != null) {
         return getBuiltinType(parent.getValue().getNodeId());
       } else {
-        return BuiltinDataType.Variant;
+        return OpcUaDataType.Variant;
       }
     }
   }

--- a/opc-ua-sdk/sdk-core/src/test/java/org/eclipse/milo/opcua/sdk/core/types/util/AbstractEncodingContext.java
+++ b/opc-ua-sdk/sdk-core/src/test/java/org/eclipse/milo/opcua/sdk/core/types/util/AbstractEncodingContext.java
@@ -12,9 +12,9 @@ package org.eclipse.milo.opcua.sdk.core.types.util;
 
 import org.eclipse.milo.opcua.sdk.core.typetree.DataType;
 import org.eclipse.milo.opcua.sdk.core.typetree.DataTypeTree;
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
 import org.eclipse.milo.opcua.stack.core.NamespaceTable;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.ServerTable;
 import org.eclipse.milo.opcua.stack.core.channel.EncodingLimits;
 import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingManager;
@@ -341,7 +341,7 @@ public abstract class AbstractEncodingContext implements EncodingContext {
         };
 
     Mockito.when(dataTypeTree.getDataType(typeId)).thenReturn(dataType);
-    Mockito.when(dataTypeTree.getBuiltinType(NodeIds.Duration)).thenReturn(BuiltinDataType.Double);
+    Mockito.when(dataTypeTree.getBuiltinType(NodeIds.Duration)).thenReturn(OpcUaDataType.Double);
 
     Mockito.when(dataTypeTree.isEnumType(NodeIds.ApplicationType)).thenReturn(true);
     Mockito.when(dataTypeTree.getDataType(NodeIds.ApplicationType))
@@ -359,13 +359,13 @@ public abstract class AbstractEncodingContext implements EncodingContext {
     Mockito.when(dataTypeTree.isStructType(NodeIds.XVType)).thenReturn(true);
 
     Mockito.when(dataTypeTree.getBuiltinType(NodeIds.AccessLevelType))
-        .thenReturn(BuiltinDataType.Byte);
+        .thenReturn(OpcUaDataType.Byte);
     Mockito.when(dataTypeTree.getBuiltinType(NodeIds.AccessRestrictionType))
-        .thenReturn(BuiltinDataType.UInt16);
+        .thenReturn(OpcUaDataType.UInt16);
     Mockito.when(dataTypeTree.getBuiltinType(NodeIds.AccessLevelExType))
-        .thenReturn(BuiltinDataType.UInt32);
+        .thenReturn(OpcUaDataType.UInt32);
     Mockito.when(dataTypeTree.getBuiltinType(NodeIds.BitFieldMaskDataType))
-        .thenReturn(BuiltinDataType.UInt64);
+        .thenReturn(OpcUaDataType.UInt64);
 
     return dataType;
   }
@@ -480,7 +480,7 @@ public abstract class AbstractEncodingContext implements EncodingContext {
         };
 
     Mockito.when(dataTypeTree.getDataType(typeId)).thenReturn(dataType);
-    Mockito.when(dataTypeTree.getBuiltinType(NodeIds.Number)).thenReturn(BuiltinDataType.Variant);
+    Mockito.when(dataTypeTree.getBuiltinType(NodeIds.Number)).thenReturn(OpcUaDataType.Variant);
     Mockito.when(dataTypeTree.isStructType(typeId)).thenReturn(true);
 
     return dataType;
@@ -520,7 +520,7 @@ public abstract class AbstractEncodingContext implements EncodingContext {
         };
 
     Mockito.when(dataTypeTree.getDataType(typeId)).thenReturn(dataType);
-    Mockito.when(dataTypeTree.getBuiltinType(NodeIds.Number)).thenReturn(BuiltinDataType.Variant);
+    Mockito.when(dataTypeTree.getBuiltinType(NodeIds.Number)).thenReturn(OpcUaDataType.Variant);
     Mockito.when(dataTypeTree.isStructType(typeId)).thenReturn(true);
 
     return dataType;

--- a/opc-ua-sdk/sdk-core/src/test/java/org/eclipse/milo/opcua/test/types/StructWithAbstractMatrixFields.java
+++ b/opc-ua-sdk/sdk-core/src/test/java/org/eclipse/milo/opcua/test/types/StructWithAbstractMatrixFields.java
@@ -11,8 +11,8 @@
 package org.eclipse.milo.opcua.test.types;
 
 import java.util.StringJoiner;
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
 import org.eclipse.milo.opcua.stack.core.NamespaceTable;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
 import org.eclipse.milo.opcua.stack.core.encoding.GenericDataTypeCodec;
 import org.eclipse.milo.opcua.stack.core.encoding.UaDecoder;
@@ -174,15 +174,15 @@ public class StructWithAbstractMatrixFields extends Structure implements UaStruc
       final Matrix att1;
       final Matrix att2;
       {
-        Matrix matrix = decoder.decodeMatrix("Number", BuiltinDataType.Variant);
+        Matrix matrix = decoder.decodeMatrix("Number", OpcUaDataType.Variant);
         number = matrix.transform(v -> ((Variant) v).getValue());
       }
       {
-        Matrix matrix = decoder.decodeMatrix("ATT1", BuiltinDataType.ExtensionObject);
+        Matrix matrix = decoder.decodeMatrix("ATT1", OpcUaDataType.ExtensionObject);
         att1 = matrix.transform(v -> ((ExtensionObject) v).decode(context));
       }
       {
-        Matrix matrix = decoder.decodeMatrix("ATT2", BuiltinDataType.ExtensionObject);
+        Matrix matrix = decoder.decodeMatrix("ATT2", OpcUaDataType.ExtensionObject);
         att2 = matrix.transform(v -> ((ExtensionObject) v).decode(context));
       }
       return new StructWithAbstractMatrixFields(number, att1, att2);

--- a/opc-ua-sdk/sdk-core/src/test/java/org/eclipse/milo/opcua/test/types/StructWithBuiltinMatrixFields.java
+++ b/opc-ua-sdk/sdk-core/src/test/java/org/eclipse/milo/opcua/test/types/StructWithBuiltinMatrixFields.java
@@ -11,8 +11,8 @@
 package org.eclipse.milo.opcua.test.types;
 
 import java.util.StringJoiner;
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
 import org.eclipse.milo.opcua.stack.core.NamespaceTable;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
 import org.eclipse.milo.opcua.stack.core.encoding.GenericDataTypeCodec;
 import org.eclipse.milo.opcua.stack.core.encoding.UaDecoder;
@@ -569,29 +569,29 @@ public class StructWithBuiltinMatrixFields extends Structure implements UaStruct
       final Matrix localizedText;
       final Matrix dataValue;
       final Matrix variant;
-      _boolean = decoder.decodeMatrix("Boolean", BuiltinDataType.Boolean);
-      sByte = decoder.decodeMatrix("SByte", BuiltinDataType.SByte);
-      _byte = decoder.decodeMatrix("Byte", BuiltinDataType.Byte);
-      int16 = decoder.decodeMatrix("Int16", BuiltinDataType.Int16);
-      uInt16 = decoder.decodeMatrix("UInt16", BuiltinDataType.UInt16);
-      int32 = decoder.decodeMatrix("Int32", BuiltinDataType.Int32);
-      uInt32 = decoder.decodeMatrix("UInt32", BuiltinDataType.UInt32);
-      int64 = decoder.decodeMatrix("Int64", BuiltinDataType.Int64);
-      uInt64 = decoder.decodeMatrix("UInt64", BuiltinDataType.UInt64);
-      _float = decoder.decodeMatrix("Float", BuiltinDataType.Float);
-      _double = decoder.decodeMatrix("Double", BuiltinDataType.Double);
-      string = decoder.decodeMatrix("String", BuiltinDataType.String);
-      dateTime = decoder.decodeMatrix("DateTime", BuiltinDataType.DateTime);
-      guid = decoder.decodeMatrix("Guid", BuiltinDataType.Guid);
-      byteString = decoder.decodeMatrix("ByteString", BuiltinDataType.ByteString);
-      xmlElement = decoder.decodeMatrix("XmlElement", BuiltinDataType.XmlElement);
-      nodeId = decoder.decodeMatrix("NodeId", BuiltinDataType.NodeId);
-      expandedNodeId = decoder.decodeMatrix("ExpandedNodeId", BuiltinDataType.ExpandedNodeId);
-      statusCode = decoder.decodeMatrix("StatusCode", BuiltinDataType.StatusCode);
-      qualifiedName = decoder.decodeMatrix("QualifiedName", BuiltinDataType.QualifiedName);
-      localizedText = decoder.decodeMatrix("LocalizedText", BuiltinDataType.LocalizedText);
-      dataValue = decoder.decodeMatrix("DataValue", BuiltinDataType.DataValue);
-      variant = decoder.decodeMatrix("Variant", BuiltinDataType.Variant);
+      _boolean = decoder.decodeMatrix("Boolean", OpcUaDataType.Boolean);
+      sByte = decoder.decodeMatrix("SByte", OpcUaDataType.SByte);
+      _byte = decoder.decodeMatrix("Byte", OpcUaDataType.Byte);
+      int16 = decoder.decodeMatrix("Int16", OpcUaDataType.Int16);
+      uInt16 = decoder.decodeMatrix("UInt16", OpcUaDataType.UInt16);
+      int32 = decoder.decodeMatrix("Int32", OpcUaDataType.Int32);
+      uInt32 = decoder.decodeMatrix("UInt32", OpcUaDataType.UInt32);
+      int64 = decoder.decodeMatrix("Int64", OpcUaDataType.Int64);
+      uInt64 = decoder.decodeMatrix("UInt64", OpcUaDataType.UInt64);
+      _float = decoder.decodeMatrix("Float", OpcUaDataType.Float);
+      _double = decoder.decodeMatrix("Double", OpcUaDataType.Double);
+      string = decoder.decodeMatrix("String", OpcUaDataType.String);
+      dateTime = decoder.decodeMatrix("DateTime", OpcUaDataType.DateTime);
+      guid = decoder.decodeMatrix("Guid", OpcUaDataType.Guid);
+      byteString = decoder.decodeMatrix("ByteString", OpcUaDataType.ByteString);
+      xmlElement = decoder.decodeMatrix("XmlElement", OpcUaDataType.XmlElement);
+      nodeId = decoder.decodeMatrix("NodeId", OpcUaDataType.NodeId);
+      expandedNodeId = decoder.decodeMatrix("ExpandedNodeId", OpcUaDataType.ExpandedNodeId);
+      statusCode = decoder.decodeMatrix("StatusCode", OpcUaDataType.StatusCode);
+      qualifiedName = decoder.decodeMatrix("QualifiedName", OpcUaDataType.QualifiedName);
+      localizedText = decoder.decodeMatrix("LocalizedText", OpcUaDataType.LocalizedText);
+      dataValue = decoder.decodeMatrix("DataValue", OpcUaDataType.DataValue);
+      variant = decoder.decodeMatrix("Variant", OpcUaDataType.Variant);
       return new StructWithBuiltinMatrixFields(
           _boolean,
           sByte,

--- a/opc-ua-sdk/sdk-core/src/test/java/org/eclipse/milo/opcua/test/types/StructWithBuiltinMatrixFieldsEx.java
+++ b/opc-ua-sdk/sdk-core/src/test/java/org/eclipse/milo/opcua/test/types/StructWithBuiltinMatrixFieldsEx.java
@@ -11,8 +11,8 @@
 package org.eclipse.milo.opcua.test.types;
 
 import java.util.StringJoiner;
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
 import org.eclipse.milo.opcua.stack.core.NamespaceTable;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
 import org.eclipse.milo.opcua.stack.core.encoding.GenericDataTypeCodec;
 import org.eclipse.milo.opcua.stack.core.encoding.UaDecoder;
@@ -600,30 +600,30 @@ public class StructWithBuiltinMatrixFieldsEx extends StructWithBuiltinMatrixFiel
       final Matrix optionSetUi16;
       final Matrix optionSetUi32;
       final Matrix optionSetUi64;
-      _boolean = decoder.decodeMatrix("Boolean", BuiltinDataType.Boolean);
-      sByte = decoder.decodeMatrix("SByte", BuiltinDataType.SByte);
-      _byte = decoder.decodeMatrix("Byte", BuiltinDataType.Byte);
-      int16 = decoder.decodeMatrix("Int16", BuiltinDataType.Int16);
-      uInt16 = decoder.decodeMatrix("UInt16", BuiltinDataType.UInt16);
-      int32 = decoder.decodeMatrix("Int32", BuiltinDataType.Int32);
-      uInt32 = decoder.decodeMatrix("UInt32", BuiltinDataType.UInt32);
-      int64 = decoder.decodeMatrix("Int64", BuiltinDataType.Int64);
-      uInt64 = decoder.decodeMatrix("UInt64", BuiltinDataType.UInt64);
-      _float = decoder.decodeMatrix("Float", BuiltinDataType.Float);
-      _double = decoder.decodeMatrix("Double", BuiltinDataType.Double);
-      string = decoder.decodeMatrix("String", BuiltinDataType.String);
-      dateTime = decoder.decodeMatrix("DateTime", BuiltinDataType.DateTime);
-      guid = decoder.decodeMatrix("Guid", BuiltinDataType.Guid);
-      byteString = decoder.decodeMatrix("ByteString", BuiltinDataType.ByteString);
-      xmlElement = decoder.decodeMatrix("XmlElement", BuiltinDataType.XmlElement);
-      nodeId = decoder.decodeMatrix("NodeId", BuiltinDataType.NodeId);
-      expandedNodeId = decoder.decodeMatrix("ExpandedNodeId", BuiltinDataType.ExpandedNodeId);
-      statusCode = decoder.decodeMatrix("StatusCode", BuiltinDataType.StatusCode);
-      qualifiedName = decoder.decodeMatrix("QualifiedName", BuiltinDataType.QualifiedName);
-      localizedText = decoder.decodeMatrix("LocalizedText", BuiltinDataType.LocalizedText);
-      dataValue = decoder.decodeMatrix("DataValue", BuiltinDataType.DataValue);
-      variant = decoder.decodeMatrix("Variant", BuiltinDataType.Variant);
-      duration = decoder.decodeMatrix("Duration", BuiltinDataType.Double);
+      _boolean = decoder.decodeMatrix("Boolean", OpcUaDataType.Boolean);
+      sByte = decoder.decodeMatrix("SByte", OpcUaDataType.SByte);
+      _byte = decoder.decodeMatrix("Byte", OpcUaDataType.Byte);
+      int16 = decoder.decodeMatrix("Int16", OpcUaDataType.Int16);
+      uInt16 = decoder.decodeMatrix("UInt16", OpcUaDataType.UInt16);
+      int32 = decoder.decodeMatrix("Int32", OpcUaDataType.Int32);
+      uInt32 = decoder.decodeMatrix("UInt32", OpcUaDataType.UInt32);
+      int64 = decoder.decodeMatrix("Int64", OpcUaDataType.Int64);
+      uInt64 = decoder.decodeMatrix("UInt64", OpcUaDataType.UInt64);
+      _float = decoder.decodeMatrix("Float", OpcUaDataType.Float);
+      _double = decoder.decodeMatrix("Double", OpcUaDataType.Double);
+      string = decoder.decodeMatrix("String", OpcUaDataType.String);
+      dateTime = decoder.decodeMatrix("DateTime", OpcUaDataType.DateTime);
+      guid = decoder.decodeMatrix("Guid", OpcUaDataType.Guid);
+      byteString = decoder.decodeMatrix("ByteString", OpcUaDataType.ByteString);
+      xmlElement = decoder.decodeMatrix("XmlElement", OpcUaDataType.XmlElement);
+      nodeId = decoder.decodeMatrix("NodeId", OpcUaDataType.NodeId);
+      expandedNodeId = decoder.decodeMatrix("ExpandedNodeId", OpcUaDataType.ExpandedNodeId);
+      statusCode = decoder.decodeMatrix("StatusCode", OpcUaDataType.StatusCode);
+      qualifiedName = decoder.decodeMatrix("QualifiedName", OpcUaDataType.QualifiedName);
+      localizedText = decoder.decodeMatrix("LocalizedText", OpcUaDataType.LocalizedText);
+      dataValue = decoder.decodeMatrix("DataValue", OpcUaDataType.DataValue);
+      variant = decoder.decodeMatrix("Variant", OpcUaDataType.Variant);
+      duration = decoder.decodeMatrix("Duration", OpcUaDataType.Double);
       {
         Matrix matrix = decoder.decodeEnumMatrix("ApplicationType");
         applicationType = matrix.transform(i -> ApplicationType.from((Integer) i));
@@ -638,18 +638,18 @@ public class StructWithBuiltinMatrixFieldsEx extends StructWithBuiltinMatrixFiel
       unionOfScalar = (Matrix) decoder.decodeStructMatrix("UnionOfScalar", UnionOfScalar.TYPE_ID);
       unionOfArray = (Matrix) decoder.decodeStructMatrix("UnionOfArray", UnionOfArray.TYPE_ID);
       {
-        Matrix matrix = decoder.decodeMatrix("OptionSetUI8", BuiltinDataType.Byte);
+        Matrix matrix = decoder.decodeMatrix("OptionSetUI8", OpcUaDataType.Byte);
         optionSetUi8 = matrix.transform(i -> new AccessLevelType((UByte) i));
       }
       {
-        Matrix matrix = decoder.decodeMatrix("OptionSetUI16", BuiltinDataType.UInt16);
+        Matrix matrix = decoder.decodeMatrix("OptionSetUI16", OpcUaDataType.UInt16);
         optionSetUi16 = matrix.transform(i -> new AccessRestrictionType((UShort) i));
       }
       {
-        Matrix matrix = decoder.decodeMatrix("OptionSetUI32", BuiltinDataType.UInt32);
+        Matrix matrix = decoder.decodeMatrix("OptionSetUI32", OpcUaDataType.UInt32);
         optionSetUi32 = matrix.transform(i -> new AccessLevelExType((UInteger) i));
       }
-      optionSetUi64 = decoder.decodeMatrix("OptionSetUI64", BuiltinDataType.UInt64);
+      optionSetUi64 = decoder.decodeMatrix("OptionSetUI64", OpcUaDataType.UInt64);
       return new StructWithBuiltinMatrixFieldsEx(
           _boolean,
           sByte,

--- a/opc-ua-sdk/sdk-core/src/test/java/org/eclipse/milo/opcua/test/types/StructWithOptionalMatrixFields.java
+++ b/opc-ua-sdk/sdk-core/src/test/java/org/eclipse/milo/opcua/test/types/StructWithOptionalMatrixFields.java
@@ -11,8 +11,8 @@
 package org.eclipse.milo.opcua.test.types;
 
 import java.util.StringJoiner;
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
 import org.eclipse.milo.opcua.stack.core.NamespaceTable;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
 import org.eclipse.milo.opcua.stack.core.encoding.GenericDataTypeCodec;
 import org.eclipse.milo.opcua.stack.core.encoding.UaDecoder;
@@ -275,21 +275,21 @@ public class StructWithOptionalMatrixFields extends Structure implements UaStruc
       final Matrix concreteTestType;
       final Matrix optionalConcreteTestType;
       final long encodingMask = decoder.decodeUInt32("EncodingMask").longValue();
-      int32 = decoder.decodeMatrix("Int32", BuiltinDataType.Int32);
+      int32 = decoder.decodeMatrix("Int32", OpcUaDataType.Int32);
       if ((encodingMask & (1L << 0)) != 0) {
-        optionalInt32 = decoder.decodeMatrix("OptionalInt32", BuiltinDataType.Int32);
+        optionalInt32 = decoder.decodeMatrix("OptionalInt32", OpcUaDataType.Int32);
       } else {
         optionalInt32 = null;
       }
-      string = decoder.decodeMatrix("String", BuiltinDataType.String);
+      string = decoder.decodeMatrix("String", OpcUaDataType.String);
       if ((encodingMask & (1L << 1)) != 0) {
-        optionalString = decoder.decodeMatrix("OptionalString", BuiltinDataType.String);
+        optionalString = decoder.decodeMatrix("OptionalString", OpcUaDataType.String);
       } else {
         optionalString = null;
       }
-      duration = decoder.decodeMatrix("Duration", BuiltinDataType.Double);
+      duration = decoder.decodeMatrix("Duration", OpcUaDataType.Double);
       if ((encodingMask & (1L << 2)) != 0) {
-        optionalDuration = decoder.decodeMatrix("OptionalDuration", BuiltinDataType.Double);
+        optionalDuration = decoder.decodeMatrix("OptionalDuration", OpcUaDataType.Double);
       } else {
         optionalDuration = null;
       }

--- a/opc-ua-sdk/sdk-core/src/test/java/org/eclipse/milo/opcua/test/types/StructWithStructureMatrixFields.java
+++ b/opc-ua-sdk/sdk-core/src/test/java/org/eclipse/milo/opcua/test/types/StructWithStructureMatrixFields.java
@@ -11,8 +11,8 @@
 package org.eclipse.milo.opcua.test.types;
 
 import java.util.StringJoiner;
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
 import org.eclipse.milo.opcua.stack.core.NamespaceTable;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
 import org.eclipse.milo.opcua.stack.core.encoding.GenericDataTypeCodec;
 import org.eclipse.milo.opcua.stack.core.encoding.UaDecoder;
@@ -167,9 +167,9 @@ public class StructWithStructureMatrixFields extends Structure implements UaStru
       final Matrix struct1;
       final Matrix struct2;
       final Matrix struct3;
-      struct1 = decoder.decodeMatrix("Struct1", BuiltinDataType.ExtensionObject);
-      struct2 = decoder.decodeMatrix("Struct2", BuiltinDataType.ExtensionObject);
-      struct3 = decoder.decodeMatrix("Struct3", BuiltinDataType.ExtensionObject);
+      struct1 = decoder.decodeMatrix("Struct1", OpcUaDataType.ExtensionObject);
+      struct2 = decoder.decodeMatrix("Struct2", OpcUaDataType.ExtensionObject);
+      struct3 = decoder.decodeMatrix("Struct3", OpcUaDataType.ExtensionObject);
       return new StructWithStructureMatrixFields(struct1, struct2, struct3);
     }
 

--- a/opc-ua-sdk/sdk-core/src/test/java/org/eclipse/milo/opcua/test/types/UnionOfMatrix.java
+++ b/opc-ua-sdk/sdk-core/src/test/java/org/eclipse/milo/opcua/test/types/UnionOfMatrix.java
@@ -10,8 +10,8 @@
 
 package org.eclipse.milo.opcua.test.types;
 
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
 import org.eclipse.milo.opcua.stack.core.NamespaceTable;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaSerializationException;
 import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
@@ -190,19 +190,19 @@ public class UnionOfMatrix extends Union {
         case 1:
           {
             final Matrix _boolean;
-            _boolean = decoder.decodeMatrix("Boolean", BuiltinDataType.Boolean);
+            _boolean = decoder.decodeMatrix("Boolean", OpcUaDataType.Boolean);
             return UnionOfMatrix.ofBoolean(_boolean);
           }
         case 2:
           {
             final Matrix sByte;
-            sByte = decoder.decodeMatrix("SByte", BuiltinDataType.SByte);
+            sByte = decoder.decodeMatrix("SByte", OpcUaDataType.SByte);
             return UnionOfMatrix.ofSByte(sByte);
           }
         case 3:
           {
             final Matrix _byte;
-            _byte = decoder.decodeMatrix("Byte", BuiltinDataType.Byte);
+            _byte = decoder.decodeMatrix("Byte", OpcUaDataType.Byte);
             return UnionOfMatrix.ofByte(_byte);
           }
         default:

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/BooleanConversions.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/BooleanConversions.java
@@ -15,7 +15,7 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ulong;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
 
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.ULong;
@@ -83,7 +83,7 @@ final class BooleanConversions {
   }
 
   @Nullable
-  static Object convert(@NonNull Object o, BuiltinDataType targetType, boolean implicit) {
+  static Object convert(@NonNull Object o, OpcUaDataType targetType, boolean implicit) {
     if (o instanceof Boolean) {
       Boolean b = (Boolean) o;
 
@@ -94,7 +94,7 @@ final class BooleanConversions {
   }
 
   @Nullable
-  static Object explicitConversion(@NonNull Boolean b, BuiltinDataType targetType) {
+  static Object explicitConversion(@NonNull Boolean b, OpcUaDataType targetType) {
     // @formatter:off
     switch (targetType) {
       case String:
@@ -106,7 +106,7 @@ final class BooleanConversions {
   }
 
   @Nullable
-  static Object implicitConversion(@NonNull Boolean b, BuiltinDataType targetType) {
+  static Object implicitConversion(@NonNull Boolean b, OpcUaDataType targetType) {
     // @formatter:off
     switch (targetType) {
       case Byte:

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/ByteConversions.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/ByteConversions.java
@@ -14,7 +14,7 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ulong;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
 
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.ULong;
@@ -82,7 +82,7 @@ final class ByteConversions {
   }
 
   @Nullable
-  static Object convert(@NonNull Object o, BuiltinDataType targetType, boolean implicit) {
+  static Object convert(@NonNull Object o, OpcUaDataType targetType, boolean implicit) {
     if (o instanceof UByte) {
       UByte b = (UByte) o;
 
@@ -93,7 +93,7 @@ final class ByteConversions {
   }
 
   @Nullable
-  static Object explicitConversion(@NonNull UByte b, BuiltinDataType targetType) {
+  static Object explicitConversion(@NonNull UByte b, OpcUaDataType targetType) {
     // @formatter:off
     switch (targetType) {
       case Boolean:
@@ -107,7 +107,7 @@ final class ByteConversions {
   }
 
   @Nullable
-  static Object implicitConversion(@NonNull UByte b, BuiltinDataType targetType) {
+  static Object implicitConversion(@NonNull UByte b, OpcUaDataType targetType) {
     // @formatter:off
     switch (targetType) {
       case Double:

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/ByteStringConversions.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/ByteStringConversions.java
@@ -13,7 +13,7 @@ package org.eclipse.milo.opcua.sdk.server.events.conversions;
 import io.netty.buffer.ByteBufUtil;
 import java.nio.ByteBuffer;
 import java.util.UUID;
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -40,7 +40,7 @@ final class ByteStringConversions {
   }
 
   @Nullable
-  static Object convert(@NonNull Object o, BuiltinDataType targetType, boolean implicit) {
+  static Object convert(@NonNull Object o, OpcUaDataType targetType, boolean implicit) {
     if (o instanceof ByteString) {
       ByteString bs = (ByteString) o;
 
@@ -51,7 +51,7 @@ final class ByteStringConversions {
   }
 
   @Nullable
-  static Object explicitConversion(@NonNull ByteString bs, BuiltinDataType targetType) {
+  static Object explicitConversion(@NonNull ByteString bs, OpcUaDataType targetType) {
     // @formatter:off
     switch (targetType) {
       case Guid:
@@ -65,7 +65,7 @@ final class ByteStringConversions {
   }
 
   @Nullable
-  static Object implicitConversion(@NonNull ByteString bs, BuiltinDataType targetType) {
+  static Object implicitConversion(@NonNull ByteString bs, OpcUaDataType targetType) {
     // no implicit conversions exist
     return null;
   }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/DateTimeConversions.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/DateTimeConversions.java
@@ -14,7 +14,7 @@ import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -42,7 +42,7 @@ final class DateTimeConversions {
   }
 
   @Nullable
-  static Object convert(@NonNull Object o, BuiltinDataType targetType, boolean implicit) {
+  static Object convert(@NonNull Object o, OpcUaDataType targetType, boolean implicit) {
     if (o instanceof DateTime) {
       DateTime d = (DateTime) o;
 
@@ -53,7 +53,7 @@ final class DateTimeConversions {
   }
 
   @Nullable
-  static Object explicitConversion(@NonNull DateTime d, BuiltinDataType targetType) {
+  static Object explicitConversion(@NonNull DateTime d, OpcUaDataType targetType) {
     // @formatter:off
     switch (targetType) {
       case String:
@@ -65,7 +65,7 @@ final class DateTimeConversions {
   }
 
   @Nullable
-  static Object implicitConversion(@NonNull DateTime d, BuiltinDataType targetType) {
+  static Object implicitConversion(@NonNull DateTime d, OpcUaDataType targetType) {
     // no implicit conversions exist
     return null;
   }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/DoubleConversions.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/DoubleConversions.java
@@ -15,7 +15,7 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ulong;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
 
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.ULong;
@@ -133,7 +133,7 @@ final class DoubleConversions {
   }
 
   @Nullable
-  static Object convert(@Nullable Object o, BuiltinDataType targetType, boolean implicit) {
+  static Object convert(@Nullable Object o, OpcUaDataType targetType, boolean implicit) {
     if (o instanceof Double) {
       Double d = (Double) o;
 
@@ -144,7 +144,7 @@ final class DoubleConversions {
   }
 
   @Nullable
-  static Object explicitConversion(@NonNull Double d, BuiltinDataType targetType) {
+  static Object explicitConversion(@NonNull Double d, OpcUaDataType targetType) {
     // @formatter:off
     switch (targetType) {
       case Boolean:
@@ -176,7 +176,7 @@ final class DoubleConversions {
   }
 
   @Nullable
-  static Object implicitConversion(@NonNull Double d, BuiltinDataType targetType) {
+  static Object implicitConversion(@NonNull Double d, OpcUaDataType targetType) {
     // no implicit conversions exist
     return null;
   }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/ExpandedNodeIdConversions.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/ExpandedNodeIdConversions.java
@@ -10,8 +10,8 @@
 
 package org.eclipse.milo.opcua.sdk.server.events.conversions;
 
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
 import org.eclipse.milo.opcua.stack.core.NamespaceTable;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.jspecify.annotations.NonNull;
@@ -33,7 +33,7 @@ final class ExpandedNodeIdConversions {
   }
 
   @Nullable
-  static Object convert(@NonNull Object o, BuiltinDataType targetType, boolean implicit) {
+  static Object convert(@NonNull Object o, OpcUaDataType targetType, boolean implicit) {
     if (o instanceof ExpandedNodeId) {
       ExpandedNodeId eni = (ExpandedNodeId) o;
 
@@ -44,7 +44,7 @@ final class ExpandedNodeIdConversions {
   }
 
   @Nullable
-  static Object explicitConversion(@NonNull ExpandedNodeId eni, BuiltinDataType targetType) {
+  static Object explicitConversion(@NonNull ExpandedNodeId eni, OpcUaDataType targetType) {
     // @formatter:off
     switch (targetType) {
       case NodeId:
@@ -56,7 +56,7 @@ final class ExpandedNodeIdConversions {
   }
 
   @Nullable
-  static Object implicitConversion(@NonNull ExpandedNodeId eni, BuiltinDataType targetType) {
+  static Object implicitConversion(@NonNull ExpandedNodeId eni, OpcUaDataType targetType) {
     // @formatter:off
     switch (targetType) {
       case String:

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/FloatConversions.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/FloatConversions.java
@@ -15,7 +15,7 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ulong;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
 
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.ULong;
@@ -119,7 +119,7 @@ final class FloatConversions {
   }
 
   @Nullable
-  static Object convert(@Nullable Object o, BuiltinDataType targetType, boolean implicit) {
+  static Object convert(@Nullable Object o, OpcUaDataType targetType, boolean implicit) {
     if (o instanceof Float) {
       Float f = (Float) o;
 
@@ -130,7 +130,7 @@ final class FloatConversions {
   }
 
   @Nullable
-  static Object explicitConversion(@NonNull Float f, BuiltinDataType targetType) {
+  static Object explicitConversion(@NonNull Float f, OpcUaDataType targetType) {
     // @formatter:off
     switch (targetType) {
       case Boolean:
@@ -160,7 +160,7 @@ final class FloatConversions {
   }
 
   @Nullable
-  static Object implicitConversion(@NonNull Float f, BuiltinDataType targetType) {
+  static Object implicitConversion(@NonNull Float f, OpcUaDataType targetType) {
     // @formatter:off
     switch (targetType) {
       case Double:

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/GuidConversions.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/GuidConversions.java
@@ -12,7 +12,7 @@ package org.eclipse.milo.opcua.sdk.server.events.conversions;
 
 import java.nio.ByteBuffer;
 import java.util.UUID;
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -36,7 +36,7 @@ final class GuidConversions {
   }
 
   @Nullable
-  static Object convert(@NonNull Object o, BuiltinDataType targetType, boolean implicit) {
+  static Object convert(@NonNull Object o, OpcUaDataType targetType, boolean implicit) {
     if (o instanceof UUID) {
       UUID uuid = (UUID) o;
 
@@ -47,7 +47,7 @@ final class GuidConversions {
   }
 
   @Nullable
-  static Object explicitConversion(@NonNull UUID uuid, BuiltinDataType targetType) {
+  static Object explicitConversion(@NonNull UUID uuid, OpcUaDataType targetType) {
     // @formatter:off
     switch (targetType) {
       case ByteString:
@@ -61,7 +61,7 @@ final class GuidConversions {
   }
 
   @Nullable
-  static Object implicitConversion(@NonNull UUID uuid, BuiltinDataType targetType) {
+  static Object implicitConversion(@NonNull UUID uuid, OpcUaDataType targetType) {
     // no implicit conversions exist
     return null;
   }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/ImplicitConversions.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/ImplicitConversions.java
@@ -10,15 +10,15 @@
 
 package org.eclipse.milo.opcua.sdk.server.events.conversions;
 
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 public class ImplicitConversions {
 
   @Nullable
-  public static Object convert(@NonNull Object sourceValue, @NonNull BuiltinDataType targetType) {
-    BuiltinDataType sourceType = BuiltinDataType.fromBackingClass(sourceValue.getClass());
+  public static Object convert(@NonNull Object sourceValue, @NonNull OpcUaDataType targetType) {
+    OpcUaDataType sourceType = OpcUaDataType.fromBackingClass(sourceValue.getClass());
 
     if (sourceType == null) {
       return null;
@@ -32,7 +32,7 @@ public class ImplicitConversions {
   }
 
   private static Object convert(
-      @NonNull Object sourceValue, BuiltinDataType sourceType, BuiltinDataType targetType) {
+      @NonNull Object sourceValue, OpcUaDataType sourceType, OpcUaDataType targetType) {
 
     switch (sourceType) {
       case Boolean:
@@ -98,7 +98,7 @@ public class ImplicitConversions {
     }
   }
 
-  public static int getPrecedence(@NonNull BuiltinDataType dataType) {
+  public static int getPrecedence(@NonNull OpcUaDataType dataType) {
     // @formatter:off
     switch (dataType) {
       case Double:

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/Int16Conversions.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/Int16Conversions.java
@@ -15,7 +15,7 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ulong;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
 
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.ULong;
@@ -103,7 +103,7 @@ final class Int16Conversions {
   }
 
   @Nullable
-  static Object convert(@Nullable Object o, BuiltinDataType targetType, boolean implicit) {
+  static Object convert(@Nullable Object o, OpcUaDataType targetType, boolean implicit) {
     if (o instanceof Short) {
       Short s = (Short) o;
 
@@ -114,7 +114,7 @@ final class Int16Conversions {
   }
 
   @Nullable
-  static Object explicitConversion(@NonNull Short s, BuiltinDataType targetType) {
+  static Object explicitConversion(@NonNull Short s, OpcUaDataType targetType) {
     // @formatter:off
     switch (targetType) {
       case Boolean:
@@ -134,7 +134,7 @@ final class Int16Conversions {
   }
 
   @Nullable
-  static Object implicitConversion(@NonNull Short s, BuiltinDataType targetType) {
+  static Object implicitConversion(@NonNull Short s, OpcUaDataType targetType) {
     // @formatter:off
     switch (targetType) {
       case Double:

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/Int32Conversions.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/Int32Conversions.java
@@ -15,7 +15,7 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ulong;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
 
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
@@ -113,7 +113,7 @@ final class Int32Conversions {
   }
 
   @Nullable
-  static Object convert(@Nullable Object o, BuiltinDataType targetType, boolean implicit) {
+  static Object convert(@Nullable Object o, OpcUaDataType targetType, boolean implicit) {
     if (o instanceof Integer) {
       Integer i = (Integer) o;
 
@@ -124,7 +124,7 @@ final class Int32Conversions {
   }
 
   @Nullable
-  static Object explicitConversion(@NonNull Integer i, BuiltinDataType targetType) {
+  static Object explicitConversion(@NonNull Integer i, OpcUaDataType targetType) {
     // @formatter:off
     switch (targetType) {
       case Boolean:
@@ -150,7 +150,7 @@ final class Int32Conversions {
   }
 
   @Nullable
-  static Object implicitConversion(@NonNull Integer i, BuiltinDataType targetType) {
+  static Object implicitConversion(@NonNull Integer i, OpcUaDataType targetType) {
     // @formatter:off
     switch (targetType) {
       case Double:

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/Int64Conversions.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/Int64Conversions.java
@@ -15,7 +15,7 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ulong;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
 
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
@@ -117,7 +117,7 @@ final class Int64Conversions {
   }
 
   @Nullable
-  static Object convert(@Nullable Object o, BuiltinDataType targetType, boolean implicit) {
+  static Object convert(@Nullable Object o, OpcUaDataType targetType, boolean implicit) {
     if (o instanceof Long) {
       Long l = (Long) o;
 
@@ -128,7 +128,7 @@ final class Int64Conversions {
   }
 
   @Nullable
-  static Object explicitConversion(@NonNull Long l, BuiltinDataType targetType) {
+  static Object explicitConversion(@NonNull Long l, OpcUaDataType targetType) {
     // @formatter:off
     switch (targetType) {
       case Boolean:
@@ -158,7 +158,7 @@ final class Int64Conversions {
   }
 
   @Nullable
-  static Object implicitConversion(@NonNull Long l, BuiltinDataType targetType) {
+  static Object implicitConversion(@NonNull Long l, OpcUaDataType targetType) {
     // @formatter:off
     switch (targetType) {
       case Double:

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/LocalizedTextConversions.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/LocalizedTextConversions.java
@@ -10,7 +10,7 @@
 
 package org.eclipse.milo.opcua.sdk.server.events.conversions;
 
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -25,7 +25,7 @@ final class LocalizedTextConversions {
   }
 
   @Nullable
-  static Object convert(@NonNull Object o, BuiltinDataType targetType, boolean implicit) {
+  static Object convert(@NonNull Object o, OpcUaDataType targetType, boolean implicit) {
     if (o instanceof LocalizedText) {
       LocalizedText text = (LocalizedText) o;
 
@@ -36,12 +36,12 @@ final class LocalizedTextConversions {
   }
 
   @Nullable
-  static Object explicitConversion(@NonNull LocalizedText text, BuiltinDataType targetType) {
+  static Object explicitConversion(@NonNull LocalizedText text, OpcUaDataType targetType) {
     return implicitConversion(text, targetType);
   }
 
   @Nullable
-  static Object implicitConversion(@NonNull LocalizedText text, BuiltinDataType targetType) {
+  static Object implicitConversion(@NonNull LocalizedText text, OpcUaDataType targetType) {
     // @formatter:off
     switch (targetType) {
       case String:

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/NodeIdConversions.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/NodeIdConversions.java
@@ -10,7 +10,7 @@
 
 package org.eclipse.milo.opcua.sdk.server.events.conversions;
 
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.jspecify.annotations.NonNull;
@@ -31,7 +31,7 @@ final class NodeIdConversions {
   }
 
   @Nullable
-  static Object convert(@NonNull Object o, BuiltinDataType targetType, boolean implicit) {
+  static Object convert(@NonNull Object o, OpcUaDataType targetType, boolean implicit) {
     if (o instanceof NodeId) {
       NodeId nodeId = (NodeId) o;
 
@@ -44,12 +44,12 @@ final class NodeIdConversions {
   }
 
   @Nullable
-  static Object explicitConversion(@NonNull NodeId nodeId, BuiltinDataType targetType) {
+  static Object explicitConversion(@NonNull NodeId nodeId, OpcUaDataType targetType) {
     return implicitConversion(nodeId, targetType);
   }
 
   @Nullable
-  static Object implicitConversion(@NonNull NodeId nodeId, BuiltinDataType targetType) {
+  static Object implicitConversion(@NonNull NodeId nodeId, OpcUaDataType targetType) {
     // @formatter:off
     switch (targetType) {
       case ExpandedNodeId:

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/QualifiedNameConversions.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/QualifiedNameConversions.java
@@ -10,7 +10,7 @@
 
 package org.eclipse.milo.opcua.sdk.server.events.conversions;
 
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
 import org.jspecify.annotations.NonNull;
@@ -31,7 +31,7 @@ final class QualifiedNameConversions {
   }
 
   @Nullable
-  static Object convert(@NonNull Object o, BuiltinDataType targetType, boolean implicit) {
+  static Object convert(@NonNull Object o, OpcUaDataType targetType, boolean implicit) {
     if (o instanceof QualifiedName) {
       QualifiedName name = (QualifiedName) o;
 
@@ -42,12 +42,12 @@ final class QualifiedNameConversions {
   }
 
   @Nullable
-  static Object explicitConversion(@NonNull QualifiedName name, BuiltinDataType targetType) {
+  static Object explicitConversion(@NonNull QualifiedName name, OpcUaDataType targetType) {
     return implicitConversion(name, targetType);
   }
 
   @Nullable
-  static Object implicitConversion(@NonNull QualifiedName name, BuiltinDataType targetType) {
+  static Object implicitConversion(@NonNull QualifiedName name, OpcUaDataType targetType) {
     // @formatter:off
     switch (targetType) {
       case String:

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/SByteConversions.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/SByteConversions.java
@@ -15,7 +15,7 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ulong;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
 
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.ULong;
@@ -99,7 +99,7 @@ final class SByteConversions {
   }
 
   @Nullable
-  static Object convert(@NonNull Object o, BuiltinDataType targetType, boolean implicit) {
+  static Object convert(@NonNull Object o, OpcUaDataType targetType, boolean implicit) {
     if (o instanceof Byte) {
       Byte b = (Byte) o;
 
@@ -110,7 +110,7 @@ final class SByteConversions {
   }
 
   @Nullable
-  static Object explicitConversion(@NonNull Byte b, BuiltinDataType targetType) {
+  static Object explicitConversion(@NonNull Byte b, OpcUaDataType targetType) {
     // @formatter:off
     switch (targetType) {
       case Boolean:
@@ -126,7 +126,7 @@ final class SByteConversions {
   }
 
   @Nullable
-  static Object implicitConversion(@NonNull Byte b, BuiltinDataType targetType) {
+  static Object implicitConversion(@NonNull Byte b, OpcUaDataType targetType) {
     // @formatter:off
     switch (targetType) {
       case Double:

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/StatusCodeConversions.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/StatusCodeConversions.java
@@ -14,7 +14,7 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ulong;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
 
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.ULong;
@@ -57,7 +57,7 @@ final class StatusCodeConversions {
   }
 
   @Nullable
-  static Object convert(@NonNull Object o, BuiltinDataType targetType, boolean implicit) {
+  static Object convert(@NonNull Object o, OpcUaDataType targetType, boolean implicit) {
     if (o instanceof StatusCode) {
       StatusCode s = (StatusCode) o;
 
@@ -68,7 +68,7 @@ final class StatusCodeConversions {
   }
 
   @Nullable
-  static Object explicitConversion(@NonNull StatusCode s, BuiltinDataType targetType) {
+  static Object explicitConversion(@NonNull StatusCode s, OpcUaDataType targetType) {
     // @formatter:off
     switch (targetType) {
       case Int16:
@@ -82,7 +82,7 @@ final class StatusCodeConversions {
   }
 
   @Nullable
-  static Object implicitConversion(@NonNull StatusCode s, BuiltinDataType targetType) {
+  static Object implicitConversion(@NonNull StatusCode s, OpcUaDataType targetType) {
     // @formatter:off
     switch (targetType) {
       case Int32:

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/StringConversions.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/StringConversions.java
@@ -16,7 +16,7 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
 import java.util.UUID;
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
@@ -196,7 +196,7 @@ final class StringConversions {
   }
 
   @Nullable
-  static Object convert(@NonNull Object o, BuiltinDataType targetType, boolean implicit) {
+  static Object convert(@NonNull Object o, OpcUaDataType targetType, boolean implicit) {
     if (o instanceof String) {
       String s = (String) o;
 
@@ -207,7 +207,7 @@ final class StringConversions {
   }
 
   @Nullable
-  static Object explicitConversion(@NonNull String s, BuiltinDataType targetType) {
+  static Object explicitConversion(@NonNull String s, OpcUaDataType targetType) {
     // @formatter:off
     switch (targetType) {
       case DateTime:
@@ -227,7 +227,7 @@ final class StringConversions {
   }
 
   @Nullable
-  static Object implicitConversion(@NonNull String s, BuiltinDataType targetType) {
+  static Object implicitConversion(@NonNull String s, OpcUaDataType targetType) {
     // @formatter:off
     switch (targetType) {
       case Boolean:

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/UInt16Conversions.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/UInt16Conversions.java
@@ -14,7 +14,7 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ulong;
 
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
@@ -106,7 +106,7 @@ final class UInt16Conversions {
   }
 
   @Nullable
-  static Object convert(@Nullable Object o, BuiltinDataType targetType, boolean implicit) {
+  static Object convert(@Nullable Object o, OpcUaDataType targetType, boolean implicit) {
     if (o instanceof UShort) {
       UShort us = (UShort) o;
 
@@ -117,7 +117,7 @@ final class UInt16Conversions {
   }
 
   @Nullable
-  static Object explicitConversion(@NonNull UShort us, BuiltinDataType targetType) {
+  static Object explicitConversion(@NonNull UShort us, OpcUaDataType targetType) {
     // @formatter:off
     switch (targetType) {
       case Boolean:
@@ -135,7 +135,7 @@ final class UInt16Conversions {
   }
 
   @Nullable
-  static Object implicitConversion(@NonNull UShort us, BuiltinDataType targetType) {
+  static Object implicitConversion(@NonNull UShort us, OpcUaDataType targetType) {
     // @formatter:off
     switch (targetType) {
       case Double:

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/UInt32Conversions.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/UInt32Conversions.java
@@ -14,7 +14,7 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ulong;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
 
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
@@ -118,7 +118,7 @@ final class UInt32Conversions {
   }
 
   @Nullable
-  static Object convert(@Nullable Object o, BuiltinDataType targetType, boolean implicit) {
+  static Object convert(@Nullable Object o, OpcUaDataType targetType, boolean implicit) {
     if (o instanceof UInteger) {
       UInteger ui = (UInteger) o;
 
@@ -129,7 +129,7 @@ final class UInt32Conversions {
   }
 
   @Nullable
-  static Object explicitConversion(@NonNull UInteger ui, BuiltinDataType targetType) {
+  static Object explicitConversion(@NonNull UInteger ui, OpcUaDataType targetType) {
     // @formatter:off
     switch (targetType) {
       case Boolean:
@@ -153,7 +153,7 @@ final class UInt32Conversions {
   }
 
   @Nullable
-  static Object implicitConversion(@NonNull UInteger ui, BuiltinDataType targetType) {
+  static Object implicitConversion(@NonNull UInteger ui, OpcUaDataType targetType) {
     // @formatter:off
     switch (targetType) {
       case Double:

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/UInt64Conversions.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/UInt64Conversions.java
@@ -14,7 +14,7 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
 
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
@@ -144,7 +144,7 @@ final class UInt64Conversions {
   }
 
   @Nullable
-  static Object convert(@Nullable Object o, BuiltinDataType targetType, boolean implicit) {
+  static Object convert(@Nullable Object o, OpcUaDataType targetType, boolean implicit) {
     if (o instanceof ULong) {
       ULong ul = (ULong) o;
 
@@ -155,7 +155,7 @@ final class UInt64Conversions {
   }
 
   @Nullable
-  static Object explicitConversion(@NonNull ULong ul, BuiltinDataType targetType) {
+  static Object explicitConversion(@NonNull ULong ul, OpcUaDataType targetType) {
     // @formatter:off
     switch (targetType) {
       case Boolean:
@@ -183,7 +183,7 @@ final class UInt64Conversions {
   }
 
   @Nullable
-  static Object implicitConversion(@NonNull ULong ul, BuiltinDataType targetType) {
+  static Object implicitConversion(@NonNull ULong ul, OpcUaDataType targetType) {
     // @formatter:off
     switch (targetType) {
       case Double:

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/Cast.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/Cast.java
@@ -15,7 +15,7 @@ import org.eclipse.milo.opcua.sdk.server.events.OperatorContext;
 import org.eclipse.milo.opcua.sdk.server.events.ValidationException;
 import org.eclipse.milo.opcua.sdk.server.events.conversions.ImplicitConversions;
 import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
@@ -52,7 +52,7 @@ public class Cast implements Operator<Object> {
     if (dataTypeIdObject instanceof NodeId) {
       NodeId dataTypeId = (NodeId) dataTypeIdObject;
 
-      BuiltinDataType dataType = BuiltinDataType.fromNodeId(dataTypeId);
+      OpcUaDataType dataType = OpcUaDataType.fromNodeId(dataTypeId);
 
       if (dataType != null) {
         return ImplicitConversions.convert(sourceValue, dataType);
@@ -62,7 +62,7 @@ public class Cast implements Operator<Object> {
     } else if (dataTypeIdObject instanceof ExpandedNodeId) {
       ExpandedNodeId dataTypeId = (ExpandedNodeId) dataTypeIdObject;
 
-      BuiltinDataType dataType = BuiltinDataType.fromNodeId(dataTypeId);
+      OpcUaDataType dataType = OpcUaDataType.fromNodeId(dataTypeId);
 
       if (dataType != null) {
         return ImplicitConversions.convert(sourceValue, dataType);

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/Equals.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/Equals.java
@@ -17,7 +17,7 @@ import org.eclipse.milo.opcua.sdk.server.events.OperatorContext;
 import org.eclipse.milo.opcua.sdk.server.events.ValidationException;
 import org.eclipse.milo.opcua.sdk.server.events.conversions.ImplicitConversions;
 import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.structured.FilterOperand;
@@ -54,8 +54,8 @@ public class Equals implements Operator<Boolean> {
       return null;
     }
 
-    BuiltinDataType dt0 = getType(value0);
-    BuiltinDataType dt1 = getType(value1);
+    OpcUaDataType dt0 = getType(value0);
+    OpcUaDataType dt1 = getType(value1);
 
     if (dt0 == null || dt1 == null) {
       throw new UaException(StatusCodes.Bad_UnexpectedError);
@@ -82,7 +82,7 @@ public class Equals implements Operator<Boolean> {
   }
 
   @Nullable
-  private static Object convert(@NonNull Object value, BuiltinDataType targetType) {
+  private static Object convert(@NonNull Object value, OpcUaDataType targetType) {
     if (value.getClass().isArray()) {
       return convertArray(value, targetType);
     } else {
@@ -90,7 +90,7 @@ public class Equals implements Operator<Boolean> {
     }
   }
 
-  private static Object convertArray(@NonNull Object array, BuiltinDataType targetType) {
+  private static Object convertArray(@NonNull Object array, OpcUaDataType targetType) {
     int[] dimensions = ArrayUtil.getDimensions(array);
 
     Object flattened = ArrayUtil.flatten(array);
@@ -117,11 +117,11 @@ public class Equals implements Operator<Boolean> {
     }
   }
 
-  private static BuiltinDataType getType(@NonNull Object o) {
+  private static OpcUaDataType getType(@NonNull Object o) {
     if (o.getClass().isArray()) {
-      return BuiltinDataType.fromBackingClass(ArrayUtil.getType(o));
+      return OpcUaDataType.fromBackingClass(ArrayUtil.getType(o));
     } else {
-      return BuiltinDataType.fromBackingClass(o.getClass());
+      return OpcUaDataType.fromBackingClass(o.getClass());
     }
   }
 }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/GreaterThan.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/GreaterThan.java
@@ -12,7 +12,7 @@ package org.eclipse.milo.opcua.sdk.server.events.operators;
 
 import org.eclipse.milo.opcua.sdk.server.events.OperatorContext;
 import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.jspecify.annotations.Nullable;
 
 public class GreaterThan extends ImplicitConversionBinaryOperator<Boolean> {
@@ -24,7 +24,7 @@ public class GreaterThan extends ImplicitConversionBinaryOperator<Boolean> {
   protected Boolean apply(
       OperatorContext context,
       BaseEventTypeNode eventNode,
-      BuiltinDataType dataType,
+      OpcUaDataType dataType,
       @Nullable Object operand0,
       @Nullable Object operand1) {
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/GreaterThanOrEqual.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/GreaterThanOrEqual.java
@@ -12,7 +12,7 @@ package org.eclipse.milo.opcua.sdk.server.events.operators;
 
 import org.eclipse.milo.opcua.sdk.server.events.OperatorContext;
 import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.jspecify.annotations.Nullable;
 
 public class GreaterThanOrEqual extends ImplicitConversionBinaryOperator<Boolean> {
@@ -24,7 +24,7 @@ public class GreaterThanOrEqual extends ImplicitConversionBinaryOperator<Boolean
   protected Boolean apply(
       OperatorContext context,
       BaseEventTypeNode eventNode,
-      BuiltinDataType dataType,
+      OpcUaDataType dataType,
       @Nullable Object operand0,
       @Nullable Object operand1) {
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/ImplicitConversionBinaryOperator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/ImplicitConversionBinaryOperator.java
@@ -16,7 +16,7 @@ import org.eclipse.milo.opcua.sdk.server.events.OperatorContext;
 import org.eclipse.milo.opcua.sdk.server.events.ValidationException;
 import org.eclipse.milo.opcua.sdk.server.events.conversions.ImplicitConversions;
 import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.structured.FilterOperand;
@@ -54,8 +54,8 @@ abstract class ImplicitConversionBinaryOperator<T> implements Operator<T> {
       return null;
     }
 
-    BuiltinDataType dt0 = getType(value0);
-    BuiltinDataType dt1 = getType(value1);
+    OpcUaDataType dt0 = getType(value0);
+    OpcUaDataType dt1 = getType(value1);
 
     if (dt0 == null || dt1 == null) {
       throw new UaException(StatusCodes.Bad_UnexpectedError);
@@ -85,13 +85,13 @@ abstract class ImplicitConversionBinaryOperator<T> implements Operator<T> {
   protected abstract T apply(
       OperatorContext context,
       BaseEventTypeNode eventNode,
-      BuiltinDataType dataType,
+      OpcUaDataType dataType,
       @Nullable Object operand0,
       @Nullable Object operand1)
       throws UaException;
 
   @Nullable
-  private static Object convert(@NonNull Object value, BuiltinDataType targetType) {
+  private static Object convert(@NonNull Object value, OpcUaDataType targetType) {
     if (value.getClass().isArray()) {
       return convertArray(value, targetType);
     } else {
@@ -99,7 +99,7 @@ abstract class ImplicitConversionBinaryOperator<T> implements Operator<T> {
     }
   }
 
-  private static Object convertArray(@NonNull Object array, BuiltinDataType targetType) {
+  private static Object convertArray(@NonNull Object array, OpcUaDataType targetType) {
     int[] dimensions = ArrayUtil.getDimensions(array);
 
     Object flattened = ArrayUtil.flatten(array);
@@ -116,11 +116,11 @@ abstract class ImplicitConversionBinaryOperator<T> implements Operator<T> {
     return ArrayUtil.unflatten(transformed, dimensions);
   }
 
-  private static BuiltinDataType getType(@NonNull Object o) {
+  private static OpcUaDataType getType(@NonNull Object o) {
     if (o.getClass().isArray()) {
-      return BuiltinDataType.fromBackingClass(ArrayUtil.getType(o));
+      return OpcUaDataType.fromBackingClass(ArrayUtil.getType(o));
     } else {
-      return BuiltinDataType.fromBackingClass(o.getClass());
+      return OpcUaDataType.fromBackingClass(o.getClass());
     }
   }
 }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/LessThan.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/LessThan.java
@@ -12,7 +12,7 @@ package org.eclipse.milo.opcua.sdk.server.events.operators;
 
 import org.eclipse.milo.opcua.sdk.server.events.OperatorContext;
 import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.jspecify.annotations.Nullable;
 
 public class LessThan extends ImplicitConversionBinaryOperator<Boolean> {
@@ -24,7 +24,7 @@ public class LessThan extends ImplicitConversionBinaryOperator<Boolean> {
   protected Boolean apply(
       OperatorContext context,
       BaseEventTypeNode eventNode,
-      BuiltinDataType dataType,
+      OpcUaDataType dataType,
       @Nullable Object operand0,
       @Nullable Object operand1) {
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/LessThanOrEqual.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/LessThanOrEqual.java
@@ -12,7 +12,7 @@ package org.eclipse.milo.opcua.sdk.server.events.operators;
 
 import org.eclipse.milo.opcua.sdk.server.events.OperatorContext;
 import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.jspecify.annotations.Nullable;
 
 public class LessThanOrEqual extends ImplicitConversionBinaryOperator<Boolean> {
@@ -24,7 +24,7 @@ public class LessThanOrEqual extends ImplicitConversionBinaryOperator<Boolean> {
   protected Boolean apply(
       OperatorContext context,
       BaseEventTypeNode eventNode,
-      BuiltinDataType dataType,
+      OpcUaDataType dataType,
       @Nullable Object operand0,
       @Nullable Object operand1) {
 

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/conversions/AbstractConversionTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/conversions/AbstractConversionTest.java
@@ -14,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
@@ -23,7 +23,7 @@ abstract class AbstractConversionTest<S> {
 
   @Test
   public void testNullConversion() {
-    for (BuiltinDataType targetType : BuiltinDataType.values()) {
+    for (OpcUaDataType targetType : OpcUaDataType.values()) {
       assertNull(convert(null, targetType, true));
       assertNull(convert(null, targetType, false));
     }
@@ -31,10 +31,10 @@ abstract class AbstractConversionTest<S> {
 
   @Test
   public void testAllConversions() {
-    for (BuiltinDataType targetType : BuiltinDataType.values()) {
+    for (OpcUaDataType targetType : OpcUaDataType.values()) {
       Conversion[] conversions = getConversions(targetType);
       ConversionType conversionType = getConversionType(targetType);
-      BuiltinDataType sourceType = BuiltinDataType.fromBackingClass(getSourceClass());
+      OpcUaDataType sourceType = OpcUaDataType.fromBackingClass(getSourceClass());
 
       if (conversionType != ConversionType.NONE) {
         if (conversions == null || conversions.length == 0) {
@@ -70,7 +70,7 @@ abstract class AbstractConversionTest<S> {
 
   @Test
   public void testExplicitConversionsCalledImplicitlyAreNull() {
-    for (BuiltinDataType targetType : BuiltinDataType.values()) {
+    for (OpcUaDataType targetType : OpcUaDataType.values()) {
       Conversion[] conversions = getConversions(targetType);
 
       for (Conversion conversion : conversions) {
@@ -89,7 +89,7 @@ abstract class AbstractConversionTest<S> {
 
   @Test
   public void testImplicitConversionsCalledExplicitly() {
-    for (BuiltinDataType targetType : BuiltinDataType.values()) {
+    for (OpcUaDataType targetType : OpcUaDataType.values()) {
       Conversion[] conversions = getConversions(targetType);
 
       for (Conversion conversion : conversions) {
@@ -115,12 +115,12 @@ abstract class AbstractConversionTest<S> {
     Conversion c = new Conversion();
     c.fromValue = fromValue;
     c.targetValue = targetValue;
-    c.targetType = BuiltinDataType.fromBackingClass(targetValue.getClass());
+    c.targetType = OpcUaDataType.fromBackingClass(targetValue.getClass());
     return c;
   }
 
   protected Conversion c(
-      @NonNull S fromValue, @Nullable Object targetValue, @NonNull BuiltinDataType targetType) {
+      @NonNull S fromValue, @Nullable Object targetValue, @NonNull OpcUaDataType targetType) {
     Conversion c = new Conversion();
     c.fromValue = fromValue;
     c.targetValue = targetValue;
@@ -130,9 +130,9 @@ abstract class AbstractConversionTest<S> {
 
   protected abstract Class<S> getSourceClass();
 
-  public abstract Conversion[] getConversions(BuiltinDataType targetType);
+  public abstract Conversion[] getConversions(OpcUaDataType targetType);
 
-  public abstract ConversionType getConversionType(BuiltinDataType targetType);
+  public abstract ConversionType getConversionType(OpcUaDataType targetType);
 
   /*
   {
@@ -160,12 +160,12 @@ abstract class AbstractConversionTest<S> {
 
   // protected abstract Conversion[] getImplicitConversions();
 
-  protected abstract Object convert(Object fromValue, BuiltinDataType targetType, boolean implicit);
+  protected abstract Object convert(Object fromValue, OpcUaDataType targetType, boolean implicit);
 
   static class Conversion {
     Object fromValue;
     Object targetValue;
-    BuiltinDataType targetType;
+    OpcUaDataType targetType;
   }
 
   enum ConversionType {

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/conversions/ByteConversionsTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/conversions/ByteConversionsTest.java
@@ -30,7 +30,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.junit.jupiter.api.Test;
 
@@ -51,7 +51,7 @@ public class ByteConversionsTest {
     for (Object[] conversion : CONVERSIONS) {
       UByte b = (UByte) conversion[0];
       Object expected = conversion[1];
-      BuiltinDataType targetType = BuiltinDataType.fromBackingClass(expected.getClass());
+      OpcUaDataType targetType = OpcUaDataType.fromBackingClass(expected.getClass());
 
       assertNotNull(targetType);
 

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/conversions/DateTimeConversionsTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/conversions/DateTimeConversionsTest.java
@@ -14,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.Calendar;
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
 import org.junit.jupiter.api.Test;
 
@@ -23,7 +23,7 @@ public class DateTimeConversionsTest {
   @Test
   public void testDateTimeToString() {
     DateTime now = DateTime.now();
-    String nowAsString = (String) DateTimeConversions.convert(now, BuiltinDataType.String, false);
+    String nowAsString = (String) DateTimeConversions.convert(now, OpcUaDataType.String, false);
 
     System.out.println("now: " + now);
     System.out.println("nowAsString: " + nowAsString);
@@ -31,7 +31,7 @@ public class DateTimeConversionsTest {
     assertNotNull(nowAsString);
 
     DateTime nowAsStringAsDateTime =
-        (DateTime) StringConversions.convert(nowAsString, BuiltinDataType.DateTime, false);
+        (DateTime) StringConversions.convert(nowAsString, OpcUaDataType.DateTime, false);
 
     System.out.println("nowAsStringAsDateTime: " + nowAsStringAsDateTime);
 

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/conversions/DoubleConversionsTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/conversions/DoubleConversionsTest.java
@@ -17,7 +17,7 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ulong;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
 
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
@@ -30,7 +30,7 @@ public class DoubleConversionsTest extends AbstractConversionTest<Double> {
   }
 
   @Override
-  public Conversion[] getConversions(BuiltinDataType targetType) {
+  public Conversion[] getConversions(OpcUaDataType targetType) {
     switch (targetType) {
       case Boolean:
         {
@@ -145,7 +145,7 @@ public class DoubleConversionsTest extends AbstractConversionTest<Double> {
   }
 
   @Override
-  public ConversionType getConversionType(BuiltinDataType targetType) {
+  public ConversionType getConversionType(OpcUaDataType targetType) {
     // @formatter:off
     switch (targetType) {
       case Boolean:
@@ -177,7 +177,7 @@ public class DoubleConversionsTest extends AbstractConversionTest<Double> {
   }
 
   @Override
-  protected Object convert(Object fromValue, BuiltinDataType targetType, boolean implicit) {
+  protected Object convert(Object fromValue, OpcUaDataType targetType, boolean implicit) {
     return DoubleConversions.convert(fromValue, targetType, implicit);
   }
 }

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/conversions/FloatConversionsTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/conversions/FloatConversionsTest.java
@@ -18,7 +18,7 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ulong;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
 
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
 
@@ -30,7 +30,7 @@ public class FloatConversionsTest extends AbstractConversionTest<Float> {
   }
 
   @Override
-  public Conversion[] getConversions(BuiltinDataType targetType) {
+  public Conversion[] getConversions(OpcUaDataType targetType) {
     switch (targetType) {
       case Boolean:
         {
@@ -137,7 +137,7 @@ public class FloatConversionsTest extends AbstractConversionTest<Float> {
   }
 
   @Override
-  public ConversionType getConversionType(BuiltinDataType targetType) {
+  public ConversionType getConversionType(OpcUaDataType targetType) {
     // @formatter:off
     switch (targetType) {
       case Boolean:
@@ -169,7 +169,7 @@ public class FloatConversionsTest extends AbstractConversionTest<Float> {
   }
 
   @Override
-  protected Object convert(Object fromValue, BuiltinDataType targetType, boolean implicit) {
+  protected Object convert(Object fromValue, OpcUaDataType targetType, boolean implicit) {
     return FloatConversions.convert(fromValue, targetType, implicit);
   }
 }

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/conversions/ImplicitConversionsTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/conversions/ImplicitConversionsTest.java
@@ -14,14 +14,14 @@ import static org.eclipse.milo.opcua.sdk.server.events.conversions.ImplicitConve
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ubyte;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.junit.jupiter.api.Test;
 
 public class ImplicitConversionsTest {
 
   @Test
   public void testConvert() {
-    assertEquals(ubyte(0), convert(false, BuiltinDataType.Byte));
-    assertEquals(ubyte(1), convert(true, BuiltinDataType.Byte));
+    assertEquals(ubyte(0), convert(false, OpcUaDataType.Byte));
+    assertEquals(ubyte(1), convert(true, OpcUaDataType.Byte));
   }
 }

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/conversions/Int16ConversionsTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/conversions/Int16ConversionsTest.java
@@ -14,7 +14,7 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ulong;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
 
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 
 public class Int16ConversionsTest extends AbstractConversionTest<Short> {
@@ -25,7 +25,7 @@ public class Int16ConversionsTest extends AbstractConversionTest<Short> {
   }
 
   @Override
-  public Conversion[] getConversions(BuiltinDataType targetType) {
+  public Conversion[] getConversions(OpcUaDataType targetType) {
     switch (targetType) {
       case Boolean:
         {
@@ -35,10 +35,10 @@ public class Int16ConversionsTest extends AbstractConversionTest<Short> {
       case Byte:
         {
           return new Conversion[] {
-            c(UByte.MIN_VALUE, UByte.MIN, BuiltinDataType.Byte),
-            c(UByte.MAX_VALUE, UByte.MAX, BuiltinDataType.Byte),
-            c((short) (UByte.MIN_VALUE - 1), null, BuiltinDataType.Byte),
-            c((short) (UByte.MAX_VALUE + 1), null, BuiltinDataType.Byte)
+            c(UByte.MIN_VALUE, UByte.MIN, OpcUaDataType.Byte),
+            c(UByte.MAX_VALUE, UByte.MAX, OpcUaDataType.Byte),
+            c((short) (UByte.MIN_VALUE - 1), null, OpcUaDataType.Byte),
+            c((short) (UByte.MAX_VALUE + 1), null, OpcUaDataType.Byte)
           };
         }
 
@@ -84,8 +84,8 @@ public class Int16ConversionsTest extends AbstractConversionTest<Short> {
             c((short) 0, (byte) 0),
             c((short) Byte.MIN_VALUE, Byte.MIN_VALUE),
             c((short) Byte.MAX_VALUE, Byte.MAX_VALUE),
-            c((short) (Byte.MIN_VALUE - 1), null, BuiltinDataType.SByte),
-            c((short) (Byte.MAX_VALUE + 1), null, BuiltinDataType.SByte)
+            c((short) (Byte.MIN_VALUE - 1), null, OpcUaDataType.SByte),
+            c((short) (Byte.MAX_VALUE + 1), null, OpcUaDataType.SByte)
           };
         }
 
@@ -99,7 +99,7 @@ public class Int16ConversionsTest extends AbstractConversionTest<Short> {
           return new Conversion[] {
             c((short) 0, ushort(0)),
             c(Short.MAX_VALUE, ushort(Short.MAX_VALUE)),
-            c((short) -1, null, BuiltinDataType.UInt16)
+            c((short) -1, null, OpcUaDataType.UInt16)
           };
         }
 
@@ -108,7 +108,7 @@ public class Int16ConversionsTest extends AbstractConversionTest<Short> {
           return new Conversion[] {
             c((short) 0, uint(0)),
             c(Short.MAX_VALUE, uint(Short.MAX_VALUE)),
-            c((short) -1, null, BuiltinDataType.UInt32)
+            c((short) -1, null, OpcUaDataType.UInt32)
           };
         }
 
@@ -117,7 +117,7 @@ public class Int16ConversionsTest extends AbstractConversionTest<Short> {
           return new Conversion[] {
             c((short) 0, ulong(0)),
             c(Short.MAX_VALUE, ulong(Short.MAX_VALUE)),
-            c((short) -1, null, BuiltinDataType.UInt64)
+            c((short) -1, null, OpcUaDataType.UInt64)
           };
         }
 
@@ -127,7 +127,7 @@ public class Int16ConversionsTest extends AbstractConversionTest<Short> {
   }
 
   @Override
-  public ConversionType getConversionType(BuiltinDataType targetType) {
+  public ConversionType getConversionType(OpcUaDataType targetType) {
     // @formatter:off
     switch (targetType) {
       case Boolean:
@@ -159,7 +159,7 @@ public class Int16ConversionsTest extends AbstractConversionTest<Short> {
   }
 
   @Override
-  protected Object convert(Object fromValue, BuiltinDataType targetType, boolean implicit) {
+  protected Object convert(Object fromValue, OpcUaDataType targetType, boolean implicit) {
     return Int16Conversions.convert(fromValue, targetType, implicit);
   }
 }

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/conversions/Int32ConversionsTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/conversions/Int32ConversionsTest.java
@@ -17,7 +17,7 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ulong;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
 
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
@@ -30,7 +30,7 @@ public class Int32ConversionsTest extends AbstractConversionTest<Integer> {
   }
 
   @Override
-  public Conversion[] getConversions(BuiltinDataType targetType) {
+  public Conversion[] getConversions(OpcUaDataType targetType) {
     switch (targetType) {
       case Boolean:
         {
@@ -140,7 +140,7 @@ public class Int32ConversionsTest extends AbstractConversionTest<Integer> {
   }
 
   @Override
-  public ConversionType getConversionType(BuiltinDataType targetType) {
+  public ConversionType getConversionType(OpcUaDataType targetType) {
     // @formatter:off
     switch (targetType) {
       case Boolean:
@@ -174,7 +174,7 @@ public class Int32ConversionsTest extends AbstractConversionTest<Integer> {
   }
 
   @Override
-  protected Object convert(Object fromValue, BuiltinDataType targetType, boolean implicit) {
+  protected Object convert(Object fromValue, OpcUaDataType targetType, boolean implicit) {
     return Int32Conversions.convert(fromValue, targetType, implicit);
   }
 }

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/conversions/Int64ConversionsTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/conversions/Int64ConversionsTest.java
@@ -17,7 +17,7 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ulong;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
 
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
@@ -31,7 +31,7 @@ public class Int64ConversionsTest extends AbstractConversionTest<Long> {
   }
 
   @Override
-  public Conversion[] getConversions(BuiltinDataType targetType) {
+  public Conversion[] getConversions(OpcUaDataType targetType) {
     switch (targetType) {
       case Boolean:
         {
@@ -146,7 +146,7 @@ public class Int64ConversionsTest extends AbstractConversionTest<Long> {
   }
 
   @Override
-  public ConversionType getConversionType(BuiltinDataType targetType) {
+  public ConversionType getConversionType(OpcUaDataType targetType) {
     // @formatter:off
     switch (targetType) {
       case Boolean:
@@ -180,7 +180,7 @@ public class Int64ConversionsTest extends AbstractConversionTest<Long> {
   }
 
   @Override
-  protected Object convert(Object fromValue, BuiltinDataType targetType, boolean implicit) {
+  protected Object convert(Object fromValue, OpcUaDataType targetType, boolean implicit) {
     return Int64Conversions.convert(fromValue, targetType, implicit);
   }
 }

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/conversions/SByteConversionsTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/conversions/SByteConversionsTest.java
@@ -15,7 +15,7 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ulong;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
 
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 
 public class SByteConversionsTest extends AbstractConversionTest<Byte> {
 
@@ -25,7 +25,7 @@ public class SByteConversionsTest extends AbstractConversionTest<Byte> {
   }
 
   @Override
-  public Conversion[] getConversions(BuiltinDataType targetType) {
+  public Conversion[] getConversions(OpcUaDataType targetType) {
     switch (targetType) {
       case Boolean:
         return new Conversion[] {c((byte) 0, Boolean.FALSE), c((byte) 1, Boolean.TRUE)};
@@ -34,7 +34,7 @@ public class SByteConversionsTest extends AbstractConversionTest<Byte> {
         return new Conversion[] {
           c((byte) 0, ubyte(0)),
           c(Byte.MAX_VALUE, ubyte(Byte.MAX_VALUE)),
-          c((byte) -1, null, BuiltinDataType.Byte)
+          c((byte) -1, null, OpcUaDataType.Byte)
         };
 
       case Double:
@@ -124,7 +124,7 @@ public class SByteConversionsTest extends AbstractConversionTest<Byte> {
   }
 
   @Override
-  public ConversionType getConversionType(BuiltinDataType targetType) {
+  public ConversionType getConversionType(OpcUaDataType targetType) {
     // @formatter:off
     switch (targetType) {
       case Boolean:
@@ -156,7 +156,7 @@ public class SByteConversionsTest extends AbstractConversionTest<Byte> {
   }
 
   @Override
-  protected Object convert(Object fromValue, BuiltinDataType targetType, boolean implicit) {
+  protected Object convert(Object fromValue, OpcUaDataType targetType, boolean implicit) {
     return SByteConversions.convert(fromValue, targetType, implicit);
   }
 }

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/conversions/StatusCodeConversionsTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/conversions/StatusCodeConversionsTest.java
@@ -14,7 +14,7 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ulong;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
 
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
 
@@ -26,7 +26,7 @@ public class StatusCodeConversionsTest extends AbstractConversionTest<StatusCode
   }
 
   @Override
-  public Conversion[] getConversions(BuiltinDataType targetType) {
+  public Conversion[] getConversions(OpcUaDataType targetType) {
     switch (targetType) {
       case Int16:
         {
@@ -81,7 +81,7 @@ public class StatusCodeConversionsTest extends AbstractConversionTest<StatusCode
   }
 
   @Override
-  public ConversionType getConversionType(BuiltinDataType targetType) {
+  public ConversionType getConversionType(OpcUaDataType targetType) {
     // @formatter:off
     switch (targetType) {
       case Int16:
@@ -103,7 +103,7 @@ public class StatusCodeConversionsTest extends AbstractConversionTest<StatusCode
   }
 
   @Override
-  protected Object convert(Object fromValue, BuiltinDataType targetType, boolean implicit) {
+  protected Object convert(Object fromValue, OpcUaDataType targetType, boolean implicit) {
     return StatusCodeConversions.convert(fromValue, targetType, implicit);
   }
 }

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/conversions/StringConversionsTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/conversions/StringConversionsTest.java
@@ -16,7 +16,7 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
 
 import java.util.UUID;
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
@@ -32,7 +32,7 @@ public class StringConversionsTest extends AbstractConversionTest<String> {
   }
 
   @Override
-  public Conversion[] getConversions(BuiltinDataType targetType) {
+  public Conversion[] getConversions(OpcUaDataType targetType) {
     switch (targetType) {
       case Boolean:
         {
@@ -55,7 +55,7 @@ public class StringConversionsTest extends AbstractConversionTest<String> {
           // Arbitrary DateTime without any nano precision because
           // they are lost going to ISO 8601 format.
           DateTime dt = new DateTime(131801928020000000L);
-          String dts = (String) DateTimeConversions.convert(dt, BuiltinDataType.String, false);
+          String dts = (String) DateTimeConversions.convert(dt, OpcUaDataType.String, false);
           return new Conversion[] {c(dts, dt)};
         }
 
@@ -142,7 +142,7 @@ public class StringConversionsTest extends AbstractConversionTest<String> {
   }
 
   @Override
-  public ConversionType getConversionType(BuiltinDataType targetType) {
+  public ConversionType getConversionType(OpcUaDataType targetType) {
     // @formatter:off
     switch (targetType) {
       case Boolean:
@@ -186,7 +186,7 @@ public class StringConversionsTest extends AbstractConversionTest<String> {
   }
 
   @Override
-  protected Object convert(Object fromValue, BuiltinDataType targetType, boolean implicit) {
+  protected Object convert(Object fromValue, OpcUaDataType targetType, boolean implicit) {
     return StringConversions.convert(fromValue, targetType, implicit);
   }
 }

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/conversions/UInt16ConversionsTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/conversions/UInt16ConversionsTest.java
@@ -15,7 +15,7 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ulong;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
 
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
@@ -28,7 +28,7 @@ public class UInt16ConversionsTest extends AbstractConversionTest<UShort> {
   }
 
   @Override
-  public Conversion[] getConversions(BuiltinDataType targetType) {
+  public Conversion[] getConversions(OpcUaDataType targetType) {
     switch (targetType) {
       case Boolean:
         {
@@ -122,7 +122,7 @@ public class UInt16ConversionsTest extends AbstractConversionTest<UShort> {
   }
 
   @Override
-  public ConversionType getConversionType(BuiltinDataType targetType) {
+  public ConversionType getConversionType(OpcUaDataType targetType) {
     // @formatter:off
     switch (targetType) {
       case Boolean:
@@ -156,7 +156,7 @@ public class UInt16ConversionsTest extends AbstractConversionTest<UShort> {
   }
 
   @Override
-  protected Object convert(Object fromValue, BuiltinDataType targetType, boolean implicit) {
+  protected Object convert(Object fromValue, OpcUaDataType targetType, boolean implicit) {
     return UInt16Conversions.convert(fromValue, targetType, implicit);
   }
 }

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/conversions/UInt32ConversionsTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/conversions/UInt32ConversionsTest.java
@@ -15,7 +15,7 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ulong;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
 
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
@@ -29,7 +29,7 @@ public class UInt32ConversionsTest extends AbstractConversionTest<UInteger> {
   }
 
   @Override
-  public Conversion[] getConversions(BuiltinDataType targetType) {
+  public Conversion[] getConversions(OpcUaDataType targetType) {
     switch (targetType) {
       case Boolean:
         {
@@ -131,7 +131,7 @@ public class UInt32ConversionsTest extends AbstractConversionTest<UInteger> {
   }
 
   @Override
-  public ConversionType getConversionType(BuiltinDataType targetType) {
+  public ConversionType getConversionType(OpcUaDataType targetType) {
     // @formatter:off
     switch (targetType) {
       case Boolean:
@@ -165,7 +165,7 @@ public class UInt32ConversionsTest extends AbstractConversionTest<UInteger> {
   }
 
   @Override
-  protected Object convert(Object fromValue, BuiltinDataType targetType, boolean implicit) {
+  protected Object convert(Object fromValue, OpcUaDataType targetType, boolean implicit) {
     return UInt32Conversions.convert(fromValue, targetType, implicit);
   }
 }

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/conversions/UInt64ConversionsTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/conversions/UInt64ConversionsTest.java
@@ -15,7 +15,7 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ulong;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
 
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
@@ -30,7 +30,7 @@ public class UInt64ConversionsTest extends AbstractConversionTest<ULong> {
   }
 
   @Override
-  public Conversion[] getConversions(BuiltinDataType targetType) {
+  public Conversion[] getConversions(OpcUaDataType targetType) {
     switch (targetType) {
       case Boolean:
         {
@@ -135,7 +135,7 @@ public class UInt64ConversionsTest extends AbstractConversionTest<ULong> {
   }
 
   @Override
-  public ConversionType getConversionType(BuiltinDataType targetType) {
+  public ConversionType getConversionType(OpcUaDataType targetType) {
     // @formatter:off
     switch (targetType) {
       case Boolean:
@@ -169,7 +169,7 @@ public class UInt64ConversionsTest extends AbstractConversionTest<ULong> {
   }
 
   @Override
-  protected Object convert(Object fromValue, BuiltinDataType targetType, boolean implicit) {
+  protected Object convert(Object fromValue, OpcUaDataType targetType, boolean implicit) {
     return UInt64Conversions.convert(fromValue, targetType, implicit);
   }
 }

--- a/opc-ua-stack/encoding-json/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonDecoder.java
+++ b/opc-ua-stack/encoding-json/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonDecoder.java
@@ -30,7 +30,7 @@ import java.util.Base64;
 import java.util.List;
 import java.util.UUID;
 import java.util.function.Function;
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaSerializationException;
 import org.eclipse.milo.opcua.stack.core.encoding.DataTypeCodec;
@@ -1076,7 +1076,7 @@ public class OpcUaJsonDecoder implements UaDecoder {
             Array.set(flatArray, i, elements.get(i));
           }
 
-          var matrix = new Matrix(flatArray, dimensions, BuiltinDataType.fromTypeId(typeId));
+          var matrix = new Matrix(flatArray, dimensions, OpcUaDataType.fromTypeId(typeId));
 
           return new Variant(matrix);
         } finally {
@@ -1552,8 +1552,7 @@ public class OpcUaJsonDecoder implements UaDecoder {
   }
 
   @Override
-  public Matrix decodeMatrix(String field, BuiltinDataType builtinDataType)
-      throws UaSerializationException {
+  public Matrix decodeMatrix(String field, OpcUaDataType dataType) throws UaSerializationException {
     try {
       if (field != null) {
         String nextName = nextName();
@@ -1563,8 +1562,7 @@ public class OpcUaJsonDecoder implements UaDecoder {
         }
       }
 
-      Object nestedArray =
-          decodeNestedMultiDimensionalArrayBuiltinValue(builtinDataType.getTypeId());
+      Object nestedArray = decodeNestedMultiDimensionalArrayBuiltinValue(dataType.getTypeId());
 
       return new Matrix(nestedArray);
     } catch (IOException e) {
@@ -1574,7 +1572,7 @@ public class OpcUaJsonDecoder implements UaDecoder {
 
   @Override
   public Matrix decodeEnumMatrix(String field) throws UaSerializationException {
-    return decodeMatrix(field, BuiltinDataType.Int32);
+    return decodeMatrix(field, OpcUaDataType.Int32);
   }
 
   @Override

--- a/opc-ua-stack/encoding-json/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoder.java
+++ b/opc-ua-stack/encoding-json/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoder.java
@@ -22,7 +22,7 @@ import java.util.Base64;
 import java.util.Stack;
 import java.util.UUID;
 import java.util.function.BiConsumer;
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaSerializationException;
 import org.eclipse.milo.opcua.stack.core.encoding.DataTypeCodec;
@@ -798,9 +798,9 @@ public class OpcUaJsonEncoder implements UaEncoder {
 
     int typeId;
     if (typeHint == TypeHint.ENUM) {
-      typeId = BuiltinDataType.Int32.getTypeId();
+      typeId = OpcUaDataType.Int32.getTypeId();
     } else if (typeHint == TypeHint.STRUCT) {
-      typeId = BuiltinDataType.ExtensionObject.getTypeId();
+      typeId = OpcUaDataType.ExtensionObject.getTypeId();
     } else if (typeHint == TypeHint.OPTION_SET) {
       // TODO this would fail on empty array
       //  would be better to have size-specific OptionSetUI subclasses, e.g. OptionSetUI8,
@@ -1372,9 +1372,9 @@ public class OpcUaJsonEncoder implements UaEncoder {
           }
         } else {
           int[] dimensions = value.getDimensions();
-          BuiltinDataType builtinDataType = value.getBuiltinDataType().orElseThrow();
+          OpcUaDataType dataType = value.getBuiltinDataType().orElseThrow();
           try {
-            encodeFlatArrayAsNested(flatArray, dimensions, builtinDataType, 0);
+            encodeFlatArrayAsNested(flatArray, dimensions, dataType, 0);
           } catch (IOException e) {
             throw new UaSerializationException(StatusCodes.Bad_EncodingError, e);
           }
@@ -1468,21 +1468,20 @@ public class OpcUaJsonEncoder implements UaEncoder {
   }
 
   private void encodeFlatArrayAsNested(
-      Object value, int[] dimensions, BuiltinDataType builtinDataType, int offset)
-      throws IOException {
+      Object value, int[] dimensions, OpcUaDataType dataType, int offset) throws IOException {
 
     if (dimensions.length == 1) {
       jsonWriter.beginArray();
       for (int i = 0; i < dimensions[0]; i++) {
         Object e = Array.get(value, offset + i);
-        encodeBuiltinTypeValue(null, builtinDataType.getTypeId(), e);
+        encodeBuiltinTypeValue(null, dataType.getTypeId(), e);
       }
       jsonWriter.endArray();
     } else {
       jsonWriter.beginArray();
       int[] tail = Arrays.copyOfRange(dimensions, 1, dimensions.length);
       for (int i = 0; i < dimensions[0]; i++) {
-        encodeFlatArrayAsNested(value, tail, builtinDataType, offset + i * length(tail));
+        encodeFlatArrayAsNested(value, tail, dataType, offset + i * length(tail));
       }
       jsonWriter.endArray();
     }

--- a/opc-ua-stack/encoding-json/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoder.java
+++ b/opc-ua-stack/encoding-json/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoder.java
@@ -1372,7 +1372,7 @@ public class OpcUaJsonEncoder implements UaEncoder {
           }
         } else {
           int[] dimensions = value.getDimensions();
-          OpcUaDataType dataType = value.getBuiltinDataType().orElseThrow();
+          OpcUaDataType dataType = value.getDataType().orElseThrow();
           try {
             encodeFlatArrayAsNested(flatArray, dimensions, dataType, 0);
           } catch (IOException e) {

--- a/opc-ua-stack/encoding-json/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonDecoderTest.java
+++ b/opc-ua-stack/encoding-json/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonDecoderTest.java
@@ -24,8 +24,8 @@ import java.time.temporal.ChronoUnit;
 import java.util.Base64;
 import java.util.Random;
 import java.util.UUID;
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
 import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
@@ -807,19 +807,19 @@ class OpcUaJsonDecoderTest {
             });
 
     decoder.reset(new StringReader("[[0,1],[2,3]]"));
-    assertEquals(matrix2d, decoder.decodeMatrix(null, BuiltinDataType.Int32));
+    assertEquals(matrix2d, decoder.decodeMatrix(null, OpcUaDataType.Int32));
 
     decoder.reset(new StringReader("[[[0,1],[2,3]],[[4,5],[6,7]]]"));
-    assertEquals(matrix3d, decoder.decodeMatrix(null, BuiltinDataType.Int32));
+    assertEquals(matrix3d, decoder.decodeMatrix(null, OpcUaDataType.Int32));
 
     decoder.reset(new StringReader("{\"foo\":[[0,1],[2,3]]}"));
     decoder.jsonReader.beginObject();
-    assertEquals(matrix2d, decoder.decodeMatrix("foo", BuiltinDataType.Int32));
+    assertEquals(matrix2d, decoder.decodeMatrix("foo", OpcUaDataType.Int32));
     decoder.jsonReader.endObject();
 
     decoder.reset(new StringReader("{\"foo\":[[[0,1],[2,3]],[[4,5],[6,7]]]}"));
     decoder.jsonReader.beginObject();
-    assertEquals(matrix3d, decoder.decodeMatrix("foo", BuiltinDataType.Int32));
+    assertEquals(matrix3d, decoder.decodeMatrix("foo", OpcUaDataType.Int32));
     decoder.jsonReader.endObject();
   }
 

--- a/opc-ua-stack/encoding-xml/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlDecoder.java
+++ b/opc-ua-stack/encoding-xml/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlDecoder.java
@@ -25,7 +25,7 @@ import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaRuntimeException;
 import org.eclipse.milo.opcua.stack.core.UaSerializationException;
@@ -1224,8 +1224,7 @@ public class OpcUaXmlDecoder implements UaDecoder {
   }
 
   @Override
-  public Matrix decodeMatrix(String field, BuiltinDataType builtinDataType)
-      throws UaSerializationException {
+  public Matrix decodeMatrix(String field, OpcUaDataType dataType) throws UaSerializationException {
     return null;
   }
 

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/OpcUaDataType.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/OpcUaDataType.java
@@ -30,7 +30,7 @@ import org.eclipse.milo.opcua.stack.core.types.enumerated.IdType;
 import org.eclipse.milo.opcua.stack.core.util.Namespaces;
 import org.jspecify.annotations.Nullable;
 
-public enum BuiltinDataType {
+public enum OpcUaDataType {
   Boolean(1, Boolean.class),
   SByte(2, Byte.class),
   Byte(3, UByte.class),
@@ -60,7 +60,7 @@ public enum BuiltinDataType {
   private final int typeId;
   private final Class<?> backingClass;
 
-  BuiltinDataType(int typeId, Class<?> backingClass) {
+  OpcUaDataType(int typeId, Class<?> backingClass) {
     this.typeId = typeId;
     this.backingClass = backingClass;
   }
@@ -79,14 +79,14 @@ public enum BuiltinDataType {
 
   private static final BiMap<Integer, Class<?>> BackingClassesById;
   private static final BiMap<NodeId, Class<?>> BackingClassesByNodeId;
-  private static final BiMap<NodeId, BuiltinDataType> DataTypesByNodeId;
+  private static final BiMap<NodeId, OpcUaDataType> DataTypesByNodeId;
 
   static {
     ImmutableBiMap.Builder<Integer, Class<?>> builder = ImmutableBiMap.builder();
     ImmutableBiMap.Builder<NodeId, Class<?>> builder2 = ImmutableBiMap.builder();
-    ImmutableBiMap.Builder<NodeId, BuiltinDataType> builder3 = ImmutableBiMap.builder();
+    ImmutableBiMap.Builder<NodeId, OpcUaDataType> builder3 = ImmutableBiMap.builder();
 
-    for (BuiltinDataType dataType : values()) {
+    for (OpcUaDataType dataType : values()) {
       builder.put(dataType.getTypeId(), dataType.getBackingClass());
       builder2.put(dataType.getNodeId(), dataType.getBackingClass());
       builder3.put(dataType.getNodeId(), dataType);
@@ -129,30 +129,30 @@ public enum BuiltinDataType {
     return null;
   }
 
-  public static @Nullable BuiltinDataType fromTypeId(int typeId) {
+  public static @Nullable OpcUaDataType fromTypeId(int typeId) {
     // TODO turn this into a lookup
-    for (BuiltinDataType builtinDataType : values()) {
-      if (builtinDataType.typeId == typeId) {
-        return builtinDataType;
+    for (OpcUaDataType dataType : values()) {
+      if (dataType.typeId == typeId) {
+        return dataType;
       }
     }
     return null;
   }
 
   @Nullable
-  public static BuiltinDataType fromBackingClass(Class<?> backingClass) {
+  public static OpcUaDataType fromBackingClass(Class<?> backingClass) {
     NodeId nodeId = BackingClassesByNodeId.inverse().get(maybeBoxPrimitive(backingClass));
 
     return nodeId != null ? DataTypesByNodeId.get(nodeId) : null;
   }
 
   @Nullable
-  public static BuiltinDataType fromNodeId(NodeId nodeId) {
+  public static OpcUaDataType fromNodeId(NodeId nodeId) {
     return DataTypesByNodeId.get(nodeId);
   }
 
   @Nullable
-  public static BuiltinDataType fromNodeId(ExpandedNodeId nodeId) {
+  public static OpcUaDataType fromNodeId(ExpandedNodeId nodeId) {
     if (nodeId.getIdentifier() instanceof UInteger
         && (Namespaces.OPC_UA.equals(nodeId.getNamespaceUri())
             || nodeId.getNamespaceIndex().intValue() == 0)) {
@@ -172,7 +172,7 @@ public enum BuiltinDataType {
   }
 
   public static boolean isBuiltin(ExpandedNodeId typeId) {
-    return BuiltinDataType.fromNodeId(typeId) != null;
+    return OpcUaDataType.fromNodeId(typeId) != null;
   }
 
   public static boolean isBuiltin(Class<?> clazz) {

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/UaDecoder.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/UaDecoder.java
@@ -12,7 +12,7 @@ package org.eclipse.milo.opcua.stack.core.encoding;
 
 import java.util.UUID;
 import java.util.function.Function;
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.UaSerializationException;
 import org.eclipse.milo.opcua.stack.core.types.UaMessageType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
@@ -157,8 +157,7 @@ public interface UaDecoder {
   <T> T[] decodeArray(String field, Function<String, T> decoder, Class<T> clazz)
       throws UaSerializationException;
 
-  Matrix decodeMatrix(String field, BuiltinDataType builtinDataType)
-      throws UaSerializationException;
+  Matrix decodeMatrix(String field, OpcUaDataType dataType) throws UaSerializationException;
 
   Matrix decodeEnumMatrix(String field) throws UaSerializationException;
 

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryDecoder.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryDecoder.java
@@ -24,7 +24,7 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaSerializationException;
 import org.eclipse.milo.opcua.stack.core.encoding.DataTypeCodec;
@@ -414,7 +414,7 @@ public class OpcUaBinaryDecoder implements UaDecoder {
 
             Object value;
             if (dimensions.length > 1) {
-              value = new Matrix(flatArray, dimensions, BuiltinDataType.fromTypeId(typeId));
+              value = new Matrix(flatArray, dimensions, OpcUaDataType.fromTypeId(typeId));
             } else {
               value = flatArray;
             }
@@ -1229,8 +1229,7 @@ public class OpcUaBinaryDecoder implements UaDecoder {
   }
 
   @Override
-  public Matrix decodeMatrix(String field, BuiltinDataType builtinDataType)
-      throws UaSerializationException {
+  public Matrix decodeMatrix(String field, OpcUaDataType dataType) throws UaSerializationException {
     int[] dimensions = decodeMatrixDimensions();
     if (dimensions == null) return null;
 
@@ -1246,21 +1245,21 @@ public class OpcUaBinaryDecoder implements UaDecoder {
     checkArrayLength(length);
 
     // TODO speed this up by switching on BuiltinDataType instead of using reflection
-    Class<?> backingClass = builtinDataType.getBackingClass();
+    Class<?> backingClass = dataType.getBackingClass();
     Object flatArray = Array.newInstance(backingClass, length);
 
     for (int i = 0; i < length; i++) {
-      Object element = decodeBuiltinType(builtinDataType.getTypeId());
+      Object element = decodeBuiltinType(dataType.getTypeId());
 
       Array.set(flatArray, i, element);
     }
 
-    return new Matrix(flatArray, dimensions, builtinDataType);
+    return new Matrix(flatArray, dimensions, dataType);
   }
 
   @Override
   public Matrix decodeEnumMatrix(String field) throws UaSerializationException {
-    return decodeMatrix(field, BuiltinDataType.Int32);
+    return decodeMatrix(field, OpcUaDataType.Int32);
   }
 
   @Override
@@ -1296,7 +1295,7 @@ public class OpcUaBinaryDecoder implements UaDecoder {
       Array.set(flatArray, i, value);
     }
 
-    return new Matrix(flatArray, dimensions, BuiltinDataType.ExtensionObject);
+    return new Matrix(flatArray, dimensions, OpcUaDataType.ExtensionObject);
   }
 
   @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryEncoder.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryEncoder.java
@@ -612,7 +612,7 @@ public class OpcUaBinaryEncoder implements UaEncoder {
           buffer.writeByte(0);
           return;
         }
-        valueClass = ((Matrix) value).getBuiltinDataType().orElseThrow().getBackingClass();
+        valueClass = ((Matrix) value).getDataType().orElseThrow().getBackingClass();
       }
 
       int typeId = TypeUtil.getBuiltinTypeId(valueClass);
@@ -1194,7 +1194,7 @@ public class OpcUaBinaryEncoder implements UaEncoder {
       assert length == Arrays.stream(dimensions).reduce(1, (left, right) -> left * right);
 
       int typeId =
-          value.getBuiltinDataType().orElseThrow().getTypeId(); // won't throw, we checked for null
+          value.getDataType().orElseThrow().getTypeId(); // won't throw, we checked for null
 
       for (int i = 0; i < length; i++) {
         Object o = Array.get(elements, i);

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/Matrix.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/Matrix.java
@@ -118,7 +118,7 @@ public class Matrix {
    *
    * @return the {@link OpcUaDataType} of the elements of this Matrix.
    */
-  public Optional<OpcUaDataType> getBuiltinDataType() {
+  public Optional<OpcUaDataType> getDataType() {
     return Optional.ofNullable(dataType);
   }
 

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/Matrix.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/Matrix.java
@@ -17,7 +17,7 @@ import java.util.Optional;
 import java.util.StringJoiner;
 import java.util.UUID;
 import java.util.function.Function;
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.types.UaEnumeratedType;
 import org.eclipse.milo.opcua.stack.core.types.UaStructuredType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
@@ -43,41 +43,41 @@ public class Matrix {
 
   private final Object flatArray;
   private final int[] dimensions;
-  private final BuiltinDataType builtinDataType;
+  private final OpcUaDataType dataType;
   private final ExpandedNodeId dataTypeId;
 
   public Matrix(@Nullable Object nestedArray) {
     if (nestedArray == null) {
       this.flatArray = null;
       this.dimensions = new int[0];
-      this.builtinDataType = null;
+      this.dataType = null;
       this.dataTypeId = null;
     } else {
       this.flatArray = ArrayUtil.flatten(nestedArray);
       this.dimensions = ArrayUtil.getDimensions(nestedArray);
-      this.builtinDataType = deriveBuiltinType(flatArray);
+      this.dataType = deriveBuiltinType(flatArray);
       this.dataTypeId = deriveDataTypeId(flatArray);
     }
 
-    assert flatArray == null || (dimensions.length > 1 && builtinDataType != null);
+    assert flatArray == null || (dimensions.length > 1 && dataType != null);
   }
 
   public Matrix(Object flatArray, int[] dimensions) {
     this.flatArray = flatArray;
     this.dimensions = dimensions;
-    this.builtinDataType = deriveBuiltinType(flatArray);
+    this.dataType = deriveBuiltinType(flatArray);
     this.dataTypeId = deriveDataTypeId(flatArray);
 
-    assert dimensions.length > 1 && builtinDataType != null;
+    assert dimensions.length > 1 && dataType != null;
   }
 
-  public Matrix(Object flatArray, int[] dimensions, BuiltinDataType builtinDataType) {
+  public Matrix(Object flatArray, int[] dimensions, OpcUaDataType dataType) {
     this.flatArray = flatArray;
     this.dimensions = dimensions;
-    this.builtinDataType = builtinDataType;
+    this.dataType = dataType;
     this.dataTypeId = deriveDataTypeId(flatArray);
 
-    assert flatArray != null && dimensions.length > 1 && builtinDataType != null;
+    assert flatArray != null && dimensions.length > 1 && dataType != null;
   }
 
   /**
@@ -112,14 +112,14 @@ public class Matrix {
   }
 
   /**
-   * Get the {@link BuiltinDataType} of the elements of this Matrix.
+   * Get the {@link OpcUaDataType} of the elements of this Matrix.
    *
    * <p>Empty only if this Matrix contains a {@code null} value.
    *
-   * @return the {@link BuiltinDataType} of the elements of this Matrix.
+   * @return the {@link OpcUaDataType} of the elements of this Matrix.
    */
-  public Optional<BuiltinDataType> getBuiltinDataType() {
-    return Optional.ofNullable(builtinDataType);
+  public Optional<OpcUaDataType> getBuiltinDataType() {
+    return Optional.ofNullable(dataType);
   }
 
   /**
@@ -194,12 +194,12 @@ public class Matrix {
     Matrix matrix = (Matrix) o;
     return Objects.deepEquals(flatArray, matrix.flatArray)
         && Arrays.equals(dimensions, matrix.dimensions)
-        && builtinDataType == matrix.builtinDataType;
+        && dataType == matrix.dataType;
   }
 
   @Override
   public int hashCode() {
-    int result = Objects.hash(flatArray, builtinDataType);
+    int result = Objects.hash(flatArray, dataType);
     result = 31 * result + Arrays.hashCode(dimensions);
     return result;
   }
@@ -208,7 +208,7 @@ public class Matrix {
   public String toString() {
     StringJoiner joiner =
         new StringJoiner(", ", Matrix.class.getSimpleName() + "{", "}")
-            .add("builtinDataType=" + builtinDataType)
+            .add("builtinDataType=" + dataType)
             .add("dataType=" + dataTypeId.toParseableString())
             .add("dimensions=" + Arrays.toString(dimensions));
 
@@ -239,31 +239,31 @@ public class Matrix {
     return joiner.toString();
   }
 
-  private static @Nullable BuiltinDataType deriveBuiltinType(Object flatArray) {
+  private static @Nullable OpcUaDataType deriveBuiltinType(Object flatArray) {
     Class<?> type = ArrayUtil.getType(flatArray);
 
     return deriveBuiltinType(type);
   }
 
-  private static @Nullable BuiltinDataType deriveBuiltinType(Class<?> type) {
+  private static @Nullable OpcUaDataType deriveBuiltinType(Class<?> type) {
     if (UaEnumeratedType.class.isAssignableFrom(type)) {
-      return BuiltinDataType.Int32;
+      return OpcUaDataType.Int32;
     } else if (UaStructuredType.class.isAssignableFrom(type)) {
-      return BuiltinDataType.ExtensionObject;
+      return OpcUaDataType.ExtensionObject;
     } else if (OptionSetUInteger.class.isAssignableFrom(type)) {
       if (OptionSetUI8.class.isAssignableFrom(type)) {
-        return BuiltinDataType.Byte;
+        return OpcUaDataType.Byte;
       } else if (OptionSetUI16.class.isAssignableFrom(type)) {
-        return BuiltinDataType.UInt16;
+        return OpcUaDataType.UInt16;
       } else if (OptionSetUI32.class.isAssignableFrom(type)) {
-        return BuiltinDataType.UInt32;
+        return OpcUaDataType.UInt32;
       } else if (OptionSetUI64.class.isAssignableFrom(type)) {
-        return BuiltinDataType.UInt64;
+        return OpcUaDataType.UInt64;
       } else {
         throw new RuntimeException("unknown OptionSetUInteger subclass: " + type);
       }
     } else {
-      return BuiltinDataType.fromBackingClass(type);
+      return OpcUaDataType.fromBackingClass(type);
     }
   }
 
@@ -285,11 +285,11 @@ public class Matrix {
         return null;
       }
     } else {
-      BuiltinDataType builtinDataType = deriveBuiltinType(type);
-      if (builtinDataType == null) {
+      OpcUaDataType dataType = deriveBuiltinType(type);
+      if (dataType == null) {
         return null;
       } else {
-        return builtinDataType.getNodeId().expanded();
+        return dataType.getNodeId().expanded();
       }
     }
   }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/Variant.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/Variant.java
@@ -72,7 +72,7 @@ public final class Variant {
     }
   }
 
-  public Optional<OpcUaDataType> getBuiltinDataType() {
+  public Optional<OpcUaDataType> getDataType() {
     if (value == null) {
       return Optional.empty();
     }
@@ -96,7 +96,7 @@ public final class Variant {
         throw new RuntimeException("unknown OptionSetUInteger subclass: " + type);
       }
     } else if (Matrix.class.isAssignableFrom(type)) {
-      return ((Matrix) value).getBuiltinDataType();
+      return ((Matrix) value).getDataType();
     } else {
       return Optional.ofNullable(OpcUaDataType.fromBackingClass(type));
     }
@@ -189,7 +189,7 @@ public final class Variant {
       checkArgument(clazzIsArray || !Variant.class.equals(clazz), "Variant cannot contain Variant");
       checkArgument(!DiagnosticInfo.class.equals(clazz), "Variant cannot contain DiagnosticInfo");
       checkArgument(
-          variant.getBuiltinDataType().isPresent(), "Variant cannot contain %s", value.getClass());
+          variant.getDataType().isPresent(), "Variant cannot contain %s", value.getClass());
     }
 
     return variant;

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/Variant.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/Variant.java
@@ -18,7 +18,7 @@ import java.util.Arrays;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.types.UaEnumeratedType;
 import org.eclipse.milo.opcua.stack.core.types.UaStructuredType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
@@ -72,7 +72,7 @@ public final class Variant {
     }
   }
 
-  public Optional<BuiltinDataType> getBuiltinDataType() {
+  public Optional<OpcUaDataType> getBuiltinDataType() {
     if (value == null) {
       return Optional.empty();
     }
@@ -80,25 +80,25 @@ public final class Variant {
     Class<?> type = value.getClass().isArray() ? ArrayUtil.getType(value) : value.getClass();
 
     if (UaEnumeratedType.class.isAssignableFrom(type)) {
-      return Optional.of(BuiltinDataType.Int32);
+      return Optional.of(OpcUaDataType.Int32);
     } else if (UaStructuredType.class.isAssignableFrom(type)) {
-      return Optional.of(BuiltinDataType.ExtensionObject);
+      return Optional.of(OpcUaDataType.ExtensionObject);
     } else if (OptionSetUInteger.class.isAssignableFrom(type)) {
       if (OptionSetUI8.class.isAssignableFrom(type)) {
-        return Optional.of(BuiltinDataType.Byte);
+        return Optional.of(OpcUaDataType.Byte);
       } else if (OptionSetUI16.class.isAssignableFrom(type)) {
-        return Optional.of(BuiltinDataType.UInt16);
+        return Optional.of(OpcUaDataType.UInt16);
       } else if (OptionSetUI32.class.isAssignableFrom(type)) {
-        return Optional.of(BuiltinDataType.UInt32);
+        return Optional.of(OpcUaDataType.UInt32);
       } else if (OptionSetUI64.class.isAssignableFrom(type)) {
-        return Optional.of(BuiltinDataType.UInt64);
+        return Optional.of(OpcUaDataType.UInt64);
       } else {
         throw new RuntimeException("unknown OptionSetUInteger subclass: " + type);
       }
     } else if (Matrix.class.isAssignableFrom(type)) {
       return ((Matrix) value).getBuiltinDataType();
     } else {
-      return Optional.ofNullable(BuiltinDataType.fromBackingClass(type));
+      return Optional.ofNullable(OpcUaDataType.fromBackingClass(type));
     }
   }
 

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/binary/VariantSerializationTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/binary/VariantSerializationTest.java
@@ -17,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Matrix;
@@ -105,7 +105,7 @@ public class VariantSerializationTest extends BinarySerializationFixture {
   public void testNullArrayEncodedWithNegativeArraySize() {
     ByteBuf buffer = Unpooled.buffer();
 
-    buffer.writeByte(BuiltinDataType.Int16.getTypeId() | (1 << 7));
+    buffer.writeByte(OpcUaDataType.Int16.getTypeId() | (1 << 7));
     buffer.writeIntLE(-1);
 
     OpcUaBinaryDecoder reader = new OpcUaBinaryDecoder(DefaultEncodingContext.INSTANCE);

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/types/builtin/MatrixTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/types/builtin/MatrixTest.java
@@ -84,9 +84,9 @@ class MatrixTest {
   }
 
   @Test
-  void getBuiltinDataType() {
-    assertEquals(OpcUaDataType.Int32, primitiveMatrix2d.getBuiltinDataType().orElse(null));
-    assertEquals(OpcUaDataType.ExtensionObject, vectorMatrix2d.getBuiltinDataType().orElse(null));
+  void getDataType() {
+    assertEquals(OpcUaDataType.Int32, primitiveMatrix2d.getDataType().orElse(null));
+    assertEquals(OpcUaDataType.ExtensionObject, vectorMatrix2d.getDataType().orElse(null));
   }
 
   @Test

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/types/builtin/MatrixTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/types/builtin/MatrixTest.java
@@ -14,7 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.types.structured.ThreeDVector;
 import org.junit.jupiter.api.Test;
 
@@ -85,15 +85,14 @@ class MatrixTest {
 
   @Test
   void getBuiltinDataType() {
-    assertEquals(BuiltinDataType.Int32, primitiveMatrix2d.getBuiltinDataType().orElse(null));
-    assertEquals(BuiltinDataType.ExtensionObject, vectorMatrix2d.getBuiltinDataType().orElse(null));
+    assertEquals(OpcUaDataType.Int32, primitiveMatrix2d.getBuiltinDataType().orElse(null));
+    assertEquals(OpcUaDataType.ExtensionObject, vectorMatrix2d.getBuiltinDataType().orElse(null));
   }
 
   @Test
   void getDataTypeId() {
     assertEquals(
-        BuiltinDataType.Int32.getNodeId().expanded(),
-        primitiveMatrix2d.getDataTypeId().orElse(null));
+        OpcUaDataType.Int32.getNodeId().expanded(), primitiveMatrix2d.getDataTypeId().orElse(null));
     assertEquals(ThreeDVector.TYPE_ID, vectorMatrix2d.getDataTypeId().orElse(null));
   }
 }

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/types/builtin/VariantTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/types/builtin/VariantTest.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.stream.Stream;
-import org.eclipse.milo.opcua.stack.core.BuiltinDataType;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.ApplicationType;
 import org.eclipse.milo.opcua.stack.core.types.structured.AccessLevelExType;
 import org.eclipse.milo.opcua.stack.core.types.structured.XVType;
@@ -56,7 +56,7 @@ public class VariantTest {
 
   @ParameterizedTest
   @MethodSource("getBuiltinDataTypeSource")
-  void getBuiltinDataType(Object input, BuiltinDataType expected) {
+  void getBuiltinDataType(Object input, OpcUaDataType expected) {
     assertEquals(expected, Variant.of(input).getBuiltinDataType().orElseThrow());
   }
 
@@ -64,37 +64,37 @@ public class VariantTest {
   void variantCanContainAbstractType() {
     Number n = 1.0f;
     Variant v = Variant.of(n);
-    assertEquals(BuiltinDataType.Float, v.getBuiltinDataType().orElseThrow());
+    assertEquals(OpcUaDataType.Float, v.getBuiltinDataType().orElseThrow());
   }
 
   private static Stream<Arguments> getBuiltinDataTypeSource() {
     return Stream.of(
-        Arguments.of(true, BuiltinDataType.Boolean),
-        Arguments.of((byte) 1, BuiltinDataType.SByte),
-        Arguments.of((short) 1, BuiltinDataType.Int16),
-        Arguments.of(1, BuiltinDataType.Int32),
-        Arguments.of(1L, BuiltinDataType.Int64),
-        Arguments.of(ubyte(1), BuiltinDataType.Byte),
-        Arguments.of(ushort(1), BuiltinDataType.UInt16),
-        Arguments.of(uint(1), BuiltinDataType.UInt32),
-        Arguments.of(ulong(1), BuiltinDataType.UInt64),
-        Arguments.of(1.0f, BuiltinDataType.Float),
-        Arguments.of(1.0d, BuiltinDataType.Double),
-        Arguments.of("foo", BuiltinDataType.String),
-        Arguments.of(ByteString.of(new byte[] {1, 2, 3}), BuiltinDataType.ByteString),
-        Arguments.of(new XmlElement("<foo/>"), BuiltinDataType.XmlElement),
-        Arguments.of(new NodeId(1, 1), BuiltinDataType.NodeId),
-        Arguments.of(new ExpandedNodeId(ushort(1), "foo", "bar"), BuiltinDataType.ExpandedNodeId),
-        Arguments.of(new StatusCode(0), BuiltinDataType.StatusCode),
-        Arguments.of(new QualifiedName(1, "foo"), BuiltinDataType.QualifiedName),
-        Arguments.of(new LocalizedText("foo"), BuiltinDataType.LocalizedText),
+        Arguments.of(true, OpcUaDataType.Boolean),
+        Arguments.of((byte) 1, OpcUaDataType.SByte),
+        Arguments.of((short) 1, OpcUaDataType.Int16),
+        Arguments.of(1, OpcUaDataType.Int32),
+        Arguments.of(1L, OpcUaDataType.Int64),
+        Arguments.of(ubyte(1), OpcUaDataType.Byte),
+        Arguments.of(ushort(1), OpcUaDataType.UInt16),
+        Arguments.of(uint(1), OpcUaDataType.UInt32),
+        Arguments.of(ulong(1), OpcUaDataType.UInt64),
+        Arguments.of(1.0f, OpcUaDataType.Float),
+        Arguments.of(1.0d, OpcUaDataType.Double),
+        Arguments.of("foo", OpcUaDataType.String),
+        Arguments.of(ByteString.of(new byte[] {1, 2, 3}), OpcUaDataType.ByteString),
+        Arguments.of(new XmlElement("<foo/>"), OpcUaDataType.XmlElement),
+        Arguments.of(new NodeId(1, 1), OpcUaDataType.NodeId),
+        Arguments.of(new ExpandedNodeId(ushort(1), "foo", "bar"), OpcUaDataType.ExpandedNodeId),
+        Arguments.of(new StatusCode(0), OpcUaDataType.StatusCode),
+        Arguments.of(new QualifiedName(1, "foo"), OpcUaDataType.QualifiedName),
+        Arguments.of(new LocalizedText("foo"), OpcUaDataType.LocalizedText),
         Arguments.of(
             new ExtensionObject(ByteString.NULL_VALUE, NodeId.NULL_VALUE),
-            BuiltinDataType.ExtensionObject),
-        Arguments.of(new DataValue(new Variant(1)), BuiltinDataType.DataValue),
-        Arguments.of(new Variant[] {new Variant(1)}, BuiltinDataType.Variant),
-        Arguments.of(ApplicationType.Client, BuiltinDataType.Int32),
-        Arguments.of(new XVType(1.0d, 2.0f), BuiltinDataType.ExtensionObject),
-        Arguments.of(new AccessLevelExType(uint(1)), BuiltinDataType.UInt32));
+            OpcUaDataType.ExtensionObject),
+        Arguments.of(new DataValue(new Variant(1)), OpcUaDataType.DataValue),
+        Arguments.of(new Variant[] {new Variant(1)}, OpcUaDataType.Variant),
+        Arguments.of(ApplicationType.Client, OpcUaDataType.Int32),
+        Arguments.of(new XVType(1.0d, 2.0f), OpcUaDataType.ExtensionObject),
+        Arguments.of(new AccessLevelExType(uint(1)), OpcUaDataType.UInt32));
   }
 }

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/types/builtin/VariantTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/types/builtin/VariantTest.java
@@ -55,19 +55,19 @@ public class VariantTest {
   }
 
   @ParameterizedTest
-  @MethodSource("getBuiltinDataTypeSource")
-  void getBuiltinDataType(Object input, OpcUaDataType expected) {
-    assertEquals(expected, Variant.of(input).getBuiltinDataType().orElseThrow());
+  @MethodSource("getDataTypeSource")
+  void getDataType(Object input, OpcUaDataType expected) {
+    assertEquals(expected, Variant.of(input).getDataType().orElseThrow());
   }
 
   @Test
   void variantCanContainAbstractType() {
     Number n = 1.0f;
     Variant v = Variant.of(n);
-    assertEquals(OpcUaDataType.Float, v.getBuiltinDataType().orElseThrow());
+    assertEquals(OpcUaDataType.Float, v.getDataType().orElseThrow());
   }
 
-  private static Stream<Arguments> getBuiltinDataTypeSource() {
+  private static Stream<Arguments> getDataTypeSource() {
     return Stream.of(
         Arguments.of(true, OpcUaDataType.Boolean),
         Arguments.of((byte) 1, OpcUaDataType.SByte),


### PR DESCRIPTION
Time to rip this band-aid off... "BuiltinDataType" is infuriatingly vague and provides no clues to what it is when being used/referenced in a codebase that uses Milo.