### PR TITLE
Use UInteger for the index type of ServerTable

### DIFF
--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/NamespaceTable.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/NamespaceTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 the Eclipse Milo Authors
+ * Copyright (c) 2025 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -10,10 +10,11 @@
 
 package org.eclipse.milo.opcua.stack.core;
 
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
 import org.eclipse.milo.opcua.stack.core.util.Namespaces;
 
 /** A {@link UriArray} intended to contain Namespace URI entries. */
-public class NamespaceTable extends UriArray {
+public class NamespaceTable extends UriArray<UShort> {
 
   /** Create a {@link NamespaceTable} seeded with {@link Namespaces#OPC_UA} at index 0. */
   public NamespaceTable() {
@@ -32,5 +33,10 @@ public class NamespaceTable extends UriArray {
     for (String uri : uris) {
       add(uri);
     }
+  }
+
+  @Override
+  protected UShort create(Number index) {
+    return UShort.valueOf(index.intValue());
   }
 }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/ServerTable.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/ServerTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 the Eclipse Milo Authors
+ * Copyright (c) 2025 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -10,5 +10,13 @@
 
 package org.eclipse.milo.opcua.stack.core;
 
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+
 /** A {@link UriArray} intended to contain Server URI entries. */
-public class ServerTable extends UriArray {}
+public class ServerTable extends UriArray<UInteger> {
+
+  @Override
+  protected UInteger create(Number index) {
+    return UInteger.valueOf(index.longValue());
+  }
+}

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryEncoder.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryEncoder.java
@@ -10,8 +10,6 @@
 
 package org.eclipse.milo.opcua.stack.core.encoding.binary;
 
-import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
-
 import io.netty.buffer.ByteBuf;
 import java.lang.reflect.Array;
 import java.nio.charset.Charset;
@@ -401,10 +399,8 @@ public class OpcUaBinaryEncoder implements UaEncoder {
     if (server instanceof ServerIndex index) {
       serverIndex = index.serverIndex();
     } else if (server instanceof ServerUri uri) {
-      UShort index = context.getServerTable().getIndex(uri.serverUri());
-      if (index != null) {
-        serverIndex = uint(index.intValue());
-      } else {
+      serverIndex = context.getServerTable().getIndex(uri.serverUri());
+      if (serverIndex == null) {
         throw new UaSerializationException(
             StatusCodes.Bad_EncodingError,
             "server uri not found in server table: " + uri.serverUri());

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/ExpandedNodeId.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/ExpandedNodeId.java
@@ -121,7 +121,7 @@ public record ExpandedNodeId(
     if (server instanceof ServerIndex index) {
       return index.serverIndex.intValue() == 0;
     } else if (server instanceof ServerReference.ServerUri uri) {
-      UShort index = serverTable.getIndex(uri.serverUri);
+      UInteger index = serverTable.getIndex(uri.serverUri);
       return index != null && index.intValue() == 0;
     } else {
       throw new IllegalStateException("ServerReference: " + server);

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/UriArrayTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/UriArrayTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 the Eclipse Milo Authors
+ * Copyright (c) 2025 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -20,9 +20,16 @@ import org.junit.jupiter.api.Test;
 
 class UriArrayTest {
 
+  UriArray<UShort> array =
+      new UriArray<UShort>() {
+        @Override
+        protected UShort create(Number index) {
+          return UShort.valueOf(index.intValue());
+        }
+      };
+
   @Test
   void add() {
-    var array = new UriArray() {};
     assertEquals(0, array.add("foo").intValue());
     assertEquals(1, array.add("bar").intValue());
     // duplicate URI not added twice, returns same index as before
@@ -31,7 +38,6 @@ class UriArrayTest {
 
   @Test
   void get() {
-    var array = new UriArray() {};
     array.add("foo");
     assertEquals("foo", array.get(0));
     array.add("bar");
@@ -40,7 +46,6 @@ class UriArrayTest {
 
   @Test
   void getIndex() {
-    var array = new UriArray() {};
     array.add("foo");
     array.add("bar");
 
@@ -55,7 +60,6 @@ class UriArrayTest {
 
   @Test
   void set() {
-    var array = new UriArray() {};
     array.add("foo");
     array.add("bar");
     assertEquals("bar", array.get(1));
@@ -66,7 +70,6 @@ class UriArrayTest {
 
   @Test
   void update() {
-    var array = new UriArray() {};
     array.add("foo");
     array.add("bar");
     assertEquals("bar", array.get(1));
@@ -77,7 +80,6 @@ class UriArrayTest {
 
   @Test
   void toArray() {
-    var array = new UriArray() {};
     array.add("foo");
     array.add("bar");
     array.add("baz");


### PR DESCRIPTION
Namespace URIs are indexed using UInt16 but server URIs are indexed using UInt32. Modify UriArray to handle different index types and then use the appropriate index type in NamespaceTable and ServerTable.
