### PR TITLE
Remove superfluous encoding ids from method interfaces

### DIFF
--- a/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/ReadWriteCustomDataTypeNodeExample.java
+++ b/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/ReadWriteCustomDataTypeNodeExample.java
@@ -69,10 +69,7 @@ public class ReadWriteCustomDataTypeNodeExample implements ClientExample {
             CustomEnumType.Field1);
     ExtensionObject modifiedXo =
         ExtensionObject.encode(
-            client.getStaticEncodingContext(),
-            modified,
-            xo.getEncodingOrTypeId(),
-            OpcUaDefaultBinaryEncoding.getInstance());
+            client.getStaticEncodingContext(), modified, OpcUaDefaultBinaryEncoding.getInstance());
 
     node.writeValue(new DataValue(new Variant(modifiedXo)));
 

--- a/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/ReadWriteCustomDataTypeNodeExample.java
+++ b/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/ReadWriteCustomDataTypeNodeExample.java
@@ -17,7 +17,6 @@ import org.eclipse.milo.examples.server.types.CustomEnumType;
 import org.eclipse.milo.examples.server.types.CustomStructType;
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
 import org.eclipse.milo.opcua.sdk.client.nodes.UaVariableNode;
-import org.eclipse.milo.opcua.stack.core.encoding.binary.OpcUaDefaultBinaryEncoding;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
@@ -68,8 +67,7 @@ public class ReadWriteCustomDataTypeNodeExample implements ClientExample {
             !decoded.isBaz(),
             CustomEnumType.Field1);
     ExtensionObject modifiedXo =
-        ExtensionObject.encode(
-            client.getStaticEncodingContext(), modified, OpcUaDefaultBinaryEncoding.getInstance());
+        ExtensionObject.encode(client.getStaticEncodingContext(), modified);
 
     node.writeValue(new DataValue(new Variant(modifiedXo)));
 

--- a/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/UnifiedAutomationReadCustomDataTypeExample1.java
+++ b/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/UnifiedAutomationReadCustomDataTypeExample1.java
@@ -146,8 +146,7 @@ public class UnifiedAutomationReadCustomDataTypeExample1 implements ClientExampl
     NodeId binaryEncodingId =
         value.getBinaryEncodingId().toNodeIdOrThrow(client.getNamespaceTable());
 
-    ExtensionObject xo =
-        ExtensionObject.encode(client.getDynamicEncodingContext(), value, binaryEncodingId);
+    ExtensionObject xo = ExtensionObject.encode(client.getDynamicEncodingContext(), value);
 
     return client
         .writeValues(List.of(nodeId), List.of(DataValue.valueOnly(new Variant(xo))))

--- a/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/UnifiedAutomationReadCustomDataTypeExample2.java
+++ b/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/UnifiedAutomationReadCustomDataTypeExample2.java
@@ -157,8 +157,7 @@ public class UnifiedAutomationReadCustomDataTypeExample2 implements ClientExampl
     NodeId binaryEncodingId = value.getDataType().getBinaryEncodingId();
     assert binaryEncodingId != null;
 
-    ExtensionObject xo =
-        ExtensionObject.encode(client.getDynamicEncodingContext(), value, binaryEncodingId);
+    ExtensionObject xo = ExtensionObject.encode(client.getDynamicEncodingContext(), value);
 
     return client
         .writeValues(List.of(nodeId), List.of(DataValue.valueOnly(new Variant(xo))))

--- a/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/UnifiedAutomationReadCustomDataTypeExampleLegacy.java
+++ b/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/UnifiedAutomationReadCustomDataTypeExampleLegacy.java
@@ -96,8 +96,7 @@ public class UnifiedAutomationReadCustomDataTypeExampleLegacy implements ClientE
     NodeId binaryEncodingId = struct.dataType().getBinaryEncodingId();
     assert binaryEncodingId != null;
 
