### PR TITLE
Check UserWriteMask in DefaultAccessController

### DIFF
--- a/opc-ua-sdk/sdk-core/src/main/java/org/eclipse/milo/opcua/sdk/core/WriteMask.java
+++ b/opc-ua-sdk/sdk-core/src/main/java/org/eclipse/milo/opcua/sdk/core/WriteMask.java
@@ -12,6 +12,7 @@ package org.eclipse.milo.opcua.sdk.core;
 
 import java.util.EnumSet;
 import java.util.Set;
+import org.eclipse.milo.opcua.stack.core.AttributeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 
 public enum WriteMask {
@@ -66,5 +67,38 @@ public enum WriteMask {
 
   public static EnumSet<WriteMask> fromMask(UInteger accessLevel) {
     return fromMask(accessLevel.intValue());
+  }
+
+  public static WriteMask forAttribute(AttributeId attributeId) {
+    return switch (attributeId) {
+      case AccessLevel -> org.eclipse.milo.opcua.sdk.core.WriteMask.AccessLevel;
+      case ArrayDimensions -> org.eclipse.milo.opcua.sdk.core.WriteMask.ArrayDimensions;
+      case BrowseName -> org.eclipse.milo.opcua.sdk.core.WriteMask.BrowseName;
+      case ContainsNoLoops -> org.eclipse.milo.opcua.sdk.core.WriteMask.ContainsNoLoops;
+      case DataType -> org.eclipse.milo.opcua.sdk.core.WriteMask.DataType;
+      case Description -> org.eclipse.milo.opcua.sdk.core.WriteMask.Description;
+      case DisplayName -> org.eclipse.milo.opcua.sdk.core.WriteMask.DisplayName;
+      case EventNotifier -> org.eclipse.milo.opcua.sdk.core.WriteMask.EventNotifier;
+      case Executable -> org.eclipse.milo.opcua.sdk.core.WriteMask.Executable;
+      case Historizing -> org.eclipse.milo.opcua.sdk.core.WriteMask.Historizing;
+      case InverseName -> org.eclipse.milo.opcua.sdk.core.WriteMask.InverseName;
+      case IsAbstract -> org.eclipse.milo.opcua.sdk.core.WriteMask.IsAbstract;
+      case MinimumSamplingInterval ->
+          org.eclipse.milo.opcua.sdk.core.WriteMask.MinimumSamplingInterval;
+      case NodeClass -> org.eclipse.milo.opcua.sdk.core.WriteMask.NodeClass;
+      case NodeId -> org.eclipse.milo.opcua.sdk.core.WriteMask.NodeId;
+      case Symmetric -> org.eclipse.milo.opcua.sdk.core.WriteMask.Symmetric;
+      case UserAccessLevel -> org.eclipse.milo.opcua.sdk.core.WriteMask.UserAccessLevel;
+      case UserExecutable -> org.eclipse.milo.opcua.sdk.core.WriteMask.UserExecutable;
+      case UserWriteMask -> org.eclipse.milo.opcua.sdk.core.WriteMask.UserWriteMask;
+      case Value -> org.eclipse.milo.opcua.sdk.core.WriteMask.ValueForVariableType;
+      case ValueRank -> org.eclipse.milo.opcua.sdk.core.WriteMask.ValueRank;
+      case WriteMask -> org.eclipse.milo.opcua.sdk.core.WriteMask.WriteMask;
+      case RolePermissions -> org.eclipse.milo.opcua.sdk.core.WriteMask.RolePermissions;
+      case AccessRestrictions -> org.eclipse.milo.opcua.sdk.core.WriteMask.AccessRestrictions;
+      case AccessLevelEx -> org.eclipse.milo.opcua.sdk.core.WriteMask.AccessLevelEx;
+      case DataTypeDefinition -> org.eclipse.milo.opcua.sdk.core.WriteMask.DataTypeDefinition;
+      default -> throw new IllegalArgumentException("unknown AttributeId: " + attributeId);
+    };
   }
 }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/AttributeWriter.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/AttributeWriter.java
@@ -10,8 +10,6 @@
 
 package org.eclipse.milo.opcua.sdk.server;
 
-import static java.util.Objects.requireNonNullElse;
-
 import java.util.EnumSet;
 import java.util.Optional;
 import java.util.Set;
@@ -72,7 +70,7 @@ public class AttributeWriter {
       // Part 3, section 5.2.10
       // https://reference.opcfoundation.org/v104/Core/docs/Part3/5.2.10/
       // The value of this Attribute is derived from the rules used by the Server to
-      // map Sessions to Roles. This mapping may be vendor specific, or it may use the
+      // map Sessions to Roles. This mapping may be vendor-specific, or it may use the
       // standard Role model defined in 4.8.
       //
       // This Attribute shall not be writeable.
@@ -102,20 +100,11 @@ public class AttributeWriter {
       }
     } else {
       // attributeId != AttributeId.Value && attributeId != AttributeId.UserRolePermissions
-      WriteMask writeMask = writeMaskForAttribute(attributeId);
+      WriteMask writeMask = WriteMask.forAttribute(attributeId);
 
       Set<WriteMask> writeMasks = WriteMask.fromMask(node.getWriteMask());
       if (!writeMasks.contains(writeMask)) {
         return new StatusCode(StatusCodes.Bad_NotWritable);
-      }
-
-      Set<WriteMask> userWriteMasks =
-          WriteMask.fromMask(
-              (UInteger)
-                  requireNonNullElse(
-                      node.getAttribute(context, AttributeId.UserWriteMask), UInteger.MIN));
-      if (!userWriteMasks.contains(writeMask)) {
-        return new StatusCode(StatusCodes.Bad_UserAccessDenied);
       }
     }
 
@@ -208,38 +197,6 @@ public class AttributeWriter {
     } catch (UaException e) {
       return e.getStatusCode();
     }
-  }
-
-  private static WriteMask writeMaskForAttribute(AttributeId attributeId) {
-    return switch (attributeId) {
-      case AccessLevel -> WriteMask.AccessLevel;
-      case ArrayDimensions -> WriteMask.ArrayDimensions;
-      case BrowseName -> WriteMask.BrowseName;
-      case ContainsNoLoops -> WriteMask.ContainsNoLoops;
-      case DataType -> WriteMask.DataType;
-      case Description -> WriteMask.Description;
-      case DisplayName -> WriteMask.DisplayName;
-      case EventNotifier -> WriteMask.EventNotifier;
-      case Executable -> WriteMask.Executable;
-      case Historizing -> WriteMask.Historizing;
-      case InverseName -> WriteMask.InverseName;
-      case IsAbstract -> WriteMask.IsAbstract;
-      case MinimumSamplingInterval -> WriteMask.MinimumSamplingInterval;
-      case NodeClass -> WriteMask.NodeClass;
-      case NodeId -> WriteMask.NodeId;
-      case Symmetric -> WriteMask.Symmetric;
-      case UserAccessLevel -> WriteMask.UserAccessLevel;
-      case UserExecutable -> WriteMask.UserExecutable;
-      case UserWriteMask -> WriteMask.UserWriteMask;
-      case Value -> WriteMask.ValueForVariableType;
-      case ValueRank -> WriteMask.ValueRank;
-      case WriteMask -> WriteMask.WriteMask;
-      case RolePermissions -> WriteMask.RolePermissions;
-      case AccessRestrictions -> WriteMask.AccessRestrictions;
-      case AccessLevelEx -> WriteMask.AccessLevelEx;
-      case DataTypeDefinition -> WriteMask.DataTypeDefinition;
-      default -> throw new IllegalArgumentException("unknown AttributeId: " + attributeId);
-    };
   }
 
   private static DataValue validateDataType(

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/servicesets/impl/DefaultAccessController.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/servicesets/impl/DefaultAccessController.java
@@ -20,6 +20,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.eclipse.milo.opcua.sdk.core.AccessLevel;
+import org.eclipse.milo.opcua.sdk.core.WriteMask;
 import org.eclipse.milo.opcua.sdk.server.AddressSpace;
 import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
 import org.eclipse.milo.opcua.sdk.server.Session;
@@ -174,10 +175,37 @@ public class DefaultAccessController implements AccessController {
             p.result = AccessResult.DENIED_USER_ACCESS;
           }
         }
