### PR TITLE
Implement Autocloseable in OpcUaXmlEncoder

### DIFF
--- a/opc-ua-stack/encoding-xml/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaDefaultXmlEncoding.java
+++ b/opc-ua-stack/encoding-xml/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaDefaultXmlEncoding.java
@@ -60,15 +60,17 @@ public class OpcUaDefaultXmlEncoding implements DataTypeEncoding {
           "no codec registered for encodingId=" + encodingId.toParseableString());
     }
 
-    OpcUaXmlEncoder encoder = new OpcUaXmlEncoder(context);
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      String xmlName =
+          OpcUaXmlEncoder.getXmlName(
+              OpcUaXmlEncoder.getNamespaceUri(context, struct.getTypeId()), struct);
 
-    String xmlName =
-        OpcUaXmlEncoder.getXmlName(
-            OpcUaXmlEncoder.getNamespaceUri(context, struct.getTypeId()), struct);
+      encoder.encodeStruct(xmlName, struct, codec);
 
-    encoder.encodeStruct(xmlName, struct, codec);
-
-    return ExtensionObject.of(XmlElement.of(encoder.getDocumentXml()), encodingId);
+      return ExtensionObject.of(XmlElement.of(encoder.getOutputString()), encodingId);
+    } catch (Exception e) {
+      throw new UaSerializationException(StatusCodes.Bad_EncodingError, e);
+    }
   }
 
   @Override

