### PR TITLE
Update JSON encoding for latest OPC UA 1.05 Part 6 draft

### DIFF
--- a/opc-ua-stack/encoding-json/pom.xml
+++ b/opc-ua-stack/encoding-json/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2024 the Eclipse Milo Authors
+  ~ Copyright (c) 2025 the Eclipse Milo Authors
   ~
   ~ This program and the accompanying materials are made
   ~ available under the terms of the Eclipse Public License 2.0
@@ -47,6 +47,12 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
       <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>

--- a/opc-ua-stack/encoding-json/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonDecoder.java
+++ b/opc-ua-stack/encoding-json/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonDecoder.java
@@ -1406,9 +1406,71 @@ public class OpcUaJsonDecoder implements UaDecoder {
         }
       }
 
-      Object nestedArray = decodeNestedMultiDimensionalArrayBuiltinValue(dataType.getTypeId());
+      if (jsonReader.peek() == JsonToken.NULL) {
+        jsonReader.nextNull();
+        return Matrix.ofNull();
+      }
 
-      return new Matrix(nestedArray);
+      if (jsonReader.peek() != JsonToken.BEGIN_OBJECT) {
+        throw new UaSerializationException(
+            StatusCodes.Bad_DecodingError,
+            String.format("readMatrix: unexpected token: %s", jsonReader.peek()));
+      }
+
+      jsonReader.beginObject();
+      try {
+        int[] dimensions = null;
+        Object flatArray = null;
+
+        while (jsonReader.peek() == JsonToken.NAME) {
+          String nextName = nextName();
+          if (nextName == null) continue;
+
+          switch (nextName) {
+            case "Array":
+              {
+                var elements = new ArrayList<>();
+                jsonReader.beginArray();
+                while (jsonReader.peek() != JsonToken.END_ARRAY) {
+                  elements.add(readBuiltinTypeValue(null, dataType.getTypeId()));
+                }
+                jsonReader.endArray();
+
+                flatArray =
+                    Array.newInstance(
+                        OpcUaDataType.getPrimitiveBackingClass(dataType.getTypeId()),
+                        elements.size());
+
+                for (int i = 0; i < elements.size(); i++) {
+                  Array.set(flatArray, i, elements.get(i));
+                }
+              }
+              break;
+            case "Dimensions":
+              {
+                var dims = new ArrayList<Integer>();
+                jsonReader.beginArray();
+                while (jsonReader.peek() == JsonToken.NUMBER) {
+                  dims.add(jsonReader.nextInt());
+                }
+                jsonReader.endArray();
+                dimensions = new int[dims.size()];
+                for (int i = 0; i < dims.size(); i++) {
+                  dimensions[i] = dims.get(i);
+                }
+              }
+              break;
+            default:
+              throw new UaSerializationException(
+                  StatusCodes.Bad_DecodingError,
+                  String.format("readLocalizedText: unexpected field: " + nextName));
+          }
+        }
+
+        return new Matrix(flatArray, dimensions, dataType);
+      } finally {
+        jsonReader.endObject();
+      }
     } catch (IOException e) {
       throw new UaSerializationException(StatusCodes.Bad_DecodingError, e);
     }

--- a/opc-ua-stack/encoding-json/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonDecoder.java
+++ b/opc-ua-stack/encoding-json/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonDecoder.java
@@ -577,9 +577,6 @@ public class OpcUaJsonDecoder implements UaDecoder {
 
   @Override
   public StatusCode decodeStatusCode(String field) throws UaSerializationException {
-    // StatusCode values shall be encoded as a JSON number for the
-    // reversible encoding.
-
     try {
       if (field != null) {
         String nextName = nextName();

--- a/opc-ua-stack/encoding-json/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonDecoder.java
+++ b/opc-ua-stack/encoding-json/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonDecoder.java
@@ -316,28 +316,23 @@ public class OpcUaJsonDecoder implements UaDecoder {
         }
       }
 
-      switch (jsonReader.peek()) {
-        case NUMBER:
-          return (float) jsonReader.nextDouble();
-        case STRING:
-          {
-            String s = jsonReader.nextString();
-            switch (s) {
-              case "Infinity":
-                return Float.POSITIVE_INFINITY;
-              case "-Infinity":
-                return Float.NEGATIVE_INFINITY;
-              case "NaN":
-                return Float.NaN;
-              default:
+      return switch (jsonReader.peek()) {
+        case NUMBER -> (float) jsonReader.nextDouble();
+        case STRING -> {
+          String s = jsonReader.nextString();
+          yield switch (s) {
+            case "Infinity" -> Float.POSITIVE_INFINITY;
+            case "-Infinity" -> Float.NEGATIVE_INFINITY;
+            case "NaN" -> Float.NaN;
+            default ->
                 throw new UaSerializationException(
                     StatusCodes.Bad_DecodingError, "readFloat: unexpected string value: " + s);
-            }
-          }
-        default:
-          throw new UaSerializationException(
-              StatusCodes.Bad_DecodingError, "readFloat: unexpected token: " + jsonReader.peek());
-      }
+          };
+        }
+        default ->
+            throw new UaSerializationException(
+                StatusCodes.Bad_DecodingError, "readFloat: unexpected token: " + jsonReader.peek());
+      };
     } catch (IOException e) {
       throw new UaSerializationException(StatusCodes.Bad_DecodingError, e);
     }
@@ -360,28 +355,24 @@ public class OpcUaJsonDecoder implements UaDecoder {
         }
       }
 
-      switch (jsonReader.peek()) {
-        case NUMBER:
-          return jsonReader.nextDouble();
-        case STRING:
-          {
-            String s = jsonReader.nextString();
-            switch (s) {
-              case "Infinity":
-                return Double.POSITIVE_INFINITY;
-              case "-Infinity":
-                return Double.NEGATIVE_INFINITY;
-              case "NaN":
-                return Double.NaN;
-              default:
+      return switch (jsonReader.peek()) {
+        case NUMBER -> jsonReader.nextDouble();
+        case STRING -> {
+          String s = jsonReader.nextString();
+          yield switch (s) {
+            case "Infinity" -> Double.POSITIVE_INFINITY;
+            case "-Infinity" -> Double.NEGATIVE_INFINITY;
+            case "NaN" -> Double.NaN;
+            default ->
                 throw new UaSerializationException(
                     StatusCodes.Bad_DecodingError, "readDouble: unexpected string value: " + s);
-            }
-          }
-        default:
-          throw new UaSerializationException(
-              StatusCodes.Bad_DecodingError, "readDouble: unexpected token: " + jsonReader.peek());
-      }
+          };
+        }
+        default ->
+            throw new UaSerializationException(
+                StatusCodes.Bad_DecodingError,
+                "readDouble: unexpected token: " + jsonReader.peek());
+      };
     } catch (IOException e) {
       throw new UaSerializationException(StatusCodes.Bad_DecodingError, e);
     }
@@ -959,62 +950,36 @@ public class OpcUaJsonDecoder implements UaDecoder {
   }
 
   private Object readBuiltinTypeValue(String field, int typeId) throws UaSerializationException {
-    switch (typeId) {
-      case 1:
-        return decodeBoolean(field);
-      case 2:
-        return decodeSByte(field);
-      case 3:
-        return decodeByte(field);
-      case 4:
-        return decodeInt16(field);
-      case 5:
-        return decodeUInt16(field);
-      case 6:
-        return decodeInt32(field);
-      case 7:
-        return decodeUInt32(field);
-      case 8:
-        return decodeInt64(field);
-      case 9:
-        return decodeUInt64(field);
-      case 10:
-        return decodeFloat(field);
-      case 11:
-        return decodeDouble(field);
-      case 12:
-        return decodeString(field);
-      case 13:
-        return decodeDateTime(field);
-      case 14:
-        return decodeGuid(field);
-      case 15:
-        return decodeByteString(field);
-      case 16:
-        return decodeXmlElement(field);
-      case 17:
-        return decodeNodeId(field);
-      case 18:
-        return decodeExpandedNodeId(field);
-      case 19:
-        return decodeStatusCode(field);
-      case 20:
-        return decodeQualifiedName(field);
-      case 21:
-        return decodeLocalizedText(field);
-      case 22:
-        return decodeExtensionObject(field);
-      case 23:
-        return decodeDataValue(field);
-      case 24:
-        return decodeVariant(field);
-      case 25:
-        return decodeDiagnosticInfo(field);
-
-      default:
-        throw new UaSerializationException(
-            StatusCodes.Bad_EncodingError, "not a built-in type: " + typeId);
-    }
+    return switch (typeId) {
+      case 1 -> decodeBoolean(field);
+      case 2 -> decodeSByte(field);
+      case 3 -> decodeByte(field);
+      case 4 -> decodeInt16(field);
+      case 5 -> decodeUInt16(field);
+      case 6 -> decodeInt32(field);
+      case 7 -> decodeUInt32(field);
+      case 8 -> decodeInt64(field);
+      case 9 -> decodeUInt64(field);
+      case 10 -> decodeFloat(field);
+      case 11 -> decodeDouble(field);
+      case 12 -> decodeString(field);
+      case 13 -> decodeDateTime(field);
+      case 14 -> decodeGuid(field);
+      case 15 -> decodeByteString(field);
+      case 16 -> decodeXmlElement(field);
+      case 17 -> decodeNodeId(field);
+      case 18 -> decodeExpandedNodeId(field);
+      case 19 -> decodeStatusCode(field);
+      case 20 -> decodeQualifiedName(field);
+      case 21 -> decodeLocalizedText(field);
+      case 22 -> decodeExtensionObject(field);
+      case 23 -> decodeDataValue(field);
+      case 24 -> decodeVariant(field);
+      case 25 -> decodeDiagnosticInfo(field);
+      default ->
+          throw new UaSerializationException(
+              StatusCodes.Bad_EncodingError, "not a built-in type: " + typeId);
+    };
   }
 
   @Override
