### PR TITLE
Fix NPE in `SessionDiagnosticsObject::onShutdown`

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/objects/SessionsDiagnosticsSummaryObject.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/objects/SessionsDiagnosticsSummaryObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 the Eclipse Milo Authors
+ * Copyright (c) 2025 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -134,12 +134,11 @@ public class SessionsDiagnosticsSummaryObject extends AbstractLifecycle {
 
       SessionDiagnosticsObject sdo =
           new SessionDiagnosticsObject(sdoNode, session, diagnosticsNodeManager);
+      sdo.startup();
 
       sessionDiagnosticsObjects.put(session.getSessionId(), sdo);
-
-      sdo.startup();
     } catch (UaException e) {
-      e.printStackTrace();
+      LoggerFactory.getLogger(getClass()).warn("Failed to create SessionDiagnosticsObject", e);
     }
   }
 


### PR DESCRIPTION
Because the `SessionDiagnosticObject` was added to the `sessionDiagnosticsObjects` map before having `startup()` called, it was possible that during shutdown we could attempt to shut down a `SessionDiagnosticObject` that hadn't been started yet, and therefore had `null` fields.

fixes #1445