--- a/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlEncoderArrayTest.java
+++ b/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlEncoderArrayTest.java
@@ -37,11 +37,13 @@ public class OpcUaXmlEncoderArrayTest {
   @ParameterizedTest(name = "array = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ArrayArguments#booleanArrayArguments")
-  void encodeBooleanArray(@Nullable Boolean[] array, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeBooleanArray("Test", array);
+  void encodeBooleanArray(@Nullable Boolean[] array, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeBooleanArray("Test", array);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     Diff diff = DiffBuilder.compare(expected).withTest(actual).ignoreWhitespace().build();
 
@@ -53,11 +55,13 @@ public class OpcUaXmlEncoderArrayTest {
   @ParameterizedTest(name = "array = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ArrayArguments#sByteArrayArguments")
-  void encodeSByteArray(@Nullable Byte[] array, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeSByteArray("Test", array);
+  void encodeSByteArray(@Nullable Byte[] array, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeSByteArray("Test", array);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     Diff diff = DiffBuilder.compare(expected).withTest(actual).ignoreWhitespace().build();
 
@@ -69,11 +73,13 @@ public class OpcUaXmlEncoderArrayTest {
   @ParameterizedTest(name = "array = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ArrayArguments#byteArrayArguments")
-  void encodeByteArray(@Nullable UByte[] array, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeByteArray("Test", array);
+  void encodeByteArray(@Nullable UByte[] array, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeByteArray("Test", array);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     Diff diff = DiffBuilder.compare(expected).withTest(actual).ignoreWhitespace().build();
 
@@ -85,11 +91,13 @@ public class OpcUaXmlEncoderArrayTest {
   @ParameterizedTest(name = "array = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ArrayArguments#int16ArrayArguments")
-  void encodeInt16Array(@Nullable Short[] array, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeInt16Array("Test", array);
+  void encodeInt16Array(@Nullable Short[] array, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeInt16Array("Test", array);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     Diff diff = DiffBuilder.compare(expected).withTest(actual).ignoreWhitespace().build();
 
@@ -101,11 +109,13 @@ public class OpcUaXmlEncoderArrayTest {
   @ParameterizedTest(name = "array = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ArrayArguments#uInt16ArrayArguments")
-  void encodeUInt16Array(@Nullable UShort[] array, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeUInt16Array("Test", array);
+  void encodeUInt16Array(@Nullable UShort[] array, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeUInt16Array("Test", array);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     Diff diff = DiffBuilder.compare(expected).withTest(actual).ignoreWhitespace().build();
 
@@ -117,11 +127,13 @@ public class OpcUaXmlEncoderArrayTest {
   @ParameterizedTest(name = "array = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ArrayArguments#int32ArrayArguments")
-  void encodeInt32Array(@Nullable Integer[] array, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeInt32Array("Test", array);
+  void encodeInt32Array(@Nullable Integer[] array, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeInt32Array("Test", array);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     Diff diff = DiffBuilder.compare(expected).withTest(actual).ignoreWhitespace().build();
 
@@ -133,11 +145,13 @@ public class OpcUaXmlEncoderArrayTest {
   @ParameterizedTest(name = "array = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ArrayArguments#uInt32ArrayArguments")
-  void encodeUInt32Array(@Nullable UInteger[] array, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeUInt32Array("Test", array);
+  void encodeUInt32Array(@Nullable UInteger[] array, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeUInt32Array("Test", array);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     Diff diff = DiffBuilder.compare(expected).withTest(actual).ignoreWhitespace().build();
 
@@ -149,11 +163,13 @@ public class OpcUaXmlEncoderArrayTest {
   @ParameterizedTest(name = "array = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ArrayArguments#int64ArrayArguments")
-  void encodeInt64Array(@Nullable Long[] array, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeInt64Array("Test", array);
+  void encodeInt64Array(@Nullable Long[] array, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeInt64Array("Test", array);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     Diff diff = DiffBuilder.compare(expected).withTest(actual).ignoreWhitespace().build();
 
@@ -165,11 +181,13 @@ public class OpcUaXmlEncoderArrayTest {
   @ParameterizedTest(name = "array = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ArrayArguments#uInt64ArrayArguments")
-  void encodeUInt64Array(@Nullable ULong[] array, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeUInt64Array("Test", array);
+  void encodeUInt64Array(@Nullable ULong[] array, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeUInt64Array("Test", array);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     Diff diff = DiffBuilder.compare(expected).withTest(actual).ignoreWhitespace().build();
 
@@ -181,11 +199,13 @@ public class OpcUaXmlEncoderArrayTest {
   @ParameterizedTest(name = "array = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ArrayArguments#floatArrayArguments")
-  void encodeFloatArray(@Nullable Float[] array, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeFloatArray("Test", array);
+  void encodeFloatArray(@Nullable Float[] array, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeFloatArray("Test", array);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     Diff diff = DiffBuilder.compare(expected).withTest(actual).ignoreWhitespace().build();
 
@@ -197,11 +217,13 @@ public class OpcUaXmlEncoderArrayTest {
   @ParameterizedTest(name = "array = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ArrayArguments#doubleArrayArguments")
-  void encodeDoubleArray(@Nullable Double[] array, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeDoubleArray("Test", array);
+  void encodeDoubleArray(@Nullable Double[] array, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeDoubleArray("Test", array);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     Diff diff = DiffBuilder.compare(expected).withTest(actual).ignoreWhitespace().build();
 
@@ -213,11 +235,13 @@ public class OpcUaXmlEncoderArrayTest {
   @ParameterizedTest(name = "array = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ArrayArguments#stringArrayArguments")
-  void encodeStringArray(@Nullable String[] array, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeStringArray("Test", array);
+  void encodeStringArray(@Nullable String[] array, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeStringArray("Test", array);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     Diff diff = DiffBuilder.compare(expected).withTest(actual).ignoreWhitespace().build();
 
@@ -229,11 +253,13 @@ public class OpcUaXmlEncoderArrayTest {
   @ParameterizedTest(name = "array = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ArrayArguments#dateTimeArrayArguments")
-  void encodeDateTimeArray(@Nullable DateTime[] array, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeDateTimeArray("Test", array);
+  void encodeDateTimeArray(@Nullable DateTime[] array, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeDateTimeArray("Test", array);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     Diff diff = DiffBuilder.compare(expected).withTest(actual).ignoreWhitespace().build();
 
@@ -245,11 +271,13 @@ public class OpcUaXmlEncoderArrayTest {
   @ParameterizedTest(name = "array = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ArrayArguments#guidArrayArguments")
-  void encodeGuidArray(@Nullable UUID[] array, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeGuidArray("Test", array);
+  void encodeGuidArray(@Nullable UUID[] array, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeGuidArray("Test", array);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     Diff diff = DiffBuilder.compare(expected).withTest(actual).ignoreWhitespace().build();
 
@@ -261,11 +289,13 @@ public class OpcUaXmlEncoderArrayTest {
   @ParameterizedTest(name = "array = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ArrayArguments#byteStringArrayArguments")
-  void encodeByteStringArray(@Nullable ByteString[] array, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeByteStringArray("Test", array);
+  void encodeByteStringArray(@Nullable ByteString[] array, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeByteStringArray("Test", array);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     Diff diff = DiffBuilder.compare(expected).withTest(actual).ignoreWhitespace().build();
 
@@ -277,11 +307,13 @@ public class OpcUaXmlEncoderArrayTest {
   @ParameterizedTest(name = "array = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ArrayArguments#xmlElementArrayArguments")
-  void encodeXmlElementArray(@Nullable XmlElement[] array, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeXmlElementArray("Test", array);
+  void encodeXmlElementArray(@Nullable XmlElement[] array, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeXmlElementArray("Test", array);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     Diff diff = DiffBuilder.compare(expected).withTest(actual).ignoreWhitespace().build();
 
@@ -293,11 +325,13 @@ public class OpcUaXmlEncoderArrayTest {
   @ParameterizedTest(name = "array = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ArrayArguments#nodeIdArrayArguments")
-  void encodeNodeIdArray(@Nullable NodeId[] array, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeNodeIdArray("Test", array);
+  void encodeNodeIdArray(@Nullable NodeId[] array, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeNodeIdArray("Test", array);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     Diff diff = DiffBuilder.compare(expected).withTest(actual).ignoreWhitespace().build();
 
@@ -309,11 +343,14 @@ public class OpcUaXmlEncoderArrayTest {
   @ParameterizedTest(name = "array = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ArrayArguments#expandedNodeIdArrayArguments")
-  void encodeExpandedNodeIdArray(@Nullable ExpandedNodeId[] array, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeExpandedNodeIdArray("Test", array);
+  void encodeExpandedNodeIdArray(@Nullable ExpandedNodeId[] array, String expected)
+      throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeExpandedNodeIdArray("Test", array);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     Diff diff = DiffBuilder.compare(expected).withTest(actual).ignoreWhitespace().build();
 
@@ -325,11 +362,13 @@ public class OpcUaXmlEncoderArrayTest {
   @ParameterizedTest(name = "array = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ArrayArguments#statusCodeArrayArguments")
-  void encodeStatusCodeArray(@Nullable StatusCode[] array, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeStatusCodeArray("Test", array);
+  void encodeStatusCodeArray(@Nullable StatusCode[] array, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeStatusCodeArray("Test", array);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     Diff diff = DiffBuilder.compare(expected).withTest(actual).ignoreWhitespace().build();
 
@@ -341,11 +380,13 @@ public class OpcUaXmlEncoderArrayTest {
   @ParameterizedTest(name = "array = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ArrayArguments#qualifiedNameArrayArguments")
-  void encodeQualifiedNameArray(@Nullable QualifiedName[] array, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeQualifiedNameArray("Test", array);
+  void encodeQualifiedNameArray(@Nullable QualifiedName[] array, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeQualifiedNameArray("Test", array);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     Diff diff = DiffBuilder.compare(expected).withTest(actual).ignoreWhitespace().build();
 
@@ -357,11 +398,13 @@ public class OpcUaXmlEncoderArrayTest {
   @ParameterizedTest(name = "array = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ArrayArguments#localizedTextArrayArguments")
-  void encodeLocalizedTextArray(@Nullable LocalizedText[] array, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeLocalizedTextArray("Test", array);
+  void encodeLocalizedTextArray(@Nullable LocalizedText[] array, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeLocalizedTextArray("Test", array);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     Diff diff = DiffBuilder.compare(expected).withTest(actual).ignoreWhitespace().build();
 
@@ -373,11 +416,14 @@ public class OpcUaXmlEncoderArrayTest {
   @ParameterizedTest(name = "array = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ArrayArguments#extensionObjectArrayArguments")
-  void encodeExtensionObjectArray(@Nullable ExtensionObject[] array, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeExtensionObjectArray("Test", array);
+  void encodeExtensionObjectArray(@Nullable ExtensionObject[] array, String expected)
+      throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeExtensionObjectArray("Test", array);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     Diff diff = DiffBuilder.compare(expected).withTest(actual).ignoreWhitespace().build();
 
@@ -389,11 +435,13 @@ public class OpcUaXmlEncoderArrayTest {
   @ParameterizedTest(name = "array = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ArrayArguments#dataValueArrayArguments")
-  void encodeDataValueArray(@Nullable DataValue[] array, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeDataValueArray("Test", array);
+  void encodeDataValueArray(@Nullable DataValue[] array, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeDataValueArray("Test", array);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     Diff diff = DiffBuilder.compare(expected).withTest(actual).ignoreWhitespace().build();
 
@@ -405,11 +453,13 @@ public class OpcUaXmlEncoderArrayTest {
   @ParameterizedTest(name = "array = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ArrayArguments#variantArrayArguments")
-  void encodeVariantArray(@Nullable Variant[] array, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeVariantArray("Test", array);
+  void encodeVariantArray(@Nullable Variant[] array, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeVariantArray("Test", array);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     Diff diff = DiffBuilder.compare(expected).withTest(actual).ignoreWhitespace().build();
 
@@ -421,11 +471,14 @@ public class OpcUaXmlEncoderArrayTest {
   @ParameterizedTest(name = "array = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ArrayArguments#diagnosticInfoArrayArguments")
-  void encodeDiagnosticInfoArray(@Nullable DiagnosticInfo[] array, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeDiagnosticInfoArray("Test", array);
+  void encodeDiagnosticInfoArray(@Nullable DiagnosticInfo[] array, String expected)
+      throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeDiagnosticInfoArray("Test", array);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     Diff diff = DiffBuilder.compare(expected).withTest(actual).ignoreWhitespace().build();
 
@@ -437,11 +490,13 @@ public class OpcUaXmlEncoderArrayTest {
   @ParameterizedTest(name = "array = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ArrayArguments#enumArrayArguments")
-  void encodeEnumArray(@Nullable UaEnumeratedType[] array, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeEnumArray("Test", array);
+  void encodeEnumArray(@Nullable UaEnumeratedType[] array, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeEnumArray("Test", array);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     Diff diff = DiffBuilder.compare(expected).withTest(actual).ignoreWhitespace().build();
 
@@ -453,11 +508,13 @@ public class OpcUaXmlEncoderArrayTest {
   @ParameterizedTest(name = "array = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ArrayArguments#structArrayArguments")
-  void encodeStructArray(@Nullable UaStructuredType[] array, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeStructArray("Test", array, XVType.TYPE_ID);
+  void encodeStructArray(@Nullable UaStructuredType[] array, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeStructArray("Test", array, XVType.TYPE_ID);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     Diff diff = DiffBuilder.compare(expected).withTest(actual).ignoreWhitespace().build();
 

--- a/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlEncoderMatrixTest.java
+++ b/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlEncoderMatrixTest.java
@@ -29,11 +29,13 @@ public class OpcUaXmlEncoderMatrixTest {
   @ParameterizedTest(name = "matrix = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.MatrixArguments#matrixOfBuiltinTypeArguments")
-  void encodeMatrixOfBuiltinType(@Nullable Matrix matrix, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeMatrix("Test", matrix);
+  void encodeMatrixOfBuiltinType(@Nullable Matrix matrix, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeMatrix("Test", matrix);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     Diff diff = DiffBuilder.compare(expected).withTest(actual).ignoreWhitespace().build();
 
@@ -45,11 +47,13 @@ public class OpcUaXmlEncoderMatrixTest {
   @ParameterizedTest(name = "matrix = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.MatrixArguments#matrixOfStructuredTypeArguments")
-  void encodeMatrixOfStructuredType(Matrix matrix, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeStructMatrix("Test", matrix, matrix.getDataTypeId().orElseThrow());
+  void encodeMatrixOfStructuredType(Matrix matrix, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeStructMatrix("Test", matrix, matrix.getDataTypeId().orElseThrow());
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     Diff diff = DiffBuilder.compare(expected).withTest(actual).ignoreWhitespace().build();
 
@@ -61,11 +65,13 @@ public class OpcUaXmlEncoderMatrixTest {
   @ParameterizedTest(name = "matrix = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.MatrixArguments#matrixOfEnumeratedTypeArguments")
-  void encodeMatrixOfEnumeratedType(Matrix matrix, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeEnumMatrix("Test", matrix);
+  void encodeMatrixOfEnumeratedType(Matrix matrix, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeEnumMatrix("Test", matrix);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     Diff diff = DiffBuilder.compare(expected).withTest(actual).ignoreWhitespace().build();
 

--- a/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlEncoderScalarTest.java
+++ b/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlEncoderScalarTest.java
@@ -36,11 +36,13 @@ public class OpcUaXmlEncoderScalarTest {
   @ParameterizedTest(name = "value = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ScalarArguments#booleanArguments")
-  void encodeBoolean(Boolean value, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeBoolean("Test", value);
+  void encodeBoolean(Boolean value, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeBoolean("Test", value);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     Diff diff = DiffBuilder.compare(expected).withTest(actual).ignoreWhitespace().build();
 
@@ -52,11 +54,13 @@ public class OpcUaXmlEncoderScalarTest {
   @ParameterizedTest(name = "value = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ScalarArguments#sByteArguments")
-  void encodeSByte(Byte value, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeSByte("Test", value);
+  void encodeSByte(Byte value, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeSByte("Test", value);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     Diff diff = DiffBuilder.compare(expected).withTest(actual).ignoreWhitespace().build();
 
@@ -67,11 +71,13 @@ public class OpcUaXmlEncoderScalarTest {
 
   @ParameterizedTest(name = "value = {0}")
   @MethodSource("org.eclipse.milo.opcua.stack.core.encoding.xml.args.ScalarArguments#byteArguments")
-  void encodeByte(UByte value, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeByte("Test", value);
+  void encodeByte(UByte value, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeByte("Test", value);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     Diff diff = DiffBuilder.compare(expected).withTest(actual).ignoreWhitespace().build();
 
@@ -83,11 +89,13 @@ public class OpcUaXmlEncoderScalarTest {
   @ParameterizedTest(name = "value = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ScalarArguments#int16Arguments")
-  void encodeInt16(Short value, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeInt16("Test", value);
+  void encodeInt16(Short value, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeInt16("Test", value);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     Diff diff = DiffBuilder.compare(expected).withTest(actual).ignoreWhitespace().build();
 
@@ -99,11 +107,13 @@ public class OpcUaXmlEncoderScalarTest {
   @ParameterizedTest(name = "value = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ScalarArguments#uInt16Arguments")
-  void encodeUInt16(UShort value, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeUInt16("Test", value);
+  void encodeUInt16(UShort value, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeUInt16("Test", value);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     Diff diff = DiffBuilder.compare(expected).withTest(actual).ignoreWhitespace().build();
 
@@ -115,11 +125,13 @@ public class OpcUaXmlEncoderScalarTest {
   @ParameterizedTest(name = "value = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ScalarArguments#int32Arguments")
-  void encodeInt32(Integer value, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeInt32("Test", value);
+  void encodeInt32(Integer value, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeInt32("Test", value);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     Diff diff = DiffBuilder.compare(expected).withTest(actual).ignoreWhitespace().build();
 
@@ -131,11 +143,13 @@ public class OpcUaXmlEncoderScalarTest {
   @ParameterizedTest(name = "value = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ScalarArguments#uInt32Arguments")
-  void encodeUInt32(UInteger value, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeUInt32("Test", value);
+  void encodeUInt32(UInteger value, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeUInt32("Test", value);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     Diff diff = DiffBuilder.compare(expected).withTest(actual).ignoreWhitespace().build();
 
@@ -147,11 +161,13 @@ public class OpcUaXmlEncoderScalarTest {
   @ParameterizedTest(name = "value = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ScalarArguments#int64Arguments")
-  void encodeInt64(Long value, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeInt64("Test", value);
+  void encodeInt64(Long value, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeInt64("Test", value);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     Diff diff = DiffBuilder.compare(expected).withTest(actual).ignoreWhitespace().build();
 
@@ -163,11 +179,13 @@ public class OpcUaXmlEncoderScalarTest {
   @ParameterizedTest(name = "value = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ScalarArguments#uInt64Arguments")
-  void encodeUInt64(ULong value, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeUInt64("Test", value);
+  void encodeUInt64(ULong value, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeUInt64("Test", value);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     Diff diff = DiffBuilder.compare(expected).withTest(actual).ignoreWhitespace().build();
 
@@ -179,11 +197,13 @@ public class OpcUaXmlEncoderScalarTest {
   @ParameterizedTest(name = "value = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ScalarArguments#floatArguments")
-  void encodeFloat(Float value, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeFloat("Test", value);
+  void encodeFloat(Float value, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeFloat("Test", value);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     Diff diff = DiffBuilder.compare(expected).withTest(actual).ignoreWhitespace().build();
 
@@ -195,11 +215,13 @@ public class OpcUaXmlEncoderScalarTest {
   @ParameterizedTest(name = "value = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ScalarArguments#doubleArguments")
-  void encodeDouble(Double value, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeDouble("Test", value);
+  void encodeDouble(Double value, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeDouble("Test", value);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     Diff diff = DiffBuilder.compare(expected).withTest(actual).ignoreWhitespace().build();
 
@@ -211,11 +233,13 @@ public class OpcUaXmlEncoderScalarTest {
   @ParameterizedTest(name = "value = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ScalarArguments#stringArguments")
-  void encodeString(@Nullable String value, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeString("Test", value);
+  void encodeString(@Nullable String value, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeString("Test", value);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     if (value == null) {
       // When encoding a null string the encoder doesn't produce any XML
@@ -232,11 +256,13 @@ public class OpcUaXmlEncoderScalarTest {
   @ParameterizedTest(name = "dateTime = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ScalarArguments#dateTimeArguments")
-  void encodeDateTime(@Nullable DateTime dateTime, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeDateTime("Test", dateTime);
+  void encodeDateTime(@Nullable DateTime dateTime, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeDateTime("Test", dateTime);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     Diff diff = DiffBuilder.compare(expected).withTest(actual).ignoreWhitespace().build();
 
@@ -247,11 +273,13 @@ public class OpcUaXmlEncoderScalarTest {
 
   @ParameterizedTest(name = "guid = {0}")
   @MethodSource("org.eclipse.milo.opcua.stack.core.encoding.xml.args.ScalarArguments#guidArguments")
-  void encodeGuid(@Nullable UUID guid, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeGuid("Test", guid);
+  void encodeGuid(@Nullable UUID guid, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeGuid("Test", guid);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     Diff diff = DiffBuilder.compare(expected).withTest(actual).ignoreWhitespace().build();
 
@@ -263,11 +291,13 @@ public class OpcUaXmlEncoderScalarTest {
   @ParameterizedTest(name = "byteString = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ScalarArguments#byteStringArguments")
-  void encodeByteString(@Nullable ByteString byteString, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeByteString("Test", byteString);
+  void encodeByteString(@Nullable ByteString byteString, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeByteString("Test", byteString);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     if (byteString == null) {
       // When encoding a null ByteString the encoder doesn't produce any XML
@@ -284,11 +314,13 @@ public class OpcUaXmlEncoderScalarTest {
   @ParameterizedTest(name = "xmlElement = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ScalarArguments#xmlElementArguments")
-  void encodeXmlElement(@Nullable XmlElement xmlElement, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeXmlElement("Test", xmlElement);
+  void encodeXmlElement(@Nullable XmlElement xmlElement, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeXmlElement("Test", xmlElement);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     if (xmlElement == null) {
       // When encoding a null XmlElement the encoder doesn't produce any XML
@@ -305,11 +337,13 @@ public class OpcUaXmlEncoderScalarTest {
   @ParameterizedTest(name = "nodeId = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ScalarArguments#nodeIdArguments")
-  void encodeNodeId(NodeId nodeId, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeNodeId("Test", nodeId);
+  void encodeNodeId(NodeId nodeId, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeNodeId("Test", nodeId);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     if (nodeId == null) {
       // When encoding a null NodeId the encoder doesn't produce any XML
@@ -326,11 +360,14 @@ public class OpcUaXmlEncoderScalarTest {
   @ParameterizedTest(name = "expandedNodeId = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ScalarArguments#expandedNodeIdArguments")
-  void encodeExpandedNodeId(@Nullable ExpandedNodeId expandedNodeId, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeExpandedNodeId("Test", expandedNodeId);
+  void encodeExpandedNodeId(@Nullable ExpandedNodeId expandedNodeId, String expected)
+      throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeExpandedNodeId("Test", expandedNodeId);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     if (expandedNodeId == null) {
       // When encoding a null ExpandedNodeId the encoder doesn't produce any XML
@@ -347,11 +384,13 @@ public class OpcUaXmlEncoderScalarTest {
   @ParameterizedTest(name = "statusCode = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ScalarArguments#statusCodeArguments")
-  void encodeStatusCode(@Nullable StatusCode statusCode, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeStatusCode("Test", statusCode);
+  void encodeStatusCode(@Nullable StatusCode statusCode, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeStatusCode("Test", statusCode);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     if (statusCode == null) {
       // When encoding a null StatusCode the encoder doesn't produce any XML
@@ -368,11 +407,14 @@ public class OpcUaXmlEncoderScalarTest {
   @ParameterizedTest(name = "qualifiedName = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ScalarArguments#qualifiedNameArguments")
-  void encodeQualifiedName(@Nullable QualifiedName qualifiedName, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeQualifiedName("Test", qualifiedName);
+  void encodeQualifiedName(@Nullable QualifiedName qualifiedName, String expected)
+      throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeQualifiedName("Test", qualifiedName);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     if (qualifiedName == null) {
       // When encoding a null QualifiedName the encoder doesn't produce any XML
@@ -389,11 +431,14 @@ public class OpcUaXmlEncoderScalarTest {
   @ParameterizedTest(name = "localizedText = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ScalarArguments#localizedTextArguments")
-  void encodeLocalizedText(@Nullable LocalizedText localizedText, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeLocalizedText("Test", localizedText);
+  void encodeLocalizedText(@Nullable LocalizedText localizedText, String expected)
+      throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeLocalizedText("Test", localizedText);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     if (localizedText == null) {
       // When encoding a null LocalizedText the encoder doesn't produce any XML
@@ -410,11 +455,14 @@ public class OpcUaXmlEncoderScalarTest {
   @ParameterizedTest(name = "extensionObject = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ScalarArguments#extensionObjectArguments")
-  void encodeExtensionObject(@Nullable ExtensionObject extensionObject, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeExtensionObject("Test", extensionObject);
+  void encodeExtensionObject(@Nullable ExtensionObject extensionObject, String expected)
+      throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeExtensionObject("Test", extensionObject);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     if (extensionObject == null) {
       // When encoding a null ExtensionObject the encoder doesn't produce any XML
@@ -431,11 +479,13 @@ public class OpcUaXmlEncoderScalarTest {
   @ParameterizedTest(name = "dataValue = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ScalarArguments#dataValueArguments")
-  void encodeDataValue(@Nullable DataValue dataValue, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeDataValue("Test", dataValue);
+  void encodeDataValue(@Nullable DataValue dataValue, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeDataValue("Test", dataValue);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     if (dataValue == null) {
       // When encoding a null DataValue the encoder doesn't produce any XML
@@ -452,11 +502,13 @@ public class OpcUaXmlEncoderScalarTest {
   @ParameterizedTest(name = "variant = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.VariantArguments#variantOfScalarArguments")
-  void encodeVariantOfScalar(Variant variant, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeVariant("Test", variant);
+  void encodeVariantOfScalar(Variant variant, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeVariant("Test", variant);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     Diff diff = DiffBuilder.compare(expected).withTest(actual).ignoreWhitespace().build();
 
@@ -468,11 +520,13 @@ public class OpcUaXmlEncoderScalarTest {
   @ParameterizedTest(name = "variant = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.VariantArguments#variantOfArrayArguments")
-  void encodeVariantOfArray(Variant variant, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeVariant("Test", variant);
+  void encodeVariantOfArray(Variant variant, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeVariant("Test", variant);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     Diff diff = DiffBuilder.compare(expected).withTest(actual).ignoreWhitespace().build();
 
@@ -484,11 +538,13 @@ public class OpcUaXmlEncoderScalarTest {
   @ParameterizedTest(name = "variant = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.VariantArguments#variantOfMatrixArguments")
-  void encodeVariantOfMatrix(Variant variant, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeVariant("Test", variant);
+  void encodeVariantOfMatrix(Variant variant, String expected) throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeVariant("Test", variant);
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     Diff diff = DiffBuilder.compare(expected).withTest(actual).ignoreWhitespace().build();
 
@@ -500,12 +556,14 @@ public class OpcUaXmlEncoderScalarTest {
   @ParameterizedTest(name = "diagnosticInfo = {0}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.ScalarArguments#diagnosticInfoArguments")
-  void encodeDiagnosticInfo(@Nullable DiagnosticInfo diagnosticInfo, String expected) {
+  void encodeDiagnosticInfo(@Nullable DiagnosticInfo diagnosticInfo, String expected)
+      throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeDiagnosticInfo("Test", diagnosticInfo);
 
-    var encoder = new OpcUaXmlEncoder(context);
-    encoder.encodeDiagnosticInfo("Test", diagnosticInfo);
-
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     if (diagnosticInfo == null) {
       // When encoding a null DiagnosticInfo the encoder doesn't produce any XML
@@ -522,15 +580,18 @@ public class OpcUaXmlEncoderScalarTest {
   @ParameterizedTest(name = "field = {0}, struct = {1}, dataTypeId = {2}")
   @MethodSource(
       "org.eclipse.milo.opcua.stack.core.encoding.xml.args.StructArguments#structArguments")
-  void encodeStruct(String field, @Nullable UaStructuredType value, String expected) {
-    var encoder = new OpcUaXmlEncoder(context);
-    if (value != null) {
-      encoder.encodeStruct(field, value, value.getTypeId());
-    } else {
-      encoder.encodeStruct(field, null, NodeId.NULL_VALUE);
-    }
+  void encodeStruct(String field, @Nullable UaStructuredType value, String expected)
+      throws Exception {
+    String actual;
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      if (value != null) {
+        encoder.encodeStruct(field, value, value.getTypeId());
+      } else {
+        encoder.encodeStruct(field, null, NodeId.NULL_VALUE);
+      }
 
-    String actual = encoder.getDocumentXml();
+      actual = encoder.getOutputString();
+    }
 
     if (value == null) {
       // When encoding a null struct the encoder doesn't produce any XML


### PR DESCRIPTION
Additional changes:
- add constructor and `reset` method that accept `Writer`
- add `getOutput` and `getOutputString` methods
- try-with-resources for all usages of OpcUaXmlEncoder
