### PR TITLE
Configure `license-tool-plugin` behind a profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,8 @@
   -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.eclipse.milo</groupId>
@@ -178,6 +178,31 @@
                 <id>attach-javadocs</id>
                 <goals>
                   <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <profile>
+      <id>eclipse-license-check</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.eclipse.dash</groupId>
+            <artifactId>license-tool-plugin</artifactId>
+            <version>1.1.0</version>
+            <configuration>
+              <projectId>iot.milo</projectId>
+              <repo>https://github.com/eclipse-milo/milo</repo>
+            </configuration>
+            <executions>
+              <execution>
+                <id>license-check</id>
+                <goals>
+                  <goal>license-check</goal>
                 </goals>
               </execution>
             </executions>
@@ -394,5 +419,12 @@
       <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
     </repository>
   </distributionManagement>
+
+  <pluginRepositories>
+    <pluginRepository>
+      <id>dash-licenses-releases</id>
+      <url>https://repo.eclipse.org/content/repositories/dash-licenses-releases/</url>
+    </pluginRepository>
+  </pluginRepositories>
 </project>
 


### PR DESCRIPTION
Runs with `mvn verify`, but only with `-Peclipse-license-check`.
