### PR TITLE
Reduce GC hotspots (AttributeId::values and AttributeFilterContext::new)

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/filters/AttributeFilterChain.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/filters/AttributeFilterChain.java
@@ -69,6 +69,9 @@ public class AttributeFilterChain {
    * @return the value for the attribute identified by {@code attributeId} from {@code node}.
    */
   public Object getAttribute(@Nullable Session session, UaNode node, AttributeId attributeId) {
+    if (filters.isEmpty()) {
+      return node.getAttribute(attributeId);
+    }
     Iterator<AttributeFilter> filterIterator = filters.iterator();
 
     AttributeFilter filter =
@@ -96,6 +99,9 @@ public class AttributeFilterChain {
    */
   public Object readAttribute(@Nullable Session session, UaNode node, AttributeId attributeId)
       throws UaException {
+    if (filters.isEmpty()) {
+      return node.getAttribute(attributeId);
+    }
     Iterator<AttributeFilter> filterIterator = filters.iterator();
 
     AttributeFilter filter =
@@ -133,6 +139,10 @@ public class AttributeFilterChain {
    */
   public void setAttribute(
       @Nullable Session session, UaNode node, AttributeId attributeId, Object value) {
+    if (filters.isEmpty()) {
+      node.setAttribute(attributeId, value);
+      return;
+    }
     Iterator<AttributeFilter> filterIterator = filters.iterator();
 
     AttributeFilter filter =
@@ -155,7 +165,10 @@ public class AttributeFilterChain {
   public void writeAttribute(
       @Nullable Session session, UaNode node, AttributeId attributeId, Object value)
       throws UaException {
-
+    if (filters.isEmpty()) {
+      node.setAttribute(attributeId, value);
+      return;
+    }
     Iterator<AttributeFilter> filterIterator = filters.iterator();
 
     AttributeFilter filter =

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/AttributeId.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/AttributeId.java
@@ -12,8 +12,10 @@ package org.eclipse.milo.opcua.stack.core;
 
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
@@ -47,6 +49,8 @@ public enum AttributeId {
   AccessRestrictions(26),
   AccessLevelEx(27);
 
+  private static final List<AttributeId> ALL;
+  
   public static final Set<AttributeId> BASE_ATTRIBUTES;
 
   public static final Set<AttributeId> DATA_TYPE_ATTRIBUTES;
@@ -66,6 +70,8 @@ public enum AttributeId {
   public static final Set<AttributeId> VIEW_ATTRIBUTES;
 
   static {
+    ALL = Arrays.asList(AttributeId.values());
+    
     var baseAttributes = new LinkedHashSet<AttributeId>();
     baseAttributes.add(NodeId);
     baseAttributes.add(NodeClass);
@@ -148,8 +154,9 @@ public enum AttributeId {
   }
 
   public static Optional<AttributeId> from(int attributeId) {
-    if (attributeId > 0 && attributeId <= values().length) {
-      return Optional.of(values()[attributeId - 1]);
+
+    if (attributeId > 0 && attributeId <= ALL.size()) {
+      return Optional.of(ALL.get(attributeId - 1));
     } else {
       return Optional.empty();
     }


### PR DESCRIPTION
I have noticed that a lot of memory is allocated when using the server and create many server-side updates of variable node values.

```java
Stack.sharedScheduledExecutor()
        .scheduleWithFixedDelay({ 
UaVariableNode::setValue(DataValue.valueOnly(Variant.ofFloat(speed)));
}, 2000, 50, TimeUnit.MILLISECONDS);
```

I could identify two hotspots:
`AttributeFilterContext::new ` which is also created without any filter (not sure whether this occurs in real situations) 
 and `AttributeId::from(int)` creates multiple `AttributeId::values` arrays.

In my performance test setup, the small changes help to reduce the GC frequency by 1:3.