### PR TITLE
Implement optional Session endpoint validation

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/SessionValidationTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/SessionValidationTest.java
@@ -1,0 +1,21 @@
+package org.eclipse.milo.opcua.sdk.client;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.eclipse.milo.opcua.sdk.test.AbstractClientServerTest;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.junit.jupiter.api.Test;
+
+public class SessionValidationTest extends AbstractClientServerTest {
+
+  @Override
+  protected void customizeClientConfig(OpcUaClientConfigBuilder configBuilder) {
+    configBuilder.setSessionEndpointValidationEnabled(true);
+  }
+
+  @Test
+  void clientConnectsWithSessionValidationEnabled() throws UaException {
+    assertNotNull(client.connect());
+    assertNotNull(client.getSession());
+  }
+}

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/test/AbstractClientServerTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/test/AbstractClientServerTest.java
@@ -12,6 +12,7 @@ package org.eclipse.milo.opcua.sdk.test;
 
 import java.util.concurrent.TimeUnit;
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClientConfigBuilder;
 import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
@@ -35,7 +36,7 @@ public abstract class AbstractClientServerTest {
 
     server.startup().get();
 
-    client = TestClient.create(server);
+    client = TestClient.create(server, this::customizeClientConfig);
 
     client.connect();
   }
@@ -56,6 +57,14 @@ public abstract class AbstractClientServerTest {
       e.printStackTrace(System.err);
     }
   }
+
+  /**
+   * Customize the configuration of the OPC UA client before it connects. This method can be
+   * overridden by subclasses to modify the default client configuration.
+   *
+   * @param configBuilder the {@link OpcUaClientConfigBuilder} to modify.
+   */
+  protected void customizeClientConfig(OpcUaClientConfigBuilder configBuilder) {}
 
   /**
    * Create a new {@link NodeId} in the {@link TestNamespace}.

--- a/opc-ua-sdk/sdk-client/pom.xml
+++ b/opc-ua-sdk/sdk-client/pom.xml
@@ -44,6 +44,24 @@
       <artifactId>jspecify</artifactId>
       <version>1.0.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClient.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClient.java
@@ -275,9 +275,15 @@ public class OpcUaClient {
           OpcTcpClientTransportConfig.newBuilder();
       configureTransport.accept(transportConfigBuilder);
 
-      OpcUaClientConfigBuilder clientConfigBuilder =
-          OpcUaClientConfig.builder().setEndpoint(endpoint);
+      OpcUaClientConfigBuilder clientConfigBuilder = OpcUaClientConfig.builder();
+      clientConfigBuilder.setEndpoint(endpoint);
+      clientConfigBuilder.setDiscoveryEndpoints(endpoints);
+      // Set up the discovery endpoints in case the user enables this, but default to false for
+      // backwards compatibility.
+      clientConfigBuilder.setSessionEndpointValidationEnabled(false);
+
       configureClient.accept(clientConfigBuilder);
+
       OpcUaClientConfig clientConfig = clientConfigBuilder.build();
 
       var transport = new OpcTcpClientTransport(transportConfigBuilder.build());

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClientConfig.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClientConfig.java
@@ -12,6 +12,8 @@ package org.eclipse.milo.opcua.sdk.client;
 
 import java.security.KeyPair;
 import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -31,6 +33,18 @@ public interface OpcUaClientConfig {
    * @return the {@link EndpointDescription} to connect to.
    */
   EndpointDescription getEndpoint();