+      } else {
+        List<NodeId> roleIds = context.getRoleIds().orElse(null);
+
+        UInteger userWriteMask = attributes.get(nodeId).userWriteMask();
+        RolePermissionType[] userRolePermissions = attributes.get(nodeId).userRolePermissions();
+
+        // first check if the UserWriteMask allows for write access
+        boolean hasAccess = checkWriteMask(attributeId, userWriteMask);
+
+        // if it does, refine access based on UserRolePermissions, if they exist
+        if (hasAccess && roleIds != null && userRolePermissions != null) {
+          hasAccess =
+              Stream.of(userRolePermissions)
+                  .anyMatch(rp -> rp.getPermissions().getWriteAttribute());
+        }
+
+        if (!hasAccess) {
+          p.result = AccessResult.DENIED_USER_ACCESS;
+        }
       }
     }
 
     return pending.stream().collect(Collectors.toMap(p -> p.value, p -> p.result, (a, b) -> b));
+  }
+
+  private static boolean checkWriteMask(UInteger attributeId, @Nullable UInteger writeMask) {
+    Set<WriteMask> writeMasks = writeMask == null ? Set.of() : WriteMask.fromMask(writeMask);
+
+    return AttributeId.from(attributeId)
+        .map(id -> writeMasks.contains(WriteMask.forAttribute(id)))
+        .orElse(false);
   }
 
   // endregion