@@ -1512,25 +1477,6 @@ public class OpcUaJsonDecoder implements UaDecoder {
                         "decodeStructMatrix: namespace not registered: " + dataTypeId));
 
     return decodeStructMatrix(field, localDataTypeId);
-  }
-
-  private Object decodeNestedMultiDimensionalArrayBuiltinValue(int typeId) throws IOException {
-    if (jsonReader.peek() == JsonToken.BEGIN_ARRAY) {
-      jsonReader.beginArray();
-      List<Object> elements = new ArrayList<>();
-      while (jsonReader.peek() != JsonToken.END_ARRAY) {
-        elements.add(decodeNestedMultiDimensionalArrayBuiltinValue(typeId));
-      }
-      jsonReader.endArray();
-
-      Object array = Array.newInstance(elements.get(0).getClass(), elements.size());
-      for (int i = 0; i < elements.size(); i++) {
-        Array.set(array, i, elements.get(i));
-      }
-      return array;
-    } else {
-      return readBuiltinTypeValue(null, typeId);
-    }
   }
 
   private Object decodeNestedMultiDimensionalArrayStructValue(DataTypeCodec codec)

--- a/opc-ua-stack/encoding-json/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoder.java
+++ b/opc-ua-stack/encoding-json/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoder.java
@@ -648,9 +648,17 @@ public class OpcUaJsonEncoder implements UaEncoder {
 
     try {
       EncoderContext context = contextPeek();
-      if (context == EncoderContext.BUILTIN || (value != null && value.isNotNull())) {
+      if (encoding == Encoding.VERBOSE
+          || context == EncoderContext.BUILTIN
+          || (value != null && value.isNotNull())) {
+
         if (field != null) {
           jsonWriter.name(field);
+        }
+
+        if (value == null || value.isNull()) {
+          jsonWriter.nullValue();
+          return;
         }
 
         jsonWriter.beginObject();

--- a/opc-ua-stack/encoding-json/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoder.java
+++ b/opc-ua-stack/encoding-json/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoder.java
@@ -592,34 +592,29 @@ public class OpcUaJsonEncoder implements UaEncoder {
 
   @Override
   public void encodeStatusCode(String field, StatusCode value) throws UaSerializationException {
-    // StatusCode values shall be encoded as a JSON number for the
-    // reversible encoding.
+    // # Compact
+    // StatusCode values shall be encoded as a JSON number.
     //
-    // For the non-reversible form, StatusCode values shall be encoded as
-    // a JSON object with the fields defined as follows:
-    //
-    // "Code":
+    // # Verbose
+    // StatusCode values shall be encoded as a JSON object with the fields defined as follows:
+    // - "Code"
     // The numeric code encoded as a JSON number.
     // The Code is omitted if the numeric code is 0 (Good).
-    //
-    // "Symbol":
-    // The string literal associated with the numeric code encoded as JSON
-    // string. e.g. 0x80AB0000 has the associated literal
-    // “BadInvalidArgument”.
+    // - "Symbol"
+    // The string literal associated with the numeric code encoded as JSON string. e.g. 0x80AB0000
+    // has the associated literal "BadInvalidArgument".
     // The Symbol is omitted if the numeric code is 0 (Good).
-    //
-    // A StatusCode of Good (0) is treated like a NULL and not encoded. If
-    // it is an element of an JSON array it is encoded as the JSON literal
-    // `null`.
+    // If the string literal is not known to the encoder the field is omitted.
 
     try {
       EncoderContext context = contextPeek();
       if (encoding == Encoding.VERBOSE
           || context == EncoderContext.BUILTIN
           || (value != null && !value.isGood())) {
+
         long code = value.value();
 
-        if (reversible) {
+        if (encoding == Encoding.COMPACT) {
           if (field != null) {
             jsonWriter.name(field);
           }

--- a/opc-ua-stack/encoding-json/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoder.java
+++ b/opc-ua-stack/encoding-json/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoder.java
@@ -702,42 +702,32 @@ public class OpcUaJsonEncoder implements UaEncoder {
   @Override
   public void encodeExtensionObject(String field, ExtensionObject value)
       throws UaSerializationException {
+
     try {
       EncoderContext context = contextPeek();
-      if (encoding == Encoding.VERBOSE || context == EncoderContext.BUILTIN || value != null) {
+      if (context == EncoderContext.BUILTIN || value != null) {
         if (field != null) {
           jsonWriter.name(field);
         }
 
-        if (value == null || value.getBody() == null) {
+        if (value == null) {
           jsonWriter.nullValue();
         } else {
-          if (reversible) {
-            jsonWriter.beginObject();
-            encodeNodeId("TypeId", value.getEncodingOrTypeId());
-            if (value instanceof ExtensionObject.Json xo) {
-              jsonWriter.name("Body").jsonValue(xo.getBody());
-            } else if (value instanceof ExtensionObject.Binary xo) {
-              jsonWriter.name("Encoding").value(1);
-              encodeByteString("Body", xo.getBody());
-            } else if (value instanceof ExtensionObject.Xml xo) {
-              jsonWriter.name("Encoding").value(2);
-              encodeXmlElement("Body", xo.getBody());
-            }
-            jsonWriter.endObject();
-          } else {
-            if (value instanceof ExtensionObject.Json xo) {
-              jsonWriter.jsonValue(xo.getBody());
-            } else if (value instanceof ExtensionObject.Binary xo) {
-              contextPush(EncoderContext.BUILTIN);
-              encodeByteString(null, xo.getBody());
-              contextPop();
-            } else if (value instanceof ExtensionObject.Xml xo) {
-              contextPush(EncoderContext.BUILTIN);
-              encodeXmlElement(null, xo.getBody());
-              contextPop();
-            }
+          value.getBody();
+          jsonWriter.beginObject();
+
+          encodeNodeId("TypeId", value.getEncodingOrTypeId());
+          if (value instanceof ExtensionObject.Json xo) {
+            jsonWriter.name("Body").jsonValue(xo.getBody());
+          } else if (value instanceof ExtensionObject.Binary xo) {
+            jsonWriter.name("Encoding").value(1);
+            encodeByteString("Body", xo.getBody());
+          } else if (value instanceof ExtensionObject.Xml xo) {
+            jsonWriter.name("Encoding").value(2);
+            encodeXmlElement("Body", xo.getBody());
           }
+
+          jsonWriter.endObject();
         }
       }
     } catch (IOException e) {

--- a/opc-ua-stack/encoding-json/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoder.java
+++ b/opc-ua-stack/encoding-json/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoder.java
@@ -499,7 +499,7 @@ public class OpcUaJsonEncoder implements UaEncoder {
             }
           }
         } else if (value.server() instanceof ServerUri uri) {
-          UShort index = encodingContext.getServerTable().getIndex(uri.serverUri());
+          UInteger index = encodingContext.getServerTable().getIndex(uri.serverUri());
           if (index == null || index.intValue() != 0) {
             sb.append("svu=").append(uri.serverUri()).append(";");
           }

--- a/opc-ua-stack/encoding-json/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoder.java
+++ b/opc-ua-stack/encoding-json/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoder.java
@@ -11,10 +11,7 @@
 package org.eclipse.milo.opcua.stack.core.encoding.json;
 
 import com.google.gson.stream.JsonWriter;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.io.Writer;
+import java.io.*;
 import java.lang.reflect.Array;
 import java.time.format.DateTimeFormatter;
 import java.util.Base64;
@@ -75,13 +72,12 @@ public class OpcUaJsonEncoder implements UaEncoder {
   EncodingContext encodingContext;
 
   public OpcUaJsonEncoder(EncodingContext encodingContext) {
-    this.encodingContext = encodingContext;
+    this(encodingContext, new StringWriter());
   }
 
   public OpcUaJsonEncoder(EncodingContext encodingContext, Writer writer) {
     this.encodingContext = encodingContext;
-
-    reset(writer);
+    this.jsonWriter = new JsonWriter(writer);
   }
 
   @Override
@@ -901,51 +897,6 @@ public class OpcUaJsonEncoder implements UaEncoder {
           encodeBuiltinTypeValue(null, typeId, optionSetValue);
           break;
         }
-    }
-  }
-
-  /** Write a multidimensional value in the reversible (flattened array) format. */
-  private void writeFlattenedMultiDimensionalVariantValue(
-      int typeId, Object value, int[] dimensions, int dimensionIndex) throws IOException {
-
-    if (dimensionIndex == 0) {
-      jsonWriter.beginArray();
-      for (int i = 0; i < dimensions[dimensionIndex]; i++) {
-        Object e = Array.get(value, i);
-        writeFlattenedMultiDimensionalVariantValue(typeId, e, dimensions, dimensionIndex + 1);
-      }
-      jsonWriter.endArray();
-    } else if (dimensionIndex == dimensions.length - 1) {
-      for (int i = 0; i < dimensions[dimensionIndex]; i++) {
-        Object e = Array.get(value, i);
-        encodeBuiltinTypeValue(null, typeId, e);
-      }
-    } else {
-      for (int i = 0; i < dimensions[dimensionIndex]; i++) {
-        Object e = Array.get(value, i);
-        writeFlattenedMultiDimensionalVariantValue(typeId, e, dimensions, dimensionIndex + 1);
-      }
-    }
-  }
-
-  /** Write a multidimensional value in the non-reversible (nested array) format. */
-  private void writeNestedMultiDimensionalVariantValue(
-      int typeId, Object value, int[] dimensions, int dimensionIndex) throws IOException {
-
-    if (dimensionIndex == dimensions.length - 1) {
-      jsonWriter.beginArray();
-      for (int i = 0; i < dimensions[dimensionIndex]; i++) {
-        Object e = Array.get(value, i);
-        encodeBuiltinTypeValue(null, typeId, e);
-      }
-      jsonWriter.endArray();
-    } else {
-      jsonWriter.beginArray();
-      for (int i = 0; i < dimensions[dimensionIndex]; i++) {
-        Object e = Array.get(value, i);
-        writeNestedMultiDimensionalVariantValue(typeId, e, dimensions, dimensionIndex + 1);
-      }
-      jsonWriter.endArray();
     }
   }
 

--- a/opc-ua-stack/encoding-json/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoder.java
+++ b/opc-ua-stack/encoding-json/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoder.java
@@ -677,27 +677,22 @@ public class OpcUaJsonEncoder implements UaEncoder {
   @Override
   public void encodeLocalizedText(String field, LocalizedText value)
       throws UaSerializationException {
+
     try {
       EncoderContext context = contextPeek();
-      if (encoding == Encoding.VERBOSE
-          || context == EncoderContext.BUILTIN
-          || (value != null && value.isNotNull())) {
+      if (context == EncoderContext.BUILTIN || (value != null && value.isNotNull())) {
         if (field != null) {
           jsonWriter.name(field);
         }
 
-        if (reversible) {
-          jsonWriter.beginObject();
-          if (value.locale() != null) {
-            jsonWriter.name("Locale").value(value.locale());
-          }
-          if (value.text() != null) {
-            jsonWriter.name("Text").value(value.text());
-          }
-          jsonWriter.endObject();
-        } else {
-          jsonWriter.value(value.text());
+        jsonWriter.beginObject();
+        if (value.locale() != null) {
+          jsonWriter.name("Locale").value(value.locale());
         }
+        if (value.text() != null) {
+          jsonWriter.name("Text").value(value.text());
+        }
+        jsonWriter.endObject();
       }
     } catch (IOException e) {
       throw new UaSerializationException(StatusCodes.Bad_EncodingError, e);
@@ -1163,7 +1158,7 @@ public class OpcUaJsonEncoder implements UaEncoder {
 
   @Override
   public void encodeEnum(String field, UaEnumeratedType value) throws UaSerializationException {
-    if (reversible) {
+    if (encoding == Encoding.COMPACT) {
       encodeInt32(field, value.getValue());
     } else {
       if (value.getName() != null) {

--- a/opc-ua-stack/encoding-json/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoder.java
+++ b/opc-ua-stack/encoding-json/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoder.java
@@ -65,8 +65,14 @@ public class OpcUaJsonEncoder implements UaEncoder {
     STRUCT
   }
 
+  public enum Encoding {
+    COMPACT,
+    VERBOSE
+  }
+
   private final Stack<EncoderContext> contextStack = new Stack<>();
 
+  Encoding encoding = Encoding.COMPACT;
   boolean reversible = true;
   JsonWriter jsonWriter;
   EncodingContext encodingContext;
@@ -122,7 +128,7 @@ public class OpcUaJsonEncoder implements UaEncoder {
   public void encodeBoolean(String field, Boolean value) throws UaSerializationException {
     try {
       EncoderContext context = contextPeek();
-      if (!reversible || context == EncoderContext.BUILTIN || value) {
+      if (encoding == Encoding.VERBOSE || context == EncoderContext.BUILTIN || value) {
         if (field != null) {
           jsonWriter.name(field);
         }
@@ -137,7 +143,7 @@ public class OpcUaJsonEncoder implements UaEncoder {
   public void encodeSByte(String field, Byte value) throws UaSerializationException {
     try {
       EncoderContext context = contextPeek();
-      if (!reversible || context == EncoderContext.BUILTIN || value != 0) {
+      if (encoding == Encoding.VERBOSE || context == EncoderContext.BUILTIN || value != 0) {
         if (field != null) {
           jsonWriter.name(field);
         }
@@ -152,7 +158,7 @@ public class OpcUaJsonEncoder implements UaEncoder {
   public void encodeInt16(String field, Short value) throws UaSerializationException {
     try {
       EncoderContext context = contextPeek();
-      if (!reversible || context == EncoderContext.BUILTIN || value != 0) {
+      if (encoding == Encoding.VERBOSE || context == EncoderContext.BUILTIN || value != 0) {
         if (field != null) {
           jsonWriter.name(field);
         }
@@ -167,7 +173,7 @@ public class OpcUaJsonEncoder implements UaEncoder {
   public void encodeInt32(String field, Integer value) throws UaSerializationException {
     try {
       EncoderContext context = contextPeek();
-      if (!reversible || context == EncoderContext.BUILTIN || value != 0) {
+      if (encoding == Encoding.VERBOSE || context == EncoderContext.BUILTIN || value != 0) {
         if (field != null) {
           jsonWriter.name(field);
         }
@@ -185,7 +191,7 @@ public class OpcUaJsonEncoder implements UaEncoder {
 
     try {
       EncoderContext context = contextPeek();
-      if (!reversible || context == EncoderContext.BUILTIN || value != 0) {
+      if (encoding == Encoding.VERBOSE || context == EncoderContext.BUILTIN || value != 0) {
         if (field != null) {
           jsonWriter.name(field);
         }
@@ -200,7 +206,9 @@ public class OpcUaJsonEncoder implements UaEncoder {
   public void encodeByte(String field, UByte value) throws UaSerializationException {
     try {
       EncoderContext context = contextPeek();
-      if (!reversible || context == EncoderContext.BUILTIN || value.intValue() != 0) {
+      if (encoding == Encoding.VERBOSE
+          || context == EncoderContext.BUILTIN
+          || value.intValue() != 0) {
         if (field != null) {
           jsonWriter.name(field);
         }
@@ -215,7 +223,9 @@ public class OpcUaJsonEncoder implements UaEncoder {
   public void encodeUInt16(String field, UShort value) throws UaSerializationException {
     try {
       EncoderContext context = contextPeek();
-      if (!reversible || context == EncoderContext.BUILTIN || value.intValue() != 0) {
+      if (encoding == Encoding.VERBOSE
+          || context == EncoderContext.BUILTIN
+          || value.intValue() != 0) {
         if (field != null) {
           jsonWriter.name(field);
         }
@@ -230,7 +240,9 @@ public class OpcUaJsonEncoder implements UaEncoder {
   public void encodeUInt32(String field, UInteger value) throws UaSerializationException {
     try {
       EncoderContext context = contextPeek();
-      if (!reversible || context == EncoderContext.BUILTIN || value.longValue() != 0L) {
+      if (encoding == Encoding.VERBOSE
+          || context == EncoderContext.BUILTIN
+          || value.longValue() != 0L) {
         if (field != null) {
           jsonWriter.name(field);
         }
@@ -249,7 +261,9 @@ public class OpcUaJsonEncoder implements UaEncoder {
 
     try {
       EncoderContext context = contextPeek();
-      if (!reversible || context == EncoderContext.BUILTIN || value.longValue() != 0L) {
+      if (encoding == Encoding.VERBOSE
+          || context == EncoderContext.BUILTIN
+          || value.longValue() != 0L) {
         if (field != null) {
           jsonWriter.name(field);
         }
@@ -270,7 +284,7 @@ public class OpcUaJsonEncoder implements UaEncoder {
 
     try {
       EncoderContext context = contextPeek();
-      if (!reversible || context == EncoderContext.BUILTIN || value != 0.0f) {
+      if (encoding == Encoding.VERBOSE || context == EncoderContext.BUILTIN || value != 0.0f) {
         if (field != null) {
           jsonWriter.name(field);
         }
@@ -299,7 +313,7 @@ public class OpcUaJsonEncoder implements UaEncoder {
 
     try {
       EncoderContext context = contextPeek();
-      if (!reversible || context == EncoderContext.BUILTIN || value != 0.0d) {
+      if (encoding == Encoding.VERBOSE || context == EncoderContext.BUILTIN || value != 0.0d) {
         if (field != null) {
           jsonWriter.name(field);
         }
@@ -326,7 +340,7 @@ public class OpcUaJsonEncoder implements UaEncoder {
 
     try {
       EncoderContext context = contextPeek();
-      if (!reversible || context == EncoderContext.BUILTIN || value != null) {
+      if (encoding == Encoding.VERBOSE || context == EncoderContext.BUILTIN || value != null) {
         if (field != null) {
           jsonWriter.name(field);
         }
@@ -349,7 +363,9 @@ public class OpcUaJsonEncoder implements UaEncoder {
 
     try {
       EncoderContext context = contextPeek();
-      if (!reversible || context == EncoderContext.BUILTIN || (value != null && value.isValid())) {
+      if (encoding == Encoding.VERBOSE
+          || context == EncoderContext.BUILTIN
+          || (value != null && value.isValid())) {
         if (field != null) {
           jsonWriter.name(field);
         }
@@ -371,7 +387,7 @@ public class OpcUaJsonEncoder implements UaEncoder {
   public void encodeGuid(String field, UUID value) throws UaSerializationException {
     try {
       EncoderContext context = contextPeek();
-      if (!reversible
+      if (encoding == Encoding.VERBOSE
           || context == EncoderContext.BUILTIN
           || (value != null
               && value.getLeastSignificantBits() != 0L
@@ -396,7 +412,7 @@ public class OpcUaJsonEncoder implements UaEncoder {
 
     try {
       EncoderContext context = contextPeek();
-      if (!reversible
+      if (encoding == Encoding.VERBOSE
           || context == EncoderContext.BUILTIN
           || (value != null && value.isNotNull())) {
         if (field != null) {
@@ -413,7 +429,7 @@ public class OpcUaJsonEncoder implements UaEncoder {
   public void encodeXmlElement(String field, XmlElement value) throws UaSerializationException {
     try {
       EncoderContext context = contextPeek();
-      if (!reversible
+      if (encoding == Encoding.VERBOSE
           || context == EncoderContext.BUILTIN
           || (value != null && value.isNotNull())) {
         if (field != null) {
@@ -430,7 +446,7 @@ public class OpcUaJsonEncoder implements UaEncoder {
   public void encodeNodeId(String field, NodeId value) throws UaSerializationException {
     try {
       EncoderContext context = contextPeek();
-      if (!reversible
+      if (encoding == Encoding.VERBOSE
           || context == EncoderContext.BUILTIN
           || (value != null && value.isNotNull())) {
         if (field != null) {
@@ -461,7 +477,7 @@ public class OpcUaJsonEncoder implements UaEncoder {
 
     try {
       EncoderContext context = contextPeek();
-      if (!reversible
+      if (encoding == Encoding.VERBOSE
           || context == EncoderContext.BUILTIN
           || (value != null && value.isNotNull())) {
 
@@ -598,7 +614,9 @@ public class OpcUaJsonEncoder implements UaEncoder {
 
     try {
       EncoderContext context = contextPeek();
-      if (!reversible || context == EncoderContext.BUILTIN || (value != null && !value.isGood())) {
+      if (encoding == Encoding.VERBOSE
+          || context == EncoderContext.BUILTIN
+          || (value != null && !value.isGood())) {
         long code = value.value();
 
         if (reversible) {
@@ -632,7 +650,7 @@ public class OpcUaJsonEncoder implements UaEncoder {
       throws UaSerializationException {
     try {
       EncoderContext context = contextPeek();
-      if (!reversible
+      if (encoding == Encoding.VERBOSE
           || context == EncoderContext.BUILTIN
           || (value != null && value.isNotNull())) {
         if (field != null) {
@@ -666,7 +684,7 @@ public class OpcUaJsonEncoder implements UaEncoder {
       throws UaSerializationException {
     try {
       EncoderContext context = contextPeek();
-      if (!reversible
+      if (encoding == Encoding.VERBOSE
           || context == EncoderContext.BUILTIN
           || (value != null && value.isNotNull())) {
         if (field != null) {
@@ -696,7 +714,7 @@ public class OpcUaJsonEncoder implements UaEncoder {
       throws UaSerializationException {
     try {
       EncoderContext context = contextPeek();
-      if (!reversible || context == EncoderContext.BUILTIN || value != null) {
+      if (encoding == Encoding.VERBOSE || context == EncoderContext.BUILTIN || value != null) {
         if (field != null) {
           jsonWriter.name(field);
         }
@@ -1092,7 +1110,7 @@ public class OpcUaJsonEncoder implements UaEncoder {
       throws UaSerializationException {
     try {
       EncoderContext context = contextPeek();
-      if (!reversible || context == EncoderContext.BUILTIN || value != null) {
+      if (encoding == Encoding.VERBOSE || context == EncoderContext.BUILTIN || value != null) {
         if (field != null) {
           jsonWriter.name(field);
         }
@@ -1399,7 +1417,7 @@ public class OpcUaJsonEncoder implements UaEncoder {
   public void encodeMatrix(String field, Matrix value) throws UaSerializationException {
     try {
       EncoderContext context = contextPeek();
-      if (!reversible
+      if (encoding == Encoding.VERBOSE
           || context == EncoderContext.BUILTIN
           || (value != null && value.isNotNull())) {
         if (field != null) {
@@ -1432,7 +1450,7 @@ public class OpcUaJsonEncoder implements UaEncoder {
   public void encodeEnumMatrix(String field, Matrix value) throws UaSerializationException {
     try {
       EncoderContext context = contextPeek();
-      if (!reversible
+      if (encoding == Encoding.VERBOSE
           || context == EncoderContext.BUILTIN
           || (value != null && value.isNotNull())) {
         if (field != null) {
@@ -1466,7 +1484,7 @@ public class OpcUaJsonEncoder implements UaEncoder {
       throws UaSerializationException {
     try {
       EncoderContext context = contextPeek();
-      if (!reversible
+      if (encoding == Encoding.VERBOSE
           || context == EncoderContext.BUILTIN
           || (value != null && value.isNotNull())) {
         if (field != null) {

--- a/opc-ua-stack/encoding-json/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoder.java
+++ b/opc-ua-stack/encoding-json/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoder.java
@@ -110,6 +110,22 @@ public class OpcUaJsonEncoder implements UaEncoder {
     jsonWriter.setHtmlSafe(false);
   }
 
+  /**
+   * Set the encoding to use.
+   *
+   * <p>{@link Encoding#COMPACT} is the default, and is used for serialization between OPC UA
+   * applications.
+   *
+   * <p>{@link Encoding#VERBOSE} is used when the consumer of the encoded JSON is something like a
+   * "cloud application", or otherwise not an OPC UA application, and cannot be deserialized by
+   * another OPC UA application's JSON decoder.
+   *
+   * @param encoding the encoding to use.
+   */
+  public void setEncoding(Encoding encoding) {
+    this.encoding = encoding;
+  }
+
   private EncoderContext contextPeek() {
     return contextStack.isEmpty() ? EncoderContext.BUILTIN : contextStack.peek();
   }
@@ -447,6 +463,7 @@ public class OpcUaJsonEncoder implements UaEncoder {
       if (encoding == Encoding.VERBOSE
           || context == EncoderContext.BUILTIN
           || (value != null && value.isNotNull())) {
+
         if (field != null) {
           jsonWriter.name(field);
         }
@@ -706,11 +723,11 @@ public class OpcUaJsonEncoder implements UaEncoder {
       jsonWriter.beginObject();
 
       Variant v = value.value();
-      if (v != null && v.isNotNull()) {
+      if (v.isNotNull()) {
         encodeVariant("Value", v);
       }
       StatusCode s = value.statusCode();
-      if (s != null && s.value() != 0L) {
+      if (s.value() != 0L) {
         encodeStatusCode("Status", s);
       }
       DateTime sourceTime = value.sourceTime();
@@ -741,8 +758,8 @@ public class OpcUaJsonEncoder implements UaEncoder {
    * @return {@code true} if all fields in {@code value} would be omitted from the encoding.
    */
   private static boolean allFieldsAreOmitted(DataValue value) {
-    return (value.value() == null || value.value().isNull())
-        && (value.statusCode() == null || value.statusCode().value() == 0L)
+    return value.value().isNull()
+        && value.statusCode().value() == 0L
         && (value.sourceTime() == null || value.sourceTime().isNull())
         && (value.sourcePicoseconds() == null || value.sourcePicoseconds().intValue() == 0)
         && (value.serverTime() == null || value.serverTime().isNull())

--- a/opc-ua-stack/encoding-json/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonDecoderTest.java
+++ b/opc-ua-stack/encoding-json/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonDecoderTest.java
@@ -54,7 +54,7 @@ class OpcUaJsonDecoderTest {
   private final EncodingContext context = new DefaultEncodingContext();
 
   @Test
-  void readBoolean() throws IOException {
+  void decodeBoolean() throws IOException {
     var decoder = new OpcUaJsonDecoder(context, new StringReader(""));
 
     decoder.reset(new StringReader("true"));
@@ -75,7 +75,7 @@ class OpcUaJsonDecoderTest {
   }
 
   @Test
-  void readSByte() throws IOException {
+  void decodeSByte() throws IOException {
     var decoder = new OpcUaJsonDecoder(context, new StringReader(""));
 
     decoder.reset(new StringReader("0"));
@@ -94,7 +94,7 @@ class OpcUaJsonDecoderTest {
   }
 
   @Test
-  void readInt16() throws IOException {
+  void decodeInt16() throws IOException {
     var decoder = new OpcUaJsonDecoder(context, new StringReader(""));
 
     decoder.reset(new StringReader("0"));
@@ -113,7 +113,7 @@ class OpcUaJsonDecoderTest {
   }
 
   @Test
-  void readInt32() throws IOException {
+  void decodeInt32() throws IOException {
     var decoder = new OpcUaJsonDecoder(context, new StringReader(""));
 
     decoder.reset(new StringReader("0"));
@@ -132,7 +132,7 @@ class OpcUaJsonDecoderTest {
   }
 
   @Test
-  void readInt64() throws IOException {
+  void decodeInt64() throws IOException {
     var decoder = new OpcUaJsonDecoder(context, new StringReader(""));
 
     decoder.reset(new StringReader("\"0\""));
@@ -151,7 +151,7 @@ class OpcUaJsonDecoderTest {
   }
 
   @Test
-  void readByte() throws IOException {
+  void decodeByte() throws IOException {
     var decoder = new OpcUaJsonDecoder(context, new StringReader(""));
 
     decoder.reset(new StringReader(String.valueOf(UByte.MIN)));
@@ -167,7 +167,7 @@ class OpcUaJsonDecoderTest {
   }
 
   @Test
-  void readUInt16() throws IOException {
+  void decodeUInt16() throws IOException {
     var decoder = new OpcUaJsonDecoder(context, new StringReader(""));
 
     decoder.reset(new StringReader(String.valueOf(UShort.MIN)));
@@ -183,7 +183,7 @@ class OpcUaJsonDecoderTest {
   }
 
   @Test
-  void readUInt32() throws IOException {
+  void decodeUInt32() throws IOException {
     var decoder = new OpcUaJsonDecoder(context, new StringReader(""));
 
     decoder.reset(new StringReader(String.valueOf(UInteger.MIN)));
@@ -199,7 +199,7 @@ class OpcUaJsonDecoderTest {
   }
 
   @Test
-  void readUInt64() throws IOException {
+  void decodeUInt64() throws IOException {
     var decoder = new OpcUaJsonDecoder(context, new StringReader(""));
 
     decoder.reset(new StringReader(String.format("\"%s\"", ULong.MIN)));
@@ -215,7 +215,7 @@ class OpcUaJsonDecoderTest {
   }
 
   @Test
-  void readFloat() throws IOException {
+  void decodeFloat() throws IOException {
     var decoder = new OpcUaJsonDecoder(context, new StringReader(""));
 
     decoder.reset(new StringReader("0.0"));
@@ -243,7 +243,7 @@ class OpcUaJsonDecoderTest {
   }
 
   @Test
-  void readDouble() throws IOException {
+  void decodeDouble() throws IOException {
     var decoder = new OpcUaJsonDecoder(context, new StringReader(""));
 
     decoder.reset(new StringReader("0.0"));
@@ -271,7 +271,7 @@ class OpcUaJsonDecoderTest {
   }
 
   @Test
-  void readString() throws IOException {
+  void decodeString() throws IOException {
     var decoder = new OpcUaJsonDecoder(context, new StringReader(""));
 
     decoder.reset(new StringReader("\"\""));
@@ -287,7 +287,7 @@ class OpcUaJsonDecoderTest {
   }
 
   @Test
-  void readDateTime() throws IOException {
+  void decodeDateTime() throws IOException {
     var decoder = new OpcUaJsonDecoder(context, new StringReader(""));
 
     decoder.reset(new StringReader(String.format("\"%s\"", DateTime.MIN_ISO_8601_STRING)));
@@ -316,7 +316,7 @@ class OpcUaJsonDecoderTest {
   }
 
   @Test
-  void readGuid() throws IOException {
+  void decodeGuid() throws IOException {
     var decoder = new OpcUaJsonDecoder(context, new StringReader(""));
 
     UUID uuid = UUID.randomUUID();
@@ -334,7 +334,7 @@ class OpcUaJsonDecoderTest {
   }
 
   @Test
-  void readByteString() throws IOException {
+  void decodeByteString() throws IOException {
     var decoder = new OpcUaJsonDecoder(context, new StringReader(""));
 
     byte[] emptyBytes = new byte[0];
@@ -356,7 +356,7 @@ class OpcUaJsonDecoderTest {
   }
 
   @Test
-  void readXmlElement() throws IOException {
+  void decodeXmlElement() throws IOException {
     var decoder = new OpcUaJsonDecoder(context, new StringReader(""));
 
     var emptyElement = new XmlElement("");
@@ -567,7 +567,7 @@ class OpcUaJsonDecoderTest {
   }
 
   @Test
-  void readStatusCode() throws IOException {
+  void decodeStatusCode() throws IOException {
     var decoder = new OpcUaJsonDecoder(context, new StringReader(""));
 
     decoder.reset(new StringReader("0"));
@@ -628,7 +628,7 @@ class OpcUaJsonDecoderTest {
   }
 
   @Test
-  void readLocalizedText() throws IOException {
+  void decodeLocalizedText() throws IOException {
     var decoder = new OpcUaJsonDecoder(context, new StringReader(""));
 
     decoder.reset(new StringReader("{\"Locale\":\"en\",\"Text\":\"foo\"}"));
@@ -687,7 +687,7 @@ class OpcUaJsonDecoderTest {
   }
 
   @Test
-  void readDataValue() throws IOException {
+  void decodeDataValue() throws IOException {
     var decoder = new OpcUaJsonDecoder(context, new StringReader(""));
 
     DateTime now = DateTime.now();
@@ -777,7 +777,7 @@ class OpcUaJsonDecoderTest {
   }
 
   @Test
-  void readVariant() throws IOException {
+  void decodeVariant() throws IOException {
     var decoder = new OpcUaJsonDecoder(context, new StringReader(""));
     context.getNamespaceTable().add("urn:eclipse:milo:test1");
 
@@ -827,7 +827,7 @@ class OpcUaJsonDecoderTest {
   }
 
   @Test
-  void readDiagnosticInfo() throws IOException {
+  void decodeDiagnosticInfo() throws IOException {
     var decoder = new OpcUaJsonDecoder(context, new StringReader(""));
 
     var diagnosticInfo = new DiagnosticInfo(0, 1, 2, 3, "foo", null, null);
@@ -874,7 +874,7 @@ class OpcUaJsonDecoderTest {
   }
 
   @Test
-  void readEnum() throws IOException {
+  void decodeEnum() throws IOException {
     var decoder = new OpcUaJsonDecoder(context, new StringReader(""));
 
     for (ApplicationType applicationType : ApplicationType.values()) {

--- a/opc-ua-stack/encoding-json/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonDecoderTest.java
+++ b/opc-ua-stack/encoding-json/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonDecoderTest.java
@@ -964,12 +964,12 @@ class OpcUaJsonDecoderTest {
 
     decoder.reset(
         new StringReader(
-            "[[{\"X\":0.0,\"Value\":1.0},{\"X\":2.0,\"Value\":3.0}],[{\"X\":4.0,\"Value\":5.0},{\"X\":6.0,\"Value\":7.0}]]"));
+            "{\"Array\":[{\"Value\":1.0},{\"X\":2.0,\"Value\":3.0},{\"X\":4.0,\"Value\":5.0},{\"X\":6.0,\"Value\":7.0}],\"Dimensions\":[2,2]}"));
     assertEquals(matrix, decoder.decodeStructMatrix(null, XVType.TYPE_ID));
 
     decoder.reset(
         new StringReader(
-            "{\"foo\":[[{\"X\":0.0,\"Value\":1.0},{\"X\":2.0,\"Value\":3.0}],[{\"X\":4.0,\"Value\":5.0},{\"X\":6.0,\"Value\":7.0}]]}"));
+            "{\"foo\":{\"Array\":[{\"Value\":1.0},{\"X\":2.0,\"Value\":3.0},{\"X\":4.0,\"Value\":5.0},{\"X\":6.0,\"Value\":7.0}],\"Dimensions\":[2,2]}}"));
     decoder.jsonReader.beginObject();
     assertEquals(matrix, decoder.decodeStructMatrix("foo", XVType.TYPE_ID));
     decoder.jsonReader.endObject();

--- a/opc-ua-stack/encoding-json/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonDecoderTest.java
+++ b/opc-ua-stack/encoding-json/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonDecoderTest.java
@@ -910,18 +910,19 @@ class OpcUaJsonDecoderTest {
               new Integer[][] {{4, 5}, {6, 7}}
             });
 
-    decoder.reset(new StringReader("[[0,1],[2,3]]"));
+    decoder.reset(new StringReader("{\"Array\":[0,1,2,3],\"Dimensions\":[2,2]}"));
     assertEquals(matrix2d, decoder.decodeMatrix(null, OpcUaDataType.Int32));
 
-    decoder.reset(new StringReader("[[[0,1],[2,3]],[[4,5],[6,7]]]"));
+    decoder.reset(new StringReader("{\"Array\":[0,1,2,3,4,5,6,7],\"Dimensions\":[2,2,2]}"));
     assertEquals(matrix3d, decoder.decodeMatrix(null, OpcUaDataType.Int32));
 
-    decoder.reset(new StringReader("{\"foo\":[[0,1],[2,3]]}"));
+    decoder.reset(new StringReader("{\"foo\":{\"Array\":[0,1,2,3],\"Dimensions\":[2,2]}}"));
     decoder.jsonReader.beginObject();
     assertEquals(matrix2d, decoder.decodeMatrix("foo", OpcUaDataType.Int32));
     decoder.jsonReader.endObject();
 
-    decoder.reset(new StringReader("{\"foo\":[[[0,1],[2,3]],[[4,5],[6,7]]]}"));
+    decoder.reset(
+        new StringReader("{\"foo\":{\"Array\":[0,1,2,3,4,5,6,7],\"Dimensions\":[2,2,2]}}"));
     decoder.jsonReader.beginObject();
     assertEquals(matrix3d, decoder.decodeMatrix("foo", OpcUaDataType.Int32));
     decoder.jsonReader.endObject();
@@ -931,10 +932,10 @@ class OpcUaJsonDecoderTest {
   void decodeEnumMatrix() throws Exception {
     var decoder = new OpcUaJsonDecoder(context, new StringReader(""));
 
-    decoder.reset(new StringReader("[[0,1],[2,3]]"));
+    decoder.reset(new StringReader("{\"Array\":[0,1,2,3],\"Dimensions\":[2,2]}"));
     assertEquals(Matrix.ofInt32(new Integer[][] {{0, 1}, {2, 3}}), decoder.decodeEnumMatrix(null));
 
-    decoder.reset(new StringReader("{\"foo\":[[0,1],[2,3]]}"));
+    decoder.reset(new StringReader("{\"foo\":{\"Array\":[0,1,2,3],\"Dimensions\":[2,2]}}"));
     decoder.jsonReader.beginObject();
     assertEquals(Matrix.ofInt32(new Integer[][] {{0, 1}, {2, 3}}), decoder.decodeEnumMatrix("foo"));
     decoder.jsonReader.endObject();

--- a/opc-ua-stack/encoding-json/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoderTest.java
+++ b/opc-ua-stack/encoding-json/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoderTest.java
@@ -821,12 +821,6 @@ class OpcUaJsonEncoderTest {
     encoder.encodeLocalizedText(null, new LocalizedText(null, null));
     assertEquals("{}", writer.toString());
 
-    encoder.reversible = false;
-    encoder.reset(writer = new StringWriter());
-    encoder.encodeLocalizedText(null, LocalizedText.english("foo"));
-    assertEquals("\"foo\"", writer.toString());
-
-    encoder.reversible = true;
     encoder.reset(writer = new StringWriter());
     encoder.jsonWriter.beginObject();
     encoder.encodeLocalizedText("foo", LocalizedText.english("foo"));
@@ -1120,9 +1114,10 @@ class OpcUaJsonEncoderTest {
   }
 
   @Test
-  void encodeEnum() throws IOException {
+  void encodeEnumCompact() throws IOException {
     var writer = new StringWriter();
     var encoder = new OpcUaJsonEncoder(context, writer);
+    encoder.encoding = Encoding.COMPACT;
 
     for (ApplicationType applicationType : ApplicationType.values()) {
       encoder.reset(writer = new StringWriter());
@@ -1135,8 +1130,13 @@ class OpcUaJsonEncoderTest {
       encoder.jsonWriter.endObject();
       assertEquals(String.format("{\"foo\":%d}", applicationType.getValue()), writer.toString());
     }
+  }
 
-    encoder.reversible = false;
+  @Test
+  void encodeEnumVerbose() throws IOException {
+    var writer = new StringWriter();
+    var encoder = new OpcUaJsonEncoder(context, writer);
+    encoder.encoding = Encoding.VERBOSE;
 
     for (ApplicationType applicationType : ApplicationType.values()) {
       String expected =

--- a/opc-ua-stack/encoding-json/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoderTest.java
+++ b/opc-ua-stack/encoding-json/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoderTest.java
@@ -860,19 +860,6 @@ class OpcUaJsonEncoderTest {
         "{\"TypeId\":\"nsu=urn:eclipse:milo:test2;i=42\",\"Encoding\":1,\"Body\":\"AAECAw==\"}",
         writer.toString());
 
-    encoder.reversible = false;
-    encoder.reset(writer = new StringWriter());
-    encoder.encodeExtensionObject(null, jsonStringXo);
-    assertEquals("{\"foo\":\"bar\",\"baz\":42}", writer.toString());
-
-    encoder.reset(writer = new StringWriter());
-    encoder.encodeExtensionObject(null, xmlElementXo);
-    assertEquals("\"<foo>bar</foo>\"", writer.toString());
-
-    encoder.reset(writer = new StringWriter());
-    encoder.encodeExtensionObject(null, byteStringXo);
-    assertEquals("\"AAECAw==\"", writer.toString());
-
     encoder.reset(writer = new StringWriter());
     encoder.encodeExtensionObject(null, null);
     assertEquals("null", writer.toString());

--- a/opc-ua-stack/encoding-json/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoderTest.java
+++ b/opc-ua-stack/encoding-json/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoderTest.java
@@ -27,6 +27,7 @@ import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
 import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
 import org.eclipse.milo.opcua.stack.core.encoding.json.OpcUaJsonEncoder.Encoding;
+import org.eclipse.milo.opcua.stack.core.types.UaStructuredType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
@@ -46,11 +47,7 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.ULong;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.ApplicationType;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.TimestampsToReturn;
-import org.eclipse.milo.opcua.stack.core.types.structured.Argument;
-import org.eclipse.milo.opcua.stack.core.types.structured.ReadRequest;
-import org.eclipse.milo.opcua.stack.core.types.structured.ReadValueId;
-import org.eclipse.milo.opcua.stack.core.types.structured.RequestHeader;
-import org.eclipse.milo.opcua.stack.core.types.structured.XVType;
+import org.eclipse.milo.opcua.stack.core.types.structured.*;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -1118,12 +1115,12 @@ class OpcUaJsonEncoderTest {
 
   @MethodSource("encodeStructCompactArguments")
   @ParameterizedTest
-  void encodeStructCompact(XVType struct, String expectedJson) {
+  void encodeStructCompact(UaStructuredType struct, String expectedJson) {
     var writer = new StringWriter();
     var encoder = new OpcUaJsonEncoder(context, writer);
     encoder.encoding = Encoding.COMPACT;
 
-    encoder.encodeStruct(null, struct, XVType.TYPE_ID);
+    encoder.encodeStruct(null, struct, struct.getTypeId());
     String encodedJson = writer.toString();
 
     assertEquals(expectedJson, encodedJson);
@@ -1133,17 +1130,21 @@ class OpcUaJsonEncoderTest {
     return Stream.of(
         Arguments.of(new XVType(0.0, 0.0f), "{}"),
         Arguments.of(new XVType(1.0, 0.0f), "{\"X\":1.0}"),
-        Arguments.of(new XVType(0.0, 1.0f), "{\"Value\":1.0}"));
+        Arguments.of(new XVType(0.0, 1.0f), "{\"Value\":1.0}"),
+        Arguments.of(
+            new EUInformation(
+                null, 0, LocalizedText.NULL_VALUE, LocalizedText.english("description")),
+            "{\"Description\":{\"Locale\":\"en\",\"Text\":\"description\"}}"));
   }
 
   @MethodSource("encodeStructVerboseArguments")
   @ParameterizedTest
-  void encodeStructVerbose(XVType struct, String expectedJson) {
+  void encodeStructVerbose(UaStructuredType struct, String expectedJson) {
     var writer = new StringWriter();
     var encoder = new OpcUaJsonEncoder(context, writer);
     encoder.encoding = Encoding.VERBOSE;
 
-    encoder.encodeStruct(null, struct, XVType.TYPE_ID);
+    encoder.encodeStruct(null, struct, struct.getTypeId());
     String encodedJson = writer.toString();
 
     assertEquals(expectedJson, encodedJson);
@@ -1153,7 +1154,11 @@ class OpcUaJsonEncoderTest {
     return Stream.of(
         Arguments.of(new XVType(0.0, 0.0f), "{\"X\":0.0,\"Value\":0.0}"),
         Arguments.of(new XVType(1.0, 0.0f), "{\"X\":1.0,\"Value\":0.0}"),
-        Arguments.of(new XVType(0.0, 1.0f), "{\"X\":0.0,\"Value\":1.0}"));
+        Arguments.of(new XVType(0.0, 1.0f), "{\"X\":0.0,\"Value\":1.0}"),
+        Arguments.of(
+            new EUInformation(
+                null, 0, LocalizedText.NULL_VALUE, LocalizedText.english("description")),
+            "{\"NamespaceUri\":null,\"UnitId\":0,\"DisplayName\":null,\"Description\":{\"Locale\":\"en\",\"Text\":\"description\"}}"));
   }
 
   @Test

--- a/opc-ua-stack/encoding-json/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoderTest.java
+++ b/opc-ua-stack/encoding-json/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoderTest.java
@@ -588,9 +588,9 @@ class OpcUaJsonEncoderTest {
         .update(
             map -> {
               map.clear();
-              map.put(ushort(0), "localhost"); // Index 0
-              map.put(ushort(1), "urn:eclipse:milo:server1"); // Index 1
-              map.put(ushort(2), "urn:eclipse:milo:server2"); // Index 2
+              map.put(uint(0), "localhost"); // Index 0
+              map.put(uint(1), "urn:eclipse:milo:server1"); // Index 1
+              map.put(uint(2), "urn:eclipse:milo:server2"); // Index 2
             });
 
     if (field != null) {

--- a/opc-ua-stack/encoding-json/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoderTest.java
+++ b/opc-ua-stack/encoding-json/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoderTest.java
@@ -1173,6 +1173,46 @@ class OpcUaJsonEncoderTest {
         writer.toString());
   }
 
+  @MethodSource("encodeStructCompactArguments")
+  @ParameterizedTest
+  void encodeStructCompact(XVType struct, String expectedJson) {
+    var writer = new StringWriter();
+    var encoder = new OpcUaJsonEncoder(context, writer);
+    encoder.encoding = OpcUaJsonEncoder.Encoding.COMPACT;
+
+    encoder.encodeStruct(null, struct, XVType.TYPE_ID);
+    String encodedJson = writer.toString();
+
+    assertEquals(expectedJson, encodedJson);
+  }
+
+  static Stream<Arguments> encodeStructCompactArguments() {
+    return Stream.of(
+        Arguments.of(new XVType(0.0, 0.0f), "{}"),
+        Arguments.of(new XVType(1.0, 0.0f), "{\"X\":1.0}"),
+        Arguments.of(new XVType(0.0, 1.0f), "{\"Value\":1.0}"));
+  }
+
+  @MethodSource("encodeStructVerboseArguments")
+  @ParameterizedTest
+  void encodeStructVerbose(XVType struct, String expectedJson) {
+    var writer = new StringWriter();
+    var encoder = new OpcUaJsonEncoder(context, writer);
+    encoder.encoding = OpcUaJsonEncoder.Encoding.VERBOSE;
+
+    encoder.encodeStruct(null, struct, XVType.TYPE_ID);
+    String encodedJson = writer.toString();
+
+    assertEquals(expectedJson, encodedJson);
+  }
+
+  static Stream<Arguments> encodeStructVerboseArguments() {
+    return Stream.of(
+        Arguments.of(new XVType(0.0, 0.0f), "{\"X\":0.0,\"Value\":0.0}"),
+        Arguments.of(new XVType(1.0, 0.0f), "{\"X\":1.0,\"Value\":0.0}"),
+        Arguments.of(new XVType(0.0, 1.0f), "{\"X\":0.0,\"Value\":1.0}"));
+  }
+
   @Test
   public void writeBooleanArray() throws IOException {
     var writer = new StringWriter();

--- a/opc-ua-stack/encoding-json/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoderTest.java
+++ b/opc-ua-stack/encoding-json/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoderTest.java
@@ -1263,23 +1263,24 @@ class OpcUaJsonEncoderTest {
 
     encoder.reset(writer = new StringWriter());
     encoder.encodeMatrix(null, matrix2d);
-    assertEquals("[[0,1],[2,3]]", writer.toString());
+    assertEquals("{\"Array\":[0,1,2,3],\"Dimensions\":[2,2]}", writer.toString());
 
     encoder.reset(writer = new StringWriter());
     encoder.encodeMatrix(null, matrix3d);
-    assertEquals("[[[0,1],[2,3]],[[4,5],[6,7]]]", writer.toString());
+    assertEquals("{\"Array\":[0,1,2,3,4,5,6,7],\"Dimensions\":[2,2,2]}", writer.toString());
 
     encoder.reset(writer = new StringWriter());
     encoder.jsonWriter.beginObject();
     encoder.encodeMatrix("foo", matrix2d);
     encoder.jsonWriter.endObject();
-    assertEquals("{\"foo\":[[0,1],[2,3]]}", writer.toString());
+    assertEquals("{\"foo\":{\"Array\":[0,1,2,3],\"Dimensions\":[2,2]}}", writer.toString());
 
     encoder.reset(writer = new StringWriter());
     encoder.jsonWriter.beginObject();
     encoder.encodeMatrix("foo", matrix3d);
     encoder.jsonWriter.endObject();
-    assertEquals("{\"foo\":[[[0,1],[2,3]],[[4,5],[6,7]]]}", writer.toString());
+    assertEquals(
+        "{\"foo\":{\"Array\":[0,1,2,3,4,5,6,7],\"Dimensions\":[2,2,2]}}", writer.toString());
   }
 
   @Test

--- a/opc-ua-stack/encoding-json/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoderTest.java
+++ b/opc-ua-stack/encoding-json/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoderTest.java
@@ -813,7 +813,7 @@ class OpcUaJsonEncoderTest {
 
     encoder.reset(writer = new StringWriter());
     encoder.encodeLocalizedText(null, new LocalizedText(null, null));
-    assertEquals("{}", writer.toString());
+    assertEquals("null", writer.toString());
 
     encoder.reset(writer = new StringWriter());
     encoder.jsonWriter.beginObject();

--- a/opc-ua-stack/encoding-json/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoderTest.java
+++ b/opc-ua-stack/encoding-json/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoderTest.java
@@ -960,7 +960,6 @@ class OpcUaJsonEncoderTest {
     var encoder = new OpcUaJsonEncoder(context, writer);
     context.getNamespaceTable().add("urn:eclipse:milo:test1");
 
-    // region reversible
     encoder.reset(writer = new StringWriter());
     encoder.encodeVariant(null, new Variant(true));
     assertEquals("{\"Type\":1,\"Body\":true}", writer.toString());
@@ -979,23 +978,6 @@ class OpcUaJsonEncoderTest {
     encoder.reset(writer = new StringWriter());
     encoder.encodeVariant(null, new Variant(Matrix.ofInt32(new int[][] {{0, 1}, {2, 3}})));
     assertEquals("{\"Type\":6,\"Body\":[0,1,2,3],\"Dimensions\":[2,2]}", writer.toString());
-    // endregion
-
-    // region non-reversible
-    encoder.reversible = false;
-    encoder.reset(writer = new StringWriter());
-    encoder.encodeVariant(null, new Variant(true));
-    assertEquals("true", writer.toString());
-
-    encoder.reset(writer = new StringWriter());
-    encoder.encodeVariant(null, new Variant(new QualifiedName(1, "foo")));
-    assertEquals("\"nsu=urn:eclipse:milo:test1;foo\"", writer.toString());
-
-    encoder.reset(writer = new StringWriter());
-    encoder.encodeVariant(
-        null, new Variant(new Variant[] {new Variant("foo"), new Variant("bar")}));
-    assertEquals("[\"foo\",\"bar\"]", writer.toString());
-    // endregion
 
     int[] value1d = {0, 1, 2, 3};
     int[][] value2d = {
@@ -1013,8 +995,6 @@ class OpcUaJsonEncoderTest {
       }
     };
 
-    // region Arrays, reversible
-    encoder.reversible = true;
     encoder.reset(writer = new StringWriter());
     encoder.encodeVariant(null, new Variant(value1d));
     assertEquals("{\"Type\":6,\"Body\":[0,1,2,3]}", writer.toString());
@@ -1027,23 +1007,6 @@ class OpcUaJsonEncoderTest {
     encoder.encodeVariant(null, new Variant(Matrix.ofInt32(value3d)));
     assertEquals(
         "{\"Type\":6,\"Body\":[0,1,2,3,4,5,6,7],\"Dimensions\":[2,2,2]}", writer.toString());
-    // endregion
-
-    // region Arrays, non-reversible
-    encoder.reversible = false;
-
-    encoder.reset(writer = new StringWriter());
-    encoder.encodeVariant(null, new Variant(value1d));
-    assertEquals("[0,1,2,3]", writer.toString());
-
-    encoder.reset(writer = new StringWriter());
-    encoder.encodeVariant(null, new Variant(Matrix.ofInt32(value2d)));
-    assertEquals("[[0,2,3],[1,3,4]]", writer.toString());
-
-    encoder.reset(writer = new StringWriter());
-    encoder.encodeVariant(null, new Variant(Matrix.ofInt32(value3d)));
-    assertEquals("[[[0,1],[2,3]],[[4,5],[6,7]]]", writer.toString());
-    // endregion
   }
 
   @Test

--- a/opc-ua-stack/encoding-json/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoderTest.java
+++ b/opc-ua-stack/encoding-json/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoderTest.java
@@ -60,7 +60,7 @@ class OpcUaJsonEncoderTest {
   private final EncodingContext context = DefaultEncodingContext.INSTANCE;
 
   @Test
-  void writeBoolean() throws IOException {
+  void encodeBoolean() throws IOException {
     var writer = new StringWriter();
     var encoder = new OpcUaJsonEncoder(context, writer);
 
@@ -79,7 +79,7 @@ class OpcUaJsonEncoderTest {
   }
 
   @Test
-  public void writeSByte() throws IOException {
+  void encodeSByte() throws IOException {
     var writer = new StringWriter();
     var encoder = new OpcUaJsonEncoder(context, writer);
 
@@ -102,7 +102,7 @@ class OpcUaJsonEncoderTest {
   }
 
   @Test
-  public void writeInt16() throws IOException {
+  void encodeInt16() throws IOException {
     var writer = new StringWriter();
     var encoder = new OpcUaJsonEncoder(context, writer);
 
@@ -125,7 +125,7 @@ class OpcUaJsonEncoderTest {
   }
 
   @Test
-  public void writeInt32() throws IOException {
+  void encodeInt32() throws IOException {
     var writer = new StringWriter();
     var encoder = new OpcUaJsonEncoder(context, writer);
 
@@ -148,7 +148,7 @@ class OpcUaJsonEncoderTest {
   }
 
   @Test
-  public void writeInt64() throws IOException {
+  void encodeInt64() throws IOException {
     var writer = new StringWriter();
     var encoder = new OpcUaJsonEncoder(context, writer);
 
@@ -174,7 +174,7 @@ class OpcUaJsonEncoderTest {
   }
 
   @Test
-  public void writeByte() throws IOException {
+  void encodeByte() throws IOException {
     var writer = new StringWriter();
     var encoder = new OpcUaJsonEncoder(context, writer);
 
@@ -193,7 +193,7 @@ class OpcUaJsonEncoderTest {
   }
 
   @Test
-  public void writeUInt16() throws IOException {
+  void encodeUInt16() throws IOException {
     var writer = new StringWriter();
     var encoder = new OpcUaJsonEncoder(context, writer);
 
@@ -212,7 +212,7 @@ class OpcUaJsonEncoderTest {
   }
 
   @Test
-  public void writeUInt32() throws IOException {
+  void encodeUInt32() throws IOException {
     var writer = new StringWriter();
     var encoder = new OpcUaJsonEncoder(context, writer);
 
@@ -231,7 +231,7 @@ class OpcUaJsonEncoderTest {
   }
 
   @Test
-  public void writeUInt64() throws IOException {
+  void encodeUInt64() throws IOException {
     var writer = new StringWriter();
     var encoder = new OpcUaJsonEncoder(context, writer);
 
@@ -258,7 +258,7 @@ class OpcUaJsonEncoderTest {
   }
 
   @Test
-  public void writeFloat() throws IOException {
+  void encodeFloat() throws IOException {
     var writer = new StringWriter();
     var encoder = new OpcUaJsonEncoder(context, writer);
 
@@ -304,7 +304,7 @@ class OpcUaJsonEncoderTest {
   }
 
   @Test
-  public void writeDouble() throws IOException {
+  void encodeDouble() throws IOException {
     var writer = new StringWriter();
     var encoder = new OpcUaJsonEncoder(context, writer);
 
@@ -350,7 +350,7 @@ class OpcUaJsonEncoderTest {
   }
 
   @Test
-  public void writeString() throws IOException {
+  void encodeString() throws IOException {
     var writer = new StringWriter();
     var encoder = new OpcUaJsonEncoder(context, writer);
 
@@ -377,7 +377,7 @@ class OpcUaJsonEncoderTest {
   }
 
   @Test
-  public void writeDateTime() throws IOException {
+  void encodeDateTime() throws IOException {
     var writer = new StringWriter();
     var encoder = new OpcUaJsonEncoder(context, writer);
 
@@ -428,7 +428,7 @@ class OpcUaJsonEncoderTest {
   }
 
   @Test
-  public void writeGuid() throws IOException {
+  void encodeGuid() throws IOException {
     var writer = new StringWriter();
     var encoder = new OpcUaJsonEncoder(context, writer);
 
@@ -448,7 +448,7 @@ class OpcUaJsonEncoderTest {
   }
 
   @Test
-  public void writeByteString() throws IOException {
+  void encodeByteString() throws IOException {
     var writer = new StringWriter();
     var encoder = new OpcUaJsonEncoder(context, writer);
 
@@ -474,7 +474,7 @@ class OpcUaJsonEncoderTest {
   }
 
   @Test
-  public void writeXmlElement() throws IOException {
+  void encodeXmlElement() throws IOException {
     var writer = new StringWriter();
     var encoder = new OpcUaJsonEncoder(context, writer);
 
@@ -702,7 +702,7 @@ class OpcUaJsonEncoderTest {
   }
 
   @Test
-  public void writeStatusCode() throws IOException {
+  void encodeStatusCode() throws IOException {
     var writer = new StringWriter();
     var encoder = new OpcUaJsonEncoder(context, writer);
 
@@ -767,7 +767,7 @@ class OpcUaJsonEncoderTest {
   }
 
   @Test
-  public void writeQualifiedName() throws IOException {
+  void encodeQualifiedName() throws IOException {
     var writer = new StringWriter();
     var encoder = new OpcUaJsonEncoder(context, writer);
 
@@ -807,7 +807,7 @@ class OpcUaJsonEncoderTest {
   }
 
   @Test
-  public void writeLocalizedText() throws IOException {
+  void encodeLocalizedText() throws IOException {
     var writer = new StringWriter();
     var encoder = new OpcUaJsonEncoder(context, writer);
 
@@ -890,7 +890,7 @@ class OpcUaJsonEncoderTest {
   }
 
   @Test
-  public void writeDataValue() throws IOException {
+  void encodeDataValue() throws IOException {
     var writer = new StringWriter();
     var encoder = new OpcUaJsonEncoder(context, writer);
 
@@ -982,7 +982,7 @@ class OpcUaJsonEncoderTest {
   }
 
   @Test
-  public void writeVariant() {
+  void encodeVariant() {
     var writer = new StringWriter();
     var encoder = new OpcUaJsonEncoder(context, writer);
 
@@ -1073,7 +1073,7 @@ class OpcUaJsonEncoderTest {
   }
 
   @Test
-  public void writeDiagnosticInfo() throws IOException {
+  void encodeDiagnosticInfo() throws IOException {
     var writer = new StringWriter();
     var encoder = new OpcUaJsonEncoder(context, writer);
 
@@ -1125,7 +1125,7 @@ class OpcUaJsonEncoderTest {
   }
 
   @Test
-  public void writeEnum() throws IOException {
+  void encodeEnum() throws IOException {
     var writer = new StringWriter();
     var encoder = new OpcUaJsonEncoder(context, writer);
 
@@ -1214,7 +1214,7 @@ class OpcUaJsonEncoderTest {
   }
 
   @Test
-  public void writeBooleanArray() throws IOException {
+  void encodeBooleanArray() throws IOException {
     var writer = new StringWriter();
     var encoder = new OpcUaJsonEncoder(context, writer);
 

--- a/opc-ua-stack/encoding-json/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoderTest.java
+++ b/opc-ua-stack/encoding-json/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoderTest.java
@@ -1246,7 +1246,7 @@ class OpcUaJsonEncoderTest {
 
     encoder.reset(writer = new StringWriter());
     encoder.encodeEnumMatrix(null, matrix);
-    assertEquals("[[0,1],[2,3]]", writer.toString());
+    assertEquals("{\"Array\":[0,1,2,3],\"Dimensions\":[2,2]}", writer.toString());
   }
 
   @Test
@@ -1265,7 +1265,7 @@ class OpcUaJsonEncoderTest {
     encoder.reset(writer = new StringWriter());
     encoder.encodeStructMatrix(null, matrix, XVType.TYPE_ID);
     assertEquals(
-        "[[{\"Value\":1.0},{\"X\":2.0,\"Value\":3.0}],[{\"X\":4.0,\"Value\":5.0},{\"X\":6.0,\"Value\":7.0}]]",
+        "{\"Array\":[{\"Value\":1.0},{\"X\":2.0,\"Value\":3.0},{\"X\":4.0,\"Value\":5.0},{\"X\":6.0,\"Value\":7.0}],\"Dimensions\":[2,2]}",
         writer.toString());
   }
 

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/ExpandedNodeId.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/ExpandedNodeId.java
@@ -66,11 +66,31 @@ public record ExpandedNodeId(
     }
   }
 
+  public @Nullable UShort getNamespaceIndex(NamespaceTable namespaceTable) {
+    if (namespace instanceof NamespaceIndex index) {
+      return index.namespaceIndex;
+    } else if (namespace instanceof NamespaceReference.NamespaceUri uri) {
+      return namespaceTable.getIndex(uri.namespaceUri);
+    } else {
+      throw new IllegalStateException("NamespaceReference: " + namespace);
+    }
+  }
+
   public @Nullable String getNamespaceUri() {
     if (namespace instanceof NamespaceReference.NamespaceUri uri) {
       return uri.namespaceUri;
     } else {
       return null;
+    }
+  }
+
+  public @Nullable String getNamespaceUri(NamespaceTable namespaceTable) {
+    if (namespace instanceof NamespaceIndex index) {
+      return namespaceTable.get(index.namespaceIndex);
+    } else if (namespace instanceof NamespaceReference.NamespaceUri uri) {
+      return uri.namespaceUri;
+    } else {
+      throw new IllegalStateException("NamespaceReference: " + namespace);
     }
   }
 
@@ -82,11 +102,32 @@ public record ExpandedNodeId(
     }
   }
 
+  public @Nullable UInteger getServerIndex(ServerTable serverTable) {
+    if (server instanceof ServerIndex index) {
+      return index.serverIndex;
+    } else if (server instanceof ServerReference.ServerUri uri) {
+      UShort index = serverTable.getIndex(uri.serverUri);
+      return index != null ? uint(index.intValue()) : null;
+    } else {
+      throw new IllegalStateException("ServerReference: " + server);
+    }
+  }
+
   public @Nullable String getServerUri() {
     if (server instanceof ServerReference.ServerUri uri) {
       return uri.serverUri;
     } else {
       return null;
+    }
+  }
+
+  public @Nullable String getServerUri(ServerTable serverTable) {
+    if (server instanceof ServerIndex index) {
+      return serverTable.get(index.serverIndex.intValue());
+    } else if (server instanceof ServerReference.ServerUri uri) {
+      return uri.serverUri;
+    } else {
+      throw new IllegalStateException("ServerReference: " + server);
     }
   }
 
@@ -269,6 +310,30 @@ public record ExpandedNodeId(
         return Optional.empty();
       }
     }
+  }
+
+  public Optional<ExpandedNodeId> absolute(ServerTable serverTable, NamespaceTable namespaceTable) {
+    ServerReference absoluteServer = server;
+    if (server instanceof ServerIndex index) {
+      String serverUri = serverTable.get(index.serverIndex.intValue());
+      if (serverUri == null) {
+        return Optional.empty();
+      } else {
+        absoluteServer = ServerReference.of(serverUri);
+      }
+    }
+
+    NamespaceReference absoluteNamespace = namespace;
+    if (namespace instanceof NamespaceIndex index) {
+      String namespaceUri = namespaceTable.get(index.namespaceIndex.intValue());
+      if (namespaceUri == null) {
+        return Optional.empty();
+      } else {
+        absoluteNamespace = NamespaceReference.of(namespaceUri);
+      }
+    }
+
+    return Optional.of(new ExpandedNodeId(absoluteServer, absoluteNamespace, identifier));
   }
 
   /**

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/ExpandedNodeId.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/ExpandedNodeId.java
@@ -106,8 +106,7 @@ public record ExpandedNodeId(
     if (server instanceof ServerIndex index) {
       return index.serverIndex;
     } else if (server instanceof ServerReference.ServerUri uri) {
-      UShort index = serverTable.getIndex(uri.serverUri);
-      return index != null ? uint(index.intValue()) : null;
+      return serverTable.getIndex(uri.serverUri);
     } else {
       throw new IllegalStateException("ServerReference: " + server);
     }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/NodeId.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/NodeId.java
@@ -208,6 +208,10 @@ public final class NodeId {
   public ExpandedNodeId expanded(NamespaceTable namespaceTable) {
     String namespaceUri = namespaceTable.get(namespaceIndex);
 
+    if (namespaceUri == null) {
+      throw new IllegalStateException("namespace index=" + namespaceIndex + " not found");
+    }
+
     if (identifier instanceof UInteger id) {
       return ExpandedNodeId.of(namespaceUri, id);
     } else if (identifier instanceof String id) {


### PR DESCRIPTION
The JSON encoding defined in part 6 has been modified after feedback from SDK vendors since `OpcUaJsonEncoder` and `OpcUaJsonDecoder` were implemented. 

Instead of "reversible" and "non-reversible" encodings there is now "verbose" and "compact". Where applicable, the "verbose" encoding eschews numeric references for which the receiving application might not have context and includes symbolic names and URIs when possible.

The types for which the encoding has changed include:
- NodeId
- ExpandedNodeId
- QualifiedName
- StatusCode
- Matrix (multi-dimension array) 
- LocalizedText (always encoded as JSON object)
- ExtensionObject (always encoded as JSON object)
- Variant (always "verbose")