### PR TITLE
"Normalize" ExpandedNodeId returned by browse services

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/servicesets/impl/helpers/BrowsePathsHelper.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/servicesets/impl/helpers/BrowsePathsHelper.java
@@ -125,7 +125,13 @@ public class BrowsePathsHelper {
     } else if (elements.size() == 1) {
       List<ExpandedNodeId> targets = target(nodeId, elements.get(0));
 
-      return targets.stream().map(n -> new BrowsePathTarget(n, UInteger.MAX)).collect(toList());
+      return targets.stream()
+          .map(
+              n -> {
+                n = BrowseUtil.normalize(n, server.getNamespaceTable());
+                return new BrowsePathTarget(n, UInteger.MAX);
+              })
+          .collect(toList());
     } else {
       RelativePathElement e = elements.get(0);
 
@@ -144,6 +150,7 @@ public class BrowsePathsHelper {
       } else {
         UInteger remaining = nextElements.isEmpty() ? UInteger.MAX : uint(nextElements.size());
 
+        nextXni = BrowseUtil.normalize(nextXni, server.getNamespaceTable());
         return List.of(new BrowsePathTarget(nextXni, remaining));
       }
     }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/servicesets/impl/helpers/BrowseUtil.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/servicesets/impl/helpers/BrowseUtil.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2025 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.servicesets.impl.helpers;
+
+import org.eclipse.milo.opcua.stack.core.NamespaceTable;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.structured.BrowsePathTarget;
+import org.eclipse.milo.opcua.stack.core.types.structured.ReferenceDescription;
+
+class BrowseUtil {
+
+  private BrowseUtil() {}
+
+  /**
+   * "Normalize" an {@link ExpandedNodeId} to be relative (index-based) if it is local and absolute
+   * (uri-based) if it is not.
+   *
+   * <p>This is required for ExpandedNodeId values returned in {@link ReferenceDescription} and
+   * {@link BrowsePathTarget}. See <a
+   * href="https://reference.opcfoundation.org/Core/Part4/v105/docs/7.30">ReferenceDescription</a>.
+   *
+   * @param nodeId the ExpandedNodeId to normalize.
+   * @param namespaceTable the NamespaceTable to use.
+   * @return the normalized ExpandedNodeId.
+   */
+  public static ExpandedNodeId normalize(ExpandedNodeId nodeId, NamespaceTable namespaceTable) {
+    if (nodeId.isLocal()) {
+      if (nodeId.isAbsolute()) {
+        nodeId = nodeId.relative(namespaceTable).orElseThrow();
+      }
+    } else {
+      if (nodeId.isRelative()) {
+        nodeId = nodeId.absolute(namespaceTable).orElseThrow();
+      }
+    }
+    return nodeId;
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/servicesets/impl/helpers/BrowseUtilTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/servicesets/impl/helpers/BrowseUtilTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2025 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.servicesets.impl.helpers;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.eclipse.milo.opcua.stack.core.NamespaceTable;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId.NamespaceReference;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId.ServerReference;
+import org.junit.jupiter.api.Test;
+
+class BrowseUtilTest {
+
+  @Test
+  void testNormalizeLocalAbsolute() {
+    NamespaceTable namespaceTable = new NamespaceTable();
+    namespaceTable.add("uri:test");
+
+    // Local (server index 0) and absolute (namespace URI)
+    ExpandedNodeId nodeId = ExpandedNodeId.of("uri:test", "test");
+    assertTrue(nodeId.isLocal());
+    assertTrue(nodeId.isAbsolute());
+
+    // Normalize should convert to relative
+    ExpandedNodeId normalized = BrowseUtil.normalize(nodeId, namespaceTable);
+    assertTrue(normalized.isLocal());
+    assertTrue(normalized.isRelative());
+    assertEquals(ushort(1), normalized.getNamespaceIndex());
+    assertEquals("test", normalized.getIdentifier());
+  }
+
+  @Test
+  void testNormalizeLocalRelative() {
+    NamespaceTable namespaceTable = new NamespaceTable();
+    namespaceTable.add("uri:test");
+
+    // Local (server index 0) and relative (namespace index)
+    ExpandedNodeId nodeId = ExpandedNodeId.of(ushort(1), "test");
+    assertTrue(nodeId.isLocal());
+    assertTrue(nodeId.isRelative());
+
+    // Normalize should keep it unchanged
+    ExpandedNodeId normalized = BrowseUtil.normalize(nodeId, namespaceTable);
+    assertTrue(normalized.isLocal());
+    assertTrue(normalized.isRelative());
+    assertEquals(ushort(1), normalized.getNamespaceIndex());
+    assertEquals("test", normalized.getIdentifier());
+    assertSame(nodeId, normalized); // Should be the same instance
+  }
+
+  @Test
+  void testNormalizeNonLocalRelative() {
+    NamespaceTable namespaceTable = new NamespaceTable();
+    namespaceTable.add("uri:test");
+
+    // Non-local (server index 1) and relative (namespace index)
+    ExpandedNodeId nodeId =
+        new ExpandedNodeId(ServerReference.of(1), NamespaceReference.of(ushort(1)), "test");
+    assertFalse(nodeId.isLocal());
+    assertTrue(nodeId.isRelative());
+
+    // Normalize should convert to absolute
+    ExpandedNodeId normalized = BrowseUtil.normalize(nodeId, namespaceTable);
+    assertFalse(normalized.isLocal());
+    assertTrue(normalized.isAbsolute());
+    assertEquals("uri:test", normalized.getNamespaceUri());
+    assertEquals("test", normalized.getIdentifier());
+  }
+
+  @Test
+  void testNormalizeNonLocalAbsolute() {
+    NamespaceTable namespaceTable = new NamespaceTable();
+    namespaceTable.add("uri:test");
+
+    // Non-local (server index 1) and absolute (namespace URI)
+    ExpandedNodeId nodeId =
+        new ExpandedNodeId(ServerReference.of(1), NamespaceReference.of("uri:test"), "test");
+    assertFalse(nodeId.isLocal());
+    assertTrue(nodeId.isAbsolute());
+
+    // Normalize should keep it unchanged
+    ExpandedNodeId normalized = BrowseUtil.normalize(nodeId, namespaceTable);
+    assertFalse(normalized.isLocal());
+    assertTrue(normalized.isAbsolute());
+    assertEquals("uri:test", normalized.getNamespaceUri());
+    assertEquals("test", normalized.getIdentifier());
+    assertSame(nodeId, normalized); // Should be the same instance
+  }
+}


### PR DESCRIPTION
- Introduce `BrowseUtil.normalize` to handle normalization of `ExpandedNodeId` values, ensuring they are relative for local nodes and absolute for non-local nodes.
- Replaced existing normalization logic across `BrowseHelper` and `BrowsePathsHelper` with calls to `BrowseUtil.normalize`.

fixes #1467