### PR TITLE
Throw UaRuntimeException for add/remove on uninitialized Subscription

### DIFF
--- a/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/ClientExampleRunner.java
+++ b/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/ClientExampleRunner.java
@@ -148,6 +148,8 @@ public class ClientExampleRunner {
             try {
               client.disconnectAsync().get();
               if (serverRequired && exampleServer != null) {
+                // let the session listener callbacks run
+                Thread.sleep(500);
                 exampleServer.shutdown().get();
               }
               Stack.releaseSharedResources();

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscriptionTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscriptionTest.java
@@ -14,6 +14,7 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
@@ -24,6 +25,7 @@ import org.eclipse.milo.opcua.sdk.client.subscriptions.OpcUaSubscription.SyncSta
 import org.eclipse.milo.opcua.sdk.test.AbstractClientServerTest;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
 import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.UaRuntimeException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.MonitoringMode;
@@ -380,5 +382,27 @@ public class OpcUaSubscriptionTest extends AbstractClientServerTest {
     assertTrue(deleteResults.stream().allMatch(r -> r.operationResult().orElseThrow().isGood()));
 
     subscription.delete();
+  }
+
+  @Test
+  void addItemsToUninitializedSubscriptionThrows() {
+    var subscription = new OpcUaSubscription(client);
+
+    assertThrows(
+        UaRuntimeException.class,
+        () ->
+            subscription.addMonitoredItem(
+                OpcUaMonitoredItem.newDataItem(NodeIds.Server_ServerStatus_CurrentTime)));
+  }
+
+  @Test
+  void removeItemsFromUninitializedSubscriptionThrows() {
+    var subscription = new OpcUaSubscription(client);
+
+    assertThrows(
+        UaRuntimeException.class,
+        () ->
+            subscription.removeMonitoredItem(
+                OpcUaMonitoredItem.newDataItem(NodeIds.Server_ServerStatus_CurrentTime)));
   }
 }

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/test/AbstractClientServerTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/test/AbstractClientServerTest.java
@@ -48,6 +48,8 @@ public abstract class AbstractClientServerTest {
       e.printStackTrace(System.err);
     }
     try {
+      // let the session listener callbacks run
+      Thread.sleep(500);
       testNamespace.shutdown();
       server.shutdown().get(2, TimeUnit.SECONDS);
     } catch (Exception e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscription.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscription.java
@@ -28,6 +28,7 @@ import org.eclipse.milo.opcua.sdk.client.SessionActivityListener;
 import org.eclipse.milo.opcua.sdk.client.UaSession;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.UaRuntimeException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
@@ -305,8 +306,13 @@ public class OpcUaSubscription {
    * called.
    *
    * @param item the MonitoredItem to add.
+   * @throws UaRuntimeException if the Subscription has not been created yet.
    */
   public void addMonitoredItem(OpcUaMonitoredItem item) {
+    if (syncState == SyncState.INITIAL) {
+      throw new UaRuntimeException(StatusCodes.Bad_InvalidState, "subscription not created yet");
+    }
+
     if (!monitoredItems.containsValue(item)) {
       if (itemsToDelete.remove(item)) {
         monitoredItems.put(item.getClientHandle().orElseThrow(), item);
@@ -328,6 +334,7 @@ public class OpcUaSubscription {
    * called.
    *
    * @param items the MonitoredItems to add.
+   * @throws UaRuntimeException if the Subscription has not been created yet.
    */
   public void addMonitoredItems(List<OpcUaMonitoredItem> items) {
     items.forEach(this::addMonitoredItem);
@@ -340,8 +347,13 @@ public class OpcUaSubscription {
    * called
    *
    * @param item the MonitoredItem to remove.
+   * @throws UaRuntimeException if the Subscription has not been created yet.
    */
   public void removeMonitoredItem(OpcUaMonitoredItem item) {
+    if (syncState == SyncState.INITIAL) {
+      throw new UaRuntimeException(StatusCodes.Bad_InvalidState, "subscription not created yet");
+    }
+
     OpcUaMonitoredItem removedItem =
         item.getClientHandle().map(monitoredItems::remove).orElse(null);
 
@@ -358,6 +370,7 @@ public class OpcUaSubscription {
    * is called.
    *
    * @param items the MonitoredItems to remove.
+   * @throws UaRuntimeException if the Subscription has not been created yet.
    */
   public void removeMonitoredItems(List<OpcUaMonitoredItem> items) {
     items.forEach(this::removeMonitoredItem);


### PR DESCRIPTION
MonitoredItems aren't supposed to be added or removed before the Subscription has been created and moved out of `SyncState.INITIAL`. Currently, nothing prevents this, which results in the Subscription subsequently moving to `SyncState.UNSYNCHRONIZED` even though it doesn't exist yet, and then eventually the call to create fails with `Bad_InvalidState`.

This guards the add/remove MonitoredItem methods with checks that throw `UaRuntimeException` if they are called before the Subscription has been created. 

Ideally these would throw `UaException` instead but I'm trying to avoid modifying the API method signatures.