### PR TITLE
Use namespace index if possible when encoding ExpandedNodeId

### DIFF
--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryEncoder.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryEncoder.java
@@ -390,6 +390,17 @@ public class OpcUaBinaryEncoder implements UaEncoder {
     NamespaceReference namespace = value.namespace();
     if (namespace instanceof NamespaceUri uri) {
       namespaceUri = uri.namespaceUri();
+
+      // If we know the namespace index, use that for the encoding.
+      // It's more compact than encoding a namespace URI.
+      // It's also a workaround for bugs observed in the CTT and UaExpert, where the Client ignores
+      // the explicitly specified namespace URI in the ExpandedNodeId and just uses the namespace
+      // index, which is always 0 when the URI is encoded.
+      UShort index = context.getNamespaceTable().getIndex(namespaceUri);
+      if (index != null) {
+        namespaceIndex = index.intValue();
+        namespaceUri = null;
+      }
     } else if (value.namespace() instanceof NamespaceIndex index) {
       namespaceIndex = index.namespaceIndex().intValue();
     }

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/binary/ExpandedNodeIdSerializationTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/binary/ExpandedNodeIdSerializationTest.java
@@ -15,6 +15,7 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.UUID;
+import org.eclipse.milo.opcua.stack.core.NamespaceTable;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId.NamespaceReference;
@@ -53,6 +54,12 @@ public class ExpandedNodeIdSerializationTest extends BinarySerializationFixture 
     writer.encodeExpandedNodeId(nodeId);
     ExpandedNodeId decoded = reader.decodeExpandedNodeId();
 
-    assertEquals(nodeId, decoded);
+    NamespaceTable namespaceTable = writer.getEncodingContext().getNamespaceTable();
+
+    assertEquals(nodeId.getIdentifier(), decoded.getIdentifier());
+    assertEquals(nodeId.getServerIndex(), decoded.getServerIndex());
+    assertEquals(nodeId.getNamespaceUri(namespaceTable), decoded.getNamespaceUri(namespaceTable));
+    assertEquals(
+        nodeId.getNamespaceIndex(namespaceTable), decoded.getNamespaceIndex(namespaceTable));
   }
 }


### PR DESCRIPTION
Using the namespace index is more compact than encoding a namespace URI.

It's also a workaround for bugs observed in the CTT and UaExpert, where the Client ignores the explicitly specified namespace URI in the ExpandedNodeId and just uses the namespace index, which is always 0 when the URI is encoded.

fixes #1450
