### PR TITLE
Disallow `null` for StatusCode field in DataValue

### DIFF
--- a/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/WriteExample.java
+++ b/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/WriteExample.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 the Eclipse Milo Authors
+ * Copyright (c) 2025 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -39,8 +39,8 @@ public class WriteExample implements ClientExample {
     for (int i = 0; i < 10; i++) {
       Variant v = Variant.ofInt32(i);
 
-      // don't write status or timestamps
-      DataValue dv = new DataValue(v, null, null);
+      // don't write timestamps
+      DataValue dv = DataValue.valueOnly(v);
 
       List<StatusCode> statusCodes = client.writeValues(nodeIds, List.of(dv));
 

--- a/opc-ua-stack/encoding-json/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoderTest.java
+++ b/opc-ua-stack/encoding-json/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoderTest.java
@@ -890,13 +890,13 @@ class OpcUaJsonEncoderTest {
 
     // omit all fields
     encoder.reset(writer = new StringWriter());
-    encoder.encodeDataValue(null, new DataValue(Variant.NULL_VALUE, null, null));
+    encoder.encodeDataValue(null, new DataValue(Variant.NULL_VALUE, StatusCode.GOOD, null));
     assertEquals("", writer.toString());
 
     // omit all fields while embedded in object
     encoder.reset(writer = new StringWriter());
     encoder.jsonWriter.beginObject();
-    encoder.encodeDataValue("foo", new DataValue(Variant.NULL_VALUE, null, null));
+    encoder.encodeDataValue("foo", new DataValue(Variant.NULL_VALUE, StatusCode.GOOD, null));
     encoder.jsonWriter.endObject();
     assertEquals("{}", writer.toString());
   }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryEncoder.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryEncoder.java
@@ -292,11 +292,11 @@ public class OpcUaBinaryEncoder implements UaEncoder {
     } else {
       int mask = 0x00;
 
-      if (value.value() != null && value.value().isNotNull()) {
+      if (value.value().isNotNull()) {
         mask |= 0x01;
       }
 
-      if (!StatusCode.GOOD.equals(value.statusCode())) {
+      if (value.getStatusCode().getValue() != 0L) {
         mask |= 0x02;
       }
 

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/DataValue.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/DataValue.java
@@ -20,7 +20,7 @@ import org.jspecify.annotations.Nullable;
 @NullMarked
 public record DataValue(
     Variant value,
-    @Nullable StatusCode statusCode,
+    StatusCode statusCode,
     @Nullable DateTime sourceTime,
     @Nullable UShort sourcePicoseconds,
     @Nullable DateTime serverTime,
@@ -42,13 +42,13 @@ public record DataValue(
     this(value, status, DateTime.now());
   }
 
-  public DataValue(Variant value, @Nullable StatusCode status, @Nullable DateTime time) {
+  public DataValue(Variant value, StatusCode status, @Nullable DateTime time) {
     this(value, status, time, time);
   }
 
   public DataValue(
       Variant value,
-      @Nullable StatusCode status,
+      StatusCode status,
       @Nullable DateTime sourceTime,
       @Nullable DateTime serverTime) {
 
@@ -59,7 +59,7 @@ public record DataValue(
     return value;
   }
 
-  public @Nullable StatusCode getStatusCode() {
+  public StatusCode getStatusCode() {
     return statusCode;
   }
 
@@ -149,19 +149,21 @@ public record DataValue(
   }
 
   /**
-   * Create a {@link DataValue} containing *only* the Variant. All other fields will be null.
+   * Create a {@link DataValue} containing only a value.
+   *
+   * <p>{@link StatusCode#GOOD} is implied, and other fields will be null.
    *
    * @param v the value {@link Variant}.
    * @return a {@link DataValue} containing only the value.
    */
   public static DataValue valueOnly(Variant v) {
-    return new DataValue(v, null, null, null, null, null);
+    return new DataValue(v, StatusCode.GOOD, null, null, null, null);
   }
 
   public static class Builder {
 
     public Variant value = Variant.NULL_VALUE;
-    public @Nullable StatusCode status;
+    public StatusCode status = StatusCode.GOOD;
     public @Nullable DateTime sourceTime;
     public @Nullable UShort sourcePicoseconds;
     public @Nullable DateTime serverTime;
@@ -188,7 +190,7 @@ public record DataValue(
       return this;
     }
 
-    public Builder setStatus(@Nullable StatusCode status) {
+    public Builder setStatus(StatusCode status) {
       this.status = status;
       return this;
     }


### PR DESCRIPTION
A `null` value is semantically the same, and encodes the same, as `StatusCodes.GOOD`. Any distinction is lost during serialization.