-    ExtensionObject xo =
-        ExtensionObject.encode(client.getDynamicEncodingContext(), struct, binaryEncodingId);
+    ExtensionObject xo = ExtensionObject.encode(client.getDynamicEncodingContext(), struct);
 
     return client
         .writeValues(List.of(nodeId), List.of(DataValue.valueOnly(new Variant(xo))))

--- a/milo-examples/server-examples/src/main/java/org/eclipse/milo/examples/server/ExampleNamespace.java
+++ b/milo-examples/server-examples/src/main/java/org/eclipse/milo/examples/server/ExampleNamespace.java
@@ -1190,8 +1190,7 @@ public class ExampleNamespace extends ManagedNamespaceWithLifecycle {
 
     CustomStructType value = new CustomStructType("foo", uint(42), true, CustomEnumType.Field0);
 
-    ExtensionObject xo =
-        ExtensionObject.encode(getServer().getStaticEncodingContext(), value, binaryEncodingId);
+    ExtensionObject xo = ExtensionObject.encode(getServer().getStaticEncodingContext(), value);
 
     customStructTypeVariable.setValue(new DataValue(new Variant(xo)));
 
@@ -1226,8 +1225,7 @@ public class ExampleNamespace extends ManagedNamespaceWithLifecycle {
 
     CustomUnionType value = CustomUnionType.ofBar("hello");
 
-    ExtensionObject xo =
-        ExtensionObject.encode(getServer().getStaticEncodingContext(), value, binaryEncodingId);
+    ExtensionObject xo = ExtensionObject.encode(getServer().getStaticEncodingContext(), value);
 
     customUnionTypeVariable.setValue(new DataValue(new Variant(xo)));
 
@@ -1287,8 +1285,7 @@ public class ExampleNamespace extends ManagedNamespaceWithLifecycle {
     NodeId binaryEncodingId = dataType.getBinaryEncodingId();
     assert binaryEncodingId != null;
 
-    ExtensionObject xo =
-        ExtensionObject.encode(getServer().getDynamicEncodingContext(), value, binaryEncodingId);
+    ExtensionObject xo = ExtensionObject.encode(getServer().getDynamicEncodingContext(), value);
 
     dynamicStructTypeVariable.setValue(new DataValue(Variant.ofExtensionObject(xo)));
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/subscriptions/Subscription.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/subscriptions/Subscription.java
@@ -509,10 +509,7 @@ public class Subscription {
 
       notificationData.add(
           ExtensionObject.encode(
-              encodingContext,
-              dataChange,
-              dataChange.getBinaryEncodingId(),
-              OpcUaDefaultBinaryEncoding.getInstance()));
+              encodingContext, dataChange, OpcUaDefaultBinaryEncoding.getInstance()));
 
       subscriptionDiagnostics.getDataChangeNotificationsCount().add(dataNotifications.size());
     }
@@ -523,10 +520,7 @@ public class Subscription {
 
       notificationData.add(
           ExtensionObject.encode(
-              encodingContext,
-              eventChange,
-              eventChange.getBinaryEncodingId(),
-              OpcUaDefaultBinaryEncoding.getInstance()));
+              encodingContext, eventChange, OpcUaDefaultBinaryEncoding.getInstance()));
 
       subscriptionDiagnostics.getEventNotificationsCount().add(eventNotifications.size());
     }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/subscriptions/Subscription.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/subscriptions/Subscription.java
@@ -39,7 +39,6 @@ import org.eclipse.milo.opcua.sdk.server.items.BaseMonitoredItem;
 import org.eclipse.milo.opcua.sdk.server.subscriptions.PublishQueue.PendingPublish;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
-import org.eclipse.milo.opcua.stack.core.encoding.binary.OpcUaDefaultBinaryEncoding;
 import org.eclipse.milo.opcua.stack.core.types.UaStructuredType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DiagnosticInfo;
