### PR TITLE
Add SBOM generation and upload workflow

### DIFF
--- a/.github/workflows/generate-maven-sbom.yml
+++ b/.github/workflows/generate-maven-sbom.yml
@@ -1,0 +1,70 @@
+name: Generate Maven SBOM
+
+on:
+  workflow_run:
+    workflows: [Maven Release]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version'
+        default: '1.0'
+        required: true
+
+env:
+  JAVA_VERSION: '17'
+  JAVA_DISTRO: 'temurin'
+  PRODUCT_PATH: './'
+  PLUGIN_VERSION: '2.7.8'
+  SBOM_TYPE: 'makeAggregateBom'
+
+permissions:
+  contents: read
+
+jobs:
+  generate-sbom:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || 
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+    outputs:
+      project-version: ${{ steps.version.outputs.PROJECT_VERSION }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha || github.event.inputs.version }}
+
+      - name: Setup Java SDK
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.JAVA_DISTRO }}
+
+      - name: Generate sbom
+        run: |
+          mvn org.cyclonedx:cyclonedx-maven-plugin:$PLUGIN_VERSION:$SBOM_TYPE -f "$PRODUCT_PATH/pom.xml"
+
+      - name: Extract product version
+        id: version
+        shell: bash
+        run: |
+          VERSION="$(jq -r '.metadata.component.version' < ${{ env.PRODUCT_PATH }}/target/bom.json)"
+          echo "PROJECT_VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "Product version is: $VERSION"
+
+      - name: Upload sbom
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: sbom
+          path: ${{ env.PRODUCT_PATH }}/target/bom.json
+
+  store-sbom-data: # stores sbom and metadata in a predefined format for otterdog to pick up
+    needs: ['generate-sbom']
+    uses: eclipse-csi/workflows/.github/workflows/store-sbom-data.yml@main
+    with:
+      projectName: 'milo'
+      projectVersion: ${{ needs.generate-sbom.outputs.project-version }}
+      bomArtifact: 'sbom'
+      bomFilename: 'bom.json'
+      parentProject: '5a8aca4c-6bd9-4755-88d6-082de6be1f48'


### PR DESCRIPTION
This PR aims to bootstrap the EF Security Team initiative of supporting projects in implementing automated SBOM generation and upload workflows, with the goal of enhancing software supply chain security.

We wanted this to seamlessly integrate with your existing release processes, so we implemented 1 workflow meant to generate an SBOM for the `milo` product.

Currently the workflow is triggered after a successful completion of the `Maven Release` workflow. A cyclonedx maven plugin (`cyclonedx-maven-plugin`) is used to generate the SBOM, which is then uploaded as an artifact. The `store-sbom-data` reusable workflow stores additional metadata about the project and upon completion, the self service system downloads the SBOM from artifacts and uploads it to our DependencyTrack [instance](https://sbom.eclipse.org/), under the `Eclipse Milo/milo` entry. After a successful workflow run, to view the uploaded results, you can log into the instance by using your EF account credentials.

We have tested the SBOM generation separately and everything worked successfully. However, due to limited permissions and inability to simulate the trigger event, we'd need  your due diligence in reviewing it, especially the trigger events, versioning and checked out refs. Our goal is to have the workflow automatically run for each new release, but only after the new version artifacts have been published - in your case that being after the successful completion of the Maven Release workflow. Checking out the correct ref with the new version without the release event was a bit tricky, especially whilst trying to maintain the manual run option, but I think that should be solved now. From a quick look, it seems this also mitigates some of the issues and concerns in [this PR](https://github.com/eclipse-milo/milo/pull/1501). If this gets merged, we'd ask if you could manually run it once so we can confirm the upload to our instance works as expected (for the version input the latest release tag/commit can be used).

For any potential integration issues with existing release processes that we might have missed, please feel free to update the workflow as needed, edits by maintainers are enabled. Additionally, if maintaining multiple parallel branches for releases, a version of the workflow should run on them as well.

Please let us know if you have any questions we can help with.

More details about our SBOM Early Adopters initiative at EF can be found in our [Security Handbook](https://eclipse-csi.github.io/security-handbook/sbom/index.html), alongside documentation on what is an SBOM, what are they used for, tooling ecosystem and our upload integration. Previous successful early adopters workflow examples are listed in the table at [SBOM Early Adopters](https://eclipse-csi.github.io/security-handbook/sbom/earlyadopters.html)

Before you submit a pull request please acknowledge the following:
- [x] You have signed an Eclipse Contributor Agreement and are committing using the same email address
- [ ] Your code contains any tests relevant to the problem you are solving
- [ ] All new and existing tests passed
- [x] Code follows the style guidelines and Checkstyle passes

See [CONTRIBUTING](https://github.com/eclipse-milo/milo/blob/master/CONTRIBUTING.md) for more information.
