### PR TITLE
Support mixed primitive/boxed equality in Variant and Matrix

### DIFF
--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/Matrix.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/Matrix.java
@@ -68,7 +68,7 @@ public class Matrix {
     this.dataType = deriveBuiltinType(flatArray);
     this.dataTypeId = deriveDataTypeId(flatArray);
 
-    assert dimensions.length > 1 && dataType != null;
+    assert flatArray != null && dimensions.length > 1 && dataType != null;
   }
 
   public Matrix(Object flatArray, int[] dimensions, OpcUaDataType dataType) {
@@ -192,9 +192,31 @@ public class Matrix {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
     Matrix matrix = (Matrix) o;
-    return Objects.deepEquals(flatArray, matrix.flatArray)
-        && Arrays.equals(dimensions, matrix.dimensions)
-        && dataType == matrix.dataType;
+
+    final Object thisArray = flatArray;
+    final Object thatArray = matrix.flatArray;
+
+    if (thisArray == thatArray) {
+      return true;
+    } else if (thisArray == null || thatArray == null) {
+      return false;
+    } else {
+      boolean thisIsPrimitive = thisArray.getClass().getComponentType().isPrimitive();
+      boolean thatIsPrimitive = thatArray.getClass().getComponentType().isPrimitive();
+
+      if (thisIsPrimitive != thatIsPrimitive) {
+        Object thisBoxed = ArrayUtil.box(thisArray);
+        Object thatBoxed = ArrayUtil.box(thatArray);
+
+        return Objects.deepEquals(thisBoxed, thatBoxed)
+            && Arrays.equals(dimensions, matrix.dimensions)
+            && dataType == matrix.dataType;
+      } else {
+        return Objects.deepEquals(thisArray, thatArray)
+            && Arrays.equals(dimensions, matrix.dimensions)
+            && dataType == matrix.dataType;
+      }
+    }
   }
 
   @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/ArrayUtil.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/ArrayUtil.java
@@ -134,6 +134,71 @@ public class ArrayUtil {
     return type;
   }
 
+  /**
+   * If the provided Object is a primitive array, return a boxed array of the same type, otherwise
+   * return the original Object.
+   *
+   * @param value the array to box.
+   * @return a boxed array of the same type, or the original Object if it is not a primitive array.
+   */
+  public static Object box(Object value) {
+    if (!value.getClass().isArray() || !value.getClass().getComponentType().isPrimitive()) {
+      return value;
+    }
+
+    if (value instanceof byte[] primitive) {
+      var boxed = new Byte[primitive.length];
+      for (int i = 0; i < boxed.length; i++) {
+        boxed[i] = primitive[i];
+      }
+      return boxed;
+    } else if (value instanceof short[] primitive) {
+      var boxed = new Short[primitive.length];
+      for (int i = 0; i < boxed.length; i++) {
+        boxed[i] = primitive[i];
+      }
+      return boxed;
+    } else if (value instanceof int[] primitive) {
+      var boxed = new Integer[primitive.length];
+      for (int i = 0; i < boxed.length; i++) {
+        boxed[i] = primitive[i];
+      }
+      return boxed;
+    } else if (value instanceof long[] primitive) {
+      var boxed = new Long[primitive.length];
+      for (int i = 0; i < boxed.length; i++) {
+        boxed[i] = primitive[i];
+      }
+      return boxed;
+    } else if (value instanceof float[] primitive) {
+      var boxed = new Float[primitive.length];
+      for (int i = 0; i < boxed.length; i++) {
+        boxed[i] = primitive[i];
+      }
+      return boxed;
+    } else if (value instanceof double[] primitive) {
+      var boxed = new Double[primitive.length];
+      for (int i = 0; i < boxed.length; i++) {
+        boxed[i] = primitive[i];
+      }
+      return boxed;
+    } else if (value instanceof char[] primitive) {
+      var boxed = new Character[primitive.length];
+      for (int i = 0; i < boxed.length; i++) {
+        boxed[i] = primitive[i];
+      }
+      return boxed;
+    } else if (value instanceof boolean[] primitive) {
+      var boxed = new Boolean[primitive.length];
+      for (int i = 0; i < boxed.length; i++) {
+        boxed[i] = primitive[i];
+      }
+      return boxed;
+    } else {
+      return value;
+    }
+  }
+
   private static int length(int[] tail) {
     int product = 1;
     for (int aTail : tail) {

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/types/builtin/MatrixTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/types/builtin/MatrixTest.java
@@ -66,9 +66,12 @@ class MatrixTest {
   }
 
   @Test
-  void matrixEquals() {
-    assertEquals(primitiveMatrix2d, new Matrix(primitiveInt2d));
-    assertEquals(boxedMatrix2d, new Matrix(boxedInt2d));
+  void primitiveBoxedEquality() {
+    int[][] primitive = new int[][] {{1, 2}, {3, 4}};
+    Integer[][] boxed = new Integer[][] {{1, 2}, {3, 4}};
+
+    assertEquals(new Matrix(primitive), new Matrix(boxed));
+    assertEquals(new Matrix(boxed), new Matrix(primitive));
   }
 
   @Test

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/types/builtin/VariantTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/types/builtin/VariantTest.java
@@ -67,6 +67,32 @@ public class VariantTest {
     assertEquals(OpcUaDataType.Float, v.getDataType().orElseThrow());
   }
 
+  @Test
+  void multiDimensionalArraysMustUseMatrix() {
+    assertThrows(IllegalArgumentException.class, () -> Variant.of(new int[2][2]));
+    assertThrows(IllegalArgumentException.class, () -> Variant.of(new int[2][2][2]));
+  }
+
+  @Test
+  void scalarEquality() {
+    assertEquals(Variant.of(1), Variant.of(1));
+  }
+
+  @Test
+  void arrayEquality() {
+    assertEquals(Variant.of(new int[] {1, 2, 3}), Variant.of(new int[] {1, 2, 3}));
+    assertEquals(Variant.of(new Integer[] {1, 2, 3}), Variant.of(new Integer[] {1, 2, 3}));
+  }
+
+  @Test
+  void primitiveBoxedEquality() {
+    int[] primitive = {1, 2, 3};
+    Integer[] boxed = {1, 2, 3};
+
+    assertEquals(Variant.of(primitive), Variant.of(boxed));
+    assertEquals(Variant.of(boxed), Variant.of(primitive));
+  }
+
   private static Stream<Arguments> getDataTypeSource() {
     return Stream.of(
         Arguments.of(true, OpcUaDataType.Boolean),


### PR DESCRIPTION
Improves usability of `equals` in Variant and Matrix by supporting equality between contained values that are primitive in one and boxed in the other, but otherwise equal. 

fixes #1384
