### PR TITLE
Unbind transports first in `OpcUaServer::shutdown`

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServer.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServer.java
@@ -313,13 +313,6 @@ public class OpcUaServer extends AbstractServiceHandler {
   }
 
   public CompletableFuture<OpcUaServer> shutdown() {
-    serverNamespace.shutdown();
-    opcUaNamespace.shutdown();
-
-    eventFactory.shutdown();
-
-    subscriptions.values().forEach(Subscription::deleteSubscription);
-
     transports
         .values()
         .forEach(
@@ -331,6 +324,13 @@ public class OpcUaServer extends AbstractServiceHandler {
               }
             });
     transports.clear();
+
+    serverNamespace.shutdown();
+    opcUaNamespace.shutdown();
+
+    eventFactory.shutdown();
+
+    subscriptions.values().forEach(Subscription::deleteSubscription);
 
     return CompletableFuture.completedFuture(this);
   }


### PR DESCRIPTION
This will disconnect clients before shutting down namespaces, which should help with some of the race conditions in the diagnostic nodes when sessions are being created as the nodes are shutting down.