@@ -507,9 +506,7 @@ public class Subscription {
           new DataChangeNotification(
               dataNotifications.toArray(new MonitoredItemNotification[0]), new DiagnosticInfo[0]);
 
-      notificationData.add(
-          ExtensionObject.encode(
-              encodingContext, dataChange, OpcUaDefaultBinaryEncoding.getInstance()));
+      notificationData.add(ExtensionObject.encode(encodingContext, dataChange));
 
       subscriptionDiagnostics.getDataChangeNotificationsCount().add(dataNotifications.size());
     }
@@ -518,9 +515,7 @@ public class Subscription {
       EventNotificationList eventChange =
           new EventNotificationList(eventNotifications.toArray(new EventFieldList[0]));
 
-      notificationData.add(
-          ExtensionObject.encode(
-              encodingContext, eventChange, OpcUaDefaultBinaryEncoding.getInstance()));
+      notificationData.add(ExtensionObject.encode(encodingContext, eventChange));
 
       subscriptionDiagnostics.getEventNotificationsCount().add(eventNotifications.size());
     }

--- a/opc-ua-stack/encoding-json/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaDefaultJsonEncodingTest.java
+++ b/opc-ua-stack/encoding-json/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaDefaultJsonEncodingTest.java
@@ -29,9 +29,9 @@ class OpcUaDefaultJsonEncodingTest {
     var value = new XVType(1.0, 2.0f);
     var encodingId = XVType.JSON_ENCODING_ID.toNodeIdOrThrow(context.getNamespaceTable());
 
-    ExtensionObject encoded = encoding.encode(context, value, encodingId);
+    ExtensionObject encoded = encoding.encode(context, value);
 
-    UaStructuredType decoded = encoding.decode(context, encoded, encodingId);
+    UaStructuredType decoded = encoding.decode(context, encoded);
 
     assertEquals(value, decoded);
   }

--- a/opc-ua-stack/encoding-xml/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlEncoder.java
+++ b/opc-ua-stack/encoding-xml/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlEncoder.java
@@ -636,10 +636,7 @@ public class OpcUaXmlEncoder implements UaEncoder {
                   UaStructuredType structValue = array[i];
                   xos[i] =
                       ExtensionObject.encode(
-                          context,
-                          structValue,
-                          structValue.getXmlEncodingId(),
-                          OpcUaDefaultXmlEncoding.getInstance());
+                          context, structValue, OpcUaDefaultXmlEncoding.getInstance());
                 }
                 encodeBuiltinTypeArrayValue(xos, OpcUaDataType.ExtensionObject);
               }
