### PR TITLE
DataType and XML Encoding Corner Cases

### DIFF
--- a/opc-ua-sdk/codec-json/src/main/java/org/eclipse/milo/sdk/core/types/json/JsonStruct.java
+++ b/opc-ua-sdk/codec-json/src/main/java/org/eclipse/milo/sdk/core/types/json/JsonStruct.java
@@ -42,7 +42,7 @@ public class JsonStruct implements UaStructuredType {
   }
 
   @Override
-  public String getEncodingName() {
+  public String getTypeName() {
     return dataType.getBrowseName().name();
   }
 

--- a/opc-ua-sdk/dtd-core/src/main/java/org/eclipse/milo/opcua/sdk/core/dtd/BsdStructWrapper.java
+++ b/opc-ua-sdk/dtd-core/src/main/java/org/eclipse/milo/opcua/sdk/core/dtd/BsdStructWrapper.java
@@ -37,7 +37,7 @@ public record BsdStructWrapper<T>(DataType dataType, T object) implements UaStru
   }
 
   @Override
-  public String getEncodingName() {
+  public String getTypeName() {
     return dataType.getBrowseName().getName();
   }
 }

--- a/opc-ua-sdk/sdk-core/src/main/java/org/eclipse/milo/opcua/sdk/core/types/DynamicType.java
+++ b/opc-ua-sdk/sdk-core/src/main/java/org/eclipse/milo/opcua/sdk/core/types/DynamicType.java
@@ -23,7 +23,7 @@ public abstract sealed class DynamicType implements UaDataType
     permits DynamicEnumType, DynamicOptionSetType, DynamicStructType, DynamicUnionType {
 
   @Override
-  public String getEncodingName() {
+  public String getTypeName() {
     return Objects.requireNonNull(getDataType().getBrowseName().name());
   }
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/namespaces/loader/DataTypeNodeLoader.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/namespaces/loader/DataTypeNodeLoader.java
@@ -1282,7 +1282,7 @@ class DataTypeNodeLoader {
         new UaDataTypeNode(
             this.context,
             new NodeId(0, 18808),
-            new QualifiedName(0, "ThreeDVector"),
+            new QualifiedName(0, "3DVector"),
             new LocalizedText("", "3DVector"),
             LocalizedText.NULL_VALUE,
             UInteger.valueOf(0),
@@ -1324,7 +1324,7 @@ class DataTypeNodeLoader {
         new UaDataTypeNode(
             this.context,
             new NodeId(0, 18810),
-            new QualifiedName(0, "ThreeDCartesianCoordinates"),
+            new QualifiedName(0, "3DCartesianCoordinates"),
             new LocalizedText("", "3DCartesianCoordinates"),
             LocalizedText.NULL_VALUE,
             UInteger.valueOf(0),
@@ -1366,7 +1366,7 @@ class DataTypeNodeLoader {
         new UaDataTypeNode(
             this.context,
             new NodeId(0, 18812),
-            new QualifiedName(0, "ThreeDOrientation"),
+            new QualifiedName(0, "3DOrientation"),
             new LocalizedText("", "3DOrientation"),
             LocalizedText.NULL_VALUE,
             UInteger.valueOf(0),
@@ -1408,7 +1408,7 @@ class DataTypeNodeLoader {
         new UaDataTypeNode(
             this.context,
             new NodeId(0, 18814),
-            new QualifiedName(0, "ThreeDFrame"),
+            new QualifiedName(0, "3DFrame"),
             new LocalizedText("", "3DFrame"),
             LocalizedText.NULL_VALUE,
             UInteger.valueOf(0),

--- a/opc-ua-stack/encoding-xml/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaDefaultXmlEncoding.java
+++ b/opc-ua-stack/encoding-xml/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaDefaultXmlEncoding.java
@@ -10,6 +10,8 @@
 
 package org.eclipse.milo.opcua.stack.core.encoding.xml;
 
+import static org.eclipse.milo.opcua.stack.core.encoding.xml.XmlSerializationUtil.encodeXmlName;
+
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -62,7 +64,7 @@ public class OpcUaDefaultXmlEncoding implements DataTypeEncoding {
 
     OpcUaXmlEncoder encoder = new OpcUaXmlEncoder(context);
 
-    encoder.encodeStruct(struct.getTypeName(), struct, codec);
+    encoder.encodeStruct(encodeXmlName(struct.getTypeName()), struct, codec);
 
     return ExtensionObject.of(XmlElement.of(encoder.getDocumentXml()), encodingId);
   }

--- a/opc-ua-stack/encoding-xml/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaDefaultXmlEncoding.java
+++ b/opc-ua-stack/encoding-xml/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaDefaultXmlEncoding.java
@@ -62,7 +62,7 @@ public class OpcUaDefaultXmlEncoding implements DataTypeEncoding {
 
     OpcUaXmlEncoder encoder = new OpcUaXmlEncoder(context);
 
-    encoder.encodeStruct(struct.getEncodingName(), struct, codec);
+    encoder.encodeStruct(struct.getTypeName(), struct, codec);
 
     return ExtensionObject.of(XmlElement.of(encoder.getDocumentXml()), encodingId);
   }

--- a/opc-ua-stack/encoding-xml/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaDefaultXmlEncoding.java
+++ b/opc-ua-stack/encoding-xml/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaDefaultXmlEncoding.java
@@ -10,8 +10,6 @@
 
 package org.eclipse.milo.opcua.stack.core.encoding.xml;
 
-import static org.eclipse.milo.opcua.stack.core.encoding.xml.XmlSerializationUtil.encodeXmlName;
-
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -64,7 +62,11 @@ public class OpcUaDefaultXmlEncoding implements DataTypeEncoding {
 
     OpcUaXmlEncoder encoder = new OpcUaXmlEncoder(context);
 
-    encoder.encodeStruct(encodeXmlName(struct.getTypeName()), struct, codec);
+    String xmlName =
+        OpcUaXmlEncoder.getXmlName(
+            OpcUaXmlEncoder.getNamespaceUri(context, struct.getTypeId()), struct);
+
+    encoder.encodeStruct(xmlName, struct, codec);
 
     return ExtensionObject.of(XmlElement.of(encoder.getDocumentXml()), encodingId);
   }

--- a/opc-ua-stack/encoding-xml/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlEncoder.java
+++ b/opc-ua-stack/encoding-xml/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlEncoder.java
@@ -1513,7 +1513,7 @@ public class OpcUaXmlEncoder implements UaEncoder {
           namespaceStack.push(namespaceUri);
 
           for (UaEnumeratedType element : value) {
-            encodeEnum(element.getEncodingName(), element);
+            encodeEnum(element.getTypeName(), element);
           }
 
           namespaceStack.pop();
@@ -1545,7 +1545,7 @@ public class OpcUaXmlEncoder implements UaEncoder {
 
         assert values != null;
         for (UaStructuredType v : values) {
-          String typeName = v.getEncodingName();
+          String typeName = v.getTypeName();
           encodeStruct(typeName, v, dataTypeId);
         }
 
@@ -1849,7 +1849,7 @@ public class OpcUaXmlEncoder implements UaEncoder {
 
             namespaceStack.push(namespaceUri);
 
-            encodeEnum(element.getEncodingName(), element);
+            encodeEnum(element.getTypeName(), element);
 
             namespaceStack.pop();
           }

--- a/opc-ua-stack/encoding-xml/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlEncoder.java
+++ b/opc-ua-stack/encoding-xml/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlEncoder.java
@@ -10,6 +10,8 @@
 
 package org.eclipse.milo.opcua.stack.core.encoding.xml;
 
+import static org.eclipse.milo.opcua.stack.core.encoding.xml.XmlSerializationUtil.encodeXmlName;
+
 import jakarta.xml.bind.DatatypeConverter;
 import java.io.StringWriter;
 import java.util.ArrayDeque;
@@ -1513,7 +1515,7 @@ public class OpcUaXmlEncoder implements UaEncoder {
           namespaceStack.push(namespaceUri);
 
           for (UaEnumeratedType element : value) {
-            encodeEnum(element.getTypeName(), element);
+            encodeEnum(encodeXmlName(element.getTypeName()), element);
           }
 
           namespaceStack.pop();
@@ -1545,8 +1547,7 @@ public class OpcUaXmlEncoder implements UaEncoder {
 
         assert values != null;
         for (UaStructuredType v : values) {
-          String typeName = v.getTypeName();
-          encodeStruct(typeName, v, dataTypeId);
+          encodeStruct(encodeXmlName(v.getTypeName()), v, dataTypeId);
         }
 
         namespaceStack.pop();
@@ -1849,7 +1850,7 @@ public class OpcUaXmlEncoder implements UaEncoder {
 
             namespaceStack.push(namespaceUri);
 
-            encodeEnum(element.getTypeName(), element);
+            encodeEnum(encodeXmlName(element.getTypeName()), element);
 
             namespaceStack.pop();
           }

--- a/opc-ua-stack/encoding-xml/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlEncoder.java
+++ b/opc-ua-stack/encoding-xml/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlEncoder.java
@@ -67,9 +67,7 @@ public class OpcUaXmlEncoder implements UaEncoder {
 
       String[] namespaces = context.getNamespaceTable().toArray();
       for (int i = 0; i < namespaces.length; i++) {
-        if (i == 0) {
-          xmlStreamWriter.setPrefix("ua", Namespaces.OPC_UA);
-        } else {
+        if (i > 0) {
           xmlStreamWriter.setPrefix("ns" + i, namespaces[i]);
         }
       }

--- a/opc-ua-stack/encoding-xml/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/xml/XmlSerializationUtil.java
+++ b/opc-ua-stack/encoding-xml/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/xml/XmlSerializationUtil.java
@@ -22,6 +22,55 @@ class XmlSerializationUtil {
 
   private XmlSerializationUtil() {}
 
+  /**
+   * Encodes a DataType Name or Structure Field Name for use in XML DataEncoding.
+   *
+   * <p>The rules applied are:
+   *
+   * <ol>
+   *   <li>Any character that is not a Unicode Letter, Digit, '_', '-', or '.' is replaced by '_'.
+   *   <li>If the resulting name starts with a character that is not a Unicode Letter, or if it
+   *       starts with "xml" (case-insensitive), an underscore '_' is prepended.
+   * </ol>
+   *
+   * @param name the original name string.
+   * @return the encoded name string, modified according to the rules if necessary.
+   */
+  static String encodeXmlName(String name) {
+    if (name == null || name.isEmpty()) {
+      return name;
+    }
+
+    var sb = new StringBuilder(name.length());
+
+    // Rule 1: Replace characters not permitted by the XML DataEncoding
+
+    for (int i = 0; i < name.length(); i++) {
+      char c = name.charAt(i);
+
+      // Allowed characters are: Unicode Letters, Digits, '_', '-', '.'
+      if (Character.isLetter(c) || Character.isDigit(c) || c == '_' || c == '-' || c == '.') {
+        sb.append(c);
+      } else {
+        // Replace non-permitted characters with an underscore
+        sb.append('_');
+      }
+    }
+
+    // Rule 2: Add prefix if the first character is not valid or if it starts with "xml"
+    // (case-insensitive)
+
+    String encoded = sb.toString();
+
+    if (!encoded.isEmpty() && !Character.isLetter(encoded.charAt(0))) {
+      return "_" + encoded;
+    } else if (encoded.length() >= 3 && encoded.substring(0, 3).equalsIgnoreCase("xml")) {
+      return "_" + encoded;
+    } else {
+      return encoded;
+    }
+  }
+
   static void writeXmlFragment(XMLStreamWriter writer, String xmlFragment)
       throws XMLStreamException {
 

--- a/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaDefaultXmlEncodingTest.java
+++ b/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaDefaultXmlEncodingTest.java
@@ -16,7 +16,6 @@ import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
 import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
 import org.eclipse.milo.opcua.stack.core.types.UaStructuredType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
-import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.structured.XVType;
 import org.junit.jupiter.api.Test;
 
@@ -28,7 +27,6 @@ class OpcUaDefaultXmlEncodingTest {
     OpcUaDefaultXmlEncoding encoding = OpcUaDefaultXmlEncoding.getInstance();
 
     var value = new XVType(1.0, 2.0f);
-    NodeId encodingId = XVType.XML_ENCODING_ID.toNodeIdOrThrow(context.getNamespaceTable());
 
     ExtensionObject encoded = encoding.encode(context, value);
 

--- a/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlEncoderTest.java
+++ b/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlEncoderTest.java
@@ -58,7 +58,7 @@ class OpcUaXmlEncoderTest {
     var expected =
 """
 <Test xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ua="http://opcfoundation.org/UA/">
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <uax:Value>
     <uax:ExtensionObject>
       <uax:TypeId>

--- a/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlEncoderTest.java
+++ b/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlEncoderTest.java
@@ -65,11 +65,11 @@ class OpcUaXmlEncoderTest {
         <uax:Identifier>i=18853</uax:Identifier>
       </uax:TypeId>
       <uax:Body>
-        <ua:_3DVector>
-          <ua:X>1.0</ua:X>
-          <ua:Y>2.0</ua:Y>
-          <ua:Z>3.0</ua:Z>
-        </ua:_3DVector>
+        <uax:ThreeDVector>
+          <uax:X>1.0</uax:X>
+          <uax:Y>2.0</uax:Y>
+          <uax:Z>3.0</uax:Z>
+        </uax:ThreeDVector>
       </uax:Body>
     </uax:ExtensionObject>
   </uax:Value>

--- a/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlEncoderTest.java
+++ b/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlEncoderTest.java
@@ -58,21 +58,21 @@ class OpcUaXmlEncoderTest {
     var expected =
 """
 <Test xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ua="http://opcfoundation.org/UA/">
-    <uax:Value>
-        <uax:ExtensionObject>
-            <uax:TypeId>
-                <uax:Identifier>i=18853</uax:Identifier>
-            </uax:TypeId>
-            <uax:Body>
-                <_3DVector>
-                    <ua:X>1.0</ua:X>
-                    <ua:Y>2.0</ua:Y>
-                    <ua:Z>3.0</ua:Z>
-                </_3DVector>
-            </uax:Body>
-        </uax:ExtensionObject>
-    </uax:Value>
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ua="http://opcfoundation.org/UA/">
+  <uax:Value>
+    <uax:ExtensionObject>
+      <uax:TypeId>
+        <uax:Identifier>i=18853</uax:Identifier>
+      </uax:TypeId>
+      <uax:Body>
+        <ua:_3DVector>
+          <ua:X>1.0</ua:X>
+          <ua:Y>2.0</ua:Y>
+          <ua:Z>3.0</ua:Z>
+        </ua:_3DVector>
+      </uax:Body>
+    </uax:ExtensionObject>
+  </uax:Value>
 </Test>
 """;
 

--- a/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/XmlSerializationUtilTest.java
+++ b/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/XmlSerializationUtilTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2025 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.core.encoding.xml;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class XmlSerializationUtilTest {
+
+  @ParameterizedTest
+  @MethodSource("encodeXmlNameTestCases")
+  void encodeXmlName(String name, String expected) {
+    assertEquals(expected, XmlSerializationUtil.encodeXmlName(name));
+  }
+
+  static Stream<Arguments> encodeXmlNameTestCases() {
+    return Stream.of(
+        Arguments.of("Hello", "Hello"),
+        // Starts with allowed char '_', but not a <letter>
+        Arguments.of("_Hello", "__Hello"),
+        // Starts with Digit
+        Arguments.of("3DHello", "_3DHello"),
+        // Starts with Unicode Letter
+        Arguments.of("冷水", "冷水"),
+        // Starts with Digit, contains spaces, parentheses, CJK period
+        Arguments.of("3 (冷水。)-Hello", "_3__冷水__-Hello"),
+        // Starts with xml (lowercase)
+        Arguments.of("xmlStarts", "_xmlStarts"),
+        // Starts with Xml (mixed case)
+        Arguments.of("XmlStarts", "_XmlStarts"),
+        // Starts with XML (uppercase)
+        Arguments.of("XMLStarts", "_XMLStarts"),
+        // Contains allowed special chars
+        Arguments.of("a-b.c_d", "a-b.c_d"),
+        // Contains spaces
+        Arguments.of(" space ", "__space_"),
+        // Invalid chars
+        Arguments.of("???", "____"),
+        // Starts with allowed char '-', but not a <letter>
+        Arguments.of("-HyphenStart", "_-HyphenStart"));
+  }
+}

--- a/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/args/ArrayArguments.java
+++ b/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/args/ArrayArguments.java
@@ -743,7 +743,7 @@ public class ArrayArguments {
             },
             """
             <Test xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd"
-              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ua="http://opcfoundation.org/UA/">
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
               <uax:ExtensionObject>
                 <uax:TypeId>
                   <uax:Identifier>i=297</uax:Identifier>
@@ -918,7 +918,7 @@ public class ArrayArguments {
             new UaEnumeratedType[] {BrowseDirection.Forward, BrowseDirection.Inverse},
             """
             <Test xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd"
-              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ua="http://opcfoundation.org/UA/">
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
               <uax:BrowseDirection>Forward_0</uax:BrowseDirection>
               <uax:BrowseDirection>Inverse_1</uax:BrowseDirection>
             </Test>
@@ -944,7 +944,7 @@ public class ArrayArguments {
             },
             """
             <Test xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd"
-              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ua="http://opcfoundation.org/UA/">
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
               <uax:XVType>
                 <uax:X>1.0</uax:X>
                 <uax:Value>2.0</uax:Value>

--- a/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/args/ArrayArguments.java
+++ b/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/args/ArrayArguments.java
@@ -749,7 +749,7 @@ public class ArrayArguments {
                   <uax:Identifier>i=297</uax:Identifier>
                 </uax:TypeId>
                 <uax:Body>
-                  <Argument>
+                  <ua:Argument>
                     <ua:Name>name</ua:Name>
                     <ua:DataType>
                       <uax:Identifier>i=1</uax:Identifier>
@@ -760,7 +760,7 @@ public class ArrayArguments {
                       <uax:Locale>en</uax:Locale>
                       <uax:Text>description</uax:Text>
                     </ua:Description>
-                  </Argument>
+                  </ua:Argument>
                 </uax:Body>
               </uax:ExtensionObject>
               <uax:ExtensionObject>
@@ -768,7 +768,7 @@ public class ArrayArguments {
                   <uax:Identifier>i=297</uax:Identifier>
                 </uax:TypeId>
                 <uax:Body>
-                  <Argument>
+                  <ua:Argument>
                     <ua:Name>name2</ua:Name>
                     <ua:DataType>
                       <uax:Identifier>i=2</uax:Identifier>
@@ -781,7 +781,7 @@ public class ArrayArguments {
                       <uax:Locale>en</uax:Locale>
                       <uax:Text>description2</uax:Text>
                     </ua:Description>
-                  </Argument>
+                  </ua:Argument>
                 </uax:Body>
               </uax:ExtensionObject>
             </Test>

--- a/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/args/ArrayArguments.java
+++ b/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/args/ArrayArguments.java
@@ -749,18 +749,18 @@ public class ArrayArguments {
                   <uax:Identifier>i=297</uax:Identifier>
                 </uax:TypeId>
                 <uax:Body>
-                  <ua:Argument>
-                    <ua:Name>name</ua:Name>
-                    <ua:DataType>
+                  <uax:Argument>
+                    <uax:Name>name</uax:Name>
+                    <uax:DataType>
                       <uax:Identifier>i=1</uax:Identifier>
-                    </ua:DataType>
-                    <ua:ValueRank>-1</ua:ValueRank>
-                    <ua:ArrayDimensions xsi:nil="true"></ua:ArrayDimensions>
-                    <ua:Description>
+                    </uax:DataType>
+                    <uax:ValueRank>-1</uax:ValueRank>
+                    <uax:ArrayDimensions xsi:nil="true"></uax:ArrayDimensions>
+                    <uax:Description>
                       <uax:Locale>en</uax:Locale>
                       <uax:Text>description</uax:Text>
-                    </ua:Description>
-                  </ua:Argument>
+                    </uax:Description>
+                  </uax:Argument>
                 </uax:Body>
               </uax:ExtensionObject>
               <uax:ExtensionObject>
@@ -768,20 +768,20 @@ public class ArrayArguments {
                   <uax:Identifier>i=297</uax:Identifier>
                 </uax:TypeId>
                 <uax:Body>
-                  <ua:Argument>
-                    <ua:Name>name2</ua:Name>
-                    <ua:DataType>
+                  <uax:Argument>
+                    <uax:Name>name2</uax:Name>
+                    <uax:DataType>
                       <uax:Identifier>i=2</uax:Identifier>
-                    </ua:DataType>
-                    <ua:ValueRank>1</ua:ValueRank>
-                    <ua:ArrayDimensions>
+                    </uax:DataType>
+                    <uax:ValueRank>1</uax:ValueRank>
+                    <uax:ArrayDimensions>
                       <uax:UInt32>1</uax:UInt32>
-                    </ua:ArrayDimensions>
-                    <ua:Description>
+                    </uax:ArrayDimensions>
+                    <uax:Description>
                       <uax:Locale>en</uax:Locale>
                       <uax:Text>description2</uax:Text>
-                    </ua:Description>
-                  </ua:Argument>
+                    </uax:Description>
+                  </uax:Argument>
                 </uax:Body>
               </uax:ExtensionObject>
             </Test>
@@ -919,8 +919,8 @@ public class ArrayArguments {
             """
             <Test xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd"
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ua="http://opcfoundation.org/UA/">
-              <ua:BrowseDirection>Forward_0</ua:BrowseDirection>
-              <ua:BrowseDirection>Inverse_1</ua:BrowseDirection>
+              <uax:BrowseDirection>Forward_0</uax:BrowseDirection>
+              <uax:BrowseDirection>Inverse_1</uax:BrowseDirection>
             </Test>
             """),
         Arguments.of(
@@ -945,18 +945,18 @@ public class ArrayArguments {
             """
             <Test xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd"
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ua="http://opcfoundation.org/UA/">
-              <ua:XVType>
-                <ua:X>1.0</ua:X>
-                <ua:Value>2.0</ua:Value>
-              </ua:XVType>
-              <ua:XVType>
-                <ua:X>3.0</ua:X>
-                <ua:Value>4.0</ua:Value>
-              </ua:XVType>
-              <ua:XVType>
-                <ua:X>NaN</ua:X>
-                <ua:Value>NaN</ua:Value>
-              </ua:XVType>
+              <uax:XVType>
+                <uax:X>1.0</uax:X>
+                <uax:Value>2.0</uax:Value>
+              </uax:XVType>
+              <uax:XVType>
+                <uax:X>3.0</uax:X>
+                <uax:Value>4.0</uax:Value>
+              </uax:XVType>
+              <uax:XVType>
+                <uax:X>NaN</uax:X>
+                <uax:Value>NaN</uax:Value>
+              </uax:XVType>
             </Test>
             """),
         Arguments.of(

--- a/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/args/MatrixArguments.java
+++ b/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/args/MatrixArguments.java
@@ -69,7 +69,7 @@ public class MatrixArguments {
                 }),
             """
             <Test xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd"
-              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ua="http://opcfoundation.org/UA/">
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
               <uax:Dimensions>
                 <uax:Int32>2</uax:Int32>
                 <uax:Int32>2</uax:Int32>
@@ -1225,7 +1225,7 @@ public class MatrixArguments {
                 }),
             """
             <Test xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd"
-              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ua="http://opcfoundation.org/UA/">
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
               <uax:Dimensions>
                 <uax:Int32>2</uax:Int32>
                 <uax:Int32>2</uax:Int32>
@@ -1466,7 +1466,7 @@ public class MatrixArguments {
                 }),
             """
             <Test xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd"
-              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ua="http://opcfoundation.org/UA/">
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
               <uax:Dimensions>
                 <uax:Int32>2</uax:Int32>
                 <uax:Int32>2</uax:Int32>
@@ -1495,7 +1495,7 @@ public class MatrixArguments {
                 }),
             """
             <Test xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd"
-              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ua="http://opcfoundation.org/UA/">
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
               <uax:Dimensions>
                 <uax:Int32>2</uax:Int32>
                 <uax:Int32>2</uax:Int32>

--- a/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/args/MatrixArguments.java
+++ b/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/args/MatrixArguments.java
@@ -80,10 +80,10 @@ public class MatrixArguments {
                     <uax:Identifier>i=12082</uax:Identifier>
                   </uax:TypeId>
                   <uax:Body>
-                    <ua:XVType>
-                      <ua:X>0.0</ua:X>
-                      <ua:Value>1.0</ua:Value>
-                    </ua:XVType>
+                    <uax:XVType>
+                      <uax:X>0.0</uax:X>
+                      <uax:Value>1.0</uax:Value>
+                    </uax:XVType>
                   </uax:Body>
                 </uax:ExtensionObject>
                 <uax:ExtensionObject>
@@ -91,10 +91,10 @@ public class MatrixArguments {
                     <uax:Identifier>i=12082</uax:Identifier>
                   </uax:TypeId>
                   <uax:Body>
-                    <ua:XVType>
-                      <ua:X>2.0</ua:X>
-                      <ua:Value>3.0</ua:Value>
-                    </ua:XVType>
+                    <uax:XVType>
+                      <uax:X>2.0</uax:X>
+                      <uax:Value>3.0</uax:Value>
+                    </uax:XVType>
                   </uax:Body>
                 </uax:ExtensionObject>
                 <uax:ExtensionObject>
@@ -102,10 +102,10 @@ public class MatrixArguments {
                     <uax:Identifier>i=12082</uax:Identifier>
                   </uax:TypeId>
                   <uax:Body>
-                    <ua:XVType>
-                      <ua:X>4.0</ua:X>
-                      <ua:Value>5.0</ua:Value>
-                    </ua:XVType>
+                    <uax:XVType>
+                      <uax:X>4.0</uax:X>
+                      <uax:Value>5.0</uax:Value>
+                    </uax:XVType>
                   </uax:Body>
                 </uax:ExtensionObject>
                 <uax:ExtensionObject>
@@ -113,10 +113,10 @@ public class MatrixArguments {
                     <uax:Identifier>i=12082</uax:Identifier>
                   </uax:TypeId>
                   <uax:Body>
-                    <ua:XVType>
-                      <ua:X>6.0</ua:X>
-                      <ua:Value>7.0</ua:Value>
-                    </ua:XVType>
+                    <uax:XVType>
+                      <uax:X>6.0</uax:X>
+                      <uax:Value>7.0</uax:Value>
+                    </uax:XVType>
                   </uax:Body>
                 </uax:ExtensionObject>
               </uax:Elements>
@@ -1236,10 +1236,10 @@ public class MatrixArguments {
                     <uax:Identifier>i=12082</uax:Identifier>
                   </uax:TypeId>
                   <uax:Body>
-                    <ua:XVType>
-                      <ua:X>1.0</ua:X>
-                      <ua:Value>2.0</ua:Value>
-                    </ua:XVType>
+                    <uax:XVType>
+                      <uax:X>1.0</uax:X>
+                      <uax:Value>2.0</uax:Value>
+                    </uax:XVType>
                   </uax:Body>
                 </uax:ExtensionObject>
                 <uax:ExtensionObject>
@@ -1247,10 +1247,10 @@ public class MatrixArguments {
                     <uax:Identifier>i=12082</uax:Identifier>
                   </uax:TypeId>
                   <uax:Body>
-                    <ua:XVType>
-                      <ua:X>3.0</ua:X>
-                      <ua:Value>4.0</ua:Value>
-                    </ua:XVType>
+                    <uax:XVType>
+                      <uax:X>3.0</uax:X>
+                      <uax:Value>4.0</uax:Value>
+                    </uax:XVType>
                   </uax:Body>
                 </uax:ExtensionObject>
                 <uax:ExtensionObject>
@@ -1258,10 +1258,10 @@ public class MatrixArguments {
                     <uax:Identifier>i=12082</uax:Identifier>
                   </uax:TypeId>
                   <uax:Body>
-                    <ua:XVType>
-                      <ua:X>5.0</ua:X>
-                      <ua:Value>6.0</ua:Value>
-                    </ua:XVType>
+                    <uax:XVType>
+                      <uax:X>5.0</uax:X>
+                      <uax:Value>6.0</uax:Value>
+                    </uax:XVType>
                   </uax:Body>
                 </uax:ExtensionObject>
                 <uax:ExtensionObject>
@@ -1269,10 +1269,10 @@ public class MatrixArguments {
                     <uax:Identifier>i=12082</uax:Identifier>
                   </uax:TypeId>
                   <uax:Body>
-                    <ua:XVType>
-                      <ua:X>7.0</ua:X>
-                      <ua:Value>8.0</ua:Value>
-                    </ua:XVType>
+                    <uax:XVType>
+                      <uax:X>7.0</uax:X>
+                      <uax:Value>8.0</uax:Value>
+                    </uax:XVType>
                   </uax:Body>
                 </uax:ExtensionObject>
               </uax:Elements>
@@ -1472,10 +1472,10 @@ public class MatrixArguments {
                 <uax:Int32>2</uax:Int32>
               </uax:Dimensions>
               <uax:Elements>
-                <ua:BrowseDirection>Forward_0</ua:BrowseDirection>
-                <ua:BrowseDirection>Inverse_1</ua:BrowseDirection>
-                <ua:BrowseDirection>Both_2</ua:BrowseDirection>
-                <ua:BrowseDirection>Invalid_3</ua:BrowseDirection>
+                <uax:BrowseDirection>Forward_0</uax:BrowseDirection>
+                <uax:BrowseDirection>Inverse_1</uax:BrowseDirection>
+                <uax:BrowseDirection>Both_2</uax:BrowseDirection>
+                <uax:BrowseDirection>Invalid_3</uax:BrowseDirection>
               </uax:Elements>
             </Test>
             """),
@@ -1502,14 +1502,14 @@ public class MatrixArguments {
                 <uax:Int32>2</uax:Int32>
               </uax:Dimensions>
               <uax:Elements>
-                <ua:BrowseDirection>Forward_0</ua:BrowseDirection>
-                <ua:BrowseDirection>Inverse_1</ua:BrowseDirection>
-                <ua:BrowseDirection>Both_2</ua:BrowseDirection>
-                <ua:BrowseDirection>Invalid_3</ua:BrowseDirection>
-                <ua:BrowseDirection>Inverse_1</ua:BrowseDirection>
-                <ua:BrowseDirection>Both_2</ua:BrowseDirection>
-                <ua:BrowseDirection>Forward_0</ua:BrowseDirection>
-                <ua:BrowseDirection>Invalid_3</ua:BrowseDirection>
+                <uax:BrowseDirection>Forward_0</uax:BrowseDirection>
+                <uax:BrowseDirection>Inverse_1</uax:BrowseDirection>
+                <uax:BrowseDirection>Both_2</uax:BrowseDirection>
+                <uax:BrowseDirection>Invalid_3</uax:BrowseDirection>
+                <uax:BrowseDirection>Inverse_1</uax:BrowseDirection>
+                <uax:BrowseDirection>Both_2</uax:BrowseDirection>
+                <uax:BrowseDirection>Forward_0</uax:BrowseDirection>
+                <uax:BrowseDirection>Invalid_3</uax:BrowseDirection>
               </uax:Elements>
             </Test>
             """));

--- a/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/args/MatrixArguments.java
+++ b/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/args/MatrixArguments.java
@@ -80,10 +80,10 @@ public class MatrixArguments {
                     <uax:Identifier>i=12082</uax:Identifier>
                   </uax:TypeId>
                   <uax:Body>
-                    <XVType>
+                    <ua:XVType>
                       <ua:X>0.0</ua:X>
                       <ua:Value>1.0</ua:Value>
-                    </XVType>
+                    </ua:XVType>
                   </uax:Body>
                 </uax:ExtensionObject>
                 <uax:ExtensionObject>
@@ -91,10 +91,10 @@ public class MatrixArguments {
                     <uax:Identifier>i=12082</uax:Identifier>
                   </uax:TypeId>
                   <uax:Body>
-                    <XVType>
+                    <ua:XVType>
                       <ua:X>2.0</ua:X>
                       <ua:Value>3.0</ua:Value>
-                    </XVType>
+                    </ua:XVType>
                   </uax:Body>
                 </uax:ExtensionObject>
                 <uax:ExtensionObject>
@@ -102,10 +102,10 @@ public class MatrixArguments {
                     <uax:Identifier>i=12082</uax:Identifier>
                   </uax:TypeId>
                   <uax:Body>
-                    <XVType>
+                    <ua:XVType>
                       <ua:X>4.0</ua:X>
                       <ua:Value>5.0</ua:Value>
-                    </XVType>
+                    </ua:XVType>
                   </uax:Body>
                 </uax:ExtensionObject>
                 <uax:ExtensionObject>
@@ -113,10 +113,10 @@ public class MatrixArguments {
                     <uax:Identifier>i=12082</uax:Identifier>
                   </uax:TypeId>
                   <uax:Body>
-                    <XVType>
+                    <ua:XVType>
                       <ua:X>6.0</ua:X>
                       <ua:Value>7.0</ua:Value>
-                    </XVType>
+                    </ua:XVType>
                   </uax:Body>
                 </uax:ExtensionObject>
               </uax:Elements>
@@ -1236,10 +1236,10 @@ public class MatrixArguments {
                     <uax:Identifier>i=12082</uax:Identifier>
                   </uax:TypeId>
                   <uax:Body>
-                    <XVType>
+                    <ua:XVType>
                       <ua:X>1.0</ua:X>
                       <ua:Value>2.0</ua:Value>
-                    </XVType>
+                    </ua:XVType>
                   </uax:Body>
                 </uax:ExtensionObject>
                 <uax:ExtensionObject>
@@ -1247,10 +1247,10 @@ public class MatrixArguments {
                     <uax:Identifier>i=12082</uax:Identifier>
                   </uax:TypeId>
                   <uax:Body>
-                    <XVType>
+                    <ua:XVType>
                       <ua:X>3.0</ua:X>
                       <ua:Value>4.0</ua:Value>
-                    </XVType>
+                    </ua:XVType>
                   </uax:Body>
                 </uax:ExtensionObject>
                 <uax:ExtensionObject>
@@ -1258,10 +1258,10 @@ public class MatrixArguments {
                     <uax:Identifier>i=12082</uax:Identifier>
                   </uax:TypeId>
                   <uax:Body>
-                    <XVType>
+                    <ua:XVType>
                       <ua:X>5.0</ua:X>
                       <ua:Value>6.0</ua:Value>
-                    </XVType>
+                    </ua:XVType>
                   </uax:Body>
                 </uax:ExtensionObject>
                 <uax:ExtensionObject>
@@ -1269,10 +1269,10 @@ public class MatrixArguments {
                     <uax:Identifier>i=12082</uax:Identifier>
                   </uax:TypeId>
                   <uax:Body>
-                    <XVType>
+                    <ua:XVType>
                       <ua:X>7.0</ua:X>
                       <ua:Value>8.0</ua:Value>
-                    </XVType>
+                    </ua:XVType>
                   </uax:Body>
                 </uax:ExtensionObject>
               </uax:Elements>

--- a/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/args/ScalarArguments.java
+++ b/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/args/ScalarArguments.java
@@ -549,10 +549,10 @@ public class ScalarArguments {
                 <uax:Identifier>i=12082</uax:Identifier>
               </uax:TypeId>
               <uax:Body>
-                <ua:XVType>
-                  <ua:X>1.0</ua:X>
-                  <ua:Value>2.0</ua:Value>
-                </ua:XVType>
+                <uax:XVType>
+                  <uax:X>1.0</uax:X>
+                  <uax:Value>2.0</uax:Value>
+                </uax:XVType>
               </uax:Body>
             </Test>
             """),

--- a/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/args/ScalarArguments.java
+++ b/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/args/ScalarArguments.java
@@ -549,10 +549,10 @@ public class ScalarArguments {
                 <uax:Identifier>i=12082</uax:Identifier>
               </uax:TypeId>
               <uax:Body>
-                <XVType>
+                <ua:XVType>
                   <ua:X>1.0</ua:X>
                   <ua:Value>2.0</ua:Value>
-                </XVType>
+                </ua:XVType>
               </uax:Body>
             </Test>
             """),

--- a/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/args/ScalarArguments.java
+++ b/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/args/ScalarArguments.java
@@ -544,7 +544,7 @@ public class ScalarArguments {
                 OpcUaDefaultXmlEncoding.getInstance()),
             """
             <Test xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd"
-              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ua="http://opcfoundation.org/UA/">
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
               <uax:TypeId>
                 <uax:Identifier>i=12082</uax:Identifier>
               </uax:TypeId>

--- a/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/args/StructArguments.java
+++ b/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/args/StructArguments.java
@@ -32,8 +32,8 @@ public class StructArguments {
             """
             <XVType xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd"
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ua="http://opcfoundation.org/UA/">
-              <ua:X>1.0</ua:X>
-              <ua:Value>2.0</ua:Value>
+              <uax:X>1.0</uax:X>
+              <uax:Value>2.0</uax:Value>
             </XVType>
             """),
 
@@ -49,16 +49,16 @@ public class StructArguments {
             """
             <Argument xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd"
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ua="http://opcfoundation.org/UA/">
-              <ua:Name>ArgumentName</ua:Name>
-              <ua:DataType>
+              <uax:Name>ArgumentName</uax:Name>
+              <uax:DataType>
                 <uax:Identifier>i=1</uax:Identifier>
-              </ua:DataType>
-              <ua:ValueRank>-1</ua:ValueRank>
-              <ua:ArrayDimensions xsi:nil="true"></ua:ArrayDimensions>
-              <ua:Description>
+              </uax:DataType>
+              <uax:ValueRank>-1</uax:ValueRank>
+              <uax:ArrayDimensions xsi:nil="true"></uax:ArrayDimensions>
+              <uax:Description>
                 <uax:Locale>en</uax:Locale>
                 <uax:Text>Description</uax:Text>
-              </ua:Description>
+              </uax:Description>
             </Argument>
             """),
 
@@ -75,12 +75,12 @@ public class StructArguments {
             """
             <BuildInfo xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd"
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ua="http://opcfoundation.org/UA/">
-              <ua:ProductUri>urn:example:product</ua:ProductUri>
-              <ua:ManufacturerName>Example Manufacturer</ua:ManufacturerName>
-              <ua:ProductName>Example Product</ua:ProductName>
-              <ua:SoftwareVersion>1.0.0</ua:SoftwareVersion>
-              <ua:BuildNumber>12345</ua:BuildNumber>
-              <ua:BuildDate>2023-01-01T00:00:00Z</ua:BuildDate>
+              <uax:ProductUri>urn:example:product</uax:ProductUri>
+              <uax:ManufacturerName>Example Manufacturer</uax:ManufacturerName>
+              <uax:ProductName>Example Product</uax:ProductName>
+              <uax:SoftwareVersion>1.0.0</uax:SoftwareVersion>
+              <uax:BuildNumber>12345</uax:BuildNumber>
+              <uax:BuildDate>2023-01-01T00:00:00Z</uax:BuildDate>
             </BuildInfo>
             """));
   }

--- a/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/args/StructArguments.java
+++ b/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/args/StructArguments.java
@@ -31,7 +31,7 @@ public class StructArguments {
             new XVType(1.0, 2.0f),
             """
             <XVType xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd"
-              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ua="http://opcfoundation.org/UA/">
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
               <uax:X>1.0</uax:X>
               <uax:Value>2.0</uax:Value>
             </XVType>
@@ -48,7 +48,7 @@ public class StructArguments {
                 LocalizedText.english("Description")),
             """
             <Argument xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd"
-              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ua="http://opcfoundation.org/UA/">
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
               <uax:Name>ArgumentName</uax:Name>
               <uax:DataType>
                 <uax:Identifier>i=1</uax:Identifier>
@@ -74,7 +74,7 @@ public class StructArguments {
                 new DateTime(Instant.parse("2023-01-01T00:00:00Z"))),
             """
             <BuildInfo xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd"
-              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ua="http://opcfoundation.org/UA/">
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
               <uax:ProductUri>urn:example:product</uax:ProductUri>
               <uax:ManufacturerName>Example Manufacturer</uax:ManufacturerName>
               <uax:ProductName>Example Product</uax:ProductName>

--- a/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/args/VariantArguments.java
+++ b/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/args/VariantArguments.java
@@ -298,7 +298,7 @@ public class VariantArguments {
                     OpcUaDefaultXmlEncoding.getInstance())),
             """
             <Test xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd"
-              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ua="http://opcfoundation.org/UA/">
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
               <uax:Value>
                 <uax:ExtensionObject>
                   <uax:TypeId>
@@ -342,7 +342,7 @@ public class VariantArguments {
                     "name", NodeId.parse("i=1"), -1, null, LocalizedText.english("description"))),
             """
             <Test xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd"
-              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ua="http://opcfoundation.org/UA/">
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
               <uax:Value>
                 <uax:ExtensionObject>
                   <uax:TypeId>
@@ -852,7 +852,7 @@ public class VariantArguments {
                 }),
             """
             <Test xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd"
-              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ua="http://opcfoundation.org/UA/">
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
               <uax:Value>
                 <uax:ListOfExtensionObject>
                   <uax:ExtensionObject>
@@ -953,7 +953,7 @@ public class VariantArguments {
                 }),
             """
             <Test xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd"
-              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ua="http://opcfoundation.org/UA/">
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
               <uax:Value>
                 <uax:ListOfExtensionObject>
                   <uax:ExtensionObject>
@@ -1733,7 +1733,7 @@ public class VariantArguments {
                     })),
             """
             <Test xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd"
-              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ua="http://opcfoundation.org/UA/">
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
               <uax:Value>
                 <uax:Matrix>
                   <uax:Dimensions>

--- a/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/args/VariantArguments.java
+++ b/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/args/VariantArguments.java
@@ -305,7 +305,7 @@ public class VariantArguments {
                     <uax:Identifier>i=297</uax:Identifier>
                   </uax:TypeId>
                   <uax:Body>
-                    <Argument>
+                    <ua:Argument>
                       <ua:Name>name</ua:Name>
                       <ua:DataType>
                         <uax:Identifier>i=1</uax:Identifier>
@@ -316,7 +316,7 @@ public class VariantArguments {
                         <uax:Locale>en</uax:Locale>
                         <uax:Text>description</uax:Text>
                       </ua:Description>
-                    </Argument>
+                    </ua:Argument>
                   </uax:Body>
                 </uax:ExtensionObject>
               </uax:Value>
@@ -349,7 +349,7 @@ public class VariantArguments {
                     <uax:Identifier>i=297</uax:Identifier>
                   </uax:TypeId>
                   <uax:Body>
-                    <Argument>
+                    <ua:Argument>
                       <ua:Name>name</ua:Name>
                       <ua:DataType>
                         <uax:Identifier>i=1</uax:Identifier>
@@ -360,7 +360,7 @@ public class VariantArguments {
                         <uax:Locale>en</uax:Locale>
                         <uax:Text>description</uax:Text>
                       </ua:Description>
-                    </Argument>
+                    </ua:Argument>
                   </uax:Body>
                 </uax:ExtensionObject>
               </uax:Value>
@@ -860,7 +860,7 @@ public class VariantArguments {
                       <uax:Identifier>i=297</uax:Identifier>
                     </uax:TypeId>
                     <uax:Body>
-                      <Argument>
+                      <ua:Argument>
                         <ua:Name>name</ua:Name>
                         <ua:DataType>
                           <uax:Identifier>i=1</uax:Identifier>
@@ -871,7 +871,7 @@ public class VariantArguments {
                           <uax:Locale>en</uax:Locale>
                           <uax:Text>description</uax:Text>
                         </ua:Description>
-                      </Argument>
+                      </ua:Argument>
                     </uax:Body>
                   </uax:ExtensionObject>
                   <uax:ExtensionObject>
@@ -879,7 +879,7 @@ public class VariantArguments {
                       <uax:Identifier>i=297</uax:Identifier>
                     </uax:TypeId>
                     <uax:Body>
-                      <Argument>
+                      <ua:Argument>
                         <ua:Name>name</ua:Name>
                         <ua:DataType>
                           <uax:Identifier>i=1</uax:Identifier>
@@ -890,7 +890,7 @@ public class VariantArguments {
                           <uax:Locale>en</uax:Locale>
                           <uax:Text>description</uax:Text>
                         </ua:Description>
-                      </Argument>
+                      </ua:Argument>
                     </uax:Body>
                   </uax:ExtensionObject>
                 </uax:ListOfExtensionObject>
@@ -961,7 +961,7 @@ public class VariantArguments {
                       <uax:Identifier>i=297</uax:Identifier>
                     </uax:TypeId>
                     <uax:Body>
-                      <Argument>
+                      <ua:Argument>
                         <ua:Name>name1</ua:Name>
                         <ua:DataType>
                           <uax:Identifier>i=1</uax:Identifier>
@@ -972,7 +972,7 @@ public class VariantArguments {
                           <uax:Locale>en</uax:Locale>
                           <uax:Text>description1</uax:Text>
                         </ua:Description>
-                      </Argument>
+                      </ua:Argument>
                     </uax:Body>
                   </uax:ExtensionObject>
                   <uax:ExtensionObject>
@@ -980,7 +980,7 @@ public class VariantArguments {
                       <uax:Identifier>i=297</uax:Identifier>
                     </uax:TypeId>
                     <uax:Body>
-                      <Argument>
+                      <ua:Argument>
                         <ua:Name>name2</ua:Name>
                         <ua:DataType>
                           <uax:Identifier>i=1</uax:Identifier>
@@ -991,7 +991,7 @@ public class VariantArguments {
                           <uax:Locale>en</uax:Locale>
                           <uax:Text>description2</uax:Text>
                         </ua:Description>
-                      </Argument>
+                      </ua:Argument>
                     </uax:Body>
                   </uax:ExtensionObject>
                 </uax:ListOfExtensionObject>
@@ -1746,10 +1746,10 @@ public class VariantArguments {
                         <uax:Identifier>i=12082</uax:Identifier>
                       </uax:TypeId>
                       <uax:Body>
-                        <XVType>
+                        <ua:XVType>
                           <ua:X>1.0</ua:X>
                           <ua:Value>2.0</ua:Value>
-                        </XVType>
+                        </ua:XVType>
                       </uax:Body>
                     </uax:ExtensionObject>
                     <uax:ExtensionObject>
@@ -1757,10 +1757,10 @@ public class VariantArguments {
                         <uax:Identifier>i=12082</uax:Identifier>
                       </uax:TypeId>
                       <uax:Body>
-                        <XVType>
+                        <ua:XVType>
                           <ua:X>3.0</ua:X>
                           <ua:Value>4.0</ua:Value>
-                        </XVType>
+                        </ua:XVType>
                       </uax:Body>
                     </uax:ExtensionObject>
                     <uax:ExtensionObject>
@@ -1768,10 +1768,10 @@ public class VariantArguments {
                         <uax:Identifier>i=12082</uax:Identifier>
                       </uax:TypeId>
                       <uax:Body>
-                        <XVType>
+                        <ua:XVType>
                           <ua:X>5.0</ua:X>
                           <ua:Value>6.0</ua:Value>
-                        </XVType>
+                        </ua:XVType>
                       </uax:Body>
                     </uax:ExtensionObject>
                     <uax:ExtensionObject>
@@ -1779,10 +1779,10 @@ public class VariantArguments {
                         <uax:Identifier>i=12082</uax:Identifier>
                       </uax:TypeId>
                       <uax:Body>
-                        <XVType>
+                        <ua:XVType>
                           <ua:X>7.0</ua:X>
                           <ua:Value>8.0</ua:Value>
-                        </XVType>
+                        </ua:XVType>
                       </uax:Body>
                     </uax:ExtensionObject>
                   </uax:Elements>

--- a/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/args/VariantArguments.java
+++ b/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/args/VariantArguments.java
@@ -305,18 +305,18 @@ public class VariantArguments {
                     <uax:Identifier>i=297</uax:Identifier>
                   </uax:TypeId>
                   <uax:Body>
-                    <ua:Argument>
-                      <ua:Name>name</ua:Name>
-                      <ua:DataType>
+                    <uax:Argument>
+                      <uax:Name>name</uax:Name>
+                      <uax:DataType>
                         <uax:Identifier>i=1</uax:Identifier>
-                      </ua:DataType>
-                      <ua:ValueRank>-1</ua:ValueRank>
-                      <ua:ArrayDimensions xsi:nil="true"></ua:ArrayDimensions>
-                      <ua:Description>
+                      </uax:DataType>
+                      <uax:ValueRank>-1</uax:ValueRank>
+                      <uax:ArrayDimensions xsi:nil="true"></uax:ArrayDimensions>
+                      <uax:Description>
                         <uax:Locale>en</uax:Locale>
                         <uax:Text>description</uax:Text>
-                      </ua:Description>
-                    </ua:Argument>
+                      </uax:Description>
+                    </uax:Argument>
                   </uax:Body>
                 </uax:ExtensionObject>
               </uax:Value>
@@ -349,18 +349,18 @@ public class VariantArguments {
                     <uax:Identifier>i=297</uax:Identifier>
                   </uax:TypeId>
                   <uax:Body>
-                    <ua:Argument>
-                      <ua:Name>name</ua:Name>
-                      <ua:DataType>
+                    <uax:Argument>
+                      <uax:Name>name</uax:Name>
+                      <uax:DataType>
                         <uax:Identifier>i=1</uax:Identifier>
-                      </ua:DataType>
-                      <ua:ValueRank>-1</ua:ValueRank>
-                      <ua:ArrayDimensions xsi:nil="true"></ua:ArrayDimensions>
-                      <ua:Description>
+                      </uax:DataType>
+                      <uax:ValueRank>-1</uax:ValueRank>
+                      <uax:ArrayDimensions xsi:nil="true"></uax:ArrayDimensions>
+                      <uax:Description>
                         <uax:Locale>en</uax:Locale>
                         <uax:Text>description</uax:Text>
-                      </ua:Description>
-                    </ua:Argument>
+                      </uax:Description>
+                    </uax:Argument>
                   </uax:Body>
                 </uax:ExtensionObject>
               </uax:Value>
@@ -860,18 +860,18 @@ public class VariantArguments {
                       <uax:Identifier>i=297</uax:Identifier>
                     </uax:TypeId>
                     <uax:Body>
-                      <ua:Argument>
-                        <ua:Name>name</ua:Name>
-                        <ua:DataType>
+                      <uax:Argument>
+                        <uax:Name>name</uax:Name>
+                        <uax:DataType>
                           <uax:Identifier>i=1</uax:Identifier>
-                        </ua:DataType>
-                        <ua:ValueRank>-1</ua:ValueRank>
-                        <ua:ArrayDimensions xsi:nil="true"></ua:ArrayDimensions>
-                        <ua:Description>
+                        </uax:DataType>
+                        <uax:ValueRank>-1</uax:ValueRank>
+                        <uax:ArrayDimensions xsi:nil="true"></uax:ArrayDimensions>
+                        <uax:Description>
                           <uax:Locale>en</uax:Locale>
                           <uax:Text>description</uax:Text>
-                        </ua:Description>
-                      </ua:Argument>
+                        </uax:Description>
+                      </uax:Argument>
                     </uax:Body>
                   </uax:ExtensionObject>
                   <uax:ExtensionObject>
@@ -879,18 +879,18 @@ public class VariantArguments {
                       <uax:Identifier>i=297</uax:Identifier>
                     </uax:TypeId>
                     <uax:Body>
-                      <ua:Argument>
-                        <ua:Name>name</ua:Name>
-                        <ua:DataType>
+                      <uax:Argument>
+                        <uax:Name>name</uax:Name>
+                        <uax:DataType>
                           <uax:Identifier>i=1</uax:Identifier>
-                        </ua:DataType>
-                        <ua:ValueRank>-1</ua:ValueRank>
-                        <ua:ArrayDimensions xsi:nil="true"></ua:ArrayDimensions>
-                        <ua:Description>
+                        </uax:DataType>
+                        <uax:ValueRank>-1</uax:ValueRank>
+                        <uax:ArrayDimensions xsi:nil="true"></uax:ArrayDimensions>
+                        <uax:Description>
                           <uax:Locale>en</uax:Locale>
                           <uax:Text>description</uax:Text>
-                        </ua:Description>
-                      </ua:Argument>
+                        </uax:Description>
+                      </uax:Argument>
                     </uax:Body>
                   </uax:ExtensionObject>
                 </uax:ListOfExtensionObject>
@@ -961,18 +961,18 @@ public class VariantArguments {
                       <uax:Identifier>i=297</uax:Identifier>
                     </uax:TypeId>
                     <uax:Body>
-                      <ua:Argument>
-                        <ua:Name>name1</ua:Name>
-                        <ua:DataType>
+                      <uax:Argument>
+                        <uax:Name>name1</uax:Name>
+                        <uax:DataType>
                           <uax:Identifier>i=1</uax:Identifier>
-                        </ua:DataType>
-                        <ua:ValueRank>-1</ua:ValueRank>
-                        <ua:ArrayDimensions xsi:nil="true"></ua:ArrayDimensions>
-                        <ua:Description>
+                        </uax:DataType>
+                        <uax:ValueRank>-1</uax:ValueRank>
+                        <uax:ArrayDimensions xsi:nil="true"></uax:ArrayDimensions>
+                        <uax:Description>
                           <uax:Locale>en</uax:Locale>
                           <uax:Text>description1</uax:Text>
-                        </ua:Description>
-                      </ua:Argument>
+                        </uax:Description>
+                      </uax:Argument>
                     </uax:Body>
                   </uax:ExtensionObject>
                   <uax:ExtensionObject>
@@ -980,18 +980,18 @@ public class VariantArguments {
                       <uax:Identifier>i=297</uax:Identifier>
                     </uax:TypeId>
                     <uax:Body>
-                      <ua:Argument>
-                        <ua:Name>name2</ua:Name>
-                        <ua:DataType>
+                      <uax:Argument>
+                        <uax:Name>name2</uax:Name>
+                        <uax:DataType>
                           <uax:Identifier>i=1</uax:Identifier>
-                        </ua:DataType>
-                        <ua:ValueRank>-1</ua:ValueRank>
-                        <ua:ArrayDimensions xsi:nil="true"></ua:ArrayDimensions>
-                        <ua:Description>
+                        </uax:DataType>
+                        <uax:ValueRank>-1</uax:ValueRank>
+                        <uax:ArrayDimensions xsi:nil="true"></uax:ArrayDimensions>
+                        <uax:Description>
                           <uax:Locale>en</uax:Locale>
                           <uax:Text>description2</uax:Text>
-                        </ua:Description>
-                      </ua:Argument>
+                        </uax:Description>
+                      </uax:Argument>
                     </uax:Body>
                   </uax:ExtensionObject>
                 </uax:ListOfExtensionObject>
@@ -1746,10 +1746,10 @@ public class VariantArguments {
                         <uax:Identifier>i=12082</uax:Identifier>
                       </uax:TypeId>
                       <uax:Body>
-                        <ua:XVType>
-                          <ua:X>1.0</ua:X>
-                          <ua:Value>2.0</ua:Value>
-                        </ua:XVType>
+                        <uax:XVType>
+                          <uax:X>1.0</uax:X>
+                          <uax:Value>2.0</uax:Value>
+                        </uax:XVType>
                       </uax:Body>
                     </uax:ExtensionObject>
                     <uax:ExtensionObject>
@@ -1757,10 +1757,10 @@ public class VariantArguments {
                         <uax:Identifier>i=12082</uax:Identifier>
                       </uax:TypeId>
                       <uax:Body>
-                        <ua:XVType>
-                          <ua:X>3.0</ua:X>
-                          <ua:Value>4.0</ua:Value>
-                        </ua:XVType>
+                        <uax:XVType>
+                          <uax:X>3.0</uax:X>
+                          <uax:Value>4.0</uax:Value>
+                        </uax:XVType>
                       </uax:Body>
                     </uax:ExtensionObject>
                     <uax:ExtensionObject>
@@ -1768,10 +1768,10 @@ public class VariantArguments {
                         <uax:Identifier>i=12082</uax:Identifier>
                       </uax:TypeId>
                       <uax:Body>
-                        <ua:XVType>
-                          <ua:X>5.0</ua:X>
-                          <ua:Value>6.0</ua:Value>
-                        </ua:XVType>
+                        <uax:XVType>
+                          <uax:X>5.0</uax:X>
+                          <uax:Value>6.0</uax:Value>
+                        </uax:XVType>
                       </uax:Body>
                     </uax:ExtensionObject>
                     <uax:ExtensionObject>
@@ -1779,10 +1779,10 @@ public class VariantArguments {
                         <uax:Identifier>i=12082</uax:Identifier>
                       </uax:TypeId>
                       <uax:Body>
-                        <ua:XVType>
-                          <ua:X>7.0</ua:X>
-                          <ua:Value>8.0</ua:Value>
-                        </ua:XVType>
+                        <uax:XVType>
+                          <uax:X>7.0</uax:X>
+                          <uax:Value>8.0</uax:Value>
+                        </uax:XVType>
                       </uax:Body>
                     </uax:ExtensionObject>
                   </uax:Elements>

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/UaDataType.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/UaDataType.java
@@ -23,20 +23,21 @@ public interface UaDataType {
   ExpandedNodeId getTypeId();
 
   /**
-   * Get the encoding name of this DataType.
+   * Get the name of this DataType.
    *
-   * <p>DataTypes have names that may be used in the JSON and XML encodings. Consequently, there are
-   * some restrictions on the characters that can be used in the name.
+   * <p>For most types this will be the simple name of the class, but there are exceptions:
    *
-   * <p>When a DataType is defined in a UANodeSet it provides a browse name and, optionally, an
-   * alternative symbolic name. When the browse name uses characters that cannot be encoded the
-   * symbolic name is used as an alternative in the encoding.
+   * <ul>
+   *   <li>types defined dynamically at runtime
+   *   <li>code generated types that had a SymbolicName defined in the NodeSet, usually because the
+   *       BrowseName is not suitable as an identifier
+   * </ul>
    *
-   * <p>Defaults to the simple name of the class, implementations should override as necessary.
+   * In these cases name of the DataType Class will differ from the actual name of the type.
    *
-   * @return the encoding name of this DataType.
+   * @return the name of this DataType.
    */
-  default String getEncodingName() {
+  default String getTypeName() {
     return getClass().getSimpleName();
   }
 }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/ThreeDCartesianCoordinates.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/ThreeDCartesianCoordinates.java
@@ -51,6 +51,11 @@ public class ThreeDCartesianCoordinates extends CartesianCoordinates implements 
   }
 
   @Override
+  public String getTypeName() {
+    return "3DCartesianCoordinates";
+  }
+
+  @Override
   public ExpandedNodeId getTypeId() {
     return TYPE_ID;
   }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/ThreeDFrame.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/ThreeDFrame.java
@@ -49,6 +49,11 @@ public class ThreeDFrame extends Frame implements UaStructuredType {
   }
 
   @Override
+  public String getTypeName() {
+    return "3DFrame";
+  }
+
+  @Override
   public ExpandedNodeId getTypeId() {
     return TYPE_ID;
   }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/ThreeDOrientation.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/ThreeDOrientation.java
@@ -51,6 +51,11 @@ public class ThreeDOrientation extends Orientation implements UaStructuredType {
   }
 
   @Override
+  public String getTypeName() {
+    return "3DOrientation";
+  }
+
+  @Override
   public ExpandedNodeId getTypeId() {
     return TYPE_ID;
   }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/ThreeDVector.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/structured/ThreeDVector.java
@@ -51,6 +51,11 @@ public class ThreeDVector extends Vector implements UaStructuredType {
   }
 
   @Override
+  public String getTypeName() {
+    return "3DVector";
+  }
+
+  @Override
   public ExpandedNodeId getTypeId() {
     return TYPE_ID;
   }


### PR DESCRIPTION
## Summary
### UaDataType
Rename `getEncodingName()` to `getTypeName()`.

### DataTypeNodeLoader
Don't generate constructors using the SymbolicName as the BrowseName.

### Generate Structures
The "ThreeD" structures need to implement `getTypeName()` because their actual names begin with "3D" - "ThreeD" is just the SymbolicName.

### XML Name Encoding Rules
With `getTypeName()` being implemented where required, the XML name encoding rules defined in https://reference.opcfoundation.org/Core/Part6/v105/docs/5.1.13 can be applied during XML encoding.

### XML Encoding
Some structure and enum elements were missing the namespace prefix. OPC UA (ns0) types get special treatment re: namespaces and XML name encoding rules.