### PR TITLE
Apply restrictions to ExpandedNodeId in ReferenceDescription 

### DIFF
--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryEncoder.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryEncoder.java
@@ -390,17 +390,6 @@ public class OpcUaBinaryEncoder implements UaEncoder {
     NamespaceReference namespace = value.namespace();
     if (namespace instanceof NamespaceUri uri) {
       namespaceUri = uri.namespaceUri();
-
-      // If we know the namespace index, use that for the encoding.
-      // It's more compact than encoding a namespace URI.
-      // It's also a workaround for bugs observed in the CTT and UaExpert, where the Client ignores
-      // the explicitly specified namespace URI in the ExpandedNodeId and just uses the namespace
-      // index, which is always 0 when the URI is encoded.
-      UShort index = context.getNamespaceTable().getIndex(namespaceUri);
-      if (index != null) {
-        namespaceIndex = index.intValue();
-        namespaceUri = null;
-      }
     } else if (value.namespace() instanceof NamespaceIndex index) {
       namespaceIndex = index.namespaceIndex().intValue();
     }

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/binary/ExpandedNodeIdSerializationTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/binary/ExpandedNodeIdSerializationTest.java
@@ -15,7 +15,6 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.UUID;
-import org.eclipse.milo.opcua.stack.core.NamespaceTable;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId.NamespaceReference;
@@ -54,12 +53,6 @@ public class ExpandedNodeIdSerializationTest extends BinarySerializationFixture 
     writer.encodeExpandedNodeId(nodeId);
     ExpandedNodeId decoded = reader.decodeExpandedNodeId();
 
-    NamespaceTable namespaceTable = writer.getEncodingContext().getNamespaceTable();
-
-    assertEquals(nodeId.getIdentifier(), decoded.getIdentifier());
-    assertEquals(nodeId.getServerIndex(), decoded.getServerIndex());
-    assertEquals(nodeId.getNamespaceUri(namespaceTable), decoded.getNamespaceUri(namespaceTable));
-    assertEquals(
-        nodeId.getNamespaceIndex(namespaceTable), decoded.getNamespaceIndex(namespaceTable));
+    assertEquals(nodeId, decoded);
   }
 }


### PR DESCRIPTION
If the server index indicates that the TargetNode is a remote Node, then the nodeId shall contain the absolute namespace URI. If the TargetNode is a local Node, the nodeId shall contain the namespace index.

See https://reference.opcfoundation.org/Core/Part4/v105/docs/7.30

fixes #1452