### PR TITLE
Remove `OpcUaClient::getOperationLimits()` call

### DIFF
--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/typetree/DataTypeTreeBuilder.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/typetree/DataTypeTreeBuilder.java
@@ -351,7 +351,6 @@ public class DataTypeTreeBuilder {
   }
 
   private static UInteger[] readOperationLimits(OpcUaClient client) throws UaException {
-    client.getOperationLimits();
     UInteger[] operationLimits = new UInteger[2];
     operationLimits[0] = uint(10);
     operationLimits[1] = uint(100);


### PR DESCRIPTION
Not sure how this ended up here, but it's a mistake.