### PR TITLE
Fix a deadlock in OpcUaClient async callbacks

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/OpcUaClientDeadlockTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/OpcUaClientDeadlockTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2025 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.eclipse.milo.opcua.sdk.test.AbstractClientServerTest;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.TimestampsToReturn;
+import org.junit.jupiter.api.Test;
+
+public class OpcUaClientDeadlockTest extends AbstractClientServerTest {
+
+  @Test
+  void deadlockInAsyncCallback() throws Exception {
+    CompletableFuture<List<DataValue>> future =
+        client.readValuesAsync(
+            0.0, TimestampsToReturn.Neither, List.of(NodeIds.Server_ServerStatus_CurrentTime));
+
+    var blockingReadComplete = new CountDownLatch(1);
+
+    future.whenComplete(
+        (values, ex) -> {
+          try {
+            client.readValue(
+                0.0, TimestampsToReturn.Neither, NodeIds.Server_ServerStatus_CurrentTime);
+
+            blockingReadComplete.countDown();
+          } catch (UaException e) {
+            throw new RuntimeException(e);
+          }
+        });
+
+    assertTrue(
+        blockingReadComplete.await(1, TimeUnit.SECONDS),
+        "timed out waiting for blocking read to complete");
+  }
+}

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/test/AbstractClientServerTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/test/AbstractClientServerTest.java
@@ -41,7 +41,7 @@ public abstract class AbstractClientServerTest {
   }
 
   @AfterAll
-  public void stopClientAndServer() throws Exception {
+  public void stopClientAndServer() {
     try {
       client.disconnectAsync().get(2, TimeUnit.SECONDS);
     } catch (Exception e) {

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/test/AbstractClientServerTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/test/AbstractClientServerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 the Eclipse Milo Authors
+ * Copyright (c) 2025 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -10,7 +10,7 @@
 
 package org.eclipse.milo.opcua.sdk.test;
 
-import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
 import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
@@ -41,11 +41,18 @@ public abstract class AbstractClientServerTest {
   }
 
   @AfterAll
-  public void stopClientAndServer() throws ExecutionException, InterruptedException {
-    client.disconnectAsync().get();
-
-    testNamespace.shutdown();
-    server.shutdown().get();
+  public void stopClientAndServer() throws Exception {
+    try {
+      client.disconnectAsync().get(2, TimeUnit.SECONDS);
+    } catch (Exception e) {
+      e.printStackTrace(System.err);
+    }
+    try {
+      testNamespace.shutdown();
+      server.shutdown().get(2, TimeUnit.SECONDS);
+    } catch (Exception e) {
+      e.printStackTrace(System.err);
+    }
   }
 
   /**


### PR DESCRIPTION
A deadlock could occur if a blocking client call was made from within the completion callback of an asynchronous client call.

The completion callbacks were being delivered using an ExecutionQueue, and a blocking call made from the callback would end up waiting for a response that needed to be delivered using the same queue.

fixes #1537