### PR TITLE
Don't explicitly encode `null` StatusCode in DataValue

### DIFF
--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryEncoder.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryEncoder.java
@@ -296,7 +296,7 @@ public class OpcUaBinaryEncoder implements UaEncoder {
         mask |= 0x01;
       }
 
-      if (!StatusCode.GOOD.equals(value.statusCode())) {
+      if (value.statusCode() != null && !StatusCode.GOOD.equals(value.statusCode())) {
         mask |= 0x02;
       }
 


### PR DESCRIPTION
A DataValue constructed with a `null` StatusCode is semantically equivalent to one with a Good (0) StatusCode, and shouldn't result in the corresponding bit in the DataValue EncodingMask field being set and an explicit 0 value being encoded.

forward port of #1390