+
+  /**
+   * Get the endpoints that were returned during discovery, i.e., during the GetEndpoints service
+   * call.
+   *
+   * <p>If not empty, and Session endpoint validation is enabled, this list will be compared with
+   * the list returned by the Server in the CreateSessionResponse when a Session is created.
+   *
+   * @return the endpoints that were returned during discovery.
+   * @see #isSessionEndpointValidationEnabled()
+   */
+  List<EndpointDescription> getDiscoveryEndpoints();
 
   /**
    * Get the {@link KeyPair} to use.
@@ -140,6 +154,16 @@ public interface OpcUaClientConfig {
   UInteger getKeepAliveTimeout();
 
   /**
+   * Whether validation of the endpoints returned in CreateSessionResponse against the discovery
+   * endpoints is enabled. The discovery endpoints must be configured and non-empty.
+   *
+   * @return true if validation of the endpoints returned in CreateSessionResponse against the
+   *     discovery endpoints is enabled.
+   * @see #getDiscoveryEndpoints()
+   */
+  boolean isSessionEndpointValidationEnabled();
+
+  /**
    * @return a new {@link OpcUaClientConfigBuilder}.
    */
   static OpcUaClientConfigBuilder builder() {
@@ -159,6 +183,7 @@ public interface OpcUaClientConfig {
 
     builder.setEndpoint(config.getEndpoint());
     config.getKeyPair().ifPresent(builder::setKeyPair);
+    builder.setDiscoveryEndpoints(new ArrayList<>(config.getDiscoveryEndpoints()));
     config.getCertificate().ifPresent(builder::setCertificate);
     config.getCertificateChain().ifPresent(builder::setCertificateChain);
     builder.setApplicationName(config.getApplicationName());
@@ -174,6 +199,7 @@ public interface OpcUaClientConfig {
     builder.setKeepAliveInterval(config.getKeepAliveInterval());
     builder.setKeepAliveTimeout(config.getKeepAliveTimeout());
     builder.setSessionLocaleIds(config.getSessionLocaleIds());
+    builder.setSessionEndpointValidationEnabled(config.isSessionEndpointValidationEnabled());
 
     return builder;
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClientConfigBuilder.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClientConfigBuilder.java
@@ -14,6 +14,7 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 
 import java.security.KeyPair;
 import java.security.cert.X509Certificate;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 import org.eclipse.milo.opcua.sdk.client.identity.AnonymousProvider;
@@ -27,6 +28,7 @@ import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
 public class OpcUaClientConfigBuilder {
 
   private EndpointDescription endpoint;
+  private List<EndpointDescription> discoveryEndpoints;
   private KeyPair keyPair;
   private X509Certificate certificate;
   private X509Certificate[] certificateChain;
@@ -52,6 +54,8 @@ public class OpcUaClientConfigBuilder {
   private UInteger keepAliveFailuresAllowed = uint(1);
   private UInteger keepAliveInterval = uint(5000);
   private UInteger keepAliveTimeout = uint(5000);
+
+  private boolean sessionEndpointValidationEnabled = false;
 
   public OpcUaClientConfigBuilder setApplicationName(LocalizedText applicationName) {
     this.applicationName = applicationName;
@@ -123,8 +127,22 @@ public class OpcUaClientConfigBuilder {
     return this;
   }
 
+  public OpcUaClientConfigBuilder setSessionEndpointValidationEnabled(
+      boolean validateSessionEndpointsEnabled) {
+
+    this.sessionEndpointValidationEnabled = validateSessionEndpointsEnabled;
+    return this;
+  }
+
   public OpcUaClientConfigBuilder setEndpoint(EndpointDescription endpoint) {
     this.endpoint = endpoint;
+    return this;
+  }
+
+  public OpcUaClientConfigBuilder setDiscoveryEndpoints(
+      List<EndpointDescription> discoveryEndpoints) {
+
+    this.discoveryEndpoints = discoveryEndpoints;
     return this;
   }
 
@@ -158,6 +176,7 @@ public class OpcUaClientConfigBuilder {
 
     return new OpcUaClientConfigImpl(
         endpoint,
+        discoveryEndpoints,
         keyPair,
         certificate,
         certificateChain,
@@ -175,12 +194,14 @@ public class OpcUaClientConfigBuilder {
         identityProvider,
         keepAliveFailuresAllowed,
         keepAliveInterval,
-        keepAliveTimeout);
+        keepAliveTimeout,
+        sessionEndpointValidationEnabled);
   }
 
   static class OpcUaClientConfigImpl implements OpcUaClientConfig {
 
     private final EndpointDescription endpoint;
+    private final List<EndpointDescription> discoveryEndpoints;
     private final KeyPair keyPair;
     private final X509Certificate certificate;
     private final X509Certificate[] certificateChain;
@@ -200,9 +221,11 @@ public class OpcUaClientConfigBuilder {
     private final UInteger keepAliveFailuresAllowed;
     private final UInteger keepAliveInterval;
     private final UInteger keepAliveTimeout;
+    private final boolean sessionEndpointValidationEnabled;
 
     OpcUaClientConfigImpl(
         EndpointDescription endpoint,
+        List<EndpointDescription> discoveryEndpoints,
         KeyPair keyPair,
         X509Certificate certificate,
         X509Certificate[] certificateChain,
@@ -220,8 +243,11 @@ public class OpcUaClientConfigBuilder {
         IdentityProvider identityProvider,
         UInteger keepAliveFailuresAllowed,
         UInteger keepAliveInterval,
-        UInteger keepAliveTimeout) {
+        UInteger keepAliveTimeout,
+        boolean sessionEndpointValidationEnabled) {
+
       this.endpoint = endpoint;
+      this.discoveryEndpoints = discoveryEndpoints;
       this.keyPair = keyPair;
       this.certificate = certificate;
       this.certificateChain = certificateChain;
@@ -240,11 +266,17 @@ public class OpcUaClientConfigBuilder {
       this.keepAliveFailuresAllowed = keepAliveFailuresAllowed;
       this.keepAliveInterval = keepAliveInterval;
       this.keepAliveTimeout = keepAliveTimeout;
+      this.sessionEndpointValidationEnabled = sessionEndpointValidationEnabled;
     }
 
     @Override
     public EndpointDescription getEndpoint() {
       return endpoint;
+    }
+
+    @Override
+    public List<EndpointDescription> getDiscoveryEndpoints() {
+      return discoveryEndpoints;
     }
 
     @Override
@@ -335,6 +367,11 @@ public class OpcUaClientConfigBuilder {
     @Override
     public UInteger getKeepAliveTimeout() {
       return keepAliveTimeout;
+    }
+
+    @Override
+    public boolean isSessionEndpointValidationEnabled() {
+      return sessionEndpointValidationEnabled;
     }
   }
 }

--- a/opc-ua-sdk/sdk-client/src/test/java/org/eclipse/milo/opcua/sdk/client/session/SessionEndpointValidationTest.java
+++ b/opc-ua-sdk/sdk-client/src/test/java/org/eclipse/milo/opcua/sdk/client/session/SessionEndpointValidationTest.java
@@ -1,0 +1,278 @@
+package org.eclipse.milo.opcua.sdk.client.session;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import org.eclipse.milo.opcua.stack.core.Stack;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.ApplicationType;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.MessageSecurityMode;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.UserTokenType;
+import org.eclipse.milo.opcua.stack.core.types.structured.ApplicationDescription;
+import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
+import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class SessionEndpointValidationTest {
+
+  private static final String TRANSPORT_OPC_TCP = Stack.TCP_UASC_UABINARY_TRANSPORT_URI;
+
+  private static final String TRANSPORT_HTTPS = Stack.HTTPS_UABINARY_TRANSPORT_URI;
+
+  @Test
+  @DisplayName("Returns without validation when no discovery endpoints match the transport profile")
+  void testNoDiscoveryForTransportReturns() {
+    List<EndpointDescription> discovery =
+        List.of(
+            endpoint(
+                "urn:app",
+                "opc.tcp://a:4840",
+                MessageSecurityMode.None,
+                "none",
+                userTokens("anon"),
+                TRANSPORT_HTTPS,
+                (short) 1));
+
+    List<EndpointDescription> session =
+        List.of(
+            endpoint(
+                "urn:app",
+                "opc.tcp://a:4840",
+                MessageSecurityMode.None,
+                "none",
+                userTokens("anon"),
+                TRANSPORT_OPC_TCP,
+                (short) 1));
+
+    assertDoesNotThrow(
+        () -> SessionFsmFactory.validateSessionEndpoints(TRANSPORT_OPC_TCP, discovery, session));
+  }
+
+  @Test
+  @DisplayName("Throws when filtered sizes differ")
+  void testSizeMismatchThrows() {
+    List<EndpointDescription> discovery = new ArrayList<>();
+    discovery.add(
+        endpoint(
+            "urn:app",
+            "opc.tcp://a:4840",
+            MessageSecurityMode.None,
+            "none",
+            userTokens("anon"),
+            TRANSPORT_OPC_TCP,
+            (short) 1));
+    discovery.add(
+        endpoint(
+            "urn:app",
+            "opc.tcp://b:4840",
+            MessageSecurityMode.None,
+            "none",
+            userTokens("anon"),
+            TRANSPORT_OPC_TCP,
+            (short) 1));
+
+    List<EndpointDescription> session =
+        List.of(
+            endpoint(
+                "urn:app",
+                "opc.tcp://a:4840",
+                MessageSecurityMode.None,
+                "none",
+                userTokens("anon"),
+                TRANSPORT_OPC_TCP,
+                (short) 1));
+
+    UaException ex =
+        assertThrows(
+            UaException.class,
+            () ->
+                SessionFsmFactory.validateSessionEndpoints(TRANSPORT_OPC_TCP, discovery, session));
+
+    assertEquals(StatusCodes.Bad_SecurityChecksFailed, ex.getStatusCode().getValue());
+  }
+
+  @Test
+  @DisplayName("Passes when all endpoints match regardless of order")
+  void testAllMatchDifferentOrder() {
+    EndpointDescription a =
+        endpoint(
+            "urn:app",
+            "opc.tcp://a:4840",
+            MessageSecurityMode.None,
+            "none",
+            userTokens("anon"),
+            TRANSPORT_OPC_TCP,
+            (short) 1);
+    EndpointDescription b =
+        endpoint(
+            "urn:app",
+            "opc.tcp://b:4840",
+            MessageSecurityMode.SignAndEncrypt,
+            "policy#Basic256Sha256",
+            userTokens("anon"),
+            TRANSPORT_OPC_TCP,
+            (short) 2);
+
+    List<EndpointDescription> discovery = List.of(a, b);
+    List<EndpointDescription> session = List.of(b, a);
+
+    assertDoesNotThrow(
+        () -> SessionFsmFactory.validateSessionEndpoints(TRANSPORT_OPC_TCP, discovery, session));
+  }
+
+  enum DiffKind {
+    ApplicationUri,
+    EndpointUrl,
+    SecurityMode,
+    SecurityPolicyUri,
+    UserIdentityTokens,
+    SecurityLevel
+  }
+
+  static Stream<Arguments> differingEndpoints() {
+    return Stream.of(
+        Arguments.of(DiffKind.ApplicationUri),
+        Arguments.of(DiffKind.EndpointUrl),
+        Arguments.of(DiffKind.SecurityMode),
+        Arguments.of(DiffKind.SecurityPolicyUri),
+        Arguments.of(DiffKind.UserIdentityTokens),
+        Arguments.of(DiffKind.SecurityLevel));
+  }
+
+  @ParameterizedTest(name = "Mismatch due to differing {0} throws UaException")
+  @MethodSource("differingEndpoints")
+  void testEndpointMismatchThrows(DiffKind kind) {
+    EndpointDescription discoveryEp =
+        endpoint(
+            "urn:app",
+            "opc.tcp://a:4840",
+            MessageSecurityMode.Sign,
+            "policy#A",
+            userTokens("anon"),
+            TRANSPORT_OPC_TCP,
+            (short) 1);
+
+    EndpointDescription sessionEp;
+    switch (kind) {
+      case ApplicationUri ->
+          sessionEp =
+              endpoint(
+                  "urn:app2",
+                  "opc.tcp://a:4840",
+                  MessageSecurityMode.Sign,
+                  "policy#A",
+                  userTokens("anon"),
+                  TRANSPORT_OPC_TCP,
+                  (short) 1);
+      case EndpointUrl ->
+          sessionEp =
+              endpoint(
+                  "urn:app",
+                  "opc.tcp://DIFF:4840",
+                  MessageSecurityMode.Sign,
+                  "policy#A",
+                  userTokens("anon"),
+                  TRANSPORT_OPC_TCP,
+                  (short) 1);
+      case SecurityMode ->
+          sessionEp =
+              endpoint(
+                  "urn:app",
+                  "opc.tcp://a:4840",
+                  MessageSecurityMode.None,
+                  "policy#A",
+                  userTokens("anon"),
+                  TRANSPORT_OPC_TCP,
+                  (short) 1);
+      case SecurityPolicyUri ->
+          sessionEp =
+              endpoint(
+                  "urn:app",
+                  "opc.tcp://a:4840",
+                  MessageSecurityMode.Sign,
+                  "policy#B",
+                  userTokens("anon"),
+                  TRANSPORT_OPC_TCP,
+                  (short) 1);
+      case UserIdentityTokens ->
+          sessionEp =
+              endpoint(
+                  "urn:app",
+                  "opc.tcp://a:4840",
+                  MessageSecurityMode.Sign,
+                  "policy#A",
+                  userTokens("DIFF"),
+                  TRANSPORT_OPC_TCP,
+                  (short) 1);
+      case SecurityLevel ->
+          sessionEp =
+              endpoint(
+                  "urn:app",
+                  "opc.tcp://a:4840",
+                  MessageSecurityMode.Sign,
+                  "policy#A",
+                  userTokens("anon"),
+                  TRANSPORT_OPC_TCP,
+                  (short) 2);
+      default -> throw new IllegalStateException("Unexpected kind: " + kind);
+    }
+
+    List<EndpointDescription> discovery = List.of(discoveryEp);
+    List<EndpointDescription> session = List.of(sessionEp);
+
+    UaException ex =
+        assertThrows(
+            UaException.class,
+            () ->
+                SessionFsmFactory.validateSessionEndpoints(TRANSPORT_OPC_TCP, discovery, session));
+
+    assertEquals(StatusCodes.Bad_SecurityChecksFailed, ex.getStatusCode().getValue());
+  }
+
+  private static EndpointDescription endpoint(
+      String applicationUri,
+      String endpointUrl,
+      MessageSecurityMode securityMode,
+      String securityPolicyUri,
+      UserTokenPolicy[] userTokens,
+      String transportProfileUri,
+      short securityLevel) {
+
+    ApplicationDescription serverDesc =
+        new ApplicationDescription(
+            applicationUri,
+            "product:uri",
+            new LocalizedText("en", "name"),
+            ApplicationType.Server,
+            null,
+            null,
+            new String[0]);
+
+    return new EndpointDescription(
+        endpointUrl,
+        serverDesc,
+        null,
+        securityMode,
+        securityPolicyUri,
+        userTokens,
+        transportProfileUri,
+        UByte.valueOf(securityLevel));
+  }
+
+  private static UserTokenPolicy[] userTokens(String policyId) {
+    return new UserTokenPolicy[] {
+      new UserTokenPolicy(policyId, UserTokenType.Anonymous, null, null, null)
+    };
+  }
+}


### PR DESCRIPTION
Adds optional validation of the endpoints returned by the CreateSession service against the endpoints returned by GetEndpoints service during discovery.


