### PR TITLE
Validate TransferSubscription for anonymous identities

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/SubscriptionTransferTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/SubscriptionTransferTest.java
@@ -29,6 +29,6 @@ public class SubscriptionTransferTest extends AbstractClientServerTest {
 
     TransferResult result = requireNonNull(response.getResults())[0];
 
-    assertEquals(StatusCodes.Bad_SecurityChecksFailed, result.getStatusCode().getValue());
+    assertEquals(StatusCodes.Bad_UserAccessDenied, result.getStatusCode().getValue());
   }
 }

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/SubscriptionTransferTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/SubscriptionTransferTest.java
@@ -1,0 +1,34 @@
+package org.eclipse.milo.opcua.sdk.client;
+
+import static java.util.Objects.requireNonNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import org.eclipse.milo.opcua.sdk.client.subscriptions.OpcUaSubscription;
+import org.eclipse.milo.opcua.sdk.test.AbstractClientServerTest;
+import org.eclipse.milo.opcua.sdk.test.TestClient;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.structured.TransferResult;
+import org.eclipse.milo.opcua.stack.core.types.structured.TransferSubscriptionsResponse;
+import org.junit.jupiter.api.Test;
+
+public class SubscriptionTransferTest extends AbstractClientServerTest {
+
+  @Test
+  void unsecureTransferBetweenAnonymousIdentitiesFails() throws UaException {
+    var subscription = new OpcUaSubscription(client);
+    subscription.create();
+
+    var client2 = TestClient.create(server, cfg -> {});
+    client2.connect();
+
+    TransferSubscriptionsResponse response =
+        client2.transferSubscriptions(
+            List.of(subscription.getSubscriptionId().orElseThrow()), false);
+
+    TransferResult result = requireNonNull(response.getResults())[0];
+
+    assertEquals(StatusCodes.Bad_SecurityChecksFailed, result.getStatusCode().getValue());
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/servicesets/impl/DefaultSubscriptionServiceSet.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/servicesets/impl/DefaultSubscriptionServiceSet.java
@@ -225,7 +225,7 @@ public class DefaultSubscriptionServiceSet implements SubscriptionServiceSet {
             if (session.getEndpoint().getSecurityMode() == MessageSecurityMode.None) {
               results.add(
                   new TransferResult(
-                      new StatusCode(StatusCodes.Bad_SecurityChecksFailed), new UInteger[0]));
+                      new StatusCode(StatusCodes.Bad_UserAccessDenied), new UInteger[0]));
               continue;
             }
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/servicesets/impl/DefaultSubscriptionServiceSet.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/servicesets/impl/DefaultSubscriptionServiceSet.java
@@ -20,6 +20,7 @@ import java.util.concurrent.CompletableFuture;
 import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
 import org.eclipse.milo.opcua.sdk.server.Session;
 import org.eclipse.milo.opcua.sdk.server.identity.Identity;
+import org.eclipse.milo.opcua.sdk.server.identity.Identity.AnonymousIdentity;
 import org.eclipse.milo.opcua.sdk.server.items.MonitoredDataItem;
 import org.eclipse.milo.opcua.sdk.server.servicesets.SubscriptionServiceSet;
 import org.eclipse.milo.opcua.sdk.server.subscriptions.Subscription;
@@ -28,6 +29,7 @@ import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DiagnosticInfo;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.MessageSecurityMode;
 import org.eclipse.milo.opcua.stack.core.types.structured.ApplicationDescription;
 import org.eclipse.milo.opcua.stack.core.types.structured.CreateSubscriptionRequest;
 import org.eclipse.milo.opcua.stack.core.types.structured.CreateSubscriptionResponse;
@@ -214,6 +216,30 @@ public class DefaultSubscriptionServiceSet implements SubscriptionServiceSet {
               new TransferResult(
                   new StatusCode(StatusCodes.Bad_UserAccessDenied), new UInteger[0]));
         } else {
+          if (session.getIdentity() instanceof AnonymousIdentity) {
+            // https://reference.opcfoundation.org/Core/Part4/v105/docs/5.14.7
+            // If the Client uses an ANONYMOUS UserTokenType, the Server shall validate if the
+            // ApplicationUri is the same for the old and the new Session and the
+            // MessageSecurityMode is SIGN or SIGN_AND_ENCRYPT.
+
+            if (session.getEndpoint().getSecurityMode() == MessageSecurityMode.None) {
+              results.add(
+                  new TransferResult(
+                      new StatusCode(StatusCodes.Bad_SecurityChecksFailed), new UInteger[0]));
+              continue;
+            }
+
+            String toUri = session.getClientDescription().getApplicationUri();
+            String fromUri = otherSession.getClientDescription().getApplicationUri();
+
+            if (!Objects.equals(toUri, fromUri)) {
+              results.add(
+                  new TransferResult(
+                      new StatusCode(StatusCodes.Bad_UserAccessDenied), new UInteger[0]));
+              continue;
+            }
+          }
+
           UInteger[] availableSequenceNumbers;
 
           synchronized (subscription) {


### PR DESCRIPTION
Adds validation for `AnonymousIdentity` during subscription transfer.
- Ensure `MessageSecurityMode` is not `None`.
- Verify `ApplicationUri` matches between sessions.

fixes #1563
