### PR TITLE
Fix NPE in `OpcUaSubscription::createMonitoredItems`

### DIFF
--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscription.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscription.java
@@ -457,6 +457,19 @@ public class OpcUaSubscription {
     var serviceOperationsResults =
         new ArrayList<MonitoredItemServiceOperationResult>(itemsToCreate.size());
 
+    ServerState serverState = this.serverState;
+    if (serverState == null) {
+      logger.debug("Bad_InvalidState: subscription not created yet");
+
+      for (OpcUaMonitoredItem item : itemsToCreate) {
+        serviceOperationsResults.add(
+            new MonitoredItemServiceOperationResult(
+                item, new StatusCode(StatusCodes.Bad_InvalidState), null));
+      }
+
+      return serviceOperationsResults;
+    }
+
     UInteger partitionSize = getMonitoredItemPartitionSize();
 
     List<List<OpcUaMonitoredItem>> partitions =
@@ -466,7 +479,7 @@ public class OpcUaSubscription {
       try {
         logger.debug(
             "id={}, createMonitoredItems partition.size(): {}",
-            serverState.subscriptionId,
+            serverState.getSubscriptionId(),
             partition.size());
 
         CreateMonitoredItemsResponse response =


### PR DESCRIPTION
Check if `serverState` is `null` before attempting to create MonitoredItems, which is possible if the user has not yet created the Subscription, or if they had created it, but it was reset because, e.g., Subscription transfer failed.

fixes #1446
