### PR TITLE
Add `IdentityValidator::getSupportedTokenTypes`

### DIFF
--- a/milo-examples/server-examples/src/main/java/org/eclipse/milo/examples/server/ExampleServer.java
+++ b/milo-examples/server-examples/src/main/java/org/eclipse/milo/examples/server/ExampleServer.java
@@ -32,6 +32,7 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.eclipse.milo.opcua.sdk.server.EndpointConfig;
 import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
 import org.eclipse.milo.opcua.sdk.server.OpcUaServerConfig;
+import org.eclipse.milo.opcua.sdk.server.identity.AnonymousIdentityValidator;
 import org.eclipse.milo.opcua.sdk.server.identity.CompositeValidator;
 import org.eclipse.milo.opcua.sdk.server.identity.UsernameIdentityValidator;
 import org.eclipse.milo.opcua.sdk.server.identity.X509IdentityValidator;
@@ -138,7 +139,6 @@ public class ExampleServer {
 
     var identityValidator =
         new UsernameIdentityValidator(
-            true,
             authChallenge -> {
               String username = authChallenge.getUsername();
               String password = authChallenge.getPassword();
@@ -178,7 +178,9 @@ public class ExampleServer {
                     "",
                     DateTime.now()))
             .setCertificateManager(certificateManager)
-            .setIdentityValidator(new CompositeValidator(identityValidator, x509IdentityValidator))
+            .setIdentityValidator(
+                new CompositeValidator(
+                    AnonymousIdentityValidator.INSTANCE, identityValidator, x509IdentityValidator))
             .setProductUri("urn:eclipse:milo:example-server")
             .build();
 

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/test/TestServer.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/test/TestServer.java
@@ -29,6 +29,8 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.eclipse.milo.opcua.sdk.server.EndpointConfig;
 import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
 import org.eclipse.milo.opcua.sdk.server.OpcUaServerConfig;
+import org.eclipse.milo.opcua.sdk.server.identity.AnonymousIdentityValidator;
+import org.eclipse.milo.opcua.sdk.server.identity.CompositeValidator;
 import org.eclipse.milo.opcua.sdk.server.identity.UsernameIdentityValidator;
 import org.eclipse.milo.opcua.sdk.server.util.HostnameUtil;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
@@ -129,7 +131,6 @@ public final class TestServer {
 
     UsernameIdentityValidator identityValidator =
         new UsernameIdentityValidator(
-            true,
             authChallenge -> {
               String username = authChallenge.getUsername();
               String password = authChallenge.getPassword();
@@ -168,7 +169,8 @@ public final class TestServer {
                     "",
                     DateTime.now()))
             .setCertificateManager(certificateManager)
-            .setIdentityValidator(identityValidator)
+            .setIdentityValidator(
+                new CompositeValidator(AnonymousIdentityValidator.INSTANCE, identityValidator))
             .setProductUri("urn:eclipse:milo:example-server")
             .build();
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractIdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractIdentityValidator.java
@@ -44,42 +44,37 @@ public abstract class AbstractIdentityValidator implements IdentityValidator {
       Session session, UserIdentityToken token, UserTokenPolicy policy, SignatureData signature)
       throws UaException {
 
-    switch (policy.getTokenType()) {
-      case Anonymous:
-        {
-          if (token instanceof AnonymousIdentityToken) {
-            return validateAnonymousToken(
-                session, (AnonymousIdentityToken) token, policy, signature);
-          }
-          break;
+    return switch (policy.getTokenType()) {
+      case Anonymous -> {
+        if (token instanceof AnonymousIdentityToken) {
+          yield validateAnonymousToken(session, (AnonymousIdentityToken) token, policy, signature);
+        } else {
+          throw new UaException(StatusCodes.Bad_IdentityTokenInvalid);
         }
-      case UserName:
-        {
-          if (token instanceof UserNameIdentityToken) {
-            return validateUsernameToken(session, (UserNameIdentityToken) token, policy, signature);
-          }
-          break;
+      }
+      case UserName -> {
+        if (token instanceof UserNameIdentityToken) {
+          yield validateUsernameToken(session, (UserNameIdentityToken) token, policy, signature);
+        } else {
+          throw new UaException(StatusCodes.Bad_IdentityTokenInvalid);
         }
-      case Certificate:
-        {
-          if (token instanceof X509IdentityToken) {
-            return validateX509Token(session, (X509IdentityToken) token, policy, signature);
-          }
-          break;
+      }
+      case Certificate -> {
+        if (token instanceof X509IdentityToken) {
+          yield validateX509Token(session, (X509IdentityToken) token, policy, signature);
+        } else {
+          throw new UaException(StatusCodes.Bad_IdentityTokenInvalid);
         }
-      case IssuedToken:
-        {
-          if (token instanceof IssuedIdentityToken) {
-            return validateIssuedIdentityToken(
-                session, (IssuedIdentityToken) token, policy, signature);
-          }
-          break;
+      }
+      case IssuedToken -> {
+        if (token instanceof IssuedIdentityToken) {
+          yield validateIssuedIdentityToken(
+              session, (IssuedIdentityToken) token, policy, signature);
+        } else {
+          throw new UaException(StatusCodes.Bad_IdentityTokenInvalid);
         }
-      default:
-        throw new UaException(StatusCodes.Bad_IdentityTokenInvalid);
-    }
-
-    throw new UaException(StatusCodes.Bad_IdentityTokenInvalid);
+      }
+    };
   }
 
   /**

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractUsernameIdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractUsernameIdentityValidator.java
@@ -12,15 +12,15 @@ package org.eclipse.milo.opcua.sdk.server.identity;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
+import java.util.Set;
 import org.eclipse.milo.opcua.sdk.server.Session;
-import org.eclipse.milo.opcua.sdk.server.identity.Identity.AnonymousIdentity;
 import org.eclipse.milo.opcua.sdk.server.identity.Identity.UsernameIdentity;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.security.SecurityAlgorithm;
 import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
-import org.eclipse.milo.opcua.stack.core.types.structured.AnonymousIdentityToken;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.UserTokenType;
 import org.eclipse.milo.opcua.stack.core.types.structured.SignatureData;
 import org.eclipse.milo.opcua.stack.core.types.structured.UserNameIdentityToken;
 import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
@@ -29,14 +29,8 @@ import org.jspecify.annotations.Nullable;
 public abstract class AbstractUsernameIdentityValidator extends AbstractIdentityValidator {
 
   @Override
-  protected AnonymousIdentity validateAnonymousToken(
-      Session session,
-      AnonymousIdentityToken token,
-      UserTokenPolicy policy,
-      SignatureData signature)
-      throws UaException {
-
-    return authenticateAnonymousOrThrow(session);
+  public Set<UserTokenType> getSupportedTokenTypes() {
+    return Set.of(UserTokenType.UserName);
   }
 
   @Override
@@ -125,16 +119,6 @@ public abstract class AbstractUsernameIdentityValidator extends AbstractIdentity
     }
   }
 
-  private AnonymousIdentity authenticateAnonymousOrThrow(Session session) throws UaException {
-    AnonymousIdentity identity = authenticateAnonymous(session);
-
-    if (identity != null) {
-      return identity;
-    } else {
-      throw new UaException(StatusCodes.Bad_UserAccessDenied);
-    }
-  }
-
   private UsernameIdentity authenticateUsernameOrThrow(
       Session session, String username, String password) throws UaException {
     UsernameIdentity identity = authenticateUsernamePassword(session, username, password);
@@ -145,16 +129,6 @@ public abstract class AbstractUsernameIdentityValidator extends AbstractIdentity
       throw new UaException(StatusCodes.Bad_UserAccessDenied);
     }
   }
-
-  /**
-   * Create and return an {@link AnonymousIdentity} for the anonymous user, or {@code null} if
-   * anonymous authentication is not allowed.
-   *
-   * @param session the {@link Session} being activated.
-   * @return an {@link AnonymousIdentity}, or {@code null} if anonymous authentication is not
-   *     allowed.
-   */
-  protected abstract @Nullable AnonymousIdentity authenticateAnonymous(Session session);
 
   /**
    * Authenticate {@code username} with {@code password}, returning a {@link UsernameIdentity} if

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractX509IdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractX509IdentityValidator.java
@@ -12,6 +12,7 @@ package org.eclipse.milo.opcua.sdk.server.identity;
 
 import com.google.common.primitives.Bytes;
 import java.security.cert.X509Certificate;
+import java.util.Set;
 import org.eclipse.milo.opcua.sdk.server.Session;
 import org.eclipse.milo.opcua.sdk.server.identity.Identity.X509UserIdentity;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
@@ -19,6 +20,7 @@ import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.security.SecurityAlgorithm;
 import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.UserTokenType;
 import org.eclipse.milo.opcua.stack.core.types.structured.SignatureData;
 import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
 import org.eclipse.milo.opcua.stack.core.types.structured.X509IdentityToken;
@@ -27,6 +29,11 @@ import org.eclipse.milo.opcua.stack.core.util.SignatureUtil;
 import org.jspecify.annotations.Nullable;
 
 public abstract class AbstractX509IdentityValidator extends AbstractIdentityValidator {
+
+  @Override
+  public Set<UserTokenType> getSupportedTokenTypes() {
+    return Set.of(UserTokenType.Certificate);
+  }
 
   @Override
   protected X509UserIdentity validateX509Token(

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AnonymousIdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AnonymousIdentityValidator.java
@@ -10,7 +10,9 @@
 
 package org.eclipse.milo.opcua.sdk.server.identity;
 
+import java.util.Set;
 import org.eclipse.milo.opcua.sdk.server.Session;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.UserTokenType;
 import org.eclipse.milo.opcua.stack.core.types.structured.AnonymousIdentityToken;
 import org.eclipse.milo.opcua.stack.core.types.structured.SignatureData;
 import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
@@ -19,6 +21,11 @@ public final class AnonymousIdentityValidator extends AbstractIdentityValidator 
 
   /** A static instance implementing AnonymousIdentityValidator */
   public static final AnonymousIdentityValidator INSTANCE = new AnonymousIdentityValidator();
+
+  @Override
+  public Set<UserTokenType> getSupportedTokenTypes() {
+    return Set.of(UserTokenType.Anonymous);
+  }
 
   @Override
   public Identity.AnonymousIdentity validateAnonymousToken(

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/IdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/IdentityValidator.java
@@ -10,8 +10,10 @@
 
 package org.eclipse.milo.opcua.sdk.server.identity;
 
+import java.util.Set;
 import org.eclipse.milo.opcua.sdk.server.Session;
 import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.UserTokenType;
 import org.eclipse.milo.opcua.stack.core.types.structured.ActivateSessionRequest;
 import org.eclipse.milo.opcua.stack.core.types.structured.SignatureData;
 import org.eclipse.milo.opcua.stack.core.types.structured.UserIdentityToken;
@@ -32,4 +34,11 @@ public interface IdentityValidator {
   Identity validateIdentityToken(
       Session session, UserIdentityToken token, UserTokenPolicy policy, SignatureData signature)
       throws UaException;
+
+  /**
+   * Return the {@link Set} of {@link UserTokenType}s supported by this {@link IdentityValidator}.
+   *
+   * @return the {@link Set} of {@link UserTokenType}s supported by this {@link IdentityValidator}.
+   */
+  Set<UserTokenType> getSupportedTokenTypes();
 }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/UsernameIdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/UsernameIdentityValidator.java
@@ -16,23 +16,10 @@ import org.jspecify.annotations.Nullable;
 
 public class UsernameIdentityValidator extends AbstractUsernameIdentityValidator {
 
-  private final boolean anonymousAccessAllowed;
   private final Predicate<AuthenticationChallenge> predicate;
 
-  public UsernameIdentityValidator(
-      boolean anonymousAccessAllowed, Predicate<AuthenticationChallenge> predicate) {
-
-    this.anonymousAccessAllowed = anonymousAccessAllowed;
+  public UsernameIdentityValidator(Predicate<AuthenticationChallenge> predicate) {
     this.predicate = predicate;
-  }
-
-  @Override
-  protected Identity.@Nullable AnonymousIdentity authenticateAnonymous(Session session) {
-    if (anonymousAccessAllowed) {
-      return new DefaultAnonymousIdentity();
-    } else {
-      return null;
-    }
   }
 
   @Override


### PR DESCRIPTION
Use this new method in `CompositeValidator` to only attempt validation with validators that support the incoming token type.

Additionally, remove the combined anonymous identity support from `UsernameIdentityValidator` and `AbstractUsernameIdentityValidator`.

Update ExampleServer to use `CompositeValidator` so it continues to support anonymous identities.

fixes #1382