@@ -701,10 +698,7 @@ public class OpcUaXmlEncoder implements UaEncoder {
               UaStructuredType structValue = (UaStructuredType) value;
               var xo =
                   ExtensionObject.encode(
-                      context,
-                      structValue,
-                      structValue.getXmlEncodingId(),
-                      OpcUaDefaultXmlEncoding.getInstance());
+                      context, structValue, OpcUaDefaultXmlEncoding.getInstance());
               encodeBuiltinTypeValue(xo, OpcUaDataType.ExtensionObject);
             }
             case OPTION_SET -> {
@@ -1896,8 +1890,7 @@ public class OpcUaXmlEncoder implements UaEncoder {
         value.transform(
             e -> {
               UaStructuredType struct = (UaStructuredType) e;
-              return ExtensionObject.encode(
-                  context, struct, dataTypeId, OpcUaDefaultXmlEncoding.getInstance());
+              return ExtensionObject.encode(context, struct, OpcUaDefaultXmlEncoding.getInstance());
             });
 
     encodeMatrix(field, transformed);

--- a/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaDefaultXmlEncodingTest.java
+++ b/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaDefaultXmlEncodingTest.java
@@ -30,9 +30,9 @@ class OpcUaDefaultXmlEncodingTest {
     var value = new XVType(1.0, 2.0f);
     NodeId encodingId = XVType.XML_ENCODING_ID.toNodeIdOrThrow(context.getNamespaceTable());
 
-    ExtensionObject encoded = encoding.encode(context, value, encodingId);
+    ExtensionObject encoded = encoding.encode(context, value);
 
-    UaStructuredType decoded = encoding.decode(context, encoded, encodingId);
+    UaStructuredType decoded = encoding.decode(context, encoded);
 
     assertEquals(value, decoded);
   }

--- a/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/args/ArrayArguments.java
+++ b/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/args/ArrayArguments.java
@@ -730,7 +730,6 @@ public class ArrayArguments {
                   new DefaultEncodingContext(),
                   new Argument(
                       "name", NodeId.parse("i=1"), -1, null, LocalizedText.english("description")),
-                  Argument.XML_ENCODING_ID,
                   OpcUaDefaultXmlEncoding.getInstance()),
               ExtensionObject.encode(
                   new DefaultEncodingContext(),
@@ -740,7 +739,6 @@ public class ArrayArguments {
                       1,
                       new UInteger[] {UInteger.valueOf(1)},
                       LocalizedText.english("description2")),
-                  Argument.XML_ENCODING_ID,
                   OpcUaDefaultXmlEncoding.getInstance())
             },
             """

--- a/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/args/MatrixArguments.java
+++ b/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/args/MatrixArguments.java
@@ -77,7 +77,7 @@ public class MatrixArguments {
               <uax:Elements>
                 <uax:ExtensionObject>
                   <uax:TypeId>
-                    <uax:Identifier>i=12080</uax:Identifier>
+                    <uax:Identifier>i=12082</uax:Identifier>
                   </uax:TypeId>
                   <uax:Body>
                     <XVType>
@@ -88,7 +88,7 @@ public class MatrixArguments {
                 </uax:ExtensionObject>
                 <uax:ExtensionObject>
                   <uax:TypeId>
-                    <uax:Identifier>i=12080</uax:Identifier>
+                    <uax:Identifier>i=12082</uax:Identifier>
                   </uax:TypeId>
                   <uax:Body>
                     <XVType>
@@ -99,7 +99,7 @@ public class MatrixArguments {
                 </uax:ExtensionObject>
                 <uax:ExtensionObject>
                   <uax:TypeId>
-                    <uax:Identifier>i=12080</uax:Identifier>
+                    <uax:Identifier>i=12082</uax:Identifier>
                   </uax:TypeId>
                   <uax:Body>
                     <XVType>
@@ -110,7 +110,7 @@ public class MatrixArguments {
                 </uax:ExtensionObject>
                 <uax:ExtensionObject>
                   <uax:TypeId>
-                    <uax:Identifier>i=12080</uax:Identifier>
+                    <uax:Identifier>i=12082</uax:Identifier>
                   </uax:TypeId>
                   <uax:Body>
                     <XVType>
@@ -1206,24 +1206,20 @@ public class MatrixArguments {
                     ExtensionObject.encode(
                         DefaultEncodingContext.INSTANCE,
                         new XVType(1.0, 2.0f),
-                        XVType.TYPE_ID,
                         OpcUaDefaultXmlEncoding.getInstance()),
                     ExtensionObject.encode(
                         DefaultEncodingContext.INSTANCE,
                         new XVType(3.0, 4.0f),
-                        XVType.TYPE_ID,
                         OpcUaDefaultXmlEncoding.getInstance())
                   },
                   {
                     ExtensionObject.encode(
                         DefaultEncodingContext.INSTANCE,
                         new XVType(5.0, 6.0f),
-                        XVType.TYPE_ID,
                         OpcUaDefaultXmlEncoding.getInstance()),
                     ExtensionObject.encode(
                         DefaultEncodingContext.INSTANCE,
                         new XVType(7.0, 8.0f),
-                        XVType.TYPE_ID,
                         OpcUaDefaultXmlEncoding.getInstance())
                   }
                 }),
@@ -1237,7 +1233,7 @@ public class MatrixArguments {
               <uax:Elements>
                 <uax:ExtensionObject>
                   <uax:TypeId>
-                    <uax:Identifier>i=12080</uax:Identifier>
+                    <uax:Identifier>i=12082</uax:Identifier>
                   </uax:TypeId>
                   <uax:Body>
                     <XVType>
@@ -1248,7 +1244,7 @@ public class MatrixArguments {
                 </uax:ExtensionObject>
                 <uax:ExtensionObject>
                   <uax:TypeId>
-                    <uax:Identifier>i=12080</uax:Identifier>
+                    <uax:Identifier>i=12082</uax:Identifier>
                   </uax:TypeId>
                   <uax:Body>
                     <XVType>
@@ -1259,7 +1255,7 @@ public class MatrixArguments {
                 </uax:ExtensionObject>
                 <uax:ExtensionObject>
                   <uax:TypeId>
-                    <uax:Identifier>i=12080</uax:Identifier>
+                    <uax:Identifier>i=12082</uax:Identifier>
                   </uax:TypeId>
                   <uax:Body>
                     <XVType>
@@ -1270,7 +1266,7 @@ public class MatrixArguments {
                 </uax:ExtensionObject>
                 <uax:ExtensionObject>
                   <uax:TypeId>
-                    <uax:Identifier>i=12080</uax:Identifier>
+                    <uax:Identifier>i=12082</uax:Identifier>
                   </uax:TypeId>
                   <uax:Body>
                     <XVType>

--- a/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/args/ScalarArguments.java
+++ b/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/args/ScalarArguments.java
@@ -541,7 +541,6 @@ public class ScalarArguments {
             ExtensionObject.encode(
                 new DefaultEncodingContext(),
                 new XVType(1.0, 2.0f),
-                XVType.XML_ENCODING_ID,
                 OpcUaDefaultXmlEncoding.getInstance()),
             """
             <Test xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd"
@@ -562,7 +561,6 @@ public class ScalarArguments {
             ExtensionObject.encode(
                 new DefaultEncodingContext(),
                 new XVType(1.0, 2.0f),
-                XVType.BINARY_ENCODING_ID,
                 OpcUaDefaultBinaryEncoding.getInstance()),
             """
             <Test xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd">

--- a/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/args/VariantArguments.java
+++ b/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/args/VariantArguments.java
@@ -295,7 +295,6 @@ public class VariantArguments {
                         -1,
                         null,
                         LocalizedText.english("description")),
-                    Argument.XML_ENCODING_ID,
                     OpcUaDefaultXmlEncoding.getInstance())),
             """
             <Test xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd"
@@ -840,7 +839,6 @@ public class VariantArguments {
                           -1,
                           null,
                           LocalizedText.english("description")),
-                      Argument.XML_ENCODING_ID,
                       OpcUaDefaultXmlEncoding.getInstance()),
                   ExtensionObject.encode(
                       new DefaultEncodingContext(),
@@ -850,7 +848,6 @@ public class VariantArguments {
                           -1,
                           null,
                           LocalizedText.english("description")),
-                      Argument.XML_ENCODING_ID,
                       OpcUaDefaultXmlEncoding.getInstance())
                 }),
             """
@@ -1746,7 +1743,7 @@ public class VariantArguments {
                   <uax:Elements>
                     <uax:ExtensionObject>
                       <uax:TypeId>
-                        <uax:Identifier>i=12080</uax:Identifier>
+                        <uax:Identifier>i=12082</uax:Identifier>
                       </uax:TypeId>
                       <uax:Body>
                         <XVType>
@@ -1757,7 +1754,7 @@ public class VariantArguments {
                     </uax:ExtensionObject>
                     <uax:ExtensionObject>
                       <uax:TypeId>
-                        <uax:Identifier>i=12080</uax:Identifier>
+                        <uax:Identifier>i=12082</uax:Identifier>
                       </uax:TypeId>
                       <uax:Body>
                         <XVType>
@@ -1768,7 +1765,7 @@ public class VariantArguments {
                     </uax:ExtensionObject>
                     <uax:ExtensionObject>
                       <uax:TypeId>
-                        <uax:Identifier>i=12080</uax:Identifier>
+                        <uax:Identifier>i=12082</uax:Identifier>
                       </uax:TypeId>
                       <uax:Body>
                         <XVType>
@@ -1779,7 +1776,7 @@ public class VariantArguments {
                     </uax:ExtensionObject>
                     <uax:ExtensionObject>
                       <uax:TypeId>
-                        <uax:Identifier>i=12080</uax:Identifier>
+                        <uax:Identifier>i=12082</uax:Identifier>
                       </uax:TypeId>
                       <uax:Body>
                         <XVType>

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/DataTypeEncoding.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/DataTypeEncoding.java
@@ -12,7 +12,6 @@ package org.eclipse.milo.opcua.stack.core.types;
 
 import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
-import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
 
 public interface DataTypeEncoding {
@@ -28,7 +27,7 @@ public interface DataTypeEncoding {
 
   QualifiedName getEncodingName();
 
-  ExtensionObject encode(EncodingContext context, UaStructuredType struct, NodeId encodingId);
+  ExtensionObject encode(EncodingContext context, UaStructuredType struct);
 
-  UaStructuredType decode(EncodingContext context, ExtensionObject encoded, NodeId encodingId);
+  UaStructuredType decode(EncodingContext context, ExtensionObject encoded);
 }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/ExtensionObject.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/ExtensionObject.java
@@ -63,11 +63,11 @@ public abstract sealed class ExtensionObject
   public abstract boolean isNull();
 
   /**
-   * Decode the value contained in this ExtensionObject using the datatype encoding that matches its
-   * body type.
+   * Decode the {@link UaStructuredType} value contained in this ExtensionObject using the datatype
+   * encoding that matches its body type.
    *
    * @param context an {@link EncodingContext}.
-   * @return the decoded value.
+   * @return the decoded {@link UaStructuredType} value.
    * @throws UaSerializationException if the decoding fails.
    */
   public final UaStructuredType decode(EncodingContext context) throws UaSerializationException {
@@ -102,12 +102,12 @@ public abstract sealed class ExtensionObject
   }
 
   /**
-   * Decode the value contained in this ExtensionObject using the specified encoding, if it hasn't
-   * already been decoded.
+   * Decode the {@link UaStructuredType} value contained in this ExtensionObject using the specified
+   * encoding, if it hasn't already been decoded.
    *
    * @param context an {@link EncodingContext}.
    * @param encoding the {@link DataTypeEncoding} to use.
-   * @return the decoded value.
+   * @return the decoded {@link UaStructuredType} value.
    * @throws UaSerializationException if the decoding fails.
    */
   public final UaStructuredType decode(EncodingContext context, DataTypeEncoding encoding)
@@ -212,10 +212,10 @@ public abstract sealed class ExtensionObject
   }
 
   /**
-   * Encode a value in the specified datatype encoding.
+   * Encode a {@link UaStructuredType} value in the specified datatype encoding.
    *
    * @param context an {@link EncodingContext}.
-   * @param struct the value to encode.
+   * @param struct the {@link UaStructuredType} value to encode.
    * @param encoding the {@link DataTypeEncoding} to use.
    * @return an {@link ExtensionObject} containing the encoded value.
    * @throws UaSerializationException if the encoding fails.

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/ExtensionObject.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/ExtensionObject.java
@@ -113,7 +113,7 @@ public abstract sealed class ExtensionObject
   public final UaStructuredType decode(EncodingContext context, DataTypeEncoding encoding)
       throws UaSerializationException {
 
-    return decoded.get(() -> encoding.decode(context, this, getEncodingOrTypeId()));
+    return decoded.get(() -> encoding.decode(context, this));
   }
 
   /**
@@ -136,7 +136,7 @@ public abstract sealed class ExtensionObject
     try {
       UaStructuredType decoded = decode(context);
 
-      return newEncoding.encode(context, decoded, newEncodingId);
+      return newEncoding.encode(context, decoded);
     } catch (UaSerializationException e) {
       LoggerFactory.getLogger(ExtensionObject.class)
           .warn("Transcoding failed: {}", e.getMessage(), e);
@@ -178,30 +178,6 @@ public abstract sealed class ExtensionObject
   }
 
   /**
-   * Encode a {@link UaStructuredType} value in the default binary encoding.
-   *
-   * @param context an {@link EncodingContext}.
-   * @param value the {@link UaStructuredType} value to encode.
-   * @return an {@link ExtensionObject} containing the encoded value.
-   * @throws UaSerializationException if the encoding fails.
-   */
-  public static ExtensionObject encode(EncodingContext context, UaStructuredType value)
-      throws UaSerializationException {
-
-    NodeId encodingId =
-        value
-            .getBinaryEncodingId()
-            .toNodeId(context.getNamespaceTable())
-            .orElseThrow(
-                () ->
-                    new UaSerializationException(
-                        StatusCodes.Bad_EncodingError,
-                        "namespace not registered: " + value.getBinaryEncodingId().namespace()));
-
-    return encode(context, value, encodingId, OpcUaDefaultBinaryEncoding.getInstance());
-  }
-
-  /**
    * Encode an array of {@link UaStructuredType} values in the default binary encoding.
    *
    * @param context an {@link EncodingContext}.
@@ -222,19 +198,17 @@ public abstract sealed class ExtensionObject
   }
 
   /**
-   * Encode a value in the default binary encoding.
+   * Encode a {@link UaStructuredType} value in the default binary encoding.
    *
    * @param context an {@link EncodingContext}.
-   * @param value the value to encode.
-   * @param encodingId the {@link NodeId} of the binary datatype encoding.
+   * @param value the {@link UaStructuredType} value to encode.
    * @return an {@link ExtensionObject} containing the encoded value.
    * @throws UaSerializationException if the encoding fails.
    */
-  public static ExtensionObject encode(
-      EncodingContext context, UaStructuredType value, NodeId encodingId)
+  public static ExtensionObject encode(EncodingContext context, UaStructuredType value)
       throws UaSerializationException {
 
-    return encodeBinary(context, value, encodingId, OpcUaDefaultBinaryEncoding.getInstance());
+    return encodeBinary(context, value, OpcUaDefaultBinaryEncoding.getInstance());
   }
 
   /**
@@ -242,86 +216,45 @@ public abstract sealed class ExtensionObject
    *
    * @param context an {@link EncodingContext}.
    * @param struct the value to encode.
-   * @param encodingOrTypeId the {@link NodeId} the datatype encoding if using Binary or XML
-   *     encoding, or the {@link NodeId} of the datatype if using JSON encoding.
    * @param encoding the {@link DataTypeEncoding} to use.
    * @return an {@link ExtensionObject} containing the encoded value.
    * @throws UaSerializationException if the encoding fails.
    */
   public static ExtensionObject encode(
-      EncodingContext context,
-      UaStructuredType struct,
-      NodeId encodingOrTypeId,
-      DataTypeEncoding encoding)
+      EncodingContext context, UaStructuredType struct, DataTypeEncoding encoding)
       throws UaSerializationException {
 
     if (encoding.getEncodingName().equals(DataTypeEncoding.BINARY_ENCODING_NAME)) {
-      return encodeBinary(context, struct, encodingOrTypeId, encoding);
+      return encodeBinary(context, struct, encoding);
     } else if (encoding.getEncodingName().equals(DataTypeEncoding.XML_ENCODING_NAME)) {
-      return encodeXml(context, struct, encodingOrTypeId, encoding);
+      return encodeXml(context, struct, encoding);
     } else if (encoding.getEncodingName().equals(DataTypeEncoding.JSON_ENCODING_NAME)) {
-      return encodeJson(context, struct, encodingOrTypeId, encoding);
+      return encodeJson(context, struct, encoding);
     } else {
       throw new UaSerializationException(
           StatusCodes.Bad_EncodingError, "unsupported encoding: " + encoding.getEncodingName());
     }
   }
 
-  /**
-   * Encode a value in the specified datatype encoding.
-   *
-   * @param context an {@link EncodingContext}.
-   * @param struct the value to encode.
-   * @param encodingOrTypeId the {@link ExpandedNodeId} the datatype encoding if using Binary or XML
-   *     encoding, or the {@link ExpandedNodeId} of the datatype if using JSON encoding.
-   * @param encoding the {@link DataTypeEncoding} to use.
-   * @return an {@link ExtensionObject} containing the encoded value.
-   * @throws UaSerializationException if the encoding fails.
-   */
-  public static ExtensionObject encode(
-      EncodingContext context,
-      UaStructuredType struct,
-      ExpandedNodeId encodingOrTypeId,
-      DataTypeEncoding encoding)
-      throws UaSerializationException {
-
-    NodeId localEncodingOrTypeId =
-        encodingOrTypeId
-            .toNodeId(context.getNamespaceTable())
-            .orElseThrow(
-                () ->
-                    new UaSerializationException(
-                        StatusCodes.Bad_EncodingError,
-                        "namespace not registered: " + encodingOrTypeId.namespace()));
-
-    return encode(context, struct, localEncodingOrTypeId, encoding);
-  }
-
   private static ExtensionObject encodeBinary(
-      EncodingContext context,
-      UaStructuredType struct,
-      NodeId encodingId,
-      DataTypeEncoding encoding)
+      EncodingContext context, UaStructuredType struct, DataTypeEncoding encoding)
       throws UaSerializationException {
 
-    return encoding.encode(context, struct, encodingId);
+    return encoding.encode(context, struct);
   }
 
   private static ExtensionObject encodeXml(
-      EncodingContext context,
-      UaStructuredType struct,
-      NodeId encodingId,
-      DataTypeEncoding encoding)
+      EncodingContext context, UaStructuredType struct, DataTypeEncoding encoding)
       throws UaSerializationException {
 
-    return encoding.encode(context, struct, encodingId);
+    return encoding.encode(context, struct);
   }
 
   private static ExtensionObject encodeJson(
-      EncodingContext context, UaStructuredType struct, NodeId typeId, DataTypeEncoding encoding)
+      EncodingContext context, UaStructuredType struct, DataTypeEncoding encoding)
       throws UaSerializationException {
 
-    return encoding.encode(context, struct, typeId);
+    return encoding.encode(context, struct);
   }
 
   /** An ExtensionObject that contains a {@link ByteString} body, used with Binary encoding. */

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaDefaultBinaryEncodingTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaDefaultBinaryEncodingTest.java
@@ -30,9 +30,9 @@ class OpcUaDefaultBinaryEncodingTest {
     var value = new XVType(1.0, 2.0f);
     NodeId encodingId = XVType.XML_ENCODING_ID.toNodeIdOrThrow(context.getNamespaceTable());
 
-    ExtensionObject encoded = encoding.encode(context, value, encodingId);
+    ExtensionObject encoded = encoding.encode(context, value);
 
-    UaStructuredType decoded = encoding.decode(context, encoded, encodingId);
+    UaStructuredType decoded = encoding.decode(context, encoded);
 
     assertEquals(value, decoded);
   }


### PR DESCRIPTION
The encode/decode methods on `DataTypeEncoding` and `ExtensionObject` no longer need to supply encoding/type NodeIds because they are implicitly available from either the `UaStructureType` being encoded or the `ExtensionObject` being decoded.