@@ -522,6 +550,7 @@ public class DefaultAccessController implements AccessController {
   record AccessControlAttributes(
       @Nullable NodeClass nodeClass,
       @Nullable AccessRestrictionType accessRestrictions,
+      @Nullable UInteger userWriteMask,
       @Nullable UByte userAccessLevel,
       @Nullable Boolean userExecutable,
       RolePermissionType @Nullable [] userRolePermissions) {}
@@ -557,6 +586,7 @@ public class DefaultAccessController implements AccessController {
                         List.of(
                             new ReadValueId(id, AttributeId.NodeClass.uid(), null, null),
                             new ReadValueId(id, AttributeId.AccessRestrictions.uid(), null, null),
+                            new ReadValueId(id, AttributeId.UserWriteMask.uid(), null, null),
                             new ReadValueId(id, AttributeId.UserAccessLevel.uid(), null, null),
                             new ReadValueId(id, AttributeId.UserExecutable.uid(), null, null),
                             new ReadValueId(id, AttributeId.UserRolePermissions.uid(), null, null));
@@ -576,7 +606,7 @@ public class DefaultAccessController implements AccessController {
 
       var attributesMap = new HashMap<NodeId, AccessControlAttributes>();
 
-      for (int i = 0; i < readValueIds.size(); i += 5) {
+      for (int i = 0; i < readValueIds.size(); i += 6) {
         NodeId nodeId = readValueIds.get(i).getNodeId();
 
         Object v0 = values.get(i).value().value();
@@ -584,9 +614,11 @@ public class DefaultAccessController implements AccessController {
         Object v2 = values.get(i + 2).value().value();
         Object v3 = values.get(i + 3).value().value();
         Object v4 = values.get(i + 4).value().value();
+        Object v5 = values.get(i + 5).value().value();
 
         NodeClass nodeClass = null;
         AccessRestrictionType accessRestrictions = null;
+        UInteger userWriteMask = null;
         UByte userAccessLevel = null;
         Boolean userExecutable = null;
         RolePermissionType[] userRolePermissions = null;
@@ -597,13 +629,16 @@ public class DefaultAccessController implements AccessController {
         if (v1 instanceof AccessRestrictionType art) {
           accessRestrictions = art;
         }
-        if (v2 instanceof UByte ub) {
+        if (v2 instanceof UInteger um) {
+          userWriteMask = um;
+        }
+        if (v3 instanceof UByte ub) {
           userAccessLevel = ub;
         }
-        if (v3 instanceof Boolean b) {
+        if (v4 instanceof Boolean b) {
           userExecutable = b;
         }
-        if (v4 instanceof RolePermissionType[] rpt) {
+        if (v5 instanceof RolePermissionType[] rpt) {
           userRolePermissions = rpt;
         }
 
@@ -611,6 +646,7 @@ public class DefaultAccessController implements AccessController {
             new AccessControlAttributes(
                 nodeClass,
                 accessRestrictions,
+                userWriteMask,
                 userAccessLevel,
                 userExecutable,
                 userRolePermissions);

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/servicesets/impl/DefaultAccessController.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/servicesets/impl/DefaultAccessController.java
@@ -197,14 +197,6 @@ public class DefaultAccessController implements AccessController {
     return pending.stream().collect(Collectors.toMap(p -> p.value, p -> p.result, (a, b) -> b));
   }
 
-  private static boolean checkWriteMask(UInteger attributeId, @Nullable UInteger writeMask) {
-    Set<WriteMask> writeMasks = writeMask == null ? Set.of() : WriteMask.fromMask(writeMask);
-
-    return AttributeId.from(attributeId)
-        .map(id -> writeMasks.contains(WriteMask.forAttribute(id)))
-        .orElse(false);
-  }
-
   // endregion
 
   // region Browse

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/servicesets/impl/DefaultAccessControllerTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/servicesets/impl/DefaultAccessControllerTest.java
@@ -10,7 +10,6 @@
 
 package org.eclipse.milo.opcua.sdk.server.servicesets.impl;
 
-import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.HashMap;
@@ -42,9 +41,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 class DefaultAccessControllerTest {
-
-  private static final org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger WM_ALL =
-      uint(0xFFFFFFFF);
 
   private static final NodeId ROLE_A = new NodeId(1, "RoleA");
   private static final NodeId ROLE_B = new NodeId(1, "RoleB");


### PR DESCRIPTION
Moves UserWriteMask check from AttributeWriter to DefaultAccessController, where it will be applied to all incoming writes and not just those to UaNodes using AttributeWriter.