### PR TITLE
Update index range behavior for `String` and `ByteString` arrays

### DIFF
--- a/opc-ua-sdk/sdk-core/src/main/java/org/eclipse/milo/opcua/sdk/core/NumericRange.java
+++ b/opc-ua-sdk/sdk-core/src/main/java/org/eclipse/milo/opcua/sdk/core/NumericRange.java
@@ -134,6 +134,7 @@ public final class NumericRange {
 
   private static Object readFromValueAtRange(Object array, NumericRange range, int dimension)
       throws UaException {
+
     int dimensionCount = range.getDimensionCount();
     Bounds bounds = range.getDimensionBounds(dimension);
     int low = bounds.getLow();
@@ -158,14 +159,22 @@ public final class NumericRange {
       } else if (array instanceof String s) {
         int length = s.length();
         if (low >= length) {
-          throw new UaException(StatusCodes.Bad_IndexRangeNoData);
+          if (dimension > 1) {
+            return null;
+          } else {
+            throw new UaException(StatusCodes.Bad_IndexRangeNoData);
+          }
         }
         int to = Math.min(high + 1, length);
         return s.substring(low, to);
       } else if (array instanceof ByteString bs) {
         int length = bs.length();
         if (low >= length) {
-          throw new UaException(StatusCodes.Bad_IndexRangeNoData);
+          if (dimension > 1) {
+            return null;
+          } else {
+            throw new UaException(StatusCodes.Bad_IndexRangeNoData);
+          }
         }
         int to = Math.min(high + 1, length);
         byte[] copy = Arrays.copyOfRange(bs.bytesOrEmpty(), low, to);

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/core/NumericRangeTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/core/NumericRangeTest.java
@@ -151,6 +151,20 @@ public class NumericRangeTest {
   }
 
   @Test
+  public void testStringArrayOutOfRange() throws UaException {
+    String[] value = {"0123456789", "012345678", "0123456"};
+    var range = NumericRange.parse("0:2,7:9");
+
+    // the expected result is ["789", "78", null]
+    var expected = new String[] {"789", "78", null};
+
+    Object result = NumericRange.readFromValueAtRange(new Variant(value), range);
+
+    assertInstanceOf(String[].class, result);
+    assertTrue(Arrays.deepEquals(expected, (String[]) result));
+  }
+
+  @Test
   public void testByteString1d() throws UaException {
     NumericRange nr = NumericRange.parse("1:2");
     Variant value = new Variant(new ByteString(new byte[] {1, 2, 3, 4}));
@@ -189,6 +203,27 @@ public class NumericRangeTest {
 
     assertInstanceOf(ByteString.class, result);
     assertEquals(byteString, result);
+  }
+
+  @Test
+  public void testByteStringArrayOutOfRange() throws UaException {
+    ByteString[] value = {
+      new ByteString(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}),
+      new ByteString(new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8}),
+      new ByteString(new byte[] {0, 1, 2, 3, 4, 5, 6})
+    };
+    var range = NumericRange.parse("0:2,7:9");
+
+    // the expected result is [ByteString([7, 8, 9]), ByteString([7, 8]), null]
+    var expected =
+        new ByteString[] {
+          new ByteString(new byte[] {7, 8, 9}), new ByteString(new byte[] {7, 8}), null
+        };
+
+    Object result = NumericRange.readFromValueAtRange(new Variant(value), range);
+
+    assertInstanceOf(ByteString[].class, result);
+    assertTrue(Arrays.deepEquals(expected, (ByteString[]) result));
   }
 
   @ParameterizedTest


### PR DESCRIPTION
Normally, when the lower bound of one of the index range parameters exceeds the length of the value it's being applied to, `Bad_IndexRangeNoData` is returned for the entire operation.

In the case of a String array or ByteString array, it has been decided that the intended behavior is to return a null or empty value instead of `Bad_IndexRangeNoData` for the entire operation.

e.g. given the value `["TestString", "Test", "String"]`, reading with index range `"0:2,7:9"` would yield `["ing", null, null]` rather than `Bad_IndexRangeNoData`.

fixes #1496