### PR TITLE
Update exception handling in client model nodes

### DIFF
--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AcknowledgeableConditionTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AcknowledgeableConditionTypeNode.java
@@ -77,8 +77,11 @@ public class AcknowledgeableConditionTypeNode extends ConditionTypeNode
   public LocalizedText readEnabledState() throws UaException {
     try {
       return readEnabledStateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class AcknowledgeableConditionTypeNode extends ConditionTypeNode
   public void writeEnabledState(LocalizedText value) throws UaException {
     try {
       writeEnabledStateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class AcknowledgeableConditionTypeNode extends ConditionTypeNode
   public TwoStateVariableTypeNode getEnabledStateNode() throws UaException {
     try {
       return getEnabledStateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -118,10 +127,7 @@ public class AcknowledgeableConditionTypeNode extends ConditionTypeNode
   public CompletableFuture<? extends TwoStateVariableTypeNode> getEnabledStateNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "EnabledState",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "EnabledState", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (TwoStateVariableTypeNode) node);
   }
 
@@ -141,8 +147,11 @@ public class AcknowledgeableConditionTypeNode extends ConditionTypeNode
   public LocalizedText readAckedState() throws UaException {
     try {
       return readAckedStateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -150,8 +159,11 @@ public class AcknowledgeableConditionTypeNode extends ConditionTypeNode
   public void writeAckedState(LocalizedText value) throws UaException {
     try {
       writeAckedStateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -173,8 +185,11 @@ public class AcknowledgeableConditionTypeNode extends ConditionTypeNode
   public TwoStateVariableTypeNode getAckedStateNode() throws UaException {
     try {
       return getAckedStateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -182,7 +197,7 @@ public class AcknowledgeableConditionTypeNode extends ConditionTypeNode
   public CompletableFuture<? extends TwoStateVariableTypeNode> getAckedStateNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "AckedState", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "AckedState", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (TwoStateVariableTypeNode) node);
   }
 
@@ -202,8 +217,11 @@ public class AcknowledgeableConditionTypeNode extends ConditionTypeNode
   public LocalizedText readConfirmedState() throws UaException {
     try {
       return readConfirmedStateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -211,8 +229,11 @@ public class AcknowledgeableConditionTypeNode extends ConditionTypeNode
   public void writeConfirmedState(LocalizedText value) throws UaException {
     try {
       writeConfirmedStateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -234,8 +255,11 @@ public class AcknowledgeableConditionTypeNode extends ConditionTypeNode
   public TwoStateVariableTypeNode getConfirmedStateNode() throws UaException {
     try {
       return getConfirmedStateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -243,10 +267,7 @@ public class AcknowledgeableConditionTypeNode extends ConditionTypeNode
   public CompletableFuture<? extends TwoStateVariableTypeNode> getConfirmedStateNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ConfirmedState",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "ConfirmedState", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (TwoStateVariableTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AggregateConfigurationTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AggregateConfigurationTypeNode.java
@@ -77,8 +77,11 @@ public class AggregateConfigurationTypeNode extends BaseObjectTypeNode
   public Boolean readTreatUncertainAsBad() throws UaException {
     try {
       return readTreatUncertainAsBadAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class AggregateConfigurationTypeNode extends BaseObjectTypeNode
   public void writeTreatUncertainAsBad(Boolean value) throws UaException {
     try {
       writeTreatUncertainAsBadAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class AggregateConfigurationTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getTreatUncertainAsBadNode() throws UaException {
     try {
       return getTreatUncertainAsBadNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -120,7 +129,7 @@ public class AggregateConfigurationTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "TreatUncertainAsBad",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -141,8 +150,11 @@ public class AggregateConfigurationTypeNode extends BaseObjectTypeNode
   public UByte readPercentDataBad() throws UaException {
     try {
       return readPercentDataBadAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -150,8 +162,11 @@ public class AggregateConfigurationTypeNode extends BaseObjectTypeNode
   public void writePercentDataBad(UByte value) throws UaException {
     try {
       writePercentDataBadAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -173,8 +188,11 @@ public class AggregateConfigurationTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getPercentDataBadNode() throws UaException {
     try {
       return getPercentDataBadNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -182,10 +200,7 @@ public class AggregateConfigurationTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getPercentDataBadNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "PercentDataBad",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "PercentDataBad", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -205,8 +220,11 @@ public class AggregateConfigurationTypeNode extends BaseObjectTypeNode
   public UByte readPercentDataGood() throws UaException {
     try {
       return readPercentDataGoodAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -214,8 +232,11 @@ public class AggregateConfigurationTypeNode extends BaseObjectTypeNode
   public void writePercentDataGood(UByte value) throws UaException {
     try {
       writePercentDataGoodAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -237,8 +258,11 @@ public class AggregateConfigurationTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getPercentDataGoodNode() throws UaException {
     try {
       return getPercentDataGoodNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -246,10 +270,7 @@ public class AggregateConfigurationTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getPercentDataGoodNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "PercentDataGood",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "PercentDataGood", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -269,8 +290,11 @@ public class AggregateConfigurationTypeNode extends BaseObjectTypeNode
   public Boolean readUseSlopedExtrapolation() throws UaException {
     try {
       return readUseSlopedExtrapolationAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -278,8 +302,11 @@ public class AggregateConfigurationTypeNode extends BaseObjectTypeNode
   public void writeUseSlopedExtrapolation(Boolean value) throws UaException {
     try {
       writeUseSlopedExtrapolationAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -302,8 +329,11 @@ public class AggregateConfigurationTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getUseSlopedExtrapolationNode() throws UaException {
     try {
       return getUseSlopedExtrapolationNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -313,7 +343,7 @@ public class AggregateConfigurationTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "UseSlopedExtrapolation",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AlarmConditionTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AlarmConditionTypeNode.java
@@ -81,8 +81,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public NodeId readInputNode() throws UaException {
     try {
       return readInputNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -90,8 +93,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public void writeInputNode(NodeId value) throws UaException {
     try {
       writeInputNodeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -113,8 +119,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public PropertyTypeNode getInputNodeNode() throws UaException {
     try {
       return getInputNodeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -122,7 +131,7 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getInputNodeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "InputNode", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "InputNode", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -142,8 +151,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public Boolean readSuppressedOrShelved() throws UaException {
     try {
       return readSuppressedOrShelvedAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -151,8 +163,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public void writeSuppressedOrShelved(Boolean value) throws UaException {
     try {
       writeSuppressedOrShelvedAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -174,8 +189,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public PropertyTypeNode getSuppressedOrShelvedNode() throws UaException {
     try {
       return getSuppressedOrShelvedNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -185,7 +203,7 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SuppressedOrShelved",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -206,8 +224,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public Double readMaxTimeShelved() throws UaException {
     try {
       return readMaxTimeShelvedAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -215,8 +236,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public void writeMaxTimeShelved(Double value) throws UaException {
     try {
       writeMaxTimeShelvedAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -238,8 +262,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public PropertyTypeNode getMaxTimeShelvedNode() throws UaException {
     try {
       return getMaxTimeShelvedNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -247,10 +274,7 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getMaxTimeShelvedNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "MaxTimeShelved",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "MaxTimeShelved", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -270,8 +294,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public Boolean readAudibleEnabled() throws UaException {
     try {
       return readAudibleEnabledAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -279,8 +306,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public void writeAudibleEnabled(Boolean value) throws UaException {
     try {
       writeAudibleEnabledAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -302,8 +332,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public PropertyTypeNode getAudibleEnabledNode() throws UaException {
     try {
       return getAudibleEnabledNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -311,10 +344,7 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getAudibleEnabledNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "AudibleEnabled",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "AudibleEnabled", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -334,8 +364,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public Double readOnDelay() throws UaException {
     try {
       return readOnDelayAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -343,8 +376,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public void writeOnDelay(Double value) throws UaException {
     try {
       writeOnDelayAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -366,8 +402,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public PropertyTypeNode getOnDelayNode() throws UaException {
     try {
       return getOnDelayNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -375,7 +414,7 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getOnDelayNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "OnDelay", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "OnDelay", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -395,8 +434,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public Double readOffDelay() throws UaException {
     try {
       return readOffDelayAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -404,8 +446,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public void writeOffDelay(Double value) throws UaException {
     try {
       writeOffDelayAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -427,8 +472,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public PropertyTypeNode getOffDelayNode() throws UaException {
     try {
       return getOffDelayNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -436,7 +484,7 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getOffDelayNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "OffDelay", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "OffDelay", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -456,8 +504,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public Double readReAlarmTime() throws UaException {
     try {
       return readReAlarmTimeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -465,8 +516,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public void writeReAlarmTime(Double value) throws UaException {
     try {
       writeReAlarmTimeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -488,8 +542,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public PropertyTypeNode getReAlarmTimeNode() throws UaException {
     try {
       return getReAlarmTimeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -497,10 +554,7 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getReAlarmTimeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ReAlarmTime",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "ReAlarmTime", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -520,8 +574,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public LocalizedText readEnabledState() throws UaException {
     try {
       return readEnabledStateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -529,8 +586,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public void writeEnabledState(LocalizedText value) throws UaException {
     try {
       writeEnabledStateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -552,8 +612,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public TwoStateVariableTypeNode getEnabledStateNode() throws UaException {
     try {
       return getEnabledStateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -561,10 +624,7 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public CompletableFuture<? extends TwoStateVariableTypeNode> getEnabledStateNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "EnabledState",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "EnabledState", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (TwoStateVariableTypeNode) node);
   }
 
@@ -584,8 +644,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public LocalizedText readActiveState() throws UaException {
     try {
       return readActiveStateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -593,8 +656,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public void writeActiveState(LocalizedText value) throws UaException {
     try {
       writeActiveStateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -616,8 +682,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public TwoStateVariableTypeNode getActiveStateNode() throws UaException {
     try {
       return getActiveStateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -625,10 +694,7 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public CompletableFuture<? extends TwoStateVariableTypeNode> getActiveStateNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ActiveState",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "ActiveState", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (TwoStateVariableTypeNode) node);
   }
 
@@ -648,8 +714,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public LocalizedText readSuppressedState() throws UaException {
     try {
       return readSuppressedStateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -657,8 +726,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public void writeSuppressedState(LocalizedText value) throws UaException {
     try {
       writeSuppressedStateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -680,8 +752,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public TwoStateVariableTypeNode getSuppressedStateNode() throws UaException {
     try {
       return getSuppressedStateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -689,10 +764,7 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public CompletableFuture<? extends TwoStateVariableTypeNode> getSuppressedStateNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "SuppressedState",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "SuppressedState", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (TwoStateVariableTypeNode) node);
   }
 
@@ -712,8 +784,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public LocalizedText readOutOfServiceState() throws UaException {
     try {
       return readOutOfServiceStateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -721,8 +796,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public void writeOutOfServiceState(LocalizedText value) throws UaException {
     try {
       writeOutOfServiceStateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -745,8 +823,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public TwoStateVariableTypeNode getOutOfServiceStateNode() throws UaException {
     try {
       return getOutOfServiceStateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -756,7 +837,7 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "OutOfServiceState",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (TwoStateVariableTypeNode) node);
   }
@@ -765,8 +846,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public ShelvedStateMachineTypeNode getShelvingStateNode() throws UaException {
     try {
       return getShelvingStateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -774,10 +858,7 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public CompletableFuture<? extends ShelvedStateMachineTypeNode> getShelvingStateNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ShelvingState",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "ShelvingState", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (ShelvedStateMachineTypeNode) node);
   }
 
@@ -797,8 +878,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public ByteString readAudibleSound() throws UaException {
     try {
       return readAudibleSoundAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -806,8 +890,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public void writeAudibleSound(ByteString value) throws UaException {
     try {
       writeAudibleSoundAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -829,8 +916,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public AudioVariableTypeNode getAudibleSoundNode() throws UaException {
     try {
       return getAudibleSoundNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -838,10 +928,7 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public CompletableFuture<? extends AudioVariableTypeNode> getAudibleSoundNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "AudibleSound",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "AudibleSound", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (AudioVariableTypeNode) node);
   }
 
@@ -861,8 +948,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public LocalizedText readSilenceState() throws UaException {
     try {
       return readSilenceStateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -870,8 +960,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public void writeSilenceState(LocalizedText value) throws UaException {
     try {
       writeSilenceStateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -893,8 +986,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public TwoStateVariableTypeNode getSilenceStateNode() throws UaException {
     try {
       return getSilenceStateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -902,10 +998,7 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public CompletableFuture<? extends TwoStateVariableTypeNode> getSilenceStateNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "SilenceState",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "SilenceState", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (TwoStateVariableTypeNode) node);
   }
 
@@ -925,8 +1018,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public Boolean readFirstInGroupFlag() throws UaException {
     try {
       return readFirstInGroupFlagAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -934,8 +1030,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public void writeFirstInGroupFlag(Boolean value) throws UaException {
     try {
       writeFirstInGroupFlagAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -957,8 +1056,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public BaseDataVariableTypeNode getFirstInGroupFlagNode() throws UaException {
     try {
       return getFirstInGroupFlagNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -968,7 +1070,7 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "FirstInGroupFlag",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -977,8 +1079,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public AlarmGroupTypeNode getFirstInGroupNode() throws UaException {
     try {
       return getFirstInGroupNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -986,10 +1091,7 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public CompletableFuture<? extends AlarmGroupTypeNode> getFirstInGroupNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "FirstInGroup",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "FirstInGroup", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (AlarmGroupTypeNode) node);
   }
 
@@ -1009,8 +1111,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public LocalizedText readLatchedState() throws UaException {
     try {
       return readLatchedStateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1018,8 +1123,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public void writeLatchedState(LocalizedText value) throws UaException {
     try {
       writeLatchedStateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1041,8 +1149,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public TwoStateVariableTypeNode getLatchedStateNode() throws UaException {
     try {
       return getLatchedStateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1050,10 +1161,7 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public CompletableFuture<? extends TwoStateVariableTypeNode> getLatchedStateNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "LatchedState",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "LatchedState", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (TwoStateVariableTypeNode) node);
   }
 
@@ -1073,8 +1181,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public Short readReAlarmRepeatCount() throws UaException {
     try {
       return readReAlarmRepeatCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1082,8 +1193,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public void writeReAlarmRepeatCount(Short value) throws UaException {
     try {
       writeReAlarmRepeatCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1105,8 +1219,11 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   public BaseDataVariableTypeNode getReAlarmRepeatCountNode() throws UaException {
     try {
       return getReAlarmRepeatCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1116,7 +1233,7 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ReAlarmRepeatCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AlarmMetricsTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AlarmMetricsTypeNode.java
@@ -78,8 +78,11 @@ public class AlarmMetricsTypeNode extends BaseObjectTypeNode implements AlarmMet
   public UInteger readAlarmCount() throws UaException {
     try {
       return readAlarmCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -87,8 +90,11 @@ public class AlarmMetricsTypeNode extends BaseObjectTypeNode implements AlarmMet
   public void writeAlarmCount(UInteger value) throws UaException {
     try {
       writeAlarmCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -110,8 +116,11 @@ public class AlarmMetricsTypeNode extends BaseObjectTypeNode implements AlarmMet
   public BaseDataVariableTypeNode getAlarmCountNode() throws UaException {
     try {
       return getAlarmCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -119,7 +128,7 @@ public class AlarmMetricsTypeNode extends BaseObjectTypeNode implements AlarmMet
   public CompletableFuture<? extends BaseDataVariableTypeNode> getAlarmCountNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "AlarmCount", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "AlarmCount", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -139,8 +148,11 @@ public class AlarmMetricsTypeNode extends BaseObjectTypeNode implements AlarmMet
   public DateTime readStartTime() throws UaException {
     try {
       return readStartTimeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -148,8 +160,11 @@ public class AlarmMetricsTypeNode extends BaseObjectTypeNode implements AlarmMet
   public void writeStartTime(DateTime value) throws UaException {
     try {
       writeStartTimeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -171,8 +186,11 @@ public class AlarmMetricsTypeNode extends BaseObjectTypeNode implements AlarmMet
   public BaseDataVariableTypeNode getStartTimeNode() throws UaException {
     try {
       return getStartTimeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -180,7 +198,7 @@ public class AlarmMetricsTypeNode extends BaseObjectTypeNode implements AlarmMet
   public CompletableFuture<? extends BaseDataVariableTypeNode> getStartTimeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "StartTime", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "StartTime", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -200,8 +218,11 @@ public class AlarmMetricsTypeNode extends BaseObjectTypeNode implements AlarmMet
   public Double readMaximumActiveState() throws UaException {
     try {
       return readMaximumActiveStateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -209,8 +230,11 @@ public class AlarmMetricsTypeNode extends BaseObjectTypeNode implements AlarmMet
   public void writeMaximumActiveState(Double value) throws UaException {
     try {
       writeMaximumActiveStateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -232,8 +256,11 @@ public class AlarmMetricsTypeNode extends BaseObjectTypeNode implements AlarmMet
   public BaseDataVariableTypeNode getMaximumActiveStateNode() throws UaException {
     try {
       return getMaximumActiveStateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -243,7 +270,7 @@ public class AlarmMetricsTypeNode extends BaseObjectTypeNode implements AlarmMet
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaximumActiveState",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -264,8 +291,11 @@ public class AlarmMetricsTypeNode extends BaseObjectTypeNode implements AlarmMet
   public Double readMaximumUnAck() throws UaException {
     try {
       return readMaximumUnAckAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -273,8 +303,11 @@ public class AlarmMetricsTypeNode extends BaseObjectTypeNode implements AlarmMet
   public void writeMaximumUnAck(Double value) throws UaException {
     try {
       writeMaximumUnAckAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -296,8 +329,11 @@ public class AlarmMetricsTypeNode extends BaseObjectTypeNode implements AlarmMet
   public BaseDataVariableTypeNode getMaximumUnAckNode() throws UaException {
     try {
       return getMaximumUnAckNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -305,10 +341,7 @@ public class AlarmMetricsTypeNode extends BaseObjectTypeNode implements AlarmMet
   public CompletableFuture<? extends BaseDataVariableTypeNode> getMaximumUnAckNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "MaximumUnAck",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "MaximumUnAck", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -328,8 +361,11 @@ public class AlarmMetricsTypeNode extends BaseObjectTypeNode implements AlarmMet
   public Double readCurrentAlarmRate() throws UaException {
     try {
       return readCurrentAlarmRateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -337,8 +373,11 @@ public class AlarmMetricsTypeNode extends BaseObjectTypeNode implements AlarmMet
   public void writeCurrentAlarmRate(Double value) throws UaException {
     try {
       writeCurrentAlarmRateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -360,8 +399,11 @@ public class AlarmMetricsTypeNode extends BaseObjectTypeNode implements AlarmMet
   public AlarmRateVariableTypeNode getCurrentAlarmRateNode() throws UaException {
     try {
       return getCurrentAlarmRateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -371,7 +413,7 @@ public class AlarmMetricsTypeNode extends BaseObjectTypeNode implements AlarmMet
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "CurrentAlarmRate",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (AlarmRateVariableTypeNode) node);
   }
@@ -392,8 +434,11 @@ public class AlarmMetricsTypeNode extends BaseObjectTypeNode implements AlarmMet
   public Double readMaximumAlarmRate() throws UaException {
     try {
       return readMaximumAlarmRateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -401,8 +446,11 @@ public class AlarmMetricsTypeNode extends BaseObjectTypeNode implements AlarmMet
   public void writeMaximumAlarmRate(Double value) throws UaException {
     try {
       writeMaximumAlarmRateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -424,8 +472,11 @@ public class AlarmMetricsTypeNode extends BaseObjectTypeNode implements AlarmMet
   public AlarmRateVariableTypeNode getMaximumAlarmRateNode() throws UaException {
     try {
       return getMaximumAlarmRateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -435,7 +486,7 @@ public class AlarmMetricsTypeNode extends BaseObjectTypeNode implements AlarmMet
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaximumAlarmRate",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (AlarmRateVariableTypeNode) node);
   }
@@ -456,8 +507,11 @@ public class AlarmMetricsTypeNode extends BaseObjectTypeNode implements AlarmMet
   public UInteger readMaximumReAlarmCount() throws UaException {
     try {
       return readMaximumReAlarmCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -465,8 +519,11 @@ public class AlarmMetricsTypeNode extends BaseObjectTypeNode implements AlarmMet
   public void writeMaximumReAlarmCount(UInteger value) throws UaException {
     try {
       writeMaximumReAlarmCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -488,8 +545,11 @@ public class AlarmMetricsTypeNode extends BaseObjectTypeNode implements AlarmMet
   public BaseDataVariableTypeNode getMaximumReAlarmCountNode() throws UaException {
     try {
       return getMaximumReAlarmCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -499,7 +559,7 @@ public class AlarmMetricsTypeNode extends BaseObjectTypeNode implements AlarmMet
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaximumReAlarmCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -520,8 +580,11 @@ public class AlarmMetricsTypeNode extends BaseObjectTypeNode implements AlarmMet
   public Double readAverageAlarmRate() throws UaException {
     try {
       return readAverageAlarmRateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -529,8 +592,11 @@ public class AlarmMetricsTypeNode extends BaseObjectTypeNode implements AlarmMet
   public void writeAverageAlarmRate(Double value) throws UaException {
     try {
       writeAverageAlarmRateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -552,8 +618,11 @@ public class AlarmMetricsTypeNode extends BaseObjectTypeNode implements AlarmMet
   public AlarmRateVariableTypeNode getAverageAlarmRateNode() throws UaException {
     try {
       return getAverageAlarmRateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -563,7 +632,7 @@ public class AlarmMetricsTypeNode extends BaseObjectTypeNode implements AlarmMet
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "AverageAlarmRate",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (AlarmRateVariableTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AliasNameCategoryTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AliasNameCategoryTypeNode.java
@@ -76,8 +76,11 @@ public class AliasNameCategoryTypeNode extends FolderTypeNode implements AliasNa
   public UInteger readLastChange() throws UaException {
     try {
       return readLastChangeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -85,8 +88,11 @@ public class AliasNameCategoryTypeNode extends FolderTypeNode implements AliasNa
   public void writeLastChange(UInteger value) throws UaException {
     try {
       writeLastChangeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -108,8 +114,11 @@ public class AliasNameCategoryTypeNode extends FolderTypeNode implements AliasNa
   public PropertyTypeNode getLastChangeNode() throws UaException {
     try {
       return getLastChangeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -117,7 +126,7 @@ public class AliasNameCategoryTypeNode extends FolderTypeNode implements AliasNa
   public CompletableFuture<? extends PropertyTypeNode> getLastChangeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "LastChange", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "LastChange", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AlternativeUnitTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AlternativeUnitTypeNode.java
@@ -79,8 +79,11 @@ public class AlternativeUnitTypeNode extends UnitTypeNode implements Alternative
   public LinearConversionDataType readLinearConversion() throws UaException {
     try {
       return readLinearConversionAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -88,8 +91,11 @@ public class AlternativeUnitTypeNode extends UnitTypeNode implements Alternative
   public void writeLinearConversion(LinearConversionDataType value) throws UaException {
     try {
       writeLinearConversionAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -114,8 +120,11 @@ public class AlternativeUnitTypeNode extends UnitTypeNode implements Alternative
   public PropertyTypeNode getLinearConversionNode() throws UaException {
     try {
       return getLinearConversionNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -125,7 +134,7 @@ public class AlternativeUnitTypeNode extends UnitTypeNode implements Alternative
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "LinearConversion",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -146,8 +155,11 @@ public class AlternativeUnitTypeNode extends UnitTypeNode implements Alternative
   public String readMathMlConversion() throws UaException {
     try {
       return readMathMlConversionAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -155,8 +167,11 @@ public class AlternativeUnitTypeNode extends UnitTypeNode implements Alternative
   public void writeMathMlConversion(String value) throws UaException {
     try {
       writeMathMlConversionAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -178,8 +193,11 @@ public class AlternativeUnitTypeNode extends UnitTypeNode implements Alternative
   public PropertyTypeNode getMathMlConversionNode() throws UaException {
     try {
       return getMathMlConversionNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -189,7 +207,7 @@ public class AlternativeUnitTypeNode extends UnitTypeNode implements Alternative
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MathMLConversion",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -210,8 +228,11 @@ public class AlternativeUnitTypeNode extends UnitTypeNode implements Alternative
   public String readMathMlInverseConversion() throws UaException {
     try {
       return readMathMlInverseConversionAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -219,8 +240,11 @@ public class AlternativeUnitTypeNode extends UnitTypeNode implements Alternative
   public void writeMathMlInverseConversion(String value) throws UaException {
     try {
       writeMathMlInverseConversionAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -243,8 +267,11 @@ public class AlternativeUnitTypeNode extends UnitTypeNode implements Alternative
   public PropertyTypeNode getMathMlInverseConversionNode() throws UaException {
     try {
       return getMathMlInverseConversionNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -254,7 +281,7 @@ public class AlternativeUnitTypeNode extends UnitTypeNode implements Alternative
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MathMLInverseConversion",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ApplicationConfigurationTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ApplicationConfigurationTypeNode.java
@@ -78,8 +78,11 @@ public class ApplicationConfigurationTypeNode extends ServerConfigurationTypeNod
   public String readApplicationUri() throws UaException {
     try {
       return readApplicationUriAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -87,8 +90,11 @@ public class ApplicationConfigurationTypeNode extends ServerConfigurationTypeNod
   public void writeApplicationUri(String value) throws UaException {
     try {
       writeApplicationUriAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -110,8 +116,11 @@ public class ApplicationConfigurationTypeNode extends ServerConfigurationTypeNod
   public PropertyTypeNode getApplicationUriNode() throws UaException {
     try {
       return getApplicationUriNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -119,10 +128,7 @@ public class ApplicationConfigurationTypeNode extends ServerConfigurationTypeNod
   public CompletableFuture<? extends PropertyTypeNode> getApplicationUriNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ApplicationUri",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "ApplicationUri", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -142,8 +148,11 @@ public class ApplicationConfigurationTypeNode extends ServerConfigurationTypeNod
   public String readProductUri() throws UaException {
     try {
       return readProductUriAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -151,8 +160,11 @@ public class ApplicationConfigurationTypeNode extends ServerConfigurationTypeNod
   public void writeProductUri(String value) throws UaException {
     try {
       writeProductUriAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -174,8 +186,11 @@ public class ApplicationConfigurationTypeNode extends ServerConfigurationTypeNod
   public PropertyTypeNode getProductUriNode() throws UaException {
     try {
       return getProductUriNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -183,7 +198,7 @@ public class ApplicationConfigurationTypeNode extends ServerConfigurationTypeNod
   public CompletableFuture<? extends PropertyTypeNode> getProductUriNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "ProductUri", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "ProductUri", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -211,8 +226,11 @@ public class ApplicationConfigurationTypeNode extends ServerConfigurationTypeNod
   public ApplicationType readApplicationType() throws UaException {
     try {
       return readApplicationTypeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -220,8 +238,11 @@ public class ApplicationConfigurationTypeNode extends ServerConfigurationTypeNod
   public void writeApplicationType(ApplicationType value) throws UaException {
     try {
       writeApplicationTypeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -251,8 +272,11 @@ public class ApplicationConfigurationTypeNode extends ServerConfigurationTypeNod
   public PropertyTypeNode getApplicationTypeNode() throws UaException {
     try {
       return getApplicationTypeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -260,10 +284,7 @@ public class ApplicationConfigurationTypeNode extends ServerConfigurationTypeNod
   public CompletableFuture<? extends PropertyTypeNode> getApplicationTypeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ApplicationType",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "ApplicationType", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -283,8 +304,11 @@ public class ApplicationConfigurationTypeNode extends ServerConfigurationTypeNod
   public Boolean readEnabled() throws UaException {
     try {
       return readEnabledAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -292,8 +316,11 @@ public class ApplicationConfigurationTypeNode extends ServerConfigurationTypeNod
   public void writeEnabled(Boolean value) throws UaException {
     try {
       writeEnabledAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -315,8 +342,11 @@ public class ApplicationConfigurationTypeNode extends ServerConfigurationTypeNod
   public PropertyTypeNode getEnabledNode() throws UaException {
     try {
       return getEnabledNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -324,7 +354,7 @@ public class ApplicationConfigurationTypeNode extends ServerConfigurationTypeNod
   public CompletableFuture<? extends PropertyTypeNode> getEnabledNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Enabled", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Enabled", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditActivateSessionEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditActivateSessionEventTypeNode.java
@@ -82,8 +82,11 @@ public class AuditActivateSessionEventTypeNode extends AuditSessionEventTypeNode
   public SignedSoftwareCertificate[] readClientSoftwareCertificates() throws UaException {
     try {
       return readClientSoftwareCertificatesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -92,8 +95,11 @@ public class AuditActivateSessionEventTypeNode extends AuditSessionEventTypeNode
       throws UaException {
     try {
       writeClientSoftwareCertificatesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -119,8 +125,11 @@ public class AuditActivateSessionEventTypeNode extends AuditSessionEventTypeNode
   public PropertyTypeNode getClientSoftwareCertificatesNode() throws UaException {
     try {
       return getClientSoftwareCertificatesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -130,7 +139,7 @@ public class AuditActivateSessionEventTypeNode extends AuditSessionEventTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ClientSoftwareCertificates",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -152,8 +161,11 @@ public class AuditActivateSessionEventTypeNode extends AuditSessionEventTypeNode
   public UserIdentityToken readUserIdentityToken() throws UaException {
     try {
       return readUserIdentityTokenAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -161,8 +173,11 @@ public class AuditActivateSessionEventTypeNode extends AuditSessionEventTypeNode
   public void writeUserIdentityToken(UserIdentityToken value) throws UaException {
     try {
       writeUserIdentityTokenAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -187,8 +202,11 @@ public class AuditActivateSessionEventTypeNode extends AuditSessionEventTypeNode
   public PropertyTypeNode getUserIdentityTokenNode() throws UaException {
     try {
       return getUserIdentityTokenNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -198,7 +216,7 @@ public class AuditActivateSessionEventTypeNode extends AuditSessionEventTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "UserIdentityToken",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -219,8 +237,11 @@ public class AuditActivateSessionEventTypeNode extends AuditSessionEventTypeNode
   public String readSecureChannelId() throws UaException {
     try {
       return readSecureChannelIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -228,8 +249,11 @@ public class AuditActivateSessionEventTypeNode extends AuditSessionEventTypeNode
   public void writeSecureChannelId(String value) throws UaException {
     try {
       writeSecureChannelIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -251,8 +275,11 @@ public class AuditActivateSessionEventTypeNode extends AuditSessionEventTypeNode
   public PropertyTypeNode getSecureChannelIdNode() throws UaException {
     try {
       return getSecureChannelIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -260,10 +287,7 @@ public class AuditActivateSessionEventTypeNode extends AuditSessionEventTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getSecureChannelIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "SecureChannelId",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "SecureChannelId", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -283,8 +307,11 @@ public class AuditActivateSessionEventTypeNode extends AuditSessionEventTypeNode
   public NodeId[] readCurrentRoleIds() throws UaException {
     try {
       return readCurrentRoleIdsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -292,8 +319,11 @@ public class AuditActivateSessionEventTypeNode extends AuditSessionEventTypeNode
   public void writeCurrentRoleIds(NodeId[] value) throws UaException {
     try {
       writeCurrentRoleIdsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -315,8 +345,11 @@ public class AuditActivateSessionEventTypeNode extends AuditSessionEventTypeNode
   public PropertyTypeNode getCurrentRoleIdsNode() throws UaException {
     try {
       return getCurrentRoleIdsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -324,10 +357,7 @@ public class AuditActivateSessionEventTypeNode extends AuditSessionEventTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getCurrentRoleIdsNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "CurrentRoleIds",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "CurrentRoleIds", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditAddNodesEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditAddNodesEventTypeNode.java
@@ -81,8 +81,11 @@ public class AuditAddNodesEventTypeNode extends AuditNodeManagementEventTypeNode
   public AddNodesItem[] readNodesToAdd() throws UaException {
     try {
       return readNodesToAddAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -90,8 +93,11 @@ public class AuditAddNodesEventTypeNode extends AuditNodeManagementEventTypeNode
   public void writeNodesToAdd(AddNodesItem[] value) throws UaException {
     try {
       writeNodesToAddAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -115,8 +121,11 @@ public class AuditAddNodesEventTypeNode extends AuditNodeManagementEventTypeNode
   public PropertyTypeNode getNodesToAddNode() throws UaException {
     try {
       return getNodesToAddNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -124,7 +133,7 @@ public class AuditAddNodesEventTypeNode extends AuditNodeManagementEventTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getNodesToAddNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "NodesToAdd", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "NodesToAdd", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditAddReferencesEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditAddReferencesEventTypeNode.java
@@ -81,8 +81,11 @@ public class AuditAddReferencesEventTypeNode extends AuditNodeManagementEventTyp
   public AddReferencesItem[] readReferencesToAdd() throws UaException {
     try {
       return readReferencesToAddAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -90,8 +93,11 @@ public class AuditAddReferencesEventTypeNode extends AuditNodeManagementEventTyp
   public void writeReferencesToAdd(AddReferencesItem[] value) throws UaException {
     try {
       writeReferencesToAddAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -116,8 +122,11 @@ public class AuditAddReferencesEventTypeNode extends AuditNodeManagementEventTyp
   public PropertyTypeNode getReferencesToAddNode() throws UaException {
     try {
       return getReferencesToAddNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -125,10 +134,7 @@ public class AuditAddReferencesEventTypeNode extends AuditNodeManagementEventTyp
   public CompletableFuture<? extends PropertyTypeNode> getReferencesToAddNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ReferencesToAdd",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "ReferencesToAdd", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditCancelEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditCancelEventTypeNode.java
@@ -77,8 +77,11 @@ public class AuditCancelEventTypeNode extends AuditSessionEventTypeNode
   public UInteger readRequestHandle() throws UaException {
     try {
       return readRequestHandleAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class AuditCancelEventTypeNode extends AuditSessionEventTypeNode
   public void writeRequestHandle(UInteger value) throws UaException {
     try {
       writeRequestHandleAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class AuditCancelEventTypeNode extends AuditSessionEventTypeNode
   public PropertyTypeNode getRequestHandleNode() throws UaException {
     try {
       return getRequestHandleNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -118,10 +127,7 @@ public class AuditCancelEventTypeNode extends AuditSessionEventTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getRequestHandleNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "RequestHandle",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "RequestHandle", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditCertificateDataMismatchEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditCertificateDataMismatchEventTypeNode.java
@@ -77,8 +77,11 @@ public class AuditCertificateDataMismatchEventTypeNode extends AuditCertificateE
   public String readInvalidHostname() throws UaException {
     try {
       return readInvalidHostnameAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class AuditCertificateDataMismatchEventTypeNode extends AuditCertificateE
   public void writeInvalidHostname(String value) throws UaException {
     try {
       writeInvalidHostnameAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class AuditCertificateDataMismatchEventTypeNode extends AuditCertificateE
   public PropertyTypeNode getInvalidHostnameNode() throws UaException {
     try {
       return getInvalidHostnameNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -118,10 +127,7 @@ public class AuditCertificateDataMismatchEventTypeNode extends AuditCertificateE
   public CompletableFuture<? extends PropertyTypeNode> getInvalidHostnameNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "InvalidHostname",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "InvalidHostname", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -141,8 +147,11 @@ public class AuditCertificateDataMismatchEventTypeNode extends AuditCertificateE
   public String readInvalidUri() throws UaException {
     try {
       return readInvalidUriAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -150,8 +159,11 @@ public class AuditCertificateDataMismatchEventTypeNode extends AuditCertificateE
   public void writeInvalidUri(String value) throws UaException {
     try {
       writeInvalidUriAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -173,8 +185,11 @@ public class AuditCertificateDataMismatchEventTypeNode extends AuditCertificateE
   public PropertyTypeNode getInvalidUriNode() throws UaException {
     try {
       return getInvalidUriNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -182,7 +197,7 @@ public class AuditCertificateDataMismatchEventTypeNode extends AuditCertificateE
   public CompletableFuture<? extends PropertyTypeNode> getInvalidUriNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "InvalidUri", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "InvalidUri", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditCertificateEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditCertificateEventTypeNode.java
@@ -78,8 +78,11 @@ public class AuditCertificateEventTypeNode extends AuditSecurityEventTypeNode
   public ByteString readCertificate() throws UaException {
     try {
       return readCertificateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -87,8 +90,11 @@ public class AuditCertificateEventTypeNode extends AuditSecurityEventTypeNode
   public void writeCertificate(ByteString value) throws UaException {
     try {
       writeCertificateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -110,8 +116,11 @@ public class AuditCertificateEventTypeNode extends AuditSecurityEventTypeNode
   public PropertyTypeNode getCertificateNode() throws UaException {
     try {
       return getCertificateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -119,10 +128,7 @@ public class AuditCertificateEventTypeNode extends AuditSecurityEventTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getCertificateNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "Certificate",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "Certificate", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditChannelEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditChannelEventTypeNode.java
@@ -77,8 +77,11 @@ public class AuditChannelEventTypeNode extends AuditSecurityEventTypeNode
   public String readSecureChannelId() throws UaException {
     try {
       return readSecureChannelIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class AuditChannelEventTypeNode extends AuditSecurityEventTypeNode
   public void writeSecureChannelId(String value) throws UaException {
     try {
       writeSecureChannelIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class AuditChannelEventTypeNode extends AuditSecurityEventTypeNode
   public PropertyTypeNode getSecureChannelIdNode() throws UaException {
     try {
       return getSecureChannelIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -118,10 +127,7 @@ public class AuditChannelEventTypeNode extends AuditSecurityEventTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getSecureChannelIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "SecureChannelId",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "SecureChannelId", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditClientEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditClientEventTypeNode.java
@@ -76,8 +76,11 @@ public class AuditClientEventTypeNode extends AuditEventTypeNode implements Audi
   public String readServerUri() throws UaException {
     try {
       return readServerUriAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -85,8 +88,11 @@ public class AuditClientEventTypeNode extends AuditEventTypeNode implements Audi
   public void writeServerUri(String value) throws UaException {
     try {
       writeServerUriAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -108,8 +114,11 @@ public class AuditClientEventTypeNode extends AuditEventTypeNode implements Audi
   public PropertyTypeNode getServerUriNode() throws UaException {
     try {
       return getServerUriNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -117,7 +126,7 @@ public class AuditClientEventTypeNode extends AuditEventTypeNode implements Audi
   public CompletableFuture<? extends PropertyTypeNode> getServerUriNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "ServerUri", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "ServerUri", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditClientUpdateMethodResultEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditClientUpdateMethodResultEventTypeNode.java
@@ -77,8 +77,11 @@ public class AuditClientUpdateMethodResultEventTypeNode extends AuditClientEvent
   public ExpandedNodeId readObjectId() throws UaException {
     try {
       return readObjectIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class AuditClientUpdateMethodResultEventTypeNode extends AuditClientEvent
   public void writeObjectId(ExpandedNodeId value) throws UaException {
     try {
       writeObjectIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class AuditClientUpdateMethodResultEventTypeNode extends AuditClientEvent
   public PropertyTypeNode getObjectIdNode() throws UaException {
     try {
       return getObjectIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -118,7 +127,7 @@ public class AuditClientUpdateMethodResultEventTypeNode extends AuditClientEvent
   public CompletableFuture<? extends PropertyTypeNode> getObjectIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "ObjectId", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "ObjectId", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -138,8 +147,11 @@ public class AuditClientUpdateMethodResultEventTypeNode extends AuditClientEvent
   public ExpandedNodeId readMethodId() throws UaException {
     try {
       return readMethodIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -147,8 +159,11 @@ public class AuditClientUpdateMethodResultEventTypeNode extends AuditClientEvent
   public void writeMethodId(ExpandedNodeId value) throws UaException {
     try {
       writeMethodIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -170,8 +185,11 @@ public class AuditClientUpdateMethodResultEventTypeNode extends AuditClientEvent
   public PropertyTypeNode getMethodIdNode() throws UaException {
     try {
       return getMethodIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -179,7 +197,7 @@ public class AuditClientUpdateMethodResultEventTypeNode extends AuditClientEvent
   public CompletableFuture<? extends PropertyTypeNode> getMethodIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "MethodId", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "MethodId", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -199,8 +217,11 @@ public class AuditClientUpdateMethodResultEventTypeNode extends AuditClientEvent
   public StatusCode readStatusCodeId() throws UaException {
     try {
       return readStatusCodeIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -208,8 +229,11 @@ public class AuditClientUpdateMethodResultEventTypeNode extends AuditClientEvent
   public void writeStatusCodeId(StatusCode value) throws UaException {
     try {
       writeStatusCodeIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -231,8 +255,11 @@ public class AuditClientUpdateMethodResultEventTypeNode extends AuditClientEvent
   public PropertyTypeNode getStatusCodeIdNode() throws UaException {
     try {
       return getStatusCodeIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -240,10 +267,7 @@ public class AuditClientUpdateMethodResultEventTypeNode extends AuditClientEvent
   public CompletableFuture<? extends PropertyTypeNode> getStatusCodeIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "StatusCodeId",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "StatusCodeId", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -263,8 +287,11 @@ public class AuditClientUpdateMethodResultEventTypeNode extends AuditClientEvent
   public Object[] readInputArguments() throws UaException {
     try {
       return readInputArgumentsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -272,8 +299,11 @@ public class AuditClientUpdateMethodResultEventTypeNode extends AuditClientEvent
   public void writeInputArguments(Object[] value) throws UaException {
     try {
       writeInputArgumentsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -295,8 +325,11 @@ public class AuditClientUpdateMethodResultEventTypeNode extends AuditClientEvent
   public PropertyTypeNode getInputArgumentsNode() throws UaException {
     try {
       return getInputArgumentsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -304,10 +337,7 @@ public class AuditClientUpdateMethodResultEventTypeNode extends AuditClientEvent
   public CompletableFuture<? extends PropertyTypeNode> getInputArgumentsNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "InputArguments",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "InputArguments", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -327,8 +357,11 @@ public class AuditClientUpdateMethodResultEventTypeNode extends AuditClientEvent
   public Object[] readOutputArguments() throws UaException {
     try {
       return readOutputArgumentsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -336,8 +369,11 @@ public class AuditClientUpdateMethodResultEventTypeNode extends AuditClientEvent
   public void writeOutputArguments(Object[] value) throws UaException {
     try {
       writeOutputArgumentsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -359,8 +395,11 @@ public class AuditClientUpdateMethodResultEventTypeNode extends AuditClientEvent
   public PropertyTypeNode getOutputArgumentsNode() throws UaException {
     try {
       return getOutputArgumentsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -368,10 +407,7 @@ public class AuditClientUpdateMethodResultEventTypeNode extends AuditClientEvent
   public CompletableFuture<? extends PropertyTypeNode> getOutputArgumentsNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "OutputArguments",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "OutputArguments", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditConditionAcknowledgeEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditConditionAcknowledgeEventTypeNode.java
@@ -78,8 +78,11 @@ public class AuditConditionAcknowledgeEventTypeNode extends AuditConditionEventT
   public ByteString readConditionEventId() throws UaException {
     try {
       return readConditionEventIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -87,8 +90,11 @@ public class AuditConditionAcknowledgeEventTypeNode extends AuditConditionEventT
   public void writeConditionEventId(ByteString value) throws UaException {
     try {
       writeConditionEventIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -110,8 +116,11 @@ public class AuditConditionAcknowledgeEventTypeNode extends AuditConditionEventT
   public PropertyTypeNode getConditionEventIdNode() throws UaException {
     try {
       return getConditionEventIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -121,7 +130,7 @@ public class AuditConditionAcknowledgeEventTypeNode extends AuditConditionEventT
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ConditionEventId",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -142,8 +151,11 @@ public class AuditConditionAcknowledgeEventTypeNode extends AuditConditionEventT
   public LocalizedText readComment() throws UaException {
     try {
       return readCommentAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -151,8 +163,11 @@ public class AuditConditionAcknowledgeEventTypeNode extends AuditConditionEventT
   public void writeComment(LocalizedText value) throws UaException {
     try {
       writeCommentAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -174,8 +189,11 @@ public class AuditConditionAcknowledgeEventTypeNode extends AuditConditionEventT
   public PropertyTypeNode getCommentNode() throws UaException {
     try {
       return getCommentNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -183,7 +201,7 @@ public class AuditConditionAcknowledgeEventTypeNode extends AuditConditionEventT
   public CompletableFuture<? extends PropertyTypeNode> getCommentNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Comment", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Comment", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditConditionCommentEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditConditionCommentEventTypeNode.java
@@ -78,8 +78,11 @@ public class AuditConditionCommentEventTypeNode extends AuditConditionEventTypeN
   public ByteString readConditionEventId() throws UaException {
     try {
       return readConditionEventIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -87,8 +90,11 @@ public class AuditConditionCommentEventTypeNode extends AuditConditionEventTypeN
   public void writeConditionEventId(ByteString value) throws UaException {
     try {
       writeConditionEventIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -110,8 +116,11 @@ public class AuditConditionCommentEventTypeNode extends AuditConditionEventTypeN
   public PropertyTypeNode getConditionEventIdNode() throws UaException {
     try {
       return getConditionEventIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -121,7 +130,7 @@ public class AuditConditionCommentEventTypeNode extends AuditConditionEventTypeN
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ConditionEventId",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -142,8 +151,11 @@ public class AuditConditionCommentEventTypeNode extends AuditConditionEventTypeN
   public LocalizedText readComment() throws UaException {
     try {
       return readCommentAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -151,8 +163,11 @@ public class AuditConditionCommentEventTypeNode extends AuditConditionEventTypeN
   public void writeComment(LocalizedText value) throws UaException {
     try {
       writeCommentAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -174,8 +189,11 @@ public class AuditConditionCommentEventTypeNode extends AuditConditionEventTypeN
   public PropertyTypeNode getCommentNode() throws UaException {
     try {
       return getCommentNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -183,7 +201,7 @@ public class AuditConditionCommentEventTypeNode extends AuditConditionEventTypeN
   public CompletableFuture<? extends PropertyTypeNode> getCommentNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Comment", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Comment", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditConditionConfirmEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditConditionConfirmEventTypeNode.java
@@ -78,8 +78,11 @@ public class AuditConditionConfirmEventTypeNode extends AuditConditionEventTypeN
   public ByteString readConditionEventId() throws UaException {
     try {
       return readConditionEventIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -87,8 +90,11 @@ public class AuditConditionConfirmEventTypeNode extends AuditConditionEventTypeN
   public void writeConditionEventId(ByteString value) throws UaException {
     try {
       writeConditionEventIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -110,8 +116,11 @@ public class AuditConditionConfirmEventTypeNode extends AuditConditionEventTypeN
   public PropertyTypeNode getConditionEventIdNode() throws UaException {
     try {
       return getConditionEventIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -121,7 +130,7 @@ public class AuditConditionConfirmEventTypeNode extends AuditConditionEventTypeN
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ConditionEventId",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -142,8 +151,11 @@ public class AuditConditionConfirmEventTypeNode extends AuditConditionEventTypeN
   public LocalizedText readComment() throws UaException {
     try {
       return readCommentAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -151,8 +163,11 @@ public class AuditConditionConfirmEventTypeNode extends AuditConditionEventTypeN
   public void writeComment(LocalizedText value) throws UaException {
     try {
       writeCommentAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -174,8 +189,11 @@ public class AuditConditionConfirmEventTypeNode extends AuditConditionEventTypeN
   public PropertyTypeNode getCommentNode() throws UaException {
     try {
       return getCommentNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -183,7 +201,7 @@ public class AuditConditionConfirmEventTypeNode extends AuditConditionEventTypeN
   public CompletableFuture<? extends PropertyTypeNode> getCommentNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Comment", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Comment", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditConditionRespondEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditConditionRespondEventTypeNode.java
@@ -77,8 +77,11 @@ public class AuditConditionRespondEventTypeNode extends AuditConditionEventTypeN
   public UInteger readSelectedResponse() throws UaException {
     try {
       return readSelectedResponseAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class AuditConditionRespondEventTypeNode extends AuditConditionEventTypeN
   public void writeSelectedResponse(UInteger value) throws UaException {
     try {
       writeSelectedResponseAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class AuditConditionRespondEventTypeNode extends AuditConditionEventTypeN
   public PropertyTypeNode getSelectedResponseNode() throws UaException {
     try {
       return getSelectedResponseNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -120,7 +129,7 @@ public class AuditConditionRespondEventTypeNode extends AuditConditionEventTypeN
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SelectedResponse",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditConditionShelvingEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditConditionShelvingEventTypeNode.java
@@ -77,8 +77,11 @@ public class AuditConditionShelvingEventTypeNode extends AuditConditionEventType
   public Double readShelvingTime() throws UaException {
     try {
       return readShelvingTimeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class AuditConditionShelvingEventTypeNode extends AuditConditionEventType
   public void writeShelvingTime(Double value) throws UaException {
     try {
       writeShelvingTimeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class AuditConditionShelvingEventTypeNode extends AuditConditionEventType
   public PropertyTypeNode getShelvingTimeNode() throws UaException {
     try {
       return getShelvingTimeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -118,10 +127,7 @@ public class AuditConditionShelvingEventTypeNode extends AuditConditionEventType
   public CompletableFuture<? extends PropertyTypeNode> getShelvingTimeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ShelvingTime",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "ShelvingTime", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditCreateSessionEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditCreateSessionEventTypeNode.java
@@ -78,8 +78,11 @@ public class AuditCreateSessionEventTypeNode extends AuditSessionEventTypeNode
   public String readSecureChannelId() throws UaException {
     try {
       return readSecureChannelIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -87,8 +90,11 @@ public class AuditCreateSessionEventTypeNode extends AuditSessionEventTypeNode
   public void writeSecureChannelId(String value) throws UaException {
     try {
       writeSecureChannelIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -110,8 +116,11 @@ public class AuditCreateSessionEventTypeNode extends AuditSessionEventTypeNode
   public PropertyTypeNode getSecureChannelIdNode() throws UaException {
     try {
       return getSecureChannelIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -119,10 +128,7 @@ public class AuditCreateSessionEventTypeNode extends AuditSessionEventTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getSecureChannelIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "SecureChannelId",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "SecureChannelId", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -142,8 +148,11 @@ public class AuditCreateSessionEventTypeNode extends AuditSessionEventTypeNode
   public ByteString readClientCertificate() throws UaException {
     try {
       return readClientCertificateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -151,8 +160,11 @@ public class AuditCreateSessionEventTypeNode extends AuditSessionEventTypeNode
   public void writeClientCertificate(ByteString value) throws UaException {
     try {
       writeClientCertificateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -174,8 +186,11 @@ public class AuditCreateSessionEventTypeNode extends AuditSessionEventTypeNode
   public PropertyTypeNode getClientCertificateNode() throws UaException {
     try {
       return getClientCertificateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -185,7 +200,7 @@ public class AuditCreateSessionEventTypeNode extends AuditSessionEventTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ClientCertificate",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -206,8 +221,11 @@ public class AuditCreateSessionEventTypeNode extends AuditSessionEventTypeNode
   public String readClientCertificateThumbprint() throws UaException {
     try {
       return readClientCertificateThumbprintAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -215,8 +233,11 @@ public class AuditCreateSessionEventTypeNode extends AuditSessionEventTypeNode
   public void writeClientCertificateThumbprint(String value) throws UaException {
     try {
       writeClientCertificateThumbprintAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -239,8 +260,11 @@ public class AuditCreateSessionEventTypeNode extends AuditSessionEventTypeNode
   public PropertyTypeNode getClientCertificateThumbprintNode() throws UaException {
     try {
       return getClientCertificateThumbprintNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -250,7 +274,7 @@ public class AuditCreateSessionEventTypeNode extends AuditSessionEventTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ClientCertificateThumbprint",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -271,8 +295,11 @@ public class AuditCreateSessionEventTypeNode extends AuditSessionEventTypeNode
   public Double readRevisedSessionTimeout() throws UaException {
     try {
       return readRevisedSessionTimeoutAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -280,8 +307,11 @@ public class AuditCreateSessionEventTypeNode extends AuditSessionEventTypeNode
   public void writeRevisedSessionTimeout(Double value) throws UaException {
     try {
       writeRevisedSessionTimeoutAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -304,8 +334,11 @@ public class AuditCreateSessionEventTypeNode extends AuditSessionEventTypeNode
   public PropertyTypeNode getRevisedSessionTimeoutNode() throws UaException {
     try {
       return getRevisedSessionTimeoutNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -315,7 +348,7 @@ public class AuditCreateSessionEventTypeNode extends AuditSessionEventTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "RevisedSessionTimeout",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditDeleteNodesEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditDeleteNodesEventTypeNode.java
@@ -81,8 +81,11 @@ public class AuditDeleteNodesEventTypeNode extends AuditNodeManagementEventTypeN
   public DeleteNodesItem[] readNodesToDelete() throws UaException {
     try {
       return readNodesToDeleteAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -90,8 +93,11 @@ public class AuditDeleteNodesEventTypeNode extends AuditNodeManagementEventTypeN
   public void writeNodesToDelete(DeleteNodesItem[] value) throws UaException {
     try {
       writeNodesToDeleteAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -115,8 +121,11 @@ public class AuditDeleteNodesEventTypeNode extends AuditNodeManagementEventTypeN
   public PropertyTypeNode getNodesToDeleteNode() throws UaException {
     try {
       return getNodesToDeleteNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -124,10 +133,7 @@ public class AuditDeleteNodesEventTypeNode extends AuditNodeManagementEventTypeN
   public CompletableFuture<? extends PropertyTypeNode> getNodesToDeleteNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "NodesToDelete",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "NodesToDelete", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditDeleteReferencesEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditDeleteReferencesEventTypeNode.java
@@ -81,8 +81,11 @@ public class AuditDeleteReferencesEventTypeNode extends AuditNodeManagementEvent
   public DeleteReferencesItem[] readReferencesToDelete() throws UaException {
     try {
       return readReferencesToDeleteAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -90,8 +93,11 @@ public class AuditDeleteReferencesEventTypeNode extends AuditNodeManagementEvent
   public void writeReferencesToDelete(DeleteReferencesItem[] value) throws UaException {
     try {
       writeReferencesToDeleteAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -116,8 +122,11 @@ public class AuditDeleteReferencesEventTypeNode extends AuditNodeManagementEvent
   public PropertyTypeNode getReferencesToDeleteNode() throws UaException {
     try {
       return getReferencesToDeleteNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -127,7 +136,7 @@ public class AuditDeleteReferencesEventTypeNode extends AuditNodeManagementEvent
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ReferencesToDelete",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditEventTypeNode.java
@@ -77,8 +77,11 @@ public class AuditEventTypeNode extends BaseEventTypeNode implements AuditEventT
   public DateTime readActionTimeStamp() throws UaException {
     try {
       return readActionTimeStampAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class AuditEventTypeNode extends BaseEventTypeNode implements AuditEventT
   public void writeActionTimeStamp(DateTime value) throws UaException {
     try {
       writeActionTimeStampAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class AuditEventTypeNode extends BaseEventTypeNode implements AuditEventT
   public PropertyTypeNode getActionTimeStampNode() throws UaException {
     try {
       return getActionTimeStampNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -118,10 +127,7 @@ public class AuditEventTypeNode extends BaseEventTypeNode implements AuditEventT
   public CompletableFuture<? extends PropertyTypeNode> getActionTimeStampNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ActionTimeStamp",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "ActionTimeStamp", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -141,8 +147,11 @@ public class AuditEventTypeNode extends BaseEventTypeNode implements AuditEventT
   public Boolean readStatus() throws UaException {
     try {
       return readStatusAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -150,8 +159,11 @@ public class AuditEventTypeNode extends BaseEventTypeNode implements AuditEventT
   public void writeStatus(Boolean value) throws UaException {
     try {
       writeStatusAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -173,8 +185,11 @@ public class AuditEventTypeNode extends BaseEventTypeNode implements AuditEventT
   public PropertyTypeNode getStatusNode() throws UaException {
     try {
       return getStatusNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -182,7 +197,7 @@ public class AuditEventTypeNode extends BaseEventTypeNode implements AuditEventT
   public CompletableFuture<? extends PropertyTypeNode> getStatusNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Status", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Status", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -202,8 +217,11 @@ public class AuditEventTypeNode extends BaseEventTypeNode implements AuditEventT
   public String readServerId() throws UaException {
     try {
       return readServerIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -211,8 +229,11 @@ public class AuditEventTypeNode extends BaseEventTypeNode implements AuditEventT
   public void writeServerId(String value) throws UaException {
     try {
       writeServerIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -234,8 +255,11 @@ public class AuditEventTypeNode extends BaseEventTypeNode implements AuditEventT
   public PropertyTypeNode getServerIdNode() throws UaException {
     try {
       return getServerIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -243,7 +267,7 @@ public class AuditEventTypeNode extends BaseEventTypeNode implements AuditEventT
   public CompletableFuture<? extends PropertyTypeNode> getServerIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "ServerId", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "ServerId", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -263,8 +287,11 @@ public class AuditEventTypeNode extends BaseEventTypeNode implements AuditEventT
   public String readClientAuditEntryId() throws UaException {
     try {
       return readClientAuditEntryIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -272,8 +299,11 @@ public class AuditEventTypeNode extends BaseEventTypeNode implements AuditEventT
   public void writeClientAuditEntryId(String value) throws UaException {
     try {
       writeClientAuditEntryIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -295,8 +325,11 @@ public class AuditEventTypeNode extends BaseEventTypeNode implements AuditEventT
   public PropertyTypeNode getClientAuditEntryIdNode() throws UaException {
     try {
       return getClientAuditEntryIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -306,7 +339,7 @@ public class AuditEventTypeNode extends BaseEventTypeNode implements AuditEventT
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ClientAuditEntryId",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -327,8 +360,11 @@ public class AuditEventTypeNode extends BaseEventTypeNode implements AuditEventT
   public String readClientUserId() throws UaException {
     try {
       return readClientUserIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -336,8 +372,11 @@ public class AuditEventTypeNode extends BaseEventTypeNode implements AuditEventT
   public void writeClientUserId(String value) throws UaException {
     try {
       writeClientUserIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -359,8 +398,11 @@ public class AuditEventTypeNode extends BaseEventTypeNode implements AuditEventT
   public PropertyTypeNode getClientUserIdNode() throws UaException {
     try {
       return getClientUserIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -368,10 +410,7 @@ public class AuditEventTypeNode extends BaseEventTypeNode implements AuditEventT
   public CompletableFuture<? extends PropertyTypeNode> getClientUserIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ClientUserId",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "ClientUserId", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditHistoryAnnotationUpdateEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditHistoryAnnotationUpdateEventTypeNode.java
@@ -88,8 +88,11 @@ public class AuditHistoryAnnotationUpdateEventTypeNode extends AuditHistoryUpdat
   public PerformUpdateType readPerformInsertReplace() throws UaException {
     try {
       return readPerformInsertReplaceAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -97,8 +100,11 @@ public class AuditHistoryAnnotationUpdateEventTypeNode extends AuditHistoryUpdat
   public void writePerformInsertReplace(PerformUpdateType value) throws UaException {
     try {
       writePerformInsertReplaceAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -129,8 +135,11 @@ public class AuditHistoryAnnotationUpdateEventTypeNode extends AuditHistoryUpdat
   public PropertyTypeNode getPerformInsertReplaceNode() throws UaException {
     try {
       return getPerformInsertReplaceNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -140,7 +149,7 @@ public class AuditHistoryAnnotationUpdateEventTypeNode extends AuditHistoryUpdat
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "PerformInsertReplace",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -163,8 +172,11 @@ public class AuditHistoryAnnotationUpdateEventTypeNode extends AuditHistoryUpdat
   public Annotation[] readNewValues() throws UaException {
     try {
       return readNewValuesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -172,8 +184,11 @@ public class AuditHistoryAnnotationUpdateEventTypeNode extends AuditHistoryUpdat
   public void writeNewValues(Annotation[] value) throws UaException {
     try {
       writeNewValuesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -197,8 +212,11 @@ public class AuditHistoryAnnotationUpdateEventTypeNode extends AuditHistoryUpdat
   public PropertyTypeNode getNewValuesNode() throws UaException {
     try {
       return getNewValuesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -206,7 +224,7 @@ public class AuditHistoryAnnotationUpdateEventTypeNode extends AuditHistoryUpdat
   public CompletableFuture<? extends PropertyTypeNode> getNewValuesNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "NewValues", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "NewValues", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -228,8 +246,11 @@ public class AuditHistoryAnnotationUpdateEventTypeNode extends AuditHistoryUpdat
   public Annotation[] readOldValues() throws UaException {
     try {
       return readOldValuesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -237,8 +258,11 @@ public class AuditHistoryAnnotationUpdateEventTypeNode extends AuditHistoryUpdat
   public void writeOldValues(Annotation[] value) throws UaException {
     try {
       writeOldValuesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -262,8 +286,11 @@ public class AuditHistoryAnnotationUpdateEventTypeNode extends AuditHistoryUpdat
   public PropertyTypeNode getOldValuesNode() throws UaException {
     try {
       return getOldValuesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -271,7 +298,7 @@ public class AuditHistoryAnnotationUpdateEventTypeNode extends AuditHistoryUpdat
   public CompletableFuture<? extends PropertyTypeNode> getOldValuesNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "OldValues", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "OldValues", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditHistoryAtTimeDeleteEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditHistoryAtTimeDeleteEventTypeNode.java
@@ -78,8 +78,11 @@ public class AuditHistoryAtTimeDeleteEventTypeNode extends AuditHistoryDeleteEve
   public DateTime[] readReqTimes() throws UaException {
     try {
       return readReqTimesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -87,8 +90,11 @@ public class AuditHistoryAtTimeDeleteEventTypeNode extends AuditHistoryDeleteEve
   public void writeReqTimes(DateTime[] value) throws UaException {
     try {
       writeReqTimesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -110,8 +116,11 @@ public class AuditHistoryAtTimeDeleteEventTypeNode extends AuditHistoryDeleteEve
   public PropertyTypeNode getReqTimesNode() throws UaException {
     try {
       return getReqTimesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -119,7 +128,7 @@ public class AuditHistoryAtTimeDeleteEventTypeNode extends AuditHistoryDeleteEve
   public CompletableFuture<? extends PropertyTypeNode> getReqTimesNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "ReqTimes", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "ReqTimes", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -139,8 +148,11 @@ public class AuditHistoryAtTimeDeleteEventTypeNode extends AuditHistoryDeleteEve
   public DataValue[] readOldValues() throws UaException {
     try {
       return readOldValuesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -148,8 +160,11 @@ public class AuditHistoryAtTimeDeleteEventTypeNode extends AuditHistoryDeleteEve
   public void writeOldValues(DataValue[] value) throws UaException {
     try {
       writeOldValuesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -171,8 +186,11 @@ public class AuditHistoryAtTimeDeleteEventTypeNode extends AuditHistoryDeleteEve
   public PropertyTypeNode getOldValuesNode() throws UaException {
     try {
       return getOldValuesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -180,7 +198,7 @@ public class AuditHistoryAtTimeDeleteEventTypeNode extends AuditHistoryDeleteEve
   public CompletableFuture<? extends PropertyTypeNode> getOldValuesNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "OldValues", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "OldValues", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditHistoryBulkInsertEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditHistoryBulkInsertEventTypeNode.java
@@ -78,8 +78,11 @@ public class AuditHistoryBulkInsertEventTypeNode extends AuditEventTypeNode
   public NodeId readUpdatedNode() throws UaException {
     try {
       return readUpdatedNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -87,8 +90,11 @@ public class AuditHistoryBulkInsertEventTypeNode extends AuditEventTypeNode
   public void writeUpdatedNode(NodeId value) throws UaException {
     try {
       writeUpdatedNodeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -110,8 +116,11 @@ public class AuditHistoryBulkInsertEventTypeNode extends AuditEventTypeNode
   public PropertyTypeNode getUpdatedNodeNode() throws UaException {
     try {
       return getUpdatedNodeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -119,10 +128,7 @@ public class AuditHistoryBulkInsertEventTypeNode extends AuditEventTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getUpdatedNodeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "UpdatedNode",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "UpdatedNode", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -142,8 +148,11 @@ public class AuditHistoryBulkInsertEventTypeNode extends AuditEventTypeNode
   public DateTime readStartTime() throws UaException {
     try {
       return readStartTimeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -151,8 +160,11 @@ public class AuditHistoryBulkInsertEventTypeNode extends AuditEventTypeNode
   public void writeStartTime(DateTime value) throws UaException {
     try {
       writeStartTimeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -174,8 +186,11 @@ public class AuditHistoryBulkInsertEventTypeNode extends AuditEventTypeNode
   public PropertyTypeNode getStartTimeNode() throws UaException {
     try {
       return getStartTimeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -183,7 +198,7 @@ public class AuditHistoryBulkInsertEventTypeNode extends AuditEventTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getStartTimeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "StartTime", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "StartTime", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -203,8 +218,11 @@ public class AuditHistoryBulkInsertEventTypeNode extends AuditEventTypeNode
   public DateTime readEndTime() throws UaException {
     try {
       return readEndTimeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -212,8 +230,11 @@ public class AuditHistoryBulkInsertEventTypeNode extends AuditEventTypeNode
   public void writeEndTime(DateTime value) throws UaException {
     try {
       writeEndTimeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -235,8 +256,11 @@ public class AuditHistoryBulkInsertEventTypeNode extends AuditEventTypeNode
   public PropertyTypeNode getEndTimeNode() throws UaException {
     try {
       return getEndTimeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -244,7 +268,7 @@ public class AuditHistoryBulkInsertEventTypeNode extends AuditEventTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getEndTimeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "EndTime", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "EndTime", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditHistoryDeleteEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditHistoryDeleteEventTypeNode.java
@@ -77,8 +77,11 @@ public class AuditHistoryDeleteEventTypeNode extends AuditHistoryUpdateEventType
   public NodeId readUpdatedNode() throws UaException {
     try {
       return readUpdatedNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class AuditHistoryDeleteEventTypeNode extends AuditHistoryUpdateEventType
   public void writeUpdatedNode(NodeId value) throws UaException {
     try {
       writeUpdatedNodeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class AuditHistoryDeleteEventTypeNode extends AuditHistoryUpdateEventType
   public PropertyTypeNode getUpdatedNodeNode() throws UaException {
     try {
       return getUpdatedNodeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -118,10 +127,7 @@ public class AuditHistoryDeleteEventTypeNode extends AuditHistoryUpdateEventType
   public CompletableFuture<? extends PropertyTypeNode> getUpdatedNodeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "UpdatedNode",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "UpdatedNode", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditHistoryEventDeleteEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditHistoryEventDeleteEventTypeNode.java
@@ -80,8 +80,11 @@ public class AuditHistoryEventDeleteEventTypeNode extends AuditHistoryDeleteEven
   public ByteString[] readEventIds() throws UaException {
     try {
       return readEventIdsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -89,8 +92,11 @@ public class AuditHistoryEventDeleteEventTypeNode extends AuditHistoryDeleteEven
   public void writeEventIds(ByteString[] value) throws UaException {
     try {
       writeEventIdsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -112,8 +118,11 @@ public class AuditHistoryEventDeleteEventTypeNode extends AuditHistoryDeleteEven
   public PropertyTypeNode getEventIdsNode() throws UaException {
     try {
       return getEventIdsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -121,7 +130,7 @@ public class AuditHistoryEventDeleteEventTypeNode extends AuditHistoryDeleteEven
   public CompletableFuture<? extends PropertyTypeNode> getEventIdsNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "EventIds", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "EventIds", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -142,8 +151,11 @@ public class AuditHistoryEventDeleteEventTypeNode extends AuditHistoryDeleteEven
   public HistoryEventFieldList readOldValues() throws UaException {
     try {
       return readOldValuesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -151,8 +163,11 @@ public class AuditHistoryEventDeleteEventTypeNode extends AuditHistoryDeleteEven
   public void writeOldValues(HistoryEventFieldList value) throws UaException {
     try {
       writeOldValuesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -175,8 +190,11 @@ public class AuditHistoryEventDeleteEventTypeNode extends AuditHistoryDeleteEven
   public PropertyTypeNode getOldValuesNode() throws UaException {
     try {
       return getOldValuesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -184,7 +202,7 @@ public class AuditHistoryEventDeleteEventTypeNode extends AuditHistoryDeleteEven
   public CompletableFuture<? extends PropertyTypeNode> getOldValuesNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "OldValues", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "OldValues", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditHistoryEventUpdateEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditHistoryEventUpdateEventTypeNode.java
@@ -81,8 +81,11 @@ public class AuditHistoryEventUpdateEventTypeNode extends AuditHistoryUpdateEven
   public NodeId readUpdatedNode() throws UaException {
     try {
       return readUpdatedNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -90,8 +93,11 @@ public class AuditHistoryEventUpdateEventTypeNode extends AuditHistoryUpdateEven
   public void writeUpdatedNode(NodeId value) throws UaException {
     try {
       writeUpdatedNodeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -113,8 +119,11 @@ public class AuditHistoryEventUpdateEventTypeNode extends AuditHistoryUpdateEven
   public PropertyTypeNode getUpdatedNodeNode() throws UaException {
     try {
       return getUpdatedNodeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -122,10 +131,7 @@ public class AuditHistoryEventUpdateEventTypeNode extends AuditHistoryUpdateEven
   public CompletableFuture<? extends PropertyTypeNode> getUpdatedNodeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "UpdatedNode",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "UpdatedNode", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -153,8 +159,11 @@ public class AuditHistoryEventUpdateEventTypeNode extends AuditHistoryUpdateEven
   public PerformUpdateType readPerformInsertReplace() throws UaException {
     try {
       return readPerformInsertReplaceAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -162,8 +171,11 @@ public class AuditHistoryEventUpdateEventTypeNode extends AuditHistoryUpdateEven
   public void writePerformInsertReplace(PerformUpdateType value) throws UaException {
     try {
       writePerformInsertReplaceAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -194,8 +206,11 @@ public class AuditHistoryEventUpdateEventTypeNode extends AuditHistoryUpdateEven
   public PropertyTypeNode getPerformInsertReplaceNode() throws UaException {
     try {
       return getPerformInsertReplaceNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -205,7 +220,7 @@ public class AuditHistoryEventUpdateEventTypeNode extends AuditHistoryUpdateEven
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "PerformInsertReplace",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -227,8 +242,11 @@ public class AuditHistoryEventUpdateEventTypeNode extends AuditHistoryUpdateEven
   public EventFilter readFilter() throws UaException {
     try {
       return readFilterAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -236,8 +254,11 @@ public class AuditHistoryEventUpdateEventTypeNode extends AuditHistoryUpdateEven
   public void writeFilter(EventFilter value) throws UaException {
     try {
       writeFilterAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -260,8 +281,11 @@ public class AuditHistoryEventUpdateEventTypeNode extends AuditHistoryUpdateEven
   public PropertyTypeNode getFilterNode() throws UaException {
     try {
       return getFilterNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -269,7 +293,7 @@ public class AuditHistoryEventUpdateEventTypeNode extends AuditHistoryUpdateEven
   public CompletableFuture<? extends PropertyTypeNode> getFilterNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Filter", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Filter", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -291,8 +315,11 @@ public class AuditHistoryEventUpdateEventTypeNode extends AuditHistoryUpdateEven
   public HistoryEventFieldList[] readNewValues() throws UaException {
     try {
       return readNewValuesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -300,8 +327,11 @@ public class AuditHistoryEventUpdateEventTypeNode extends AuditHistoryUpdateEven
   public void writeNewValues(HistoryEventFieldList[] value) throws UaException {
     try {
       writeNewValuesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -325,8 +355,11 @@ public class AuditHistoryEventUpdateEventTypeNode extends AuditHistoryUpdateEven
   public PropertyTypeNode getNewValuesNode() throws UaException {
     try {
       return getNewValuesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -334,7 +367,7 @@ public class AuditHistoryEventUpdateEventTypeNode extends AuditHistoryUpdateEven
   public CompletableFuture<? extends PropertyTypeNode> getNewValuesNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "NewValues", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "NewValues", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -356,8 +389,11 @@ public class AuditHistoryEventUpdateEventTypeNode extends AuditHistoryUpdateEven
   public HistoryEventFieldList[] readOldValues() throws UaException {
     try {
       return readOldValuesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -365,8 +401,11 @@ public class AuditHistoryEventUpdateEventTypeNode extends AuditHistoryUpdateEven
   public void writeOldValues(HistoryEventFieldList[] value) throws UaException {
     try {
       writeOldValuesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -390,8 +429,11 @@ public class AuditHistoryEventUpdateEventTypeNode extends AuditHistoryUpdateEven
   public PropertyTypeNode getOldValuesNode() throws UaException {
     try {
       return getOldValuesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -399,7 +441,7 @@ public class AuditHistoryEventUpdateEventTypeNode extends AuditHistoryUpdateEven
   public CompletableFuture<? extends PropertyTypeNode> getOldValuesNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "OldValues", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "OldValues", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditHistoryRawModifyDeleteEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditHistoryRawModifyDeleteEventTypeNode.java
@@ -78,8 +78,11 @@ public class AuditHistoryRawModifyDeleteEventTypeNode extends AuditHistoryDelete
   public Boolean readIsDeleteModified() throws UaException {
     try {
       return readIsDeleteModifiedAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -87,8 +90,11 @@ public class AuditHistoryRawModifyDeleteEventTypeNode extends AuditHistoryDelete
   public void writeIsDeleteModified(Boolean value) throws UaException {
     try {
       writeIsDeleteModifiedAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -110,8 +116,11 @@ public class AuditHistoryRawModifyDeleteEventTypeNode extends AuditHistoryDelete
   public PropertyTypeNode getIsDeleteModifiedNode() throws UaException {
     try {
       return getIsDeleteModifiedNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -121,7 +130,7 @@ public class AuditHistoryRawModifyDeleteEventTypeNode extends AuditHistoryDelete
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "IsDeleteModified",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -142,8 +151,11 @@ public class AuditHistoryRawModifyDeleteEventTypeNode extends AuditHistoryDelete
   public DateTime readStartTime() throws UaException {
     try {
       return readStartTimeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -151,8 +163,11 @@ public class AuditHistoryRawModifyDeleteEventTypeNode extends AuditHistoryDelete
   public void writeStartTime(DateTime value) throws UaException {
     try {
       writeStartTimeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -174,8 +189,11 @@ public class AuditHistoryRawModifyDeleteEventTypeNode extends AuditHistoryDelete
   public PropertyTypeNode getStartTimeNode() throws UaException {
     try {
       return getStartTimeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -183,7 +201,7 @@ public class AuditHistoryRawModifyDeleteEventTypeNode extends AuditHistoryDelete
   public CompletableFuture<? extends PropertyTypeNode> getStartTimeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "StartTime", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "StartTime", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -203,8 +221,11 @@ public class AuditHistoryRawModifyDeleteEventTypeNode extends AuditHistoryDelete
   public DateTime readEndTime() throws UaException {
     try {
       return readEndTimeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -212,8 +233,11 @@ public class AuditHistoryRawModifyDeleteEventTypeNode extends AuditHistoryDelete
   public void writeEndTime(DateTime value) throws UaException {
     try {
       writeEndTimeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -235,8 +259,11 @@ public class AuditHistoryRawModifyDeleteEventTypeNode extends AuditHistoryDelete
   public PropertyTypeNode getEndTimeNode() throws UaException {
     try {
       return getEndTimeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -244,7 +271,7 @@ public class AuditHistoryRawModifyDeleteEventTypeNode extends AuditHistoryDelete
   public CompletableFuture<? extends PropertyTypeNode> getEndTimeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "EndTime", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "EndTime", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -264,8 +291,11 @@ public class AuditHistoryRawModifyDeleteEventTypeNode extends AuditHistoryDelete
   public DataValue[] readOldValues() throws UaException {
     try {
       return readOldValuesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -273,8 +303,11 @@ public class AuditHistoryRawModifyDeleteEventTypeNode extends AuditHistoryDelete
   public void writeOldValues(DataValue[] value) throws UaException {
     try {
       writeOldValuesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -296,8 +329,11 @@ public class AuditHistoryRawModifyDeleteEventTypeNode extends AuditHistoryDelete
   public PropertyTypeNode getOldValuesNode() throws UaException {
     try {
       return getOldValuesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -305,7 +341,7 @@ public class AuditHistoryRawModifyDeleteEventTypeNode extends AuditHistoryDelete
   public CompletableFuture<? extends PropertyTypeNode> getOldValuesNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "OldValues", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "OldValues", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditHistoryUpdateEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditHistoryUpdateEventTypeNode.java
@@ -77,8 +77,11 @@ public class AuditHistoryUpdateEventTypeNode extends AuditUpdateEventTypeNode
   public NodeId readParameterDataTypeId() throws UaException {
     try {
       return readParameterDataTypeIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class AuditHistoryUpdateEventTypeNode extends AuditUpdateEventTypeNode
   public void writeParameterDataTypeId(NodeId value) throws UaException {
     try {
       writeParameterDataTypeIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class AuditHistoryUpdateEventTypeNode extends AuditUpdateEventTypeNode
   public PropertyTypeNode getParameterDataTypeIdNode() throws UaException {
     try {
       return getParameterDataTypeIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -120,7 +129,7 @@ public class AuditHistoryUpdateEventTypeNode extends AuditUpdateEventTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ParameterDataTypeId",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditHistoryValueUpdateEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditHistoryValueUpdateEventTypeNode.java
@@ -78,8 +78,11 @@ public class AuditHistoryValueUpdateEventTypeNode extends AuditHistoryUpdateEven
   public NodeId readUpdatedNode() throws UaException {
     try {
       return readUpdatedNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -87,8 +90,11 @@ public class AuditHistoryValueUpdateEventTypeNode extends AuditHistoryUpdateEven
   public void writeUpdatedNode(NodeId value) throws UaException {
     try {
       writeUpdatedNodeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -110,8 +116,11 @@ public class AuditHistoryValueUpdateEventTypeNode extends AuditHistoryUpdateEven
   public PropertyTypeNode getUpdatedNodeNode() throws UaException {
     try {
       return getUpdatedNodeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -119,10 +128,7 @@ public class AuditHistoryValueUpdateEventTypeNode extends AuditHistoryUpdateEven
   public CompletableFuture<? extends PropertyTypeNode> getUpdatedNodeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "UpdatedNode",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "UpdatedNode", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -150,8 +156,11 @@ public class AuditHistoryValueUpdateEventTypeNode extends AuditHistoryUpdateEven
   public PerformUpdateType readPerformInsertReplace() throws UaException {
     try {
       return readPerformInsertReplaceAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -159,8 +168,11 @@ public class AuditHistoryValueUpdateEventTypeNode extends AuditHistoryUpdateEven
   public void writePerformInsertReplace(PerformUpdateType value) throws UaException {
     try {
       writePerformInsertReplaceAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -191,8 +203,11 @@ public class AuditHistoryValueUpdateEventTypeNode extends AuditHistoryUpdateEven
   public PropertyTypeNode getPerformInsertReplaceNode() throws UaException {
     try {
       return getPerformInsertReplaceNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -202,7 +217,7 @@ public class AuditHistoryValueUpdateEventTypeNode extends AuditHistoryUpdateEven
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "PerformInsertReplace",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -223,8 +238,11 @@ public class AuditHistoryValueUpdateEventTypeNode extends AuditHistoryUpdateEven
   public DataValue[] readNewValues() throws UaException {
     try {
       return readNewValuesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -232,8 +250,11 @@ public class AuditHistoryValueUpdateEventTypeNode extends AuditHistoryUpdateEven
   public void writeNewValues(DataValue[] value) throws UaException {
     try {
       writeNewValuesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -255,8 +276,11 @@ public class AuditHistoryValueUpdateEventTypeNode extends AuditHistoryUpdateEven
   public PropertyTypeNode getNewValuesNode() throws UaException {
     try {
       return getNewValuesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -264,7 +288,7 @@ public class AuditHistoryValueUpdateEventTypeNode extends AuditHistoryUpdateEven
   public CompletableFuture<? extends PropertyTypeNode> getNewValuesNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "NewValues", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "NewValues", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -284,8 +308,11 @@ public class AuditHistoryValueUpdateEventTypeNode extends AuditHistoryUpdateEven
   public DataValue[] readOldValues() throws UaException {
     try {
       return readOldValuesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -293,8 +320,11 @@ public class AuditHistoryValueUpdateEventTypeNode extends AuditHistoryUpdateEven
   public void writeOldValues(DataValue[] value) throws UaException {
     try {
       writeOldValuesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -316,8 +346,11 @@ public class AuditHistoryValueUpdateEventTypeNode extends AuditHistoryUpdateEven
   public PropertyTypeNode getOldValuesNode() throws UaException {
     try {
       return getOldValuesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -325,7 +358,7 @@ public class AuditHistoryValueUpdateEventTypeNode extends AuditHistoryUpdateEven
   public CompletableFuture<? extends PropertyTypeNode> getOldValuesNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "OldValues", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "OldValues", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditOpenSecureChannelEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditOpenSecureChannelEventTypeNode.java
@@ -80,8 +80,11 @@ public class AuditOpenSecureChannelEventTypeNode extends AuditChannelEventTypeNo
   public ByteString readClientCertificate() throws UaException {
     try {
       return readClientCertificateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -89,8 +92,11 @@ public class AuditOpenSecureChannelEventTypeNode extends AuditChannelEventTypeNo
   public void writeClientCertificate(ByteString value) throws UaException {
     try {
       writeClientCertificateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -112,8 +118,11 @@ public class AuditOpenSecureChannelEventTypeNode extends AuditChannelEventTypeNo
   public PropertyTypeNode getClientCertificateNode() throws UaException {
     try {
       return getClientCertificateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -123,7 +132,7 @@ public class AuditOpenSecureChannelEventTypeNode extends AuditChannelEventTypeNo
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ClientCertificate",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -144,8 +153,11 @@ public class AuditOpenSecureChannelEventTypeNode extends AuditChannelEventTypeNo
   public String readClientCertificateThumbprint() throws UaException {
     try {
       return readClientCertificateThumbprintAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -153,8 +165,11 @@ public class AuditOpenSecureChannelEventTypeNode extends AuditChannelEventTypeNo
   public void writeClientCertificateThumbprint(String value) throws UaException {
     try {
       writeClientCertificateThumbprintAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -177,8 +192,11 @@ public class AuditOpenSecureChannelEventTypeNode extends AuditChannelEventTypeNo
   public PropertyTypeNode getClientCertificateThumbprintNode() throws UaException {
     try {
       return getClientCertificateThumbprintNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -188,7 +206,7 @@ public class AuditOpenSecureChannelEventTypeNode extends AuditChannelEventTypeNo
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ClientCertificateThumbprint",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -217,8 +235,11 @@ public class AuditOpenSecureChannelEventTypeNode extends AuditChannelEventTypeNo
   public SecurityTokenRequestType readRequestType() throws UaException {
     try {
       return readRequestTypeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -226,8 +247,11 @@ public class AuditOpenSecureChannelEventTypeNode extends AuditChannelEventTypeNo
   public void writeRequestType(SecurityTokenRequestType value) throws UaException {
     try {
       writeRequestTypeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -257,8 +281,11 @@ public class AuditOpenSecureChannelEventTypeNode extends AuditChannelEventTypeNo
   public PropertyTypeNode getRequestTypeNode() throws UaException {
     try {
       return getRequestTypeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -266,10 +293,7 @@ public class AuditOpenSecureChannelEventTypeNode extends AuditChannelEventTypeNo
   public CompletableFuture<? extends PropertyTypeNode> getRequestTypeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "RequestType",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "RequestType", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -289,8 +313,11 @@ public class AuditOpenSecureChannelEventTypeNode extends AuditChannelEventTypeNo
   public String readSecurityPolicyUri() throws UaException {
     try {
       return readSecurityPolicyUriAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -298,8 +325,11 @@ public class AuditOpenSecureChannelEventTypeNode extends AuditChannelEventTypeNo
   public void writeSecurityPolicyUri(String value) throws UaException {
     try {
       writeSecurityPolicyUriAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -321,8 +351,11 @@ public class AuditOpenSecureChannelEventTypeNode extends AuditChannelEventTypeNo
   public PropertyTypeNode getSecurityPolicyUriNode() throws UaException {
     try {
       return getSecurityPolicyUriNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -332,7 +365,7 @@ public class AuditOpenSecureChannelEventTypeNode extends AuditChannelEventTypeNo
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SecurityPolicyUri",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -361,8 +394,11 @@ public class AuditOpenSecureChannelEventTypeNode extends AuditChannelEventTypeNo
   public MessageSecurityMode readSecurityMode() throws UaException {
     try {
       return readSecurityModeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -370,8 +406,11 @@ public class AuditOpenSecureChannelEventTypeNode extends AuditChannelEventTypeNo
   public void writeSecurityMode(MessageSecurityMode value) throws UaException {
     try {
       writeSecurityModeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -401,8 +440,11 @@ public class AuditOpenSecureChannelEventTypeNode extends AuditChannelEventTypeNo
   public PropertyTypeNode getSecurityModeNode() throws UaException {
     try {
       return getSecurityModeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -410,10 +452,7 @@ public class AuditOpenSecureChannelEventTypeNode extends AuditChannelEventTypeNo
   public CompletableFuture<? extends PropertyTypeNode> getSecurityModeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "SecurityMode",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "SecurityMode", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -433,8 +472,11 @@ public class AuditOpenSecureChannelEventTypeNode extends AuditChannelEventTypeNo
   public Double readRequestedLifetime() throws UaException {
     try {
       return readRequestedLifetimeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -442,8 +484,11 @@ public class AuditOpenSecureChannelEventTypeNode extends AuditChannelEventTypeNo
   public void writeRequestedLifetime(Double value) throws UaException {
     try {
       writeRequestedLifetimeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -465,8 +510,11 @@ public class AuditOpenSecureChannelEventTypeNode extends AuditChannelEventTypeNo
   public PropertyTypeNode getRequestedLifetimeNode() throws UaException {
     try {
       return getRequestedLifetimeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -476,7 +524,7 @@ public class AuditOpenSecureChannelEventTypeNode extends AuditChannelEventTypeNo
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "RequestedLifetime",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -497,8 +545,11 @@ public class AuditOpenSecureChannelEventTypeNode extends AuditChannelEventTypeNo
   public ByteString readCertificateErrorEventId() throws UaException {
     try {
       return readCertificateErrorEventIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -506,8 +557,11 @@ public class AuditOpenSecureChannelEventTypeNode extends AuditChannelEventTypeNo
   public void writeCertificateErrorEventId(ByteString value) throws UaException {
     try {
       writeCertificateErrorEventIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -530,8 +584,11 @@ public class AuditOpenSecureChannelEventTypeNode extends AuditChannelEventTypeNo
   public PropertyTypeNode getCertificateErrorEventIdNode() throws UaException {
     try {
       return getCertificateErrorEventIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -541,7 +598,7 @@ public class AuditOpenSecureChannelEventTypeNode extends AuditChannelEventTypeNo
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "CertificateErrorEventId",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditProgramTransitionEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditProgramTransitionEventTypeNode.java
@@ -77,8 +77,11 @@ public class AuditProgramTransitionEventTypeNode extends AuditUpdateStateEventTy
   public UInteger readTransitionNumber() throws UaException {
     try {
       return readTransitionNumberAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class AuditProgramTransitionEventTypeNode extends AuditUpdateStateEventTy
   public void writeTransitionNumber(UInteger value) throws UaException {
     try {
       writeTransitionNumberAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class AuditProgramTransitionEventTypeNode extends AuditUpdateStateEventTy
   public PropertyTypeNode getTransitionNumberNode() throws UaException {
     try {
       return getTransitionNumberNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -120,7 +129,7 @@ public class AuditProgramTransitionEventTypeNode extends AuditUpdateStateEventTy
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "TransitionNumber",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditSecurityEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditSecurityEventTypeNode.java
@@ -77,8 +77,11 @@ public class AuditSecurityEventTypeNode extends AuditEventTypeNode
   public StatusCode readStatusCodeId() throws UaException {
     try {
       return readStatusCodeIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class AuditSecurityEventTypeNode extends AuditEventTypeNode
   public void writeStatusCodeId(StatusCode value) throws UaException {
     try {
       writeStatusCodeIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class AuditSecurityEventTypeNode extends AuditEventTypeNode
   public PropertyTypeNode getStatusCodeIdNode() throws UaException {
     try {
       return getStatusCodeIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -118,10 +127,7 @@ public class AuditSecurityEventTypeNode extends AuditEventTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getStatusCodeIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "StatusCodeId",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "StatusCodeId", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditSessionEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditSessionEventTypeNode.java
@@ -77,8 +77,11 @@ public class AuditSessionEventTypeNode extends AuditSecurityEventTypeNode
   public NodeId readSessionId() throws UaException {
     try {
       return readSessionIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class AuditSessionEventTypeNode extends AuditSecurityEventTypeNode
   public void writeSessionId(NodeId value) throws UaException {
     try {
       writeSessionIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class AuditSessionEventTypeNode extends AuditSecurityEventTypeNode
   public PropertyTypeNode getSessionIdNode() throws UaException {
     try {
       return getSessionIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -118,7 +127,7 @@ public class AuditSessionEventTypeNode extends AuditSecurityEventTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getSessionIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "SessionId", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "SessionId", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditUpdateMethodEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditUpdateMethodEventTypeNode.java
@@ -77,8 +77,11 @@ public class AuditUpdateMethodEventTypeNode extends AuditEventTypeNode
   public NodeId readMethodId() throws UaException {
     try {
       return readMethodIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class AuditUpdateMethodEventTypeNode extends AuditEventTypeNode
   public void writeMethodId(NodeId value) throws UaException {
     try {
       writeMethodIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class AuditUpdateMethodEventTypeNode extends AuditEventTypeNode
   public PropertyTypeNode getMethodIdNode() throws UaException {
     try {
       return getMethodIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -118,7 +127,7 @@ public class AuditUpdateMethodEventTypeNode extends AuditEventTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getMethodIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "MethodId", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "MethodId", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -138,8 +147,11 @@ public class AuditUpdateMethodEventTypeNode extends AuditEventTypeNode
   public StatusCode readStatusCodeId() throws UaException {
     try {
       return readStatusCodeIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -147,8 +159,11 @@ public class AuditUpdateMethodEventTypeNode extends AuditEventTypeNode
   public void writeStatusCodeId(StatusCode value) throws UaException {
     try {
       writeStatusCodeIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -170,8 +185,11 @@ public class AuditUpdateMethodEventTypeNode extends AuditEventTypeNode
   public PropertyTypeNode getStatusCodeIdNode() throws UaException {
     try {
       return getStatusCodeIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -179,10 +197,7 @@ public class AuditUpdateMethodEventTypeNode extends AuditEventTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getStatusCodeIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "StatusCodeId",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "StatusCodeId", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -202,8 +217,11 @@ public class AuditUpdateMethodEventTypeNode extends AuditEventTypeNode
   public Object[] readInputArguments() throws UaException {
     try {
       return readInputArgumentsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -211,8 +229,11 @@ public class AuditUpdateMethodEventTypeNode extends AuditEventTypeNode
   public void writeInputArguments(Object[] value) throws UaException {
     try {
       writeInputArgumentsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -234,8 +255,11 @@ public class AuditUpdateMethodEventTypeNode extends AuditEventTypeNode
   public PropertyTypeNode getInputArgumentsNode() throws UaException {
     try {
       return getInputArgumentsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -243,10 +267,7 @@ public class AuditUpdateMethodEventTypeNode extends AuditEventTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getInputArgumentsNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "InputArguments",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "InputArguments", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -266,8 +287,11 @@ public class AuditUpdateMethodEventTypeNode extends AuditEventTypeNode
   public Object[] readOutputArguments() throws UaException {
     try {
       return readOutputArgumentsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -275,8 +299,11 @@ public class AuditUpdateMethodEventTypeNode extends AuditEventTypeNode
   public void writeOutputArguments(Object[] value) throws UaException {
     try {
       writeOutputArgumentsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -298,8 +325,11 @@ public class AuditUpdateMethodEventTypeNode extends AuditEventTypeNode
   public PropertyTypeNode getOutputArgumentsNode() throws UaException {
     try {
       return getOutputArgumentsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -307,10 +337,7 @@ public class AuditUpdateMethodEventTypeNode extends AuditEventTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getOutputArgumentsNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "OutputArguments",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "OutputArguments", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditUpdateStateEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditUpdateStateEventTypeNode.java
@@ -77,8 +77,11 @@ public class AuditUpdateStateEventTypeNode extends AuditUpdateMethodEventTypeNod
   public Object readOldStateId() throws UaException {
     try {
       return readOldStateIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class AuditUpdateStateEventTypeNode extends AuditUpdateMethodEventTypeNod
   public void writeOldStateId(Object value) throws UaException {
     try {
       writeOldStateIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class AuditUpdateStateEventTypeNode extends AuditUpdateMethodEventTypeNod
   public PropertyTypeNode getOldStateIdNode() throws UaException {
     try {
       return getOldStateIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -118,7 +127,7 @@ public class AuditUpdateStateEventTypeNode extends AuditUpdateMethodEventTypeNod
   public CompletableFuture<? extends PropertyTypeNode> getOldStateIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "OldStateId", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "OldStateId", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -138,8 +147,11 @@ public class AuditUpdateStateEventTypeNode extends AuditUpdateMethodEventTypeNod
   public Object readNewStateId() throws UaException {
     try {
       return readNewStateIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -147,8 +159,11 @@ public class AuditUpdateStateEventTypeNode extends AuditUpdateMethodEventTypeNod
   public void writeNewStateId(Object value) throws UaException {
     try {
       writeNewStateIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -170,8 +185,11 @@ public class AuditUpdateStateEventTypeNode extends AuditUpdateMethodEventTypeNod
   public PropertyTypeNode getNewStateIdNode() throws UaException {
     try {
       return getNewStateIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -179,7 +197,7 @@ public class AuditUpdateStateEventTypeNode extends AuditUpdateMethodEventTypeNod
   public CompletableFuture<? extends PropertyTypeNode> getNewStateIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "NewStateId", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "NewStateId", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditUrlMismatchEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditUrlMismatchEventTypeNode.java
@@ -77,8 +77,11 @@ public class AuditUrlMismatchEventTypeNode extends AuditCreateSessionEventTypeNo
   public String readEndpointUrl() throws UaException {
     try {
       return readEndpointUrlAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class AuditUrlMismatchEventTypeNode extends AuditCreateSessionEventTypeNo
   public void writeEndpointUrl(String value) throws UaException {
     try {
       writeEndpointUrlAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class AuditUrlMismatchEventTypeNode extends AuditCreateSessionEventTypeNo
   public PropertyTypeNode getEndpointUrlNode() throws UaException {
     try {
       return getEndpointUrlNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -118,10 +127,7 @@ public class AuditUrlMismatchEventTypeNode extends AuditCreateSessionEventTypeNo
   public CompletableFuture<? extends PropertyTypeNode> getEndpointUrlNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "EndpointUrl",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "EndpointUrl", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditWriteUpdateEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditWriteUpdateEventTypeNode.java
@@ -77,8 +77,11 @@ public class AuditWriteUpdateEventTypeNode extends AuditUpdateEventTypeNode
   public UInteger readAttributeId() throws UaException {
     try {
       return readAttributeIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class AuditWriteUpdateEventTypeNode extends AuditUpdateEventTypeNode
   public void writeAttributeId(UInteger value) throws UaException {
     try {
       writeAttributeIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class AuditWriteUpdateEventTypeNode extends AuditUpdateEventTypeNode
   public PropertyTypeNode getAttributeIdNode() throws UaException {
     try {
       return getAttributeIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -118,10 +127,7 @@ public class AuditWriteUpdateEventTypeNode extends AuditUpdateEventTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getAttributeIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "AttributeId",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "AttributeId", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -141,8 +147,11 @@ public class AuditWriteUpdateEventTypeNode extends AuditUpdateEventTypeNode
   public String readIndexRange() throws UaException {
     try {
       return readIndexRangeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -150,8 +159,11 @@ public class AuditWriteUpdateEventTypeNode extends AuditUpdateEventTypeNode
   public void writeIndexRange(String value) throws UaException {
     try {
       writeIndexRangeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -173,8 +185,11 @@ public class AuditWriteUpdateEventTypeNode extends AuditUpdateEventTypeNode
   public PropertyTypeNode getIndexRangeNode() throws UaException {
     try {
       return getIndexRangeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -182,7 +197,7 @@ public class AuditWriteUpdateEventTypeNode extends AuditUpdateEventTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getIndexRangeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "IndexRange", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "IndexRange", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -202,8 +217,11 @@ public class AuditWriteUpdateEventTypeNode extends AuditUpdateEventTypeNode
   public Object readOldValue() throws UaException {
     try {
       return readOldValueAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -211,8 +229,11 @@ public class AuditWriteUpdateEventTypeNode extends AuditUpdateEventTypeNode
   public void writeOldValue(Object value) throws UaException {
     try {
       writeOldValueAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -234,8 +255,11 @@ public class AuditWriteUpdateEventTypeNode extends AuditUpdateEventTypeNode
   public PropertyTypeNode getOldValueNode() throws UaException {
     try {
       return getOldValueNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -243,7 +267,7 @@ public class AuditWriteUpdateEventTypeNode extends AuditUpdateEventTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getOldValueNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "OldValue", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "OldValue", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -263,8 +287,11 @@ public class AuditWriteUpdateEventTypeNode extends AuditUpdateEventTypeNode
   public Object readNewValue() throws UaException {
     try {
       return readNewValueAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -272,8 +299,11 @@ public class AuditWriteUpdateEventTypeNode extends AuditUpdateEventTypeNode
   public void writeNewValue(Object value) throws UaException {
     try {
       writeNewValueAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -295,8 +325,11 @@ public class AuditWriteUpdateEventTypeNode extends AuditUpdateEventTypeNode
   public PropertyTypeNode getNewValueNode() throws UaException {
     try {
       return getNewValueNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -304,7 +337,7 @@ public class AuditWriteUpdateEventTypeNode extends AuditUpdateEventTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getNewValueNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "NewValue", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "NewValue", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuthorizationServiceConfigurationTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuthorizationServiceConfigurationTypeNode.java
@@ -78,8 +78,11 @@ public class AuthorizationServiceConfigurationTypeNode extends BaseObjectTypeNod
   public String readServiceUri() throws UaException {
     try {
       return readServiceUriAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -87,8 +90,11 @@ public class AuthorizationServiceConfigurationTypeNode extends BaseObjectTypeNod
   public void writeServiceUri(String value) throws UaException {
     try {
       writeServiceUriAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -110,8 +116,11 @@ public class AuthorizationServiceConfigurationTypeNode extends BaseObjectTypeNod
   public PropertyTypeNode getServiceUriNode() throws UaException {
     try {
       return getServiceUriNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -119,7 +128,7 @@ public class AuthorizationServiceConfigurationTypeNode extends BaseObjectTypeNod
   public CompletableFuture<? extends PropertyTypeNode> getServiceUriNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "ServiceUri", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "ServiceUri", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -139,8 +148,11 @@ public class AuthorizationServiceConfigurationTypeNode extends BaseObjectTypeNod
   public ByteString readServiceCertificate() throws UaException {
     try {
       return readServiceCertificateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -148,8 +160,11 @@ public class AuthorizationServiceConfigurationTypeNode extends BaseObjectTypeNod
   public void writeServiceCertificate(ByteString value) throws UaException {
     try {
       writeServiceCertificateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -171,8 +186,11 @@ public class AuthorizationServiceConfigurationTypeNode extends BaseObjectTypeNod
   public PropertyTypeNode getServiceCertificateNode() throws UaException {
     try {
       return getServiceCertificateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -182,7 +200,7 @@ public class AuthorizationServiceConfigurationTypeNode extends BaseObjectTypeNod
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ServiceCertificate",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -203,8 +221,11 @@ public class AuthorizationServiceConfigurationTypeNode extends BaseObjectTypeNod
   public String readIssuerEndpointUrl() throws UaException {
     try {
       return readIssuerEndpointUrlAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -212,8 +233,11 @@ public class AuthorizationServiceConfigurationTypeNode extends BaseObjectTypeNod
   public void writeIssuerEndpointUrl(String value) throws UaException {
     try {
       writeIssuerEndpointUrlAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -235,8 +259,11 @@ public class AuthorizationServiceConfigurationTypeNode extends BaseObjectTypeNod
   public PropertyTypeNode getIssuerEndpointUrlNode() throws UaException {
     try {
       return getIssuerEndpointUrlNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -246,7 +273,7 @@ public class AuthorizationServiceConfigurationTypeNode extends BaseObjectTypeNod
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "IssuerEndpointUrl",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/BaseEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/BaseEventTypeNode.java
@@ -81,8 +81,11 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public ByteString readEventId() throws UaException {
     try {
       return readEventIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -90,8 +93,11 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public void writeEventId(ByteString value) throws UaException {
     try {
       writeEventIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -113,8 +119,11 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public PropertyTypeNode getEventIdNode() throws UaException {
     try {
       return getEventIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -122,7 +131,7 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public CompletableFuture<? extends PropertyTypeNode> getEventIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "EventId", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "EventId", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -142,8 +151,11 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public NodeId readEventType() throws UaException {
     try {
       return readEventTypeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -151,8 +163,11 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public void writeEventType(NodeId value) throws UaException {
     try {
       writeEventTypeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -174,8 +189,11 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public PropertyTypeNode getEventTypeNode() throws UaException {
     try {
       return getEventTypeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -183,7 +201,7 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public CompletableFuture<? extends PropertyTypeNode> getEventTypeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "EventType", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "EventType", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -203,8 +221,11 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public NodeId readSourceNode() throws UaException {
     try {
       return readSourceNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -212,8 +233,11 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public void writeSourceNode(NodeId value) throws UaException {
     try {
       writeSourceNodeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -235,8 +259,11 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public PropertyTypeNode getSourceNodeNode() throws UaException {
     try {
       return getSourceNodeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -244,7 +271,7 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public CompletableFuture<? extends PropertyTypeNode> getSourceNodeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "SourceNode", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "SourceNode", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -264,8 +291,11 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public String readSourceName() throws UaException {
     try {
       return readSourceNameAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -273,8 +303,11 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public void writeSourceName(String value) throws UaException {
     try {
       writeSourceNameAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -296,8 +329,11 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public PropertyTypeNode getSourceNameNode() throws UaException {
     try {
       return getSourceNameNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -305,7 +341,7 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public CompletableFuture<? extends PropertyTypeNode> getSourceNameNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "SourceName", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "SourceName", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -325,8 +361,11 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public DateTime readTime() throws UaException {
     try {
       return readTimeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -334,8 +373,11 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public void writeTime(DateTime value) throws UaException {
     try {
       writeTimeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -357,8 +399,11 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public PropertyTypeNode getTimeNode() throws UaException {
     try {
       return getTimeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -366,7 +411,7 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public CompletableFuture<? extends PropertyTypeNode> getTimeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Time", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Time", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -386,8 +431,11 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public DateTime readReceiveTime() throws UaException {
     try {
       return readReceiveTimeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -395,8 +443,11 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public void writeReceiveTime(DateTime value) throws UaException {
     try {
       writeReceiveTimeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -418,8 +469,11 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public PropertyTypeNode getReceiveTimeNode() throws UaException {
     try {
       return getReceiveTimeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -427,10 +481,7 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public CompletableFuture<? extends PropertyTypeNode> getReceiveTimeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ReceiveTime",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "ReceiveTime", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -451,8 +502,11 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public TimeZoneDataType readLocalTime() throws UaException {
     try {
       return readLocalTimeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -460,8 +514,11 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public void writeLocalTime(TimeZoneDataType value) throws UaException {
     try {
       writeLocalTimeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -484,8 +541,11 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public PropertyTypeNode getLocalTimeNode() throws UaException {
     try {
       return getLocalTimeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -493,7 +553,7 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public CompletableFuture<? extends PropertyTypeNode> getLocalTimeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "LocalTime", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "LocalTime", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -513,8 +573,11 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public LocalizedText readMessage() throws UaException {
     try {
       return readMessageAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -522,8 +585,11 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public void writeMessage(LocalizedText value) throws UaException {
     try {
       writeMessageAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -545,8 +611,11 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public PropertyTypeNode getMessageNode() throws UaException {
     try {
       return getMessageNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -554,7 +623,7 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public CompletableFuture<? extends PropertyTypeNode> getMessageNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Message", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Message", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -574,8 +643,11 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public UShort readSeverity() throws UaException {
     try {
       return readSeverityAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -583,8 +655,11 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public void writeSeverity(UShort value) throws UaException {
     try {
       writeSeverityAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -606,8 +681,11 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public PropertyTypeNode getSeverityNode() throws UaException {
     try {
       return getSeverityNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -615,7 +693,7 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public CompletableFuture<? extends PropertyTypeNode> getSeverityNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Severity", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Severity", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -635,8 +713,11 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public NodeId readConditionClassId() throws UaException {
     try {
       return readConditionClassIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -644,8 +725,11 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public void writeConditionClassId(NodeId value) throws UaException {
     try {
       writeConditionClassIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -667,8 +751,11 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public PropertyTypeNode getConditionClassIdNode() throws UaException {
     try {
       return getConditionClassIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -678,7 +765,7 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ConditionClassId",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -699,8 +786,11 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public LocalizedText readConditionClassName() throws UaException {
     try {
       return readConditionClassNameAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -708,8 +798,11 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public void writeConditionClassName(LocalizedText value) throws UaException {
     try {
       writeConditionClassNameAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -732,8 +825,11 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public PropertyTypeNode getConditionClassNameNode() throws UaException {
     try {
       return getConditionClassNameNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -743,7 +839,7 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ConditionClassName",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -764,8 +860,11 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public NodeId[] readConditionSubClassId() throws UaException {
     try {
       return readConditionSubClassIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -773,8 +872,11 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public void writeConditionSubClassId(NodeId[] value) throws UaException {
     try {
       writeConditionSubClassIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -796,8 +898,11 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public PropertyTypeNode getConditionSubClassIdNode() throws UaException {
     try {
       return getConditionSubClassIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -807,7 +912,7 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ConditionSubClassId",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -828,8 +933,11 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public LocalizedText[] readConditionSubClassName() throws UaException {
     try {
       return readConditionSubClassNameAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -837,8 +945,11 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public void writeConditionSubClassName(LocalizedText[] value) throws UaException {
     try {
       writeConditionSubClassNameAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -861,8 +972,11 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   public PropertyTypeNode getConditionSubClassNameNode() throws UaException {
     try {
       return getConditionSubClassNameNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -872,7 +986,7 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ConditionSubClassName",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/BrokerConnectionTransportTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/BrokerConnectionTransportTypeNode.java
@@ -77,8 +77,11 @@ public class BrokerConnectionTransportTypeNode extends ConnectionTransportTypeNo
   public String readResourceUri() throws UaException {
     try {
       return readResourceUriAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class BrokerConnectionTransportTypeNode extends ConnectionTransportTypeNo
   public void writeResourceUri(String value) throws UaException {
     try {
       writeResourceUriAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class BrokerConnectionTransportTypeNode extends ConnectionTransportTypeNo
   public PropertyTypeNode getResourceUriNode() throws UaException {
     try {
       return getResourceUriNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -118,10 +127,7 @@ public class BrokerConnectionTransportTypeNode extends ConnectionTransportTypeNo
   public CompletableFuture<? extends PropertyTypeNode> getResourceUriNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ResourceUri",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "ResourceUri", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -141,8 +147,11 @@ public class BrokerConnectionTransportTypeNode extends ConnectionTransportTypeNo
   public String readAuthenticationProfileUri() throws UaException {
     try {
       return readAuthenticationProfileUriAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -150,8 +159,11 @@ public class BrokerConnectionTransportTypeNode extends ConnectionTransportTypeNo
   public void writeAuthenticationProfileUri(String value) throws UaException {
     try {
       writeAuthenticationProfileUriAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -174,8 +186,11 @@ public class BrokerConnectionTransportTypeNode extends ConnectionTransportTypeNo
   public PropertyTypeNode getAuthenticationProfileUriNode() throws UaException {
     try {
       return getAuthenticationProfileUriNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -185,7 +200,7 @@ public class BrokerConnectionTransportTypeNode extends ConnectionTransportTypeNo
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "AuthenticationProfileUri",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/BrokerDataSetReaderTransportTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/BrokerDataSetReaderTransportTypeNode.java
@@ -78,8 +78,11 @@ public class BrokerDataSetReaderTransportTypeNode extends DataSetReaderTransport
   public String readQueueName() throws UaException {
     try {
       return readQueueNameAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -87,8 +90,11 @@ public class BrokerDataSetReaderTransportTypeNode extends DataSetReaderTransport
   public void writeQueueName(String value) throws UaException {
     try {
       writeQueueNameAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -110,8 +116,11 @@ public class BrokerDataSetReaderTransportTypeNode extends DataSetReaderTransport
   public PropertyTypeNode getQueueNameNode() throws UaException {
     try {
       return getQueueNameNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -119,7 +128,7 @@ public class BrokerDataSetReaderTransportTypeNode extends DataSetReaderTransport
   public CompletableFuture<? extends PropertyTypeNode> getQueueNameNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "QueueName", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "QueueName", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -139,8 +148,11 @@ public class BrokerDataSetReaderTransportTypeNode extends DataSetReaderTransport
   public String readResourceUri() throws UaException {
     try {
       return readResourceUriAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -148,8 +160,11 @@ public class BrokerDataSetReaderTransportTypeNode extends DataSetReaderTransport
   public void writeResourceUri(String value) throws UaException {
     try {
       writeResourceUriAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -171,8 +186,11 @@ public class BrokerDataSetReaderTransportTypeNode extends DataSetReaderTransport
   public PropertyTypeNode getResourceUriNode() throws UaException {
     try {
       return getResourceUriNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -180,10 +198,7 @@ public class BrokerDataSetReaderTransportTypeNode extends DataSetReaderTransport
   public CompletableFuture<? extends PropertyTypeNode> getResourceUriNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ResourceUri",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "ResourceUri", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -203,8 +218,11 @@ public class BrokerDataSetReaderTransportTypeNode extends DataSetReaderTransport
   public String readAuthenticationProfileUri() throws UaException {
     try {
       return readAuthenticationProfileUriAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -212,8 +230,11 @@ public class BrokerDataSetReaderTransportTypeNode extends DataSetReaderTransport
   public void writeAuthenticationProfileUri(String value) throws UaException {
     try {
       writeAuthenticationProfileUriAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -236,8 +257,11 @@ public class BrokerDataSetReaderTransportTypeNode extends DataSetReaderTransport
   public PropertyTypeNode getAuthenticationProfileUriNode() throws UaException {
     try {
       return getAuthenticationProfileUriNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -247,7 +271,7 @@ public class BrokerDataSetReaderTransportTypeNode extends DataSetReaderTransport
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "AuthenticationProfileUri",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -277,8 +301,11 @@ public class BrokerDataSetReaderTransportTypeNode extends DataSetReaderTransport
   public BrokerTransportQualityOfService readRequestedDeliveryGuarantee() throws UaException {
     try {
       return readRequestedDeliveryGuaranteeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -287,8 +314,11 @@ public class BrokerDataSetReaderTransportTypeNode extends DataSetReaderTransport
       throws UaException {
     try {
       writeRequestedDeliveryGuaranteeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -320,8 +350,11 @@ public class BrokerDataSetReaderTransportTypeNode extends DataSetReaderTransport
   public PropertyTypeNode getRequestedDeliveryGuaranteeNode() throws UaException {
     try {
       return getRequestedDeliveryGuaranteeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -331,7 +364,7 @@ public class BrokerDataSetReaderTransportTypeNode extends DataSetReaderTransport
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "RequestedDeliveryGuarantee",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -352,8 +385,11 @@ public class BrokerDataSetReaderTransportTypeNode extends DataSetReaderTransport
   public String readMetaDataQueueName() throws UaException {
     try {
       return readMetaDataQueueNameAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -361,8 +397,11 @@ public class BrokerDataSetReaderTransportTypeNode extends DataSetReaderTransport
   public void writeMetaDataQueueName(String value) throws UaException {
     try {
       writeMetaDataQueueNameAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -384,8 +423,11 @@ public class BrokerDataSetReaderTransportTypeNode extends DataSetReaderTransport
   public PropertyTypeNode getMetaDataQueueNameNode() throws UaException {
     try {
       return getMetaDataQueueNameNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -395,7 +437,7 @@ public class BrokerDataSetReaderTransportTypeNode extends DataSetReaderTransport
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MetaDataQueueName",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/BrokerDataSetWriterTransportTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/BrokerDataSetWriterTransportTypeNode.java
@@ -78,8 +78,11 @@ public class BrokerDataSetWriterTransportTypeNode extends DataSetWriterTransport
   public String readQueueName() throws UaException {
     try {
       return readQueueNameAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -87,8 +90,11 @@ public class BrokerDataSetWriterTransportTypeNode extends DataSetWriterTransport
   public void writeQueueName(String value) throws UaException {
     try {
       writeQueueNameAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -110,8 +116,11 @@ public class BrokerDataSetWriterTransportTypeNode extends DataSetWriterTransport
   public PropertyTypeNode getQueueNameNode() throws UaException {
     try {
       return getQueueNameNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -119,7 +128,7 @@ public class BrokerDataSetWriterTransportTypeNode extends DataSetWriterTransport
   public CompletableFuture<? extends PropertyTypeNode> getQueueNameNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "QueueName", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "QueueName", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -139,8 +148,11 @@ public class BrokerDataSetWriterTransportTypeNode extends DataSetWriterTransport
   public String readMetaDataQueueName() throws UaException {
     try {
       return readMetaDataQueueNameAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -148,8 +160,11 @@ public class BrokerDataSetWriterTransportTypeNode extends DataSetWriterTransport
   public void writeMetaDataQueueName(String value) throws UaException {
     try {
       writeMetaDataQueueNameAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -171,8 +186,11 @@ public class BrokerDataSetWriterTransportTypeNode extends DataSetWriterTransport
   public PropertyTypeNode getMetaDataQueueNameNode() throws UaException {
     try {
       return getMetaDataQueueNameNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -182,7 +200,7 @@ public class BrokerDataSetWriterTransportTypeNode extends DataSetWriterTransport
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MetaDataQueueName",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -203,8 +221,11 @@ public class BrokerDataSetWriterTransportTypeNode extends DataSetWriterTransport
   public String readResourceUri() throws UaException {
     try {
       return readResourceUriAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -212,8 +233,11 @@ public class BrokerDataSetWriterTransportTypeNode extends DataSetWriterTransport
   public void writeResourceUri(String value) throws UaException {
     try {
       writeResourceUriAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -235,8 +259,11 @@ public class BrokerDataSetWriterTransportTypeNode extends DataSetWriterTransport
   public PropertyTypeNode getResourceUriNode() throws UaException {
     try {
       return getResourceUriNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -244,10 +271,7 @@ public class BrokerDataSetWriterTransportTypeNode extends DataSetWriterTransport
   public CompletableFuture<? extends PropertyTypeNode> getResourceUriNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ResourceUri",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "ResourceUri", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -267,8 +291,11 @@ public class BrokerDataSetWriterTransportTypeNode extends DataSetWriterTransport
   public String readAuthenticationProfileUri() throws UaException {
     try {
       return readAuthenticationProfileUriAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -276,8 +303,11 @@ public class BrokerDataSetWriterTransportTypeNode extends DataSetWriterTransport
   public void writeAuthenticationProfileUri(String value) throws UaException {
     try {
       writeAuthenticationProfileUriAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -300,8 +330,11 @@ public class BrokerDataSetWriterTransportTypeNode extends DataSetWriterTransport
   public PropertyTypeNode getAuthenticationProfileUriNode() throws UaException {
     try {
       return getAuthenticationProfileUriNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -311,7 +344,7 @@ public class BrokerDataSetWriterTransportTypeNode extends DataSetWriterTransport
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "AuthenticationProfileUri",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -341,8 +374,11 @@ public class BrokerDataSetWriterTransportTypeNode extends DataSetWriterTransport
   public BrokerTransportQualityOfService readRequestedDeliveryGuarantee() throws UaException {
     try {
       return readRequestedDeliveryGuaranteeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -351,8 +387,11 @@ public class BrokerDataSetWriterTransportTypeNode extends DataSetWriterTransport
       throws UaException {
     try {
       writeRequestedDeliveryGuaranteeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -384,8 +423,11 @@ public class BrokerDataSetWriterTransportTypeNode extends DataSetWriterTransport
   public PropertyTypeNode getRequestedDeliveryGuaranteeNode() throws UaException {
     try {
       return getRequestedDeliveryGuaranteeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -395,7 +437,7 @@ public class BrokerDataSetWriterTransportTypeNode extends DataSetWriterTransport
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "RequestedDeliveryGuarantee",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -416,8 +458,11 @@ public class BrokerDataSetWriterTransportTypeNode extends DataSetWriterTransport
   public Double readMetaDataUpdateTime() throws UaException {
     try {
       return readMetaDataUpdateTimeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -425,8 +470,11 @@ public class BrokerDataSetWriterTransportTypeNode extends DataSetWriterTransport
   public void writeMetaDataUpdateTime(Double value) throws UaException {
     try {
       writeMetaDataUpdateTimeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -448,8 +496,11 @@ public class BrokerDataSetWriterTransportTypeNode extends DataSetWriterTransport
   public PropertyTypeNode getMetaDataUpdateTimeNode() throws UaException {
     try {
       return getMetaDataUpdateTimeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -459,7 +510,7 @@ public class BrokerDataSetWriterTransportTypeNode extends DataSetWriterTransport
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MetaDataUpdateTime",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/BrokerWriterGroupTransportTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/BrokerWriterGroupTransportTypeNode.java
@@ -78,8 +78,11 @@ public class BrokerWriterGroupTransportTypeNode extends WriterGroupTransportType
   public String readQueueName() throws UaException {
     try {
       return readQueueNameAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -87,8 +90,11 @@ public class BrokerWriterGroupTransportTypeNode extends WriterGroupTransportType
   public void writeQueueName(String value) throws UaException {
     try {
       writeQueueNameAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -110,8 +116,11 @@ public class BrokerWriterGroupTransportTypeNode extends WriterGroupTransportType
   public PropertyTypeNode getQueueNameNode() throws UaException {
     try {
       return getQueueNameNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -119,7 +128,7 @@ public class BrokerWriterGroupTransportTypeNode extends WriterGroupTransportType
   public CompletableFuture<? extends PropertyTypeNode> getQueueNameNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "QueueName", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "QueueName", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -139,8 +148,11 @@ public class BrokerWriterGroupTransportTypeNode extends WriterGroupTransportType
   public String readResourceUri() throws UaException {
     try {
       return readResourceUriAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -148,8 +160,11 @@ public class BrokerWriterGroupTransportTypeNode extends WriterGroupTransportType
   public void writeResourceUri(String value) throws UaException {
     try {
       writeResourceUriAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -171,8 +186,11 @@ public class BrokerWriterGroupTransportTypeNode extends WriterGroupTransportType
   public PropertyTypeNode getResourceUriNode() throws UaException {
     try {
       return getResourceUriNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -180,10 +198,7 @@ public class BrokerWriterGroupTransportTypeNode extends WriterGroupTransportType
   public CompletableFuture<? extends PropertyTypeNode> getResourceUriNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ResourceUri",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "ResourceUri", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -203,8 +218,11 @@ public class BrokerWriterGroupTransportTypeNode extends WriterGroupTransportType
   public String readAuthenticationProfileUri() throws UaException {
     try {
       return readAuthenticationProfileUriAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -212,8 +230,11 @@ public class BrokerWriterGroupTransportTypeNode extends WriterGroupTransportType
   public void writeAuthenticationProfileUri(String value) throws UaException {
     try {
       writeAuthenticationProfileUriAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -236,8 +257,11 @@ public class BrokerWriterGroupTransportTypeNode extends WriterGroupTransportType
   public PropertyTypeNode getAuthenticationProfileUriNode() throws UaException {
     try {
       return getAuthenticationProfileUriNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -247,7 +271,7 @@ public class BrokerWriterGroupTransportTypeNode extends WriterGroupTransportType
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "AuthenticationProfileUri",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -277,8 +301,11 @@ public class BrokerWriterGroupTransportTypeNode extends WriterGroupTransportType
   public BrokerTransportQualityOfService readRequestedDeliveryGuarantee() throws UaException {
     try {
       return readRequestedDeliveryGuaranteeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -287,8 +314,11 @@ public class BrokerWriterGroupTransportTypeNode extends WriterGroupTransportType
       throws UaException {
     try {
       writeRequestedDeliveryGuaranteeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -320,8 +350,11 @@ public class BrokerWriterGroupTransportTypeNode extends WriterGroupTransportType
   public PropertyTypeNode getRequestedDeliveryGuaranteeNode() throws UaException {
     try {
       return getRequestedDeliveryGuaranteeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -331,7 +364,7 @@ public class BrokerWriterGroupTransportTypeNode extends WriterGroupTransportType
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "RequestedDeliveryGuarantee",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/CertificateExpirationAlarmTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/CertificateExpirationAlarmTypeNode.java
@@ -79,8 +79,11 @@ public class CertificateExpirationAlarmTypeNode extends SystemOffNormalAlarmType
   public DateTime readExpirationDate() throws UaException {
     try {
       return readExpirationDateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -88,8 +91,11 @@ public class CertificateExpirationAlarmTypeNode extends SystemOffNormalAlarmType
   public void writeExpirationDate(DateTime value) throws UaException {
     try {
       writeExpirationDateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -111,8 +117,11 @@ public class CertificateExpirationAlarmTypeNode extends SystemOffNormalAlarmType
   public PropertyTypeNode getExpirationDateNode() throws UaException {
     try {
       return getExpirationDateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -120,10 +129,7 @@ public class CertificateExpirationAlarmTypeNode extends SystemOffNormalAlarmType
   public CompletableFuture<? extends PropertyTypeNode> getExpirationDateNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ExpirationDate",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "ExpirationDate", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -143,8 +149,11 @@ public class CertificateExpirationAlarmTypeNode extends SystemOffNormalAlarmType
   public Double readExpirationLimit() throws UaException {
     try {
       return readExpirationLimitAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -152,8 +161,11 @@ public class CertificateExpirationAlarmTypeNode extends SystemOffNormalAlarmType
   public void writeExpirationLimit(Double value) throws UaException {
     try {
       writeExpirationLimitAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -175,8 +187,11 @@ public class CertificateExpirationAlarmTypeNode extends SystemOffNormalAlarmType
   public PropertyTypeNode getExpirationLimitNode() throws UaException {
     try {
       return getExpirationLimitNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -184,10 +199,7 @@ public class CertificateExpirationAlarmTypeNode extends SystemOffNormalAlarmType
   public CompletableFuture<? extends PropertyTypeNode> getExpirationLimitNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ExpirationLimit",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "ExpirationLimit", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -207,8 +219,11 @@ public class CertificateExpirationAlarmTypeNode extends SystemOffNormalAlarmType
   public NodeId readCertificateType() throws UaException {
     try {
       return readCertificateTypeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -216,8 +231,11 @@ public class CertificateExpirationAlarmTypeNode extends SystemOffNormalAlarmType
   public void writeCertificateType(NodeId value) throws UaException {
     try {
       writeCertificateTypeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -239,8 +257,11 @@ public class CertificateExpirationAlarmTypeNode extends SystemOffNormalAlarmType
   public PropertyTypeNode getCertificateTypeNode() throws UaException {
     try {
       return getCertificateTypeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -248,10 +269,7 @@ public class CertificateExpirationAlarmTypeNode extends SystemOffNormalAlarmType
   public CompletableFuture<? extends PropertyTypeNode> getCertificateTypeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "CertificateType",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "CertificateType", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -271,8 +289,11 @@ public class CertificateExpirationAlarmTypeNode extends SystemOffNormalAlarmType
   public ByteString readCertificate() throws UaException {
     try {
       return readCertificateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -280,8 +301,11 @@ public class CertificateExpirationAlarmTypeNode extends SystemOffNormalAlarmType
   public void writeCertificate(ByteString value) throws UaException {
     try {
       writeCertificateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -303,8 +327,11 @@ public class CertificateExpirationAlarmTypeNode extends SystemOffNormalAlarmType
   public PropertyTypeNode getCertificateNode() throws UaException {
     try {
       return getCertificateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -312,10 +339,7 @@ public class CertificateExpirationAlarmTypeNode extends SystemOffNormalAlarmType
   public CompletableFuture<? extends PropertyTypeNode> getCertificateNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "Certificate",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "Certificate", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/CertificateGroupFolderTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/CertificateGroupFolderTypeNode.java
@@ -60,8 +60,11 @@ public class CertificateGroupFolderTypeNode extends FolderTypeNode
   public CertificateGroupTypeNode getDefaultApplicationGroupNode() throws UaException {
     try {
       return getDefaultApplicationGroupNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -72,7 +75,7 @@ public class CertificateGroupFolderTypeNode extends FolderTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "DefaultApplicationGroup",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (CertificateGroupTypeNode) node);
   }
@@ -81,8 +84,11 @@ public class CertificateGroupFolderTypeNode extends FolderTypeNode
   public CertificateGroupTypeNode getDefaultHttpsGroupNode() throws UaException {
     try {
       return getDefaultHttpsGroupNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -92,7 +98,7 @@ public class CertificateGroupFolderTypeNode extends FolderTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "DefaultHttpsGroup",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (CertificateGroupTypeNode) node);
   }
@@ -101,8 +107,11 @@ public class CertificateGroupFolderTypeNode extends FolderTypeNode
   public CertificateGroupTypeNode getDefaultUserTokenGroupNode() throws UaException {
     try {
       return getDefaultUserTokenGroupNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -112,7 +121,7 @@ public class CertificateGroupFolderTypeNode extends FolderTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "DefaultUserTokenGroup",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (CertificateGroupTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/CertificateGroupTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/CertificateGroupTypeNode.java
@@ -76,8 +76,11 @@ public class CertificateGroupTypeNode extends BaseObjectTypeNode implements Cert
   public NodeId[] readCertificateTypes() throws UaException {
     try {
       return readCertificateTypesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -85,8 +88,11 @@ public class CertificateGroupTypeNode extends BaseObjectTypeNode implements Cert
   public void writeCertificateTypes(NodeId[] value) throws UaException {
     try {
       writeCertificateTypesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -108,8 +114,11 @@ public class CertificateGroupTypeNode extends BaseObjectTypeNode implements Cert
   public PropertyTypeNode getCertificateTypesNode() throws UaException {
     try {
       return getCertificateTypesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -119,7 +128,7 @@ public class CertificateGroupTypeNode extends BaseObjectTypeNode implements Cert
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "CertificateTypes",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -128,8 +137,11 @@ public class CertificateGroupTypeNode extends BaseObjectTypeNode implements Cert
   public TrustListTypeNode getTrustListNode() throws UaException {
     try {
       return getTrustListNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -137,7 +149,7 @@ public class CertificateGroupTypeNode extends BaseObjectTypeNode implements Cert
   public CompletableFuture<? extends TrustListTypeNode> getTrustListNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "TrustList", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "TrustList", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (TrustListTypeNode) node);
   }
 
@@ -145,8 +157,11 @@ public class CertificateGroupTypeNode extends BaseObjectTypeNode implements Cert
   public CertificateExpirationAlarmTypeNode getCertificateExpiredNode() throws UaException {
     try {
       return getCertificateExpiredNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -157,7 +172,7 @@ public class CertificateGroupTypeNode extends BaseObjectTypeNode implements Cert
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "CertificateExpired",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (CertificateExpirationAlarmTypeNode) node);
   }
@@ -166,8 +181,11 @@ public class CertificateGroupTypeNode extends BaseObjectTypeNode implements Cert
   public TrustListOutOfDateAlarmTypeNode getTrustListOutOfDateNode() throws UaException {
     try {
       return getTrustListOutOfDateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -178,7 +196,7 @@ public class CertificateGroupTypeNode extends BaseObjectTypeNode implements Cert
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "TrustListOutOfDate",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (TrustListOutOfDateAlarmTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/CertificateUpdatedAuditEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/CertificateUpdatedAuditEventTypeNode.java
@@ -77,8 +77,11 @@ public class CertificateUpdatedAuditEventTypeNode extends AuditUpdateMethodEvent
   public NodeId readCertificateGroup() throws UaException {
     try {
       return readCertificateGroupAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class CertificateUpdatedAuditEventTypeNode extends AuditUpdateMethodEvent
   public void writeCertificateGroup(NodeId value) throws UaException {
     try {
       writeCertificateGroupAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class CertificateUpdatedAuditEventTypeNode extends AuditUpdateMethodEvent
   public PropertyTypeNode getCertificateGroupNode() throws UaException {
     try {
       return getCertificateGroupNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -120,7 +129,7 @@ public class CertificateUpdatedAuditEventTypeNode extends AuditUpdateMethodEvent
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "CertificateGroup",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -141,8 +150,11 @@ public class CertificateUpdatedAuditEventTypeNode extends AuditUpdateMethodEvent
   public NodeId readCertificateType() throws UaException {
     try {
       return readCertificateTypeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -150,8 +162,11 @@ public class CertificateUpdatedAuditEventTypeNode extends AuditUpdateMethodEvent
   public void writeCertificateType(NodeId value) throws UaException {
     try {
       writeCertificateTypeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -173,8 +188,11 @@ public class CertificateUpdatedAuditEventTypeNode extends AuditUpdateMethodEvent
   public PropertyTypeNode getCertificateTypeNode() throws UaException {
     try {
       return getCertificateTypeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -182,10 +200,7 @@ public class CertificateUpdatedAuditEventTypeNode extends AuditUpdateMethodEvent
   public CompletableFuture<? extends PropertyTypeNode> getCertificateTypeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "CertificateType",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "CertificateType", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ConditionTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ConditionTypeNode.java
@@ -79,8 +79,11 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   public NodeId readConditionClassId() throws UaException {
     try {
       return readConditionClassIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -88,8 +91,11 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   public void writeConditionClassId(NodeId value) throws UaException {
     try {
       writeConditionClassIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -111,8 +117,11 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   public PropertyTypeNode getConditionClassIdNode() throws UaException {
     try {
       return getConditionClassIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -122,7 +131,7 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ConditionClassId",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -143,8 +152,11 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   public LocalizedText readConditionClassName() throws UaException {
     try {
       return readConditionClassNameAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -152,8 +164,11 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   public void writeConditionClassName(LocalizedText value) throws UaException {
     try {
       writeConditionClassNameAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -176,8 +191,11 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   public PropertyTypeNode getConditionClassNameNode() throws UaException {
     try {
       return getConditionClassNameNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -187,7 +205,7 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ConditionClassName",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -208,8 +226,11 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   public NodeId[] readConditionSubClassId() throws UaException {
     try {
       return readConditionSubClassIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -217,8 +238,11 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   public void writeConditionSubClassId(NodeId[] value) throws UaException {
     try {
       writeConditionSubClassIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -240,8 +264,11 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   public PropertyTypeNode getConditionSubClassIdNode() throws UaException {
     try {
       return getConditionSubClassIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -251,7 +278,7 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ConditionSubClassId",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -272,8 +299,11 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   public LocalizedText[] readConditionSubClassName() throws UaException {
     try {
       return readConditionSubClassNameAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -281,8 +311,11 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   public void writeConditionSubClassName(LocalizedText[] value) throws UaException {
     try {
       writeConditionSubClassNameAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -305,8 +338,11 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   public PropertyTypeNode getConditionSubClassNameNode() throws UaException {
     try {
       return getConditionSubClassNameNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -316,7 +352,7 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ConditionSubClassName",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -337,8 +373,11 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   public String readConditionName() throws UaException {
     try {
       return readConditionNameAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -346,8 +385,11 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   public void writeConditionName(String value) throws UaException {
     try {
       writeConditionNameAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -369,8 +411,11 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   public PropertyTypeNode getConditionNameNode() throws UaException {
     try {
       return getConditionNameNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -378,10 +423,7 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   public CompletableFuture<? extends PropertyTypeNode> getConditionNameNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ConditionName",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "ConditionName", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -401,8 +443,11 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   public NodeId readBranchId() throws UaException {
     try {
       return readBranchIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -410,8 +455,11 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   public void writeBranchId(NodeId value) throws UaException {
     try {
       writeBranchIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -433,8 +481,11 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   public PropertyTypeNode getBranchIdNode() throws UaException {
     try {
       return getBranchIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -442,7 +493,7 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   public CompletableFuture<? extends PropertyTypeNode> getBranchIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "BranchId", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "BranchId", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -462,8 +513,11 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   public Boolean readRetain() throws UaException {
     try {
       return readRetainAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -471,8 +525,11 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   public void writeRetain(Boolean value) throws UaException {
     try {
       writeRetainAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -494,8 +551,11 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   public PropertyTypeNode getRetainNode() throws UaException {
     try {
       return getRetainNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -503,7 +563,7 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   public CompletableFuture<? extends PropertyTypeNode> getRetainNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Retain", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Retain", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -523,8 +583,11 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   public Boolean readSupportsFilteredRetain() throws UaException {
     try {
       return readSupportsFilteredRetainAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -532,8 +595,11 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   public void writeSupportsFilteredRetain(Boolean value) throws UaException {
     try {
       writeSupportsFilteredRetainAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -556,8 +622,11 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   public PropertyTypeNode getSupportsFilteredRetainNode() throws UaException {
     try {
       return getSupportsFilteredRetainNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -567,7 +636,7 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SupportsFilteredRetain",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -588,8 +657,11 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   public String readClientUserId() throws UaException {
     try {
       return readClientUserIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -597,8 +669,11 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   public void writeClientUserId(String value) throws UaException {
     try {
       writeClientUserIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -620,8 +695,11 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   public PropertyTypeNode getClientUserIdNode() throws UaException {
     try {
       return getClientUserIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -629,10 +707,7 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   public CompletableFuture<? extends PropertyTypeNode> getClientUserIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ClientUserId",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "ClientUserId", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -652,8 +727,11 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   public LocalizedText readEnabledState() throws UaException {
     try {
       return readEnabledStateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -661,8 +739,11 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   public void writeEnabledState(LocalizedText value) throws UaException {
     try {
       writeEnabledStateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -684,8 +765,11 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   public TwoStateVariableTypeNode getEnabledStateNode() throws UaException {
     try {
       return getEnabledStateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -693,10 +777,7 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   public CompletableFuture<? extends TwoStateVariableTypeNode> getEnabledStateNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "EnabledState",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "EnabledState", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (TwoStateVariableTypeNode) node);
   }
 
@@ -716,8 +797,11 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   public StatusCode readQuality() throws UaException {
     try {
       return readQualityAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -725,8 +809,11 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   public void writeQuality(StatusCode value) throws UaException {
     try {
       writeQualityAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -748,8 +835,11 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   public ConditionVariableTypeNode getQualityNode() throws UaException {
     try {
       return getQualityNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -757,7 +847,7 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   public CompletableFuture<? extends ConditionVariableTypeNode> getQualityNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Quality", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "Quality", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (ConditionVariableTypeNode) node);
   }
 
@@ -777,8 +867,11 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   public UShort readLastSeverity() throws UaException {
     try {
       return readLastSeverityAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -786,8 +879,11 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   public void writeLastSeverity(UShort value) throws UaException {
     try {
       writeLastSeverityAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -809,8 +905,11 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   public ConditionVariableTypeNode getLastSeverityNode() throws UaException {
     try {
       return getLastSeverityNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -818,10 +917,7 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   public CompletableFuture<? extends ConditionVariableTypeNode> getLastSeverityNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "LastSeverity",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "LastSeverity", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (ConditionVariableTypeNode) node);
   }
 
@@ -841,8 +937,11 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   public LocalizedText readComment() throws UaException {
     try {
       return readCommentAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -850,8 +949,11 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   public void writeComment(LocalizedText value) throws UaException {
     try {
       writeCommentAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -873,8 +975,11 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   public ConditionVariableTypeNode getCommentNode() throws UaException {
     try {
       return getCommentNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -882,7 +987,7 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   public CompletableFuture<? extends ConditionVariableTypeNode> getCommentNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Comment", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "Comment", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (ConditionVariableTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/DataSetReaderTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/DataSetReaderTypeNode.java
@@ -83,8 +83,11 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public Object readPublisherId() throws UaException {
     try {
       return readPublisherIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -92,8 +95,11 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public void writePublisherId(Object value) throws UaException {
     try {
       writePublisherIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -115,8 +121,11 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public PropertyTypeNode getPublisherIdNode() throws UaException {
     try {
       return getPublisherIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -124,10 +133,7 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public CompletableFuture<? extends PropertyTypeNode> getPublisherIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "PublisherId",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "PublisherId", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -147,8 +153,11 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public UShort readWriterGroupId() throws UaException {
     try {
       return readWriterGroupIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -156,8 +165,11 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public void writeWriterGroupId(UShort value) throws UaException {
     try {
       writeWriterGroupIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -179,8 +191,11 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public PropertyTypeNode getWriterGroupIdNode() throws UaException {
     try {
       return getWriterGroupIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -188,10 +203,7 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public CompletableFuture<? extends PropertyTypeNode> getWriterGroupIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "WriterGroupId",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "WriterGroupId", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -211,8 +223,11 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public UShort readDataSetWriterId() throws UaException {
     try {
       return readDataSetWriterIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -220,8 +235,11 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public void writeDataSetWriterId(UShort value) throws UaException {
     try {
       writeDataSetWriterIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -243,8 +261,11 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public PropertyTypeNode getDataSetWriterIdNode() throws UaException {
     try {
       return getDataSetWriterIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -252,10 +273,7 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public CompletableFuture<? extends PropertyTypeNode> getDataSetWriterIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "DataSetWriterId",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "DataSetWriterId", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -276,8 +294,11 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public DataSetMetaDataType readDataSetMetaData() throws UaException {
     try {
       return readDataSetMetaDataAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -285,8 +306,11 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public void writeDataSetMetaData(DataSetMetaDataType value) throws UaException {
     try {
       writeDataSetMetaDataAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -311,8 +335,11 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public PropertyTypeNode getDataSetMetaDataNode() throws UaException {
     try {
       return getDataSetMetaDataNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -320,10 +347,7 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public CompletableFuture<? extends PropertyTypeNode> getDataSetMetaDataNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "DataSetMetaData",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "DataSetMetaData", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -343,8 +367,11 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public DataSetFieldContentMask readDataSetFieldContentMask() throws UaException {
     try {
       return readDataSetFieldContentMaskAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -352,8 +379,11 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public void writeDataSetFieldContentMask(DataSetFieldContentMask value) throws UaException {
     try {
       writeDataSetFieldContentMaskAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -376,8 +406,11 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public PropertyTypeNode getDataSetFieldContentMaskNode() throws UaException {
     try {
       return getDataSetFieldContentMaskNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -387,7 +420,7 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "DataSetFieldContentMask",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -408,8 +441,11 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public Double readMessageReceiveTimeout() throws UaException {
     try {
       return readMessageReceiveTimeoutAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -417,8 +453,11 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public void writeMessageReceiveTimeout(Double value) throws UaException {
     try {
       writeMessageReceiveTimeoutAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -441,8 +480,11 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public PropertyTypeNode getMessageReceiveTimeoutNode() throws UaException {
     try {
       return getMessageReceiveTimeoutNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -452,7 +494,7 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MessageReceiveTimeout",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -473,8 +515,11 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public UInteger readKeyFrameCount() throws UaException {
     try {
       return readKeyFrameCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -482,8 +527,11 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public void writeKeyFrameCount(UInteger value) throws UaException {
     try {
       writeKeyFrameCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -505,8 +553,11 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public PropertyTypeNode getKeyFrameCountNode() throws UaException {
     try {
       return getKeyFrameCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -514,10 +565,7 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public CompletableFuture<? extends PropertyTypeNode> getKeyFrameCountNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "KeyFrameCount",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "KeyFrameCount", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -537,8 +585,11 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public String readHeaderLayoutUri() throws UaException {
     try {
       return readHeaderLayoutUriAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -546,8 +597,11 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public void writeHeaderLayoutUri(String value) throws UaException {
     try {
       writeHeaderLayoutUriAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -569,8 +623,11 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public PropertyTypeNode getHeaderLayoutUriNode() throws UaException {
     try {
       return getHeaderLayoutUriNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -578,10 +635,7 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public CompletableFuture<? extends PropertyTypeNode> getHeaderLayoutUriNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "HeaderLayoutUri",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "HeaderLayoutUri", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -609,8 +663,11 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public MessageSecurityMode readSecurityMode() throws UaException {
     try {
       return readSecurityModeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -618,8 +675,11 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public void writeSecurityMode(MessageSecurityMode value) throws UaException {
     try {
       writeSecurityModeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -649,8 +709,11 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public PropertyTypeNode getSecurityModeNode() throws UaException {
     try {
       return getSecurityModeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -658,10 +721,7 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public CompletableFuture<? extends PropertyTypeNode> getSecurityModeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "SecurityMode",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "SecurityMode", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -681,8 +741,11 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public String readSecurityGroupId() throws UaException {
     try {
       return readSecurityGroupIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -690,8 +753,11 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public void writeSecurityGroupId(String value) throws UaException {
     try {
       writeSecurityGroupIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -713,8 +779,11 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public PropertyTypeNode getSecurityGroupIdNode() throws UaException {
     try {
       return getSecurityGroupIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -722,10 +791,7 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public CompletableFuture<? extends PropertyTypeNode> getSecurityGroupIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "SecurityGroupId",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "SecurityGroupId", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -747,8 +813,11 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public EndpointDescription[] readSecurityKeyServices() throws UaException {
     try {
       return readSecurityKeyServicesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -756,8 +825,11 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public void writeSecurityKeyServices(EndpointDescription[] value) throws UaException {
     try {
       writeSecurityKeyServicesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -782,8 +854,11 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public PropertyTypeNode getSecurityKeyServicesNode() throws UaException {
     try {
       return getSecurityKeyServicesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -793,7 +868,7 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SecurityKeyServices",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -816,8 +891,11 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public KeyValuePair[] readDataSetReaderProperties() throws UaException {
     try {
       return readDataSetReaderPropertiesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -825,8 +903,11 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public void writeDataSetReaderProperties(KeyValuePair[] value) throws UaException {
     try {
       writeDataSetReaderPropertiesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -851,8 +932,11 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public PropertyTypeNode getDataSetReaderPropertiesNode() throws UaException {
     try {
       return getDataSetReaderPropertiesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -862,7 +946,7 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "DataSetReaderProperties",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -871,8 +955,11 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public DataSetReaderTransportTypeNode getTransportSettingsNode() throws UaException {
     try {
       return getTransportSettingsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -883,7 +970,7 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "TransportSettings",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (DataSetReaderTransportTypeNode) node);
   }
@@ -892,8 +979,11 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public DataSetReaderMessageTypeNode getMessageSettingsNode() throws UaException {
     try {
       return getMessageSettingsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -901,10 +991,7 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public CompletableFuture<? extends DataSetReaderMessageTypeNode> getMessageSettingsNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "MessageSettings",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "MessageSettings", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (DataSetReaderMessageTypeNode) node);
   }
 
@@ -912,8 +999,11 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public PubSubStatusTypeNode getStatusNode() throws UaException {
     try {
       return getStatusNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -921,7 +1011,7 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public CompletableFuture<? extends PubSubStatusTypeNode> getStatusNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Status", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "Status", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (PubSubStatusTypeNode) node);
   }
 
@@ -929,8 +1019,11 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public PubSubDiagnosticsDataSetReaderTypeNode getDiagnosticsNode() throws UaException {
     try {
       return getDiagnosticsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -939,10 +1032,7 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
       getDiagnosticsNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "Diagnostics",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "Diagnostics", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (PubSubDiagnosticsDataSetReaderTypeNode) node);
   }
 
@@ -950,8 +1040,11 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   public SubscribedDataSetTypeNode getSubscribedDataSetNode() throws UaException {
     try {
       return getSubscribedDataSetNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -961,7 +1054,7 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SubscribedDataSet",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (SubscribedDataSetTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/DataSetWriterTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/DataSetWriterTypeNode.java
@@ -80,8 +80,11 @@ public class DataSetWriterTypeNode extends BaseObjectTypeNode implements DataSet
   public UShort readDataSetWriterId() throws UaException {
     try {
       return readDataSetWriterIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -89,8 +92,11 @@ public class DataSetWriterTypeNode extends BaseObjectTypeNode implements DataSet
   public void writeDataSetWriterId(UShort value) throws UaException {
     try {
       writeDataSetWriterIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -112,8 +118,11 @@ public class DataSetWriterTypeNode extends BaseObjectTypeNode implements DataSet
   public PropertyTypeNode getDataSetWriterIdNode() throws UaException {
     try {
       return getDataSetWriterIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -121,10 +130,7 @@ public class DataSetWriterTypeNode extends BaseObjectTypeNode implements DataSet
   public CompletableFuture<? extends PropertyTypeNode> getDataSetWriterIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "DataSetWriterId",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "DataSetWriterId", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -144,8 +150,11 @@ public class DataSetWriterTypeNode extends BaseObjectTypeNode implements DataSet
   public DataSetFieldContentMask readDataSetFieldContentMask() throws UaException {
     try {
       return readDataSetFieldContentMaskAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -153,8 +162,11 @@ public class DataSetWriterTypeNode extends BaseObjectTypeNode implements DataSet
   public void writeDataSetFieldContentMask(DataSetFieldContentMask value) throws UaException {
     try {
       writeDataSetFieldContentMaskAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -177,8 +189,11 @@ public class DataSetWriterTypeNode extends BaseObjectTypeNode implements DataSet
   public PropertyTypeNode getDataSetFieldContentMaskNode() throws UaException {
     try {
       return getDataSetFieldContentMaskNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -188,7 +203,7 @@ public class DataSetWriterTypeNode extends BaseObjectTypeNode implements DataSet
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "DataSetFieldContentMask",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -209,8 +224,11 @@ public class DataSetWriterTypeNode extends BaseObjectTypeNode implements DataSet
   public UInteger readKeyFrameCount() throws UaException {
     try {
       return readKeyFrameCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -218,8 +236,11 @@ public class DataSetWriterTypeNode extends BaseObjectTypeNode implements DataSet
   public void writeKeyFrameCount(UInteger value) throws UaException {
     try {
       writeKeyFrameCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -241,8 +262,11 @@ public class DataSetWriterTypeNode extends BaseObjectTypeNode implements DataSet
   public PropertyTypeNode getKeyFrameCountNode() throws UaException {
     try {
       return getKeyFrameCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -250,10 +274,7 @@ public class DataSetWriterTypeNode extends BaseObjectTypeNode implements DataSet
   public CompletableFuture<? extends PropertyTypeNode> getKeyFrameCountNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "KeyFrameCount",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "KeyFrameCount", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -275,8 +296,11 @@ public class DataSetWriterTypeNode extends BaseObjectTypeNode implements DataSet
   public KeyValuePair[] readDataSetWriterProperties() throws UaException {
     try {
       return readDataSetWriterPropertiesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -284,8 +308,11 @@ public class DataSetWriterTypeNode extends BaseObjectTypeNode implements DataSet
   public void writeDataSetWriterProperties(KeyValuePair[] value) throws UaException {
     try {
       writeDataSetWriterPropertiesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -310,8 +337,11 @@ public class DataSetWriterTypeNode extends BaseObjectTypeNode implements DataSet
   public PropertyTypeNode getDataSetWriterPropertiesNode() throws UaException {
     try {
       return getDataSetWriterPropertiesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -321,7 +351,7 @@ public class DataSetWriterTypeNode extends BaseObjectTypeNode implements DataSet
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "DataSetWriterProperties",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -330,8 +360,11 @@ public class DataSetWriterTypeNode extends BaseObjectTypeNode implements DataSet
   public DataSetWriterTransportTypeNode getTransportSettingsNode() throws UaException {
     try {
       return getTransportSettingsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -342,7 +375,7 @@ public class DataSetWriterTypeNode extends BaseObjectTypeNode implements DataSet
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "TransportSettings",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (DataSetWriterTransportTypeNode) node);
   }
@@ -351,8 +384,11 @@ public class DataSetWriterTypeNode extends BaseObjectTypeNode implements DataSet
   public DataSetWriterMessageTypeNode getMessageSettingsNode() throws UaException {
     try {
       return getMessageSettingsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -360,10 +396,7 @@ public class DataSetWriterTypeNode extends BaseObjectTypeNode implements DataSet
   public CompletableFuture<? extends DataSetWriterMessageTypeNode> getMessageSettingsNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "MessageSettings",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "MessageSettings", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (DataSetWriterMessageTypeNode) node);
   }
 
@@ -371,8 +404,11 @@ public class DataSetWriterTypeNode extends BaseObjectTypeNode implements DataSet
   public PubSubStatusTypeNode getStatusNode() throws UaException {
     try {
       return getStatusNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -380,7 +416,7 @@ public class DataSetWriterTypeNode extends BaseObjectTypeNode implements DataSet
   public CompletableFuture<? extends PubSubStatusTypeNode> getStatusNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Status", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "Status", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (PubSubStatusTypeNode) node);
   }
 
@@ -388,8 +424,11 @@ public class DataSetWriterTypeNode extends BaseObjectTypeNode implements DataSet
   public PubSubDiagnosticsDataSetWriterTypeNode getDiagnosticsNode() throws UaException {
     try {
       return getDiagnosticsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -398,10 +437,7 @@ public class DataSetWriterTypeNode extends BaseObjectTypeNode implements DataSet
       getDiagnosticsNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "Diagnostics",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "Diagnostics", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (PubSubDiagnosticsDataSetWriterTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/DatagramConnectionTransportTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/DatagramConnectionTransportTypeNode.java
@@ -79,8 +79,11 @@ public class DatagramConnectionTransportTypeNode extends ConnectionTransportType
   public UInteger readDiscoveryAnnounceRate() throws UaException {
     try {
       return readDiscoveryAnnounceRateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -88,8 +91,11 @@ public class DatagramConnectionTransportTypeNode extends ConnectionTransportType
   public void writeDiscoveryAnnounceRate(UInteger value) throws UaException {
     try {
       writeDiscoveryAnnounceRateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -112,8 +118,11 @@ public class DatagramConnectionTransportTypeNode extends ConnectionTransportType
   public PropertyTypeNode getDiscoveryAnnounceRateNode() throws UaException {
     try {
       return getDiscoveryAnnounceRateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -123,7 +132,7 @@ public class DatagramConnectionTransportTypeNode extends ConnectionTransportType
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "DiscoveryAnnounceRate",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -144,8 +153,11 @@ public class DatagramConnectionTransportTypeNode extends ConnectionTransportType
   public UInteger readDiscoveryMaxMessageSize() throws UaException {
     try {
       return readDiscoveryMaxMessageSizeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -153,8 +165,11 @@ public class DatagramConnectionTransportTypeNode extends ConnectionTransportType
   public void writeDiscoveryMaxMessageSize(UInteger value) throws UaException {
     try {
       writeDiscoveryMaxMessageSizeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -177,8 +192,11 @@ public class DatagramConnectionTransportTypeNode extends ConnectionTransportType
   public PropertyTypeNode getDiscoveryMaxMessageSizeNode() throws UaException {
     try {
       return getDiscoveryMaxMessageSizeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -188,7 +206,7 @@ public class DatagramConnectionTransportTypeNode extends ConnectionTransportType
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "DiscoveryMaxMessageSize",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -209,8 +227,11 @@ public class DatagramConnectionTransportTypeNode extends ConnectionTransportType
   public String readQosCategory() throws UaException {
     try {
       return readQosCategoryAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -218,8 +239,11 @@ public class DatagramConnectionTransportTypeNode extends ConnectionTransportType
   public void writeQosCategory(String value) throws UaException {
     try {
       writeQosCategoryAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -241,8 +265,11 @@ public class DatagramConnectionTransportTypeNode extends ConnectionTransportType
   public PropertyTypeNode getQosCategoryNode() throws UaException {
     try {
       return getQosCategoryNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -250,10 +277,7 @@ public class DatagramConnectionTransportTypeNode extends ConnectionTransportType
   public CompletableFuture<? extends PropertyTypeNode> getQosCategoryNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "QosCategory",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "QosCategory", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -275,8 +299,11 @@ public class DatagramConnectionTransportTypeNode extends ConnectionTransportType
   public QosDataType[] readDatagramQos() throws UaException {
     try {
       return readDatagramQosAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -284,8 +311,11 @@ public class DatagramConnectionTransportTypeNode extends ConnectionTransportType
   public void writeDatagramQos(QosDataType[] value) throws UaException {
     try {
       writeDatagramQosAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -309,8 +339,11 @@ public class DatagramConnectionTransportTypeNode extends ConnectionTransportType
   public PropertyTypeNode getDatagramQosNode() throws UaException {
     try {
       return getDatagramQosNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -318,10 +351,7 @@ public class DatagramConnectionTransportTypeNode extends ConnectionTransportType
   public CompletableFuture<? extends PropertyTypeNode> getDatagramQosNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "DatagramQos",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "DatagramQos", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -329,8 +359,11 @@ public class DatagramConnectionTransportTypeNode extends ConnectionTransportType
   public NetworkAddressTypeNode getDiscoveryAddressNode() throws UaException {
     try {
       return getDiscoveryAddressNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -340,7 +373,7 @@ public class DatagramConnectionTransportTypeNode extends ConnectionTransportType
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "DiscoveryAddress",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (NetworkAddressTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/DatagramDataSetReaderTransportTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/DatagramDataSetReaderTransportTypeNode.java
@@ -79,8 +79,11 @@ public class DatagramDataSetReaderTransportTypeNode extends DataSetReaderTranspo
   public String readQosCategory() throws UaException {
     try {
       return readQosCategoryAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -88,8 +91,11 @@ public class DatagramDataSetReaderTransportTypeNode extends DataSetReaderTranspo
   public void writeQosCategory(String value) throws UaException {
     try {
       writeQosCategoryAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -111,8 +117,11 @@ public class DatagramDataSetReaderTransportTypeNode extends DataSetReaderTranspo
   public PropertyTypeNode getQosCategoryNode() throws UaException {
     try {
       return getQosCategoryNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -120,10 +129,7 @@ public class DatagramDataSetReaderTransportTypeNode extends DataSetReaderTranspo
   public CompletableFuture<? extends PropertyTypeNode> getQosCategoryNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "QosCategory",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "QosCategory", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -145,8 +151,11 @@ public class DatagramDataSetReaderTransportTypeNode extends DataSetReaderTranspo
   public ReceiveQosDataType[] readDatagramQos() throws UaException {
     try {
       return readDatagramQosAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -154,8 +163,11 @@ public class DatagramDataSetReaderTransportTypeNode extends DataSetReaderTranspo
   public void writeDatagramQos(ReceiveQosDataType[] value) throws UaException {
     try {
       writeDatagramQosAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -179,8 +191,11 @@ public class DatagramDataSetReaderTransportTypeNode extends DataSetReaderTranspo
   public PropertyTypeNode getDatagramQosNode() throws UaException {
     try {
       return getDatagramQosNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -188,10 +203,7 @@ public class DatagramDataSetReaderTransportTypeNode extends DataSetReaderTranspo
   public CompletableFuture<? extends PropertyTypeNode> getDatagramQosNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "DatagramQos",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "DatagramQos", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -211,8 +223,11 @@ public class DatagramDataSetReaderTransportTypeNode extends DataSetReaderTranspo
   public String readTopic() throws UaException {
     try {
       return readTopicAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -220,8 +235,11 @@ public class DatagramDataSetReaderTransportTypeNode extends DataSetReaderTranspo
   public void writeTopic(String value) throws UaException {
     try {
       writeTopicAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -243,8 +261,11 @@ public class DatagramDataSetReaderTransportTypeNode extends DataSetReaderTranspo
   public PropertyTypeNode getTopicNode() throws UaException {
     try {
       return getTopicNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -252,7 +273,7 @@ public class DatagramDataSetReaderTransportTypeNode extends DataSetReaderTranspo
   public CompletableFuture<? extends PropertyTypeNode> getTopicNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Topic", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Topic", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -260,8 +281,11 @@ public class DatagramDataSetReaderTransportTypeNode extends DataSetReaderTranspo
   public NetworkAddressTypeNode getAddressNode() throws UaException {
     try {
       return getAddressNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -269,7 +293,7 @@ public class DatagramDataSetReaderTransportTypeNode extends DataSetReaderTranspo
   public CompletableFuture<? extends NetworkAddressTypeNode> getAddressNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Address", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "Address", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (NetworkAddressTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/DatagramWriterGroupTransportTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/DatagramWriterGroupTransportTypeNode.java
@@ -79,8 +79,11 @@ public class DatagramWriterGroupTransportTypeNode extends WriterGroupTransportTy
   public UByte readMessageRepeatCount() throws UaException {
     try {
       return readMessageRepeatCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -88,8 +91,11 @@ public class DatagramWriterGroupTransportTypeNode extends WriterGroupTransportTy
   public void writeMessageRepeatCount(UByte value) throws UaException {
     try {
       writeMessageRepeatCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -111,8 +117,11 @@ public class DatagramWriterGroupTransportTypeNode extends WriterGroupTransportTy
   public PropertyTypeNode getMessageRepeatCountNode() throws UaException {
     try {
       return getMessageRepeatCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -122,7 +131,7 @@ public class DatagramWriterGroupTransportTypeNode extends WriterGroupTransportTy
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MessageRepeatCount",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -143,8 +152,11 @@ public class DatagramWriterGroupTransportTypeNode extends WriterGroupTransportTy
   public Double readMessageRepeatDelay() throws UaException {
     try {
       return readMessageRepeatDelayAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -152,8 +164,11 @@ public class DatagramWriterGroupTransportTypeNode extends WriterGroupTransportTy
   public void writeMessageRepeatDelay(Double value) throws UaException {
     try {
       writeMessageRepeatDelayAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -175,8 +190,11 @@ public class DatagramWriterGroupTransportTypeNode extends WriterGroupTransportTy
   public PropertyTypeNode getMessageRepeatDelayNode() throws UaException {
     try {
       return getMessageRepeatDelayNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -186,7 +204,7 @@ public class DatagramWriterGroupTransportTypeNode extends WriterGroupTransportTy
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MessageRepeatDelay",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -207,8 +225,11 @@ public class DatagramWriterGroupTransportTypeNode extends WriterGroupTransportTy
   public String readQosCategory() throws UaException {
     try {
       return readQosCategoryAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -216,8 +237,11 @@ public class DatagramWriterGroupTransportTypeNode extends WriterGroupTransportTy
   public void writeQosCategory(String value) throws UaException {
     try {
       writeQosCategoryAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -239,8 +263,11 @@ public class DatagramWriterGroupTransportTypeNode extends WriterGroupTransportTy
   public PropertyTypeNode getQosCategoryNode() throws UaException {
     try {
       return getQosCategoryNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -248,10 +275,7 @@ public class DatagramWriterGroupTransportTypeNode extends WriterGroupTransportTy
   public CompletableFuture<? extends PropertyTypeNode> getQosCategoryNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "QosCategory",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "QosCategory", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -273,8 +297,11 @@ public class DatagramWriterGroupTransportTypeNode extends WriterGroupTransportTy
   public TransmitQosDataType[] readDatagramQos() throws UaException {
     try {
       return readDatagramQosAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -282,8 +309,11 @@ public class DatagramWriterGroupTransportTypeNode extends WriterGroupTransportTy
   public void writeDatagramQos(TransmitQosDataType[] value) throws UaException {
     try {
       writeDatagramQosAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -307,8 +337,11 @@ public class DatagramWriterGroupTransportTypeNode extends WriterGroupTransportTy
   public PropertyTypeNode getDatagramQosNode() throws UaException {
     try {
       return getDatagramQosNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -316,10 +349,7 @@ public class DatagramWriterGroupTransportTypeNode extends WriterGroupTransportTy
   public CompletableFuture<? extends PropertyTypeNode> getDatagramQosNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "DatagramQos",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "DatagramQos", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -339,8 +369,11 @@ public class DatagramWriterGroupTransportTypeNode extends WriterGroupTransportTy
   public UInteger readDiscoveryAnnounceRate() throws UaException {
     try {
       return readDiscoveryAnnounceRateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -348,8 +381,11 @@ public class DatagramWriterGroupTransportTypeNode extends WriterGroupTransportTy
   public void writeDiscoveryAnnounceRate(UInteger value) throws UaException {
     try {
       writeDiscoveryAnnounceRateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -372,8 +408,11 @@ public class DatagramWriterGroupTransportTypeNode extends WriterGroupTransportTy
   public PropertyTypeNode getDiscoveryAnnounceRateNode() throws UaException {
     try {
       return getDiscoveryAnnounceRateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -383,7 +422,7 @@ public class DatagramWriterGroupTransportTypeNode extends WriterGroupTransportTy
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "DiscoveryAnnounceRate",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -404,8 +443,11 @@ public class DatagramWriterGroupTransportTypeNode extends WriterGroupTransportTy
   public String readTopic() throws UaException {
     try {
       return readTopicAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -413,8 +455,11 @@ public class DatagramWriterGroupTransportTypeNode extends WriterGroupTransportTy
   public void writeTopic(String value) throws UaException {
     try {
       writeTopicAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -436,8 +481,11 @@ public class DatagramWriterGroupTransportTypeNode extends WriterGroupTransportTy
   public PropertyTypeNode getTopicNode() throws UaException {
     try {
       return getTopicNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -445,7 +493,7 @@ public class DatagramWriterGroupTransportTypeNode extends WriterGroupTransportTy
   public CompletableFuture<? extends PropertyTypeNode> getTopicNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Topic", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Topic", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -453,8 +501,11 @@ public class DatagramWriterGroupTransportTypeNode extends WriterGroupTransportTy
   public NetworkAddressTypeNode getAddressNode() throws UaException {
     try {
       return getAddressNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -462,7 +513,7 @@ public class DatagramWriterGroupTransportTypeNode extends WriterGroupTransportTy
   public CompletableFuture<? extends NetworkAddressTypeNode> getAddressNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Address", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "Address", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (NetworkAddressTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/DialogConditionTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/DialogConditionTypeNode.java
@@ -77,8 +77,11 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
   public LocalizedText readPrompt() throws UaException {
     try {
       return readPromptAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
   public void writePrompt(LocalizedText value) throws UaException {
     try {
       writePromptAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
   public PropertyTypeNode getPromptNode() throws UaException {
     try {
       return getPromptNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -118,7 +127,7 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
   public CompletableFuture<? extends PropertyTypeNode> getPromptNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Prompt", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Prompt", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -138,8 +147,11 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
   public LocalizedText[] readResponseOptionSet() throws UaException {
     try {
       return readResponseOptionSetAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -147,8 +159,11 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
   public void writeResponseOptionSet(LocalizedText[] value) throws UaException {
     try {
       writeResponseOptionSetAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -171,8 +186,11 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
   public PropertyTypeNode getResponseOptionSetNode() throws UaException {
     try {
       return getResponseOptionSetNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -182,7 +200,7 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ResponseOptionSet",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -203,8 +221,11 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
   public Integer readDefaultResponse() throws UaException {
     try {
       return readDefaultResponseAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -212,8 +233,11 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
   public void writeDefaultResponse(Integer value) throws UaException {
     try {
       writeDefaultResponseAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -235,8 +259,11 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
   public PropertyTypeNode getDefaultResponseNode() throws UaException {
     try {
       return getDefaultResponseNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -244,10 +271,7 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
   public CompletableFuture<? extends PropertyTypeNode> getDefaultResponseNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "DefaultResponse",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "DefaultResponse", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -267,8 +291,11 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
   public Integer readOkResponse() throws UaException {
     try {
       return readOkResponseAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -276,8 +303,11 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
   public void writeOkResponse(Integer value) throws UaException {
     try {
       writeOkResponseAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -299,8 +329,11 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
   public PropertyTypeNode getOkResponseNode() throws UaException {
     try {
       return getOkResponseNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -308,7 +341,7 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
   public CompletableFuture<? extends PropertyTypeNode> getOkResponseNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "OkResponse", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "OkResponse", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -328,8 +361,11 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
   public Integer readCancelResponse() throws UaException {
     try {
       return readCancelResponseAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -337,8 +373,11 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
   public void writeCancelResponse(Integer value) throws UaException {
     try {
       writeCancelResponseAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -360,8 +399,11 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
   public PropertyTypeNode getCancelResponseNode() throws UaException {
     try {
       return getCancelResponseNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -369,10 +411,7 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
   public CompletableFuture<? extends PropertyTypeNode> getCancelResponseNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "CancelResponse",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "CancelResponse", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -392,8 +431,11 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
   public Integer readLastResponse() throws UaException {
     try {
       return readLastResponseAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -401,8 +443,11 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
   public void writeLastResponse(Integer value) throws UaException {
     try {
       writeLastResponseAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -424,8 +469,11 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
   public PropertyTypeNode getLastResponseNode() throws UaException {
     try {
       return getLastResponseNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -433,10 +481,7 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
   public CompletableFuture<? extends PropertyTypeNode> getLastResponseNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "LastResponse",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "LastResponse", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -456,8 +501,11 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
   public LocalizedText readEnabledState() throws UaException {
     try {
       return readEnabledStateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -465,8 +513,11 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
   public void writeEnabledState(LocalizedText value) throws UaException {
     try {
       writeEnabledStateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -488,8 +539,11 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
   public TwoStateVariableTypeNode getEnabledStateNode() throws UaException {
     try {
       return getEnabledStateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -497,10 +551,7 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
   public CompletableFuture<? extends TwoStateVariableTypeNode> getEnabledStateNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "EnabledState",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "EnabledState", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (TwoStateVariableTypeNode) node);
   }
 
@@ -520,8 +571,11 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
   public LocalizedText readDialogState() throws UaException {
     try {
       return readDialogStateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -529,8 +583,11 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
   public void writeDialogState(LocalizedText value) throws UaException {
     try {
       writeDialogStateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -552,8 +609,11 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
   public TwoStateVariableTypeNode getDialogStateNode() throws UaException {
     try {
       return getDialogStateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -561,10 +621,7 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
   public CompletableFuture<? extends TwoStateVariableTypeNode> getDialogStateNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "DialogState",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "DialogState", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (TwoStateVariableTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/DiscrepancyAlarmTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/DiscrepancyAlarmTypeNode.java
@@ -77,8 +77,11 @@ public class DiscrepancyAlarmTypeNode extends AlarmConditionTypeNode
   public NodeId readTargetValueNode() throws UaException {
     try {
       return readTargetValueNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class DiscrepancyAlarmTypeNode extends AlarmConditionTypeNode
   public void writeTargetValueNode(NodeId value) throws UaException {
     try {
       writeTargetValueNodeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class DiscrepancyAlarmTypeNode extends AlarmConditionTypeNode
   public PropertyTypeNode getTargetValueNodeNode() throws UaException {
     try {
       return getTargetValueNodeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -118,10 +127,7 @@ public class DiscrepancyAlarmTypeNode extends AlarmConditionTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getTargetValueNodeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "TargetValueNode",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "TargetValueNode", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -141,8 +147,11 @@ public class DiscrepancyAlarmTypeNode extends AlarmConditionTypeNode
   public Double readExpectedTime() throws UaException {
     try {
       return readExpectedTimeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -150,8 +159,11 @@ public class DiscrepancyAlarmTypeNode extends AlarmConditionTypeNode
   public void writeExpectedTime(Double value) throws UaException {
     try {
       writeExpectedTimeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -173,8 +185,11 @@ public class DiscrepancyAlarmTypeNode extends AlarmConditionTypeNode
   public PropertyTypeNode getExpectedTimeNode() throws UaException {
     try {
       return getExpectedTimeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -182,10 +197,7 @@ public class DiscrepancyAlarmTypeNode extends AlarmConditionTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getExpectedTimeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ExpectedTime",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "ExpectedTime", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -205,8 +217,11 @@ public class DiscrepancyAlarmTypeNode extends AlarmConditionTypeNode
   public Double readTolerance() throws UaException {
     try {
       return readToleranceAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -214,8 +229,11 @@ public class DiscrepancyAlarmTypeNode extends AlarmConditionTypeNode
   public void writeTolerance(Double value) throws UaException {
     try {
       writeToleranceAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -237,8 +255,11 @@ public class DiscrepancyAlarmTypeNode extends AlarmConditionTypeNode
   public PropertyTypeNode getToleranceNode() throws UaException {
     try {
       return getToleranceNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -246,7 +267,7 @@ public class DiscrepancyAlarmTypeNode extends AlarmConditionTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getToleranceNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Tolerance", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Tolerance", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ExclusiveDeviationAlarmTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ExclusiveDeviationAlarmTypeNode.java
@@ -77,8 +77,11 @@ public class ExclusiveDeviationAlarmTypeNode extends ExclusiveLimitAlarmTypeNode
   public NodeId readSetpointNode() throws UaException {
     try {
       return readSetpointNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class ExclusiveDeviationAlarmTypeNode extends ExclusiveLimitAlarmTypeNode
   public void writeSetpointNode(NodeId value) throws UaException {
     try {
       writeSetpointNodeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class ExclusiveDeviationAlarmTypeNode extends ExclusiveLimitAlarmTypeNode
   public PropertyTypeNode getSetpointNodeNode() throws UaException {
     try {
       return getSetpointNodeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -118,10 +127,7 @@ public class ExclusiveDeviationAlarmTypeNode extends ExclusiveLimitAlarmTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getSetpointNodeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "SetpointNode",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "SetpointNode", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -141,8 +147,11 @@ public class ExclusiveDeviationAlarmTypeNode extends ExclusiveLimitAlarmTypeNode
   public NodeId readBaseSetpointNode() throws UaException {
     try {
       return readBaseSetpointNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -150,8 +159,11 @@ public class ExclusiveDeviationAlarmTypeNode extends ExclusiveLimitAlarmTypeNode
   public void writeBaseSetpointNode(NodeId value) throws UaException {
     try {
       writeBaseSetpointNodeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -173,8 +185,11 @@ public class ExclusiveDeviationAlarmTypeNode extends ExclusiveLimitAlarmTypeNode
   public PropertyTypeNode getBaseSetpointNodeNode() throws UaException {
     try {
       return getBaseSetpointNodeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -184,7 +199,7 @@ public class ExclusiveDeviationAlarmTypeNode extends ExclusiveLimitAlarmTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "BaseSetpointNode",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ExclusiveLimitAlarmTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ExclusiveLimitAlarmTypeNode.java
@@ -77,8 +77,11 @@ public class ExclusiveLimitAlarmTypeNode extends LimitAlarmTypeNode
   public LocalizedText readActiveState() throws UaException {
     try {
       return readActiveStateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class ExclusiveLimitAlarmTypeNode extends LimitAlarmTypeNode
   public void writeActiveState(LocalizedText value) throws UaException {
     try {
       writeActiveStateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class ExclusiveLimitAlarmTypeNode extends LimitAlarmTypeNode
   public TwoStateVariableTypeNode getActiveStateNode() throws UaException {
     try {
       return getActiveStateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -118,10 +127,7 @@ public class ExclusiveLimitAlarmTypeNode extends LimitAlarmTypeNode
   public CompletableFuture<? extends TwoStateVariableTypeNode> getActiveStateNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ActiveState",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "ActiveState", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (TwoStateVariableTypeNode) node);
   }
 
@@ -129,8 +135,11 @@ public class ExclusiveLimitAlarmTypeNode extends LimitAlarmTypeNode
   public ExclusiveLimitStateMachineTypeNode getLimitStateNode() throws UaException {
     try {
       return getLimitStateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -138,7 +147,7 @@ public class ExclusiveLimitAlarmTypeNode extends LimitAlarmTypeNode
   public CompletableFuture<? extends ExclusiveLimitStateMachineTypeNode> getLimitStateNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "LimitState", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "LimitState", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (ExclusiveLimitStateMachineTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ExclusiveLimitStateMachineTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ExclusiveLimitStateMachineTypeNode.java
@@ -60,8 +60,11 @@ public class ExclusiveLimitStateMachineTypeNode extends FiniteStateMachineTypeNo
   public StateTypeNode getHighHighNode() throws UaException {
     try {
       return getHighHighNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -69,7 +72,7 @@ public class ExclusiveLimitStateMachineTypeNode extends FiniteStateMachineTypeNo
   public CompletableFuture<? extends StateTypeNode> getHighHighNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "HighHigh", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "HighHigh", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (StateTypeNode) node);
   }
 
@@ -77,8 +80,11 @@ public class ExclusiveLimitStateMachineTypeNode extends FiniteStateMachineTypeNo
   public StateTypeNode getHighNode() throws UaException {
     try {
       return getHighNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,7 +92,7 @@ public class ExclusiveLimitStateMachineTypeNode extends FiniteStateMachineTypeNo
   public CompletableFuture<? extends StateTypeNode> getHighNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "High", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "High", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (StateTypeNode) node);
   }
 
@@ -94,8 +100,11 @@ public class ExclusiveLimitStateMachineTypeNode extends FiniteStateMachineTypeNo
   public StateTypeNode getLowNode() throws UaException {
     try {
       return getLowNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -103,7 +112,7 @@ public class ExclusiveLimitStateMachineTypeNode extends FiniteStateMachineTypeNo
   public CompletableFuture<? extends StateTypeNode> getLowNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Low", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "Low", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (StateTypeNode) node);
   }
 
@@ -111,8 +120,11 @@ public class ExclusiveLimitStateMachineTypeNode extends FiniteStateMachineTypeNo
   public StateTypeNode getLowLowNode() throws UaException {
     try {
       return getLowLowNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -120,7 +132,7 @@ public class ExclusiveLimitStateMachineTypeNode extends FiniteStateMachineTypeNo
   public CompletableFuture<? extends StateTypeNode> getLowLowNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "LowLow", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "LowLow", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (StateTypeNode) node);
   }
 
@@ -128,8 +140,11 @@ public class ExclusiveLimitStateMachineTypeNode extends FiniteStateMachineTypeNo
   public TransitionTypeNode getLowLowToLowNode() throws UaException {
     try {
       return getLowLowToLowNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -137,10 +152,7 @@ public class ExclusiveLimitStateMachineTypeNode extends FiniteStateMachineTypeNo
   public CompletableFuture<? extends TransitionTypeNode> getLowLowToLowNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "LowLowToLow",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "LowLowToLow", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (TransitionTypeNode) node);
   }
 
@@ -148,8 +160,11 @@ public class ExclusiveLimitStateMachineTypeNode extends FiniteStateMachineTypeNo
   public TransitionTypeNode getLowToLowLowNode() throws UaException {
     try {
       return getLowToLowLowNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -157,10 +172,7 @@ public class ExclusiveLimitStateMachineTypeNode extends FiniteStateMachineTypeNo
   public CompletableFuture<? extends TransitionTypeNode> getLowToLowLowNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "LowToLowLow",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "LowToLowLow", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (TransitionTypeNode) node);
   }
 
@@ -168,8 +180,11 @@ public class ExclusiveLimitStateMachineTypeNode extends FiniteStateMachineTypeNo
   public TransitionTypeNode getHighHighToHighNode() throws UaException {
     try {
       return getHighHighToHighNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -177,10 +192,7 @@ public class ExclusiveLimitStateMachineTypeNode extends FiniteStateMachineTypeNo
   public CompletableFuture<? extends TransitionTypeNode> getHighHighToHighNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "HighHighToHigh",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "HighHighToHigh", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (TransitionTypeNode) node);
   }
 
@@ -188,8 +200,11 @@ public class ExclusiveLimitStateMachineTypeNode extends FiniteStateMachineTypeNo
   public TransitionTypeNode getHighToHighHighNode() throws UaException {
     try {
       return getHighToHighHighNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -197,10 +212,7 @@ public class ExclusiveLimitStateMachineTypeNode extends FiniteStateMachineTypeNo
   public CompletableFuture<? extends TransitionTypeNode> getHighToHighHighNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "HighToHighHigh",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "HighToHighHigh", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (TransitionTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ExclusiveRateOfChangeAlarmTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ExclusiveRateOfChangeAlarmTypeNode.java
@@ -80,8 +80,11 @@ public class ExclusiveRateOfChangeAlarmTypeNode extends ExclusiveLimitAlarmTypeN
   public EUInformation readEngineeringUnits() throws UaException {
     try {
       return readEngineeringUnitsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -89,8 +92,11 @@ public class ExclusiveRateOfChangeAlarmTypeNode extends ExclusiveLimitAlarmTypeN
   public void writeEngineeringUnits(EUInformation value) throws UaException {
     try {
       writeEngineeringUnitsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -114,8 +120,11 @@ public class ExclusiveRateOfChangeAlarmTypeNode extends ExclusiveLimitAlarmTypeN
   public PropertyTypeNode getEngineeringUnitsNode() throws UaException {
     try {
       return getEngineeringUnitsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -125,7 +134,7 @@ public class ExclusiveRateOfChangeAlarmTypeNode extends ExclusiveLimitAlarmTypeN
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "EngineeringUnits",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/FileTransferStateMachineTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/FileTransferStateMachineTypeNode.java
@@ -60,8 +60,11 @@ public class FileTransferStateMachineTypeNode extends FiniteStateMachineTypeNode
   public InitialStateTypeNode getIdleNode() throws UaException {
     try {
       return getIdleNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -69,7 +72,7 @@ public class FileTransferStateMachineTypeNode extends FiniteStateMachineTypeNode
   public CompletableFuture<? extends InitialStateTypeNode> getIdleNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Idle", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "Idle", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (InitialStateTypeNode) node);
   }
 
@@ -77,8 +80,11 @@ public class FileTransferStateMachineTypeNode extends FiniteStateMachineTypeNode
   public StateTypeNode getReadPrepareNode() throws UaException {
     try {
       return getReadPrepareNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,10 +92,7 @@ public class FileTransferStateMachineTypeNode extends FiniteStateMachineTypeNode
   public CompletableFuture<? extends StateTypeNode> getReadPrepareNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ReadPrepare",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "ReadPrepare", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (StateTypeNode) node);
   }
 
@@ -97,8 +100,11 @@ public class FileTransferStateMachineTypeNode extends FiniteStateMachineTypeNode
   public StateTypeNode getReadTransferNode() throws UaException {
     try {
       return getReadTransferNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -106,10 +112,7 @@ public class FileTransferStateMachineTypeNode extends FiniteStateMachineTypeNode
   public CompletableFuture<? extends StateTypeNode> getReadTransferNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ReadTransfer",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "ReadTransfer", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (StateTypeNode) node);
   }
 
@@ -117,8 +120,11 @@ public class FileTransferStateMachineTypeNode extends FiniteStateMachineTypeNode
   public StateTypeNode getApplyWriteNode() throws UaException {
     try {
       return getApplyWriteNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -126,7 +132,7 @@ public class FileTransferStateMachineTypeNode extends FiniteStateMachineTypeNode
   public CompletableFuture<? extends StateTypeNode> getApplyWriteNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "ApplyWrite", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "ApplyWrite", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (StateTypeNode) node);
   }
 
@@ -134,8 +140,11 @@ public class FileTransferStateMachineTypeNode extends FiniteStateMachineTypeNode
   public StateTypeNode getErrorNode() throws UaException {
     try {
       return getErrorNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -143,7 +152,7 @@ public class FileTransferStateMachineTypeNode extends FiniteStateMachineTypeNode
   public CompletableFuture<? extends StateTypeNode> getErrorNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Error", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "Error", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (StateTypeNode) node);
   }
 
@@ -151,8 +160,11 @@ public class FileTransferStateMachineTypeNode extends FiniteStateMachineTypeNode
   public TransitionTypeNode getIdleToReadPrepareNode() throws UaException {
     try {
       return getIdleToReadPrepareNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -162,7 +174,7 @@ public class FileTransferStateMachineTypeNode extends FiniteStateMachineTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "IdleToReadPrepare",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (TransitionTypeNode) node);
   }
@@ -171,8 +183,11 @@ public class FileTransferStateMachineTypeNode extends FiniteStateMachineTypeNode
   public TransitionTypeNode getReadPrepareToReadTransferNode() throws UaException {
     try {
       return getReadPrepareToReadTransferNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -182,7 +197,7 @@ public class FileTransferStateMachineTypeNode extends FiniteStateMachineTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ReadPrepareToReadTransfer",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (TransitionTypeNode) node);
   }
@@ -191,8 +206,11 @@ public class FileTransferStateMachineTypeNode extends FiniteStateMachineTypeNode
   public TransitionTypeNode getReadTransferToIdleNode() throws UaException {
     try {
       return getReadTransferToIdleNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -202,7 +220,7 @@ public class FileTransferStateMachineTypeNode extends FiniteStateMachineTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ReadTransferToIdle",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (TransitionTypeNode) node);
   }
@@ -211,8 +229,11 @@ public class FileTransferStateMachineTypeNode extends FiniteStateMachineTypeNode
   public TransitionTypeNode getIdleToApplyWriteNode() throws UaException {
     try {
       return getIdleToApplyWriteNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -222,7 +243,7 @@ public class FileTransferStateMachineTypeNode extends FiniteStateMachineTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "IdleToApplyWrite",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (TransitionTypeNode) node);
   }
@@ -231,8 +252,11 @@ public class FileTransferStateMachineTypeNode extends FiniteStateMachineTypeNode
   public TransitionTypeNode getApplyWriteToIdleNode() throws UaException {
     try {
       return getApplyWriteToIdleNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -242,7 +266,7 @@ public class FileTransferStateMachineTypeNode extends FiniteStateMachineTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ApplyWriteToIdle",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (TransitionTypeNode) node);
   }
@@ -251,8 +275,11 @@ public class FileTransferStateMachineTypeNode extends FiniteStateMachineTypeNode
   public TransitionTypeNode getReadPrepareToErrorNode() throws UaException {
     try {
       return getReadPrepareToErrorNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -262,7 +289,7 @@ public class FileTransferStateMachineTypeNode extends FiniteStateMachineTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ReadPrepareToError",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (TransitionTypeNode) node);
   }
@@ -271,8 +298,11 @@ public class FileTransferStateMachineTypeNode extends FiniteStateMachineTypeNode
   public TransitionTypeNode getReadTransferToErrorNode() throws UaException {
     try {
       return getReadTransferToErrorNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -282,7 +312,7 @@ public class FileTransferStateMachineTypeNode extends FiniteStateMachineTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ReadTransferToError",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (TransitionTypeNode) node);
   }
@@ -291,8 +321,11 @@ public class FileTransferStateMachineTypeNode extends FiniteStateMachineTypeNode
   public TransitionTypeNode getApplyWriteToErrorNode() throws UaException {
     try {
       return getApplyWriteToErrorNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -302,7 +335,7 @@ public class FileTransferStateMachineTypeNode extends FiniteStateMachineTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ApplyWriteToError",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (TransitionTypeNode) node);
   }
@@ -311,8 +344,11 @@ public class FileTransferStateMachineTypeNode extends FiniteStateMachineTypeNode
   public TransitionTypeNode getErrorToIdleNode() throws UaException {
     try {
       return getErrorToIdleNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -320,10 +356,7 @@ public class FileTransferStateMachineTypeNode extends FiniteStateMachineTypeNode
   public CompletableFuture<? extends TransitionTypeNode> getErrorToIdleNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ErrorToIdle",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "ErrorToIdle", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (TransitionTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/FileTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/FileTypeNode.java
@@ -79,8 +79,11 @@ public class FileTypeNode extends BaseObjectTypeNode implements FileType {
   public ULong readSize() throws UaException {
     try {
       return readSizeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -88,8 +91,11 @@ public class FileTypeNode extends BaseObjectTypeNode implements FileType {
   public void writeSize(ULong value) throws UaException {
     try {
       writeSizeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -111,8 +117,11 @@ public class FileTypeNode extends BaseObjectTypeNode implements FileType {
   public PropertyTypeNode getSizeNode() throws UaException {
     try {
       return getSizeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -120,7 +129,7 @@ public class FileTypeNode extends BaseObjectTypeNode implements FileType {
   public CompletableFuture<? extends PropertyTypeNode> getSizeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Size", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Size", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -140,8 +149,11 @@ public class FileTypeNode extends BaseObjectTypeNode implements FileType {
   public Boolean readWritable() throws UaException {
     try {
       return readWritableAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -149,8 +161,11 @@ public class FileTypeNode extends BaseObjectTypeNode implements FileType {
   public void writeWritable(Boolean value) throws UaException {
     try {
       writeWritableAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -172,8 +187,11 @@ public class FileTypeNode extends BaseObjectTypeNode implements FileType {
   public PropertyTypeNode getWritableNode() throws UaException {
     try {
       return getWritableNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -181,7 +199,7 @@ public class FileTypeNode extends BaseObjectTypeNode implements FileType {
   public CompletableFuture<? extends PropertyTypeNode> getWritableNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Writable", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Writable", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -201,8 +219,11 @@ public class FileTypeNode extends BaseObjectTypeNode implements FileType {
   public Boolean readUserWritable() throws UaException {
     try {
       return readUserWritableAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -210,8 +231,11 @@ public class FileTypeNode extends BaseObjectTypeNode implements FileType {
   public void writeUserWritable(Boolean value) throws UaException {
     try {
       writeUserWritableAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -233,8 +257,11 @@ public class FileTypeNode extends BaseObjectTypeNode implements FileType {
   public PropertyTypeNode getUserWritableNode() throws UaException {
     try {
       return getUserWritableNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -242,10 +269,7 @@ public class FileTypeNode extends BaseObjectTypeNode implements FileType {
   public CompletableFuture<? extends PropertyTypeNode> getUserWritableNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "UserWritable",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "UserWritable", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -265,8 +289,11 @@ public class FileTypeNode extends BaseObjectTypeNode implements FileType {
   public UShort readOpenCount() throws UaException {
     try {
       return readOpenCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -274,8 +301,11 @@ public class FileTypeNode extends BaseObjectTypeNode implements FileType {
   public void writeOpenCount(UShort value) throws UaException {
     try {
       writeOpenCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -297,8 +327,11 @@ public class FileTypeNode extends BaseObjectTypeNode implements FileType {
   public PropertyTypeNode getOpenCountNode() throws UaException {
     try {
       return getOpenCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -306,7 +339,7 @@ public class FileTypeNode extends BaseObjectTypeNode implements FileType {
   public CompletableFuture<? extends PropertyTypeNode> getOpenCountNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "OpenCount", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "OpenCount", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -326,8 +359,11 @@ public class FileTypeNode extends BaseObjectTypeNode implements FileType {
   public String readMimeType() throws UaException {
     try {
       return readMimeTypeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -335,8 +371,11 @@ public class FileTypeNode extends BaseObjectTypeNode implements FileType {
   public void writeMimeType(String value) throws UaException {
     try {
       writeMimeTypeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -358,8 +397,11 @@ public class FileTypeNode extends BaseObjectTypeNode implements FileType {
   public PropertyTypeNode getMimeTypeNode() throws UaException {
     try {
       return getMimeTypeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -367,7 +409,7 @@ public class FileTypeNode extends BaseObjectTypeNode implements FileType {
   public CompletableFuture<? extends PropertyTypeNode> getMimeTypeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "MimeType", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "MimeType", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -387,8 +429,11 @@ public class FileTypeNode extends BaseObjectTypeNode implements FileType {
   public UInteger readMaxByteStringLength() throws UaException {
     try {
       return readMaxByteStringLengthAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -396,8 +441,11 @@ public class FileTypeNode extends BaseObjectTypeNode implements FileType {
   public void writeMaxByteStringLength(UInteger value) throws UaException {
     try {
       writeMaxByteStringLengthAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -419,8 +467,11 @@ public class FileTypeNode extends BaseObjectTypeNode implements FileType {
   public PropertyTypeNode getMaxByteStringLengthNode() throws UaException {
     try {
       return getMaxByteStringLengthNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -430,7 +481,7 @@ public class FileTypeNode extends BaseObjectTypeNode implements FileType {
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaxByteStringLength",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -451,8 +502,11 @@ public class FileTypeNode extends BaseObjectTypeNode implements FileType {
   public DateTime readLastModifiedTime() throws UaException {
     try {
       return readLastModifiedTimeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -460,8 +514,11 @@ public class FileTypeNode extends BaseObjectTypeNode implements FileType {
   public void writeLastModifiedTime(DateTime value) throws UaException {
     try {
       writeLastModifiedTimeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -483,8 +540,11 @@ public class FileTypeNode extends BaseObjectTypeNode implements FileType {
   public PropertyTypeNode getLastModifiedTimeNode() throws UaException {
     try {
       return getLastModifiedTimeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -494,7 +554,7 @@ public class FileTypeNode extends BaseObjectTypeNode implements FileType {
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "LastModifiedTime",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/FiniteStateMachineTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/FiniteStateMachineTypeNode.java
@@ -79,8 +79,11 @@ public class FiniteStateMachineTypeNode extends StateMachineTypeNode
   public LocalizedText readCurrentState() throws UaException {
     try {
       return readCurrentStateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -88,8 +91,11 @@ public class FiniteStateMachineTypeNode extends StateMachineTypeNode
   public void writeCurrentState(LocalizedText value) throws UaException {
     try {
       writeCurrentStateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -111,8 +117,11 @@ public class FiniteStateMachineTypeNode extends StateMachineTypeNode
   public FiniteStateVariableTypeNode getCurrentStateNode() throws UaException {
     try {
       return getCurrentStateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -120,10 +129,7 @@ public class FiniteStateMachineTypeNode extends StateMachineTypeNode
   public CompletableFuture<? extends FiniteStateVariableTypeNode> getCurrentStateNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "CurrentState",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "CurrentState", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (FiniteStateVariableTypeNode) node);
   }
 
@@ -143,8 +149,11 @@ public class FiniteStateMachineTypeNode extends StateMachineTypeNode
   public LocalizedText readLastTransition() throws UaException {
     try {
       return readLastTransitionAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -152,8 +161,11 @@ public class FiniteStateMachineTypeNode extends StateMachineTypeNode
   public void writeLastTransition(LocalizedText value) throws UaException {
     try {
       writeLastTransitionAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -175,8 +187,11 @@ public class FiniteStateMachineTypeNode extends StateMachineTypeNode
   public FiniteTransitionVariableTypeNode getLastTransitionNode() throws UaException {
     try {
       return getLastTransitionNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -185,10 +200,7 @@ public class FiniteStateMachineTypeNode extends StateMachineTypeNode
       getLastTransitionNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "LastTransition",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "LastTransition", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (FiniteTransitionVariableTypeNode) node);
   }
 
@@ -208,8 +220,11 @@ public class FiniteStateMachineTypeNode extends StateMachineTypeNode
   public NodeId[] readAvailableStates() throws UaException {
     try {
       return readAvailableStatesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -217,8 +232,11 @@ public class FiniteStateMachineTypeNode extends StateMachineTypeNode
   public void writeAvailableStates(NodeId[] value) throws UaException {
     try {
       writeAvailableStatesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -240,8 +258,11 @@ public class FiniteStateMachineTypeNode extends StateMachineTypeNode
   public BaseDataVariableTypeNode getAvailableStatesNode() throws UaException {
     try {
       return getAvailableStatesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -249,10 +270,7 @@ public class FiniteStateMachineTypeNode extends StateMachineTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getAvailableStatesNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "AvailableStates",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "AvailableStates", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -272,8 +290,11 @@ public class FiniteStateMachineTypeNode extends StateMachineTypeNode
   public NodeId[] readAvailableTransitions() throws UaException {
     try {
       return readAvailableTransitionsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -281,8 +302,11 @@ public class FiniteStateMachineTypeNode extends StateMachineTypeNode
   public void writeAvailableTransitions(NodeId[] value) throws UaException {
     try {
       writeAvailableTransitionsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -305,8 +329,11 @@ public class FiniteStateMachineTypeNode extends StateMachineTypeNode
   public BaseDataVariableTypeNode getAvailableTransitionsNode() throws UaException {
     try {
       return getAvailableTransitionsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -316,7 +343,7 @@ public class FiniteStateMachineTypeNode extends StateMachineTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "AvailableTransitions",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/GeneralModelChangeEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/GeneralModelChangeEventTypeNode.java
@@ -81,8 +81,11 @@ public class GeneralModelChangeEventTypeNode extends BaseModelChangeEventTypeNod
   public ModelChangeStructureDataType[] readChanges() throws UaException {
     try {
       return readChangesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -90,8 +93,11 @@ public class GeneralModelChangeEventTypeNode extends BaseModelChangeEventTypeNod
   public void writeChanges(ModelChangeStructureDataType[] value) throws UaException {
     try {
       writeChangesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -115,8 +121,11 @@ public class GeneralModelChangeEventTypeNode extends BaseModelChangeEventTypeNod
   public PropertyTypeNode getChangesNode() throws UaException {
     try {
       return getChangesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -124,7 +133,7 @@ public class GeneralModelChangeEventTypeNode extends BaseModelChangeEventTypeNod
   public CompletableFuture<? extends PropertyTypeNode> getChangesNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Changes", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Changes", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/HistoricalDataConfigurationTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/HistoricalDataConfigurationTypeNode.java
@@ -79,8 +79,11 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   public Boolean readStepped() throws UaException {
     try {
       return readSteppedAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -88,8 +91,11 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   public void writeStepped(Boolean value) throws UaException {
     try {
       writeSteppedAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -111,8 +117,11 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getSteppedNode() throws UaException {
     try {
       return getSteppedNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -120,7 +129,7 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getSteppedNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Stepped", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Stepped", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -140,8 +149,11 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   public String readDefinition() throws UaException {
     try {
       return readDefinitionAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -149,8 +161,11 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   public void writeDefinition(String value) throws UaException {
     try {
       writeDefinitionAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -172,8 +187,11 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getDefinitionNode() throws UaException {
     try {
       return getDefinitionNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -181,7 +199,7 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getDefinitionNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Definition", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Definition", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -201,8 +219,11 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   public Double readMaxTimeInterval() throws UaException {
     try {
       return readMaxTimeIntervalAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -210,8 +231,11 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   public void writeMaxTimeInterval(Double value) throws UaException {
     try {
       writeMaxTimeIntervalAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -233,8 +257,11 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getMaxTimeIntervalNode() throws UaException {
     try {
       return getMaxTimeIntervalNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -242,10 +269,7 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getMaxTimeIntervalNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "MaxTimeInterval",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "MaxTimeInterval", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -265,8 +289,11 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   public Double readMinTimeInterval() throws UaException {
     try {
       return readMinTimeIntervalAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -274,8 +301,11 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   public void writeMinTimeInterval(Double value) throws UaException {
     try {
       writeMinTimeIntervalAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -297,8 +327,11 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getMinTimeIntervalNode() throws UaException {
     try {
       return getMinTimeIntervalNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -306,10 +339,7 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getMinTimeIntervalNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "MinTimeInterval",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "MinTimeInterval", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -329,8 +359,11 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   public Double readExceptionDeviation() throws UaException {
     try {
       return readExceptionDeviationAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -338,8 +371,11 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   public void writeExceptionDeviation(Double value) throws UaException {
     try {
       writeExceptionDeviationAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -361,8 +397,11 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getExceptionDeviationNode() throws UaException {
     try {
       return getExceptionDeviationNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -372,7 +411,7 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ExceptionDeviation",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -401,8 +440,11 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   public ExceptionDeviationFormat readExceptionDeviationFormat() throws UaException {
     try {
       return readExceptionDeviationFormatAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -410,8 +452,11 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   public void writeExceptionDeviationFormat(ExceptionDeviationFormat value) throws UaException {
     try {
       writeExceptionDeviationFormatAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -442,8 +487,11 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getExceptionDeviationFormatNode() throws UaException {
     try {
       return getExceptionDeviationFormatNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -453,7 +501,7 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ExceptionDeviationFormat",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -474,8 +522,11 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   public DateTime readStartOfArchive() throws UaException {
     try {
       return readStartOfArchiveAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -483,8 +534,11 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   public void writeStartOfArchive(DateTime value) throws UaException {
     try {
       writeStartOfArchiveAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -506,8 +560,11 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getStartOfArchiveNode() throws UaException {
     try {
       return getStartOfArchiveNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -515,10 +572,7 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getStartOfArchiveNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "StartOfArchive",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "StartOfArchive", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -538,8 +592,11 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   public DateTime readStartOfOnlineArchive() throws UaException {
     try {
       return readStartOfOnlineArchiveAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -547,8 +604,11 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   public void writeStartOfOnlineArchive(DateTime value) throws UaException {
     try {
       writeStartOfOnlineArchiveAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -571,8 +631,11 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getStartOfOnlineArchiveNode() throws UaException {
     try {
       return getStartOfOnlineArchiveNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -582,7 +645,7 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "StartOfOnlineArchive",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -603,8 +666,11 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   public Boolean readServerTimestampSupported() throws UaException {
     try {
       return readServerTimestampSupportedAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -612,8 +678,11 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   public void writeServerTimestampSupported(Boolean value) throws UaException {
     try {
       writeServerTimestampSupportedAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -636,8 +705,11 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getServerTimestampSupportedNode() throws UaException {
     try {
       return getServerTimestampSupportedNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -647,7 +719,7 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ServerTimestampSupported",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -668,8 +740,11 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   public Double readMaxTimeStoredValues() throws UaException {
     try {
       return readMaxTimeStoredValuesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -677,8 +752,11 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   public void writeMaxTimeStoredValues(Double value) throws UaException {
     try {
       writeMaxTimeStoredValuesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -700,8 +778,11 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getMaxTimeStoredValuesNode() throws UaException {
     try {
       return getMaxTimeStoredValuesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -711,7 +792,7 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaxTimeStoredValues",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -732,8 +813,11 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   public UInteger readMaxCountStoredValues() throws UaException {
     try {
       return readMaxCountStoredValuesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -741,8 +825,11 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   public void writeMaxCountStoredValues(UInteger value) throws UaException {
     try {
       writeMaxCountStoredValuesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -765,8 +852,11 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getMaxCountStoredValuesNode() throws UaException {
     try {
       return getMaxCountStoredValuesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -776,7 +866,7 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaxCountStoredValues",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -785,8 +875,11 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   public AggregateConfigurationTypeNode getAggregateConfigurationNode() throws UaException {
     try {
       return getAggregateConfigurationNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -797,7 +890,7 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "AggregateConfiguration",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (AggregateConfigurationTypeNode) node);
   }
@@ -806,8 +899,11 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   public FolderTypeNode getAggregateFunctionsNode() throws UaException {
     try {
       return getAggregateFunctionsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -817,7 +913,7 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "AggregateFunctions",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (FolderTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/HistoricalEventConfigurationTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/HistoricalEventConfigurationTypeNode.java
@@ -80,8 +80,11 @@ public class HistoricalEventConfigurationTypeNode extends BaseObjectTypeNode
   public DateTime readStartOfArchive() throws UaException {
     try {
       return readStartOfArchiveAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -89,8 +92,11 @@ public class HistoricalEventConfigurationTypeNode extends BaseObjectTypeNode
   public void writeStartOfArchive(DateTime value) throws UaException {
     try {
       writeStartOfArchiveAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -112,8 +118,11 @@ public class HistoricalEventConfigurationTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getStartOfArchiveNode() throws UaException {
     try {
       return getStartOfArchiveNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -121,10 +130,7 @@ public class HistoricalEventConfigurationTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getStartOfArchiveNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "StartOfArchive",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "StartOfArchive", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -144,8 +150,11 @@ public class HistoricalEventConfigurationTypeNode extends BaseObjectTypeNode
   public DateTime readStartOfOnlineArchive() throws UaException {
     try {
       return readStartOfOnlineArchiveAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -153,8 +162,11 @@ public class HistoricalEventConfigurationTypeNode extends BaseObjectTypeNode
   public void writeStartOfOnlineArchive(DateTime value) throws UaException {
     try {
       writeStartOfOnlineArchiveAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -177,8 +189,11 @@ public class HistoricalEventConfigurationTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getStartOfOnlineArchiveNode() throws UaException {
     try {
       return getStartOfOnlineArchiveNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -188,7 +203,7 @@ public class HistoricalEventConfigurationTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "StartOfOnlineArchive",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -211,8 +226,11 @@ public class HistoricalEventConfigurationTypeNode extends BaseObjectTypeNode
   public SimpleAttributeOperand[] readSortByEventFields() throws UaException {
     try {
       return readSortByEventFieldsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -220,8 +238,11 @@ public class HistoricalEventConfigurationTypeNode extends BaseObjectTypeNode
   public void writeSortByEventFields(SimpleAttributeOperand[] value) throws UaException {
     try {
       writeSortByEventFieldsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -246,8 +267,11 @@ public class HistoricalEventConfigurationTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getSortByEventFieldsNode() throws UaException {
     try {
       return getSortByEventFieldsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -257,7 +281,7 @@ public class HistoricalEventConfigurationTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SortByEventFields",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -266,8 +290,11 @@ public class HistoricalEventConfigurationTypeNode extends BaseObjectTypeNode
   public FolderTypeNode getEventTypesNode() throws UaException {
     try {
       return getEventTypesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -275,7 +302,7 @@ public class HistoricalEventConfigurationTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends FolderTypeNode> getEventTypesNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "EventTypes", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "EventTypes", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (FolderTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/HistoricalExternalEventSourceTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/HistoricalExternalEventSourceTypeNode.java
@@ -81,8 +81,11 @@ public class HistoricalExternalEventSourceTypeNode extends BaseObjectTypeNode
   public String readServer() throws UaException {
     try {
       return readServerAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -90,8 +93,11 @@ public class HistoricalExternalEventSourceTypeNode extends BaseObjectTypeNode
   public void writeServer(String value) throws UaException {
     try {
       writeServerAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -113,8 +119,11 @@ public class HistoricalExternalEventSourceTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getServerNode() throws UaException {
     try {
       return getServerNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -122,7 +131,7 @@ public class HistoricalExternalEventSourceTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getServerNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Server", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Server", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -142,8 +151,11 @@ public class HistoricalExternalEventSourceTypeNode extends BaseObjectTypeNode
   public String readEndpointUrl() throws UaException {
     try {
       return readEndpointUrlAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -151,8 +163,11 @@ public class HistoricalExternalEventSourceTypeNode extends BaseObjectTypeNode
   public void writeEndpointUrl(String value) throws UaException {
     try {
       writeEndpointUrlAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -174,8 +189,11 @@ public class HistoricalExternalEventSourceTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getEndpointUrlNode() throws UaException {
     try {
       return getEndpointUrlNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -183,10 +201,7 @@ public class HistoricalExternalEventSourceTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getEndpointUrlNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "EndpointUrl",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "EndpointUrl", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -214,8 +229,11 @@ public class HistoricalExternalEventSourceTypeNode extends BaseObjectTypeNode
   public MessageSecurityMode readSecurityMode() throws UaException {
     try {
       return readSecurityModeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -223,8 +241,11 @@ public class HistoricalExternalEventSourceTypeNode extends BaseObjectTypeNode
   public void writeSecurityMode(MessageSecurityMode value) throws UaException {
     try {
       writeSecurityModeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -254,8 +275,11 @@ public class HistoricalExternalEventSourceTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getSecurityModeNode() throws UaException {
     try {
       return getSecurityModeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -263,10 +287,7 @@ public class HistoricalExternalEventSourceTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getSecurityModeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "SecurityMode",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "SecurityMode", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -286,8 +307,11 @@ public class HistoricalExternalEventSourceTypeNode extends BaseObjectTypeNode
   public String readSecurityPolicyUri() throws UaException {
     try {
       return readSecurityPolicyUriAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -295,8 +319,11 @@ public class HistoricalExternalEventSourceTypeNode extends BaseObjectTypeNode
   public void writeSecurityPolicyUri(String value) throws UaException {
     try {
       writeSecurityPolicyUriAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -318,8 +345,11 @@ public class HistoricalExternalEventSourceTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getSecurityPolicyUriNode() throws UaException {
     try {
       return getSecurityPolicyUriNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -329,7 +359,7 @@ public class HistoricalExternalEventSourceTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SecurityPolicyUri",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -351,8 +381,11 @@ public class HistoricalExternalEventSourceTypeNode extends BaseObjectTypeNode
   public UserTokenPolicy readIdentityTokenPolicy() throws UaException {
     try {
       return readIdentityTokenPolicyAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -360,8 +393,11 @@ public class HistoricalExternalEventSourceTypeNode extends BaseObjectTypeNode
   public void writeIdentityTokenPolicy(UserTokenPolicy value) throws UaException {
     try {
       writeIdentityTokenPolicyAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -386,8 +422,11 @@ public class HistoricalExternalEventSourceTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getIdentityTokenPolicyNode() throws UaException {
     try {
       return getIdentityTokenPolicyNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -397,7 +436,7 @@ public class HistoricalExternalEventSourceTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "IdentityTokenPolicy",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -418,8 +457,11 @@ public class HistoricalExternalEventSourceTypeNode extends BaseObjectTypeNode
   public String readTransportProfileUri() throws UaException {
     try {
       return readTransportProfileUriAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -427,8 +469,11 @@ public class HistoricalExternalEventSourceTypeNode extends BaseObjectTypeNode
   public void writeTransportProfileUri(String value) throws UaException {
     try {
       writeTransportProfileUriAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -450,8 +495,11 @@ public class HistoricalExternalEventSourceTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getTransportProfileUriNode() throws UaException {
     try {
       return getTransportProfileUriNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -461,7 +509,7 @@ public class HistoricalExternalEventSourceTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "TransportProfileUri",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -483,8 +531,11 @@ public class HistoricalExternalEventSourceTypeNode extends BaseObjectTypeNode
   public EventFilter readHistoricalEventFilter() throws UaException {
     try {
       return readHistoricalEventFilterAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -492,8 +543,11 @@ public class HistoricalExternalEventSourceTypeNode extends BaseObjectTypeNode
   public void writeHistoricalEventFilter(EventFilter value) throws UaException {
     try {
       writeHistoricalEventFilterAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -518,8 +572,11 @@ public class HistoricalExternalEventSourceTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getHistoricalEventFilterNode() throws UaException {
     try {
       return getHistoricalEventFilterNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -529,7 +586,7 @@ public class HistoricalExternalEventSourceTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "HistoricalEventFilter",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/HistoryServerCapabilitiesTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/HistoryServerCapabilitiesTypeNode.java
@@ -77,8 +77,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public Boolean readAccessHistoryDataCapability() throws UaException {
     try {
       return readAccessHistoryDataCapabilityAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeAccessHistoryDataCapability(Boolean value) throws UaException {
     try {
       writeAccessHistoryDataCapabilityAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -110,8 +116,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getAccessHistoryDataCapabilityNode() throws UaException {
     try {
       return getAccessHistoryDataCapabilityNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -121,7 +130,7 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "AccessHistoryDataCapability",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -142,8 +151,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public Boolean readAccessHistoryEventsCapability() throws UaException {
     try {
       return readAccessHistoryEventsCapabilityAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -151,8 +163,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeAccessHistoryEventsCapability(Boolean value) throws UaException {
     try {
       writeAccessHistoryEventsCapabilityAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -175,8 +190,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getAccessHistoryEventsCapabilityNode() throws UaException {
     try {
       return getAccessHistoryEventsCapabilityNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -186,7 +204,7 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "AccessHistoryEventsCapability",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -207,8 +225,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public UInteger readMaxReturnDataValues() throws UaException {
     try {
       return readMaxReturnDataValuesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -216,8 +237,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeMaxReturnDataValues(UInteger value) throws UaException {
     try {
       writeMaxReturnDataValuesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -239,8 +263,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getMaxReturnDataValuesNode() throws UaException {
     try {
       return getMaxReturnDataValuesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -250,7 +277,7 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaxReturnDataValues",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -271,8 +298,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public UInteger readMaxReturnEventValues() throws UaException {
     try {
       return readMaxReturnEventValuesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -280,8 +310,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeMaxReturnEventValues(UInteger value) throws UaException {
     try {
       writeMaxReturnEventValuesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -304,8 +337,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getMaxReturnEventValuesNode() throws UaException {
     try {
       return getMaxReturnEventValuesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -315,7 +351,7 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaxReturnEventValues",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -336,8 +372,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public Boolean readInsertDataCapability() throws UaException {
     try {
       return readInsertDataCapabilityAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -345,8 +384,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeInsertDataCapability(Boolean value) throws UaException {
     try {
       writeInsertDataCapabilityAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -369,8 +411,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getInsertDataCapabilityNode() throws UaException {
     try {
       return getInsertDataCapabilityNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -380,7 +425,7 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "InsertDataCapability",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -401,8 +446,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public Boolean readReplaceDataCapability() throws UaException {
     try {
       return readReplaceDataCapabilityAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -410,8 +458,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeReplaceDataCapability(Boolean value) throws UaException {
     try {
       writeReplaceDataCapabilityAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -434,8 +485,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getReplaceDataCapabilityNode() throws UaException {
     try {
       return getReplaceDataCapabilityNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -445,7 +499,7 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ReplaceDataCapability",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -466,8 +520,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public Boolean readUpdateDataCapability() throws UaException {
     try {
       return readUpdateDataCapabilityAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -475,8 +532,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeUpdateDataCapability(Boolean value) throws UaException {
     try {
       writeUpdateDataCapabilityAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -499,8 +559,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getUpdateDataCapabilityNode() throws UaException {
     try {
       return getUpdateDataCapabilityNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -510,7 +573,7 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "UpdateDataCapability",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -531,8 +594,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public Boolean readDeleteRawCapability() throws UaException {
     try {
       return readDeleteRawCapabilityAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -540,8 +606,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeDeleteRawCapability(Boolean value) throws UaException {
     try {
       writeDeleteRawCapabilityAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -563,8 +632,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getDeleteRawCapabilityNode() throws UaException {
     try {
       return getDeleteRawCapabilityNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -574,7 +646,7 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "DeleteRawCapability",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -595,8 +667,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public Boolean readDeleteAtTimeCapability() throws UaException {
     try {
       return readDeleteAtTimeCapabilityAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -604,8 +679,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeDeleteAtTimeCapability(Boolean value) throws UaException {
     try {
       writeDeleteAtTimeCapabilityAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -628,8 +706,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getDeleteAtTimeCapabilityNode() throws UaException {
     try {
       return getDeleteAtTimeCapabilityNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -639,7 +720,7 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "DeleteAtTimeCapability",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -660,8 +741,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public Boolean readInsertEventCapability() throws UaException {
     try {
       return readInsertEventCapabilityAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -669,8 +753,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeInsertEventCapability(Boolean value) throws UaException {
     try {
       writeInsertEventCapabilityAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -693,8 +780,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getInsertEventCapabilityNode() throws UaException {
     try {
       return getInsertEventCapabilityNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -704,7 +794,7 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "InsertEventCapability",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -725,8 +815,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public Boolean readReplaceEventCapability() throws UaException {
     try {
       return readReplaceEventCapabilityAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -734,8 +827,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeReplaceEventCapability(Boolean value) throws UaException {
     try {
       writeReplaceEventCapabilityAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -758,8 +854,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getReplaceEventCapabilityNode() throws UaException {
     try {
       return getReplaceEventCapabilityNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -769,7 +868,7 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ReplaceEventCapability",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -790,8 +889,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public Boolean readUpdateEventCapability() throws UaException {
     try {
       return readUpdateEventCapabilityAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -799,8 +901,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeUpdateEventCapability(Boolean value) throws UaException {
     try {
       writeUpdateEventCapabilityAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -823,8 +928,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getUpdateEventCapabilityNode() throws UaException {
     try {
       return getUpdateEventCapabilityNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -834,7 +942,7 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "UpdateEventCapability",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -855,8 +963,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public Boolean readDeleteEventCapability() throws UaException {
     try {
       return readDeleteEventCapabilityAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -864,8 +975,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeDeleteEventCapability(Boolean value) throws UaException {
     try {
       writeDeleteEventCapabilityAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -888,8 +1002,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getDeleteEventCapabilityNode() throws UaException {
     try {
       return getDeleteEventCapabilityNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -899,7 +1016,7 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "DeleteEventCapability",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -920,8 +1037,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public Boolean readInsertAnnotationCapability() throws UaException {
     try {
       return readInsertAnnotationCapabilityAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -929,8 +1049,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeInsertAnnotationCapability(Boolean value) throws UaException {
     try {
       writeInsertAnnotationCapabilityAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -953,8 +1076,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getInsertAnnotationCapabilityNode() throws UaException {
     try {
       return getInsertAnnotationCapabilityNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -964,7 +1090,7 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "InsertAnnotationCapability",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -985,8 +1111,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public Boolean readServerTimestampSupported() throws UaException {
     try {
       return readServerTimestampSupportedAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -994,8 +1123,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeServerTimestampSupported(Boolean value) throws UaException {
     try {
       writeServerTimestampSupportedAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1018,8 +1150,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getServerTimestampSupportedNode() throws UaException {
     try {
       return getServerTimestampSupportedNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1029,7 +1164,7 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ServerTimestampSupported",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -1038,8 +1173,11 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public FolderTypeNode getAggregateFunctionsNode() throws UaException {
     try {
       return getAggregateFunctionsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1049,7 +1187,7 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "AggregateFunctions",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (FolderTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IBaseEthernetCapabilitiesTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IBaseEthernetCapabilitiesTypeNode.java
@@ -77,8 +77,11 @@ public class IBaseEthernetCapabilitiesTypeNode extends BaseInterfaceTypeNode
   public Boolean readVlanTagCapable() throws UaException {
     try {
       return readVlanTagCapableAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class IBaseEthernetCapabilitiesTypeNode extends BaseInterfaceTypeNode
   public void writeVlanTagCapable(Boolean value) throws UaException {
     try {
       writeVlanTagCapableAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class IBaseEthernetCapabilitiesTypeNode extends BaseInterfaceTypeNode
   public BaseDataVariableTypeNode getVlanTagCapableNode() throws UaException {
     try {
       return getVlanTagCapableNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -118,10 +127,7 @@ public class IBaseEthernetCapabilitiesTypeNode extends BaseInterfaceTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getVlanTagCapableNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "VlanTagCapable",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "VlanTagCapable", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IIeeeAutoNegotiationStatusTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IIeeeAutoNegotiationStatusTypeNode.java
@@ -86,8 +86,11 @@ public class IIeeeAutoNegotiationStatusTypeNode extends BaseInterfaceTypeNode
   public NegotiationStatus readNegotiationStatus() throws UaException {
     try {
       return readNegotiationStatusAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -95,8 +98,11 @@ public class IIeeeAutoNegotiationStatusTypeNode extends BaseInterfaceTypeNode
   public void writeNegotiationStatus(NegotiationStatus value) throws UaException {
     try {
       writeNegotiationStatusAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -127,8 +133,11 @@ public class IIeeeAutoNegotiationStatusTypeNode extends BaseInterfaceTypeNode
   public BaseDataVariableTypeNode getNegotiationStatusNode() throws UaException {
     try {
       return getNegotiationStatusNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -138,7 +147,7 @@ public class IIeeeAutoNegotiationStatusTypeNode extends BaseInterfaceTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "NegotiationStatus",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IIeeeBaseEthernetPortTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IIeeeBaseEthernetPortTypeNode.java
@@ -81,8 +81,11 @@ public class IIeeeBaseEthernetPortTypeNode extends BaseInterfaceTypeNode
   public ULong readSpeed() throws UaException {
     try {
       return readSpeedAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -90,8 +93,11 @@ public class IIeeeBaseEthernetPortTypeNode extends BaseInterfaceTypeNode
   public void writeSpeed(ULong value) throws UaException {
     try {
       writeSpeedAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -113,8 +119,11 @@ public class IIeeeBaseEthernetPortTypeNode extends BaseInterfaceTypeNode
   public AnalogUnitTypeNode getSpeedNode() throws UaException {
     try {
       return getSpeedNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -122,7 +131,7 @@ public class IIeeeBaseEthernetPortTypeNode extends BaseInterfaceTypeNode
   public CompletableFuture<? extends AnalogUnitTypeNode> getSpeedNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Speed", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "Speed", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (AnalogUnitTypeNode) node);
   }
 
@@ -150,8 +159,11 @@ public class IIeeeBaseEthernetPortTypeNode extends BaseInterfaceTypeNode
   public Duplex readDuplex() throws UaException {
     try {
       return readDuplexAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -159,8 +171,11 @@ public class IIeeeBaseEthernetPortTypeNode extends BaseInterfaceTypeNode
   public void writeDuplex(Duplex value) throws UaException {
     try {
       writeDuplexAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -190,8 +205,11 @@ public class IIeeeBaseEthernetPortTypeNode extends BaseInterfaceTypeNode
   public BaseDataVariableTypeNode getDuplexNode() throws UaException {
     try {
       return getDuplexNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -199,7 +217,7 @@ public class IIeeeBaseEthernetPortTypeNode extends BaseInterfaceTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getDuplexNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Duplex", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "Duplex", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -219,8 +237,11 @@ public class IIeeeBaseEthernetPortTypeNode extends BaseInterfaceTypeNode
   public UShort readMaxFrameLength() throws UaException {
     try {
       return readMaxFrameLengthAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -228,8 +249,11 @@ public class IIeeeBaseEthernetPortTypeNode extends BaseInterfaceTypeNode
   public void writeMaxFrameLength(UShort value) throws UaException {
     try {
       writeMaxFrameLengthAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -251,8 +275,11 @@ public class IIeeeBaseEthernetPortTypeNode extends BaseInterfaceTypeNode
   public BaseDataVariableTypeNode getMaxFrameLengthNode() throws UaException {
     try {
       return getMaxFrameLengthNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -260,10 +287,7 @@ public class IIeeeBaseEthernetPortTypeNode extends BaseInterfaceTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getMaxFrameLengthNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "MaxFrameLength",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "MaxFrameLength", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IIeeeBaseTsnStatusStreamTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IIeeeBaseTsnStatusStreamTypeNode.java
@@ -88,8 +88,11 @@ public class IIeeeBaseTsnStatusStreamTypeNode extends BaseInterfaceTypeNode
   public TsnTalkerStatus readTalkerStatus() throws UaException {
     try {
       return readTalkerStatusAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -97,8 +100,11 @@ public class IIeeeBaseTsnStatusStreamTypeNode extends BaseInterfaceTypeNode
   public void writeTalkerStatus(TsnTalkerStatus value) throws UaException {
     try {
       writeTalkerStatusAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -128,8 +134,11 @@ public class IIeeeBaseTsnStatusStreamTypeNode extends BaseInterfaceTypeNode
   public BaseDataVariableTypeNode getTalkerStatusNode() throws UaException {
     try {
       return getTalkerStatusNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -137,10 +146,7 @@ public class IIeeeBaseTsnStatusStreamTypeNode extends BaseInterfaceTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getTalkerStatusNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "TalkerStatus",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "TalkerStatus", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -168,8 +174,11 @@ public class IIeeeBaseTsnStatusStreamTypeNode extends BaseInterfaceTypeNode
   public TsnListenerStatus readListenerStatus() throws UaException {
     try {
       return readListenerStatusAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -177,8 +186,11 @@ public class IIeeeBaseTsnStatusStreamTypeNode extends BaseInterfaceTypeNode
   public void writeListenerStatus(TsnListenerStatus value) throws UaException {
     try {
       writeListenerStatusAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -208,8 +220,11 @@ public class IIeeeBaseTsnStatusStreamTypeNode extends BaseInterfaceTypeNode
   public BaseDataVariableTypeNode getListenerStatusNode() throws UaException {
     try {
       return getListenerStatusNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -217,10 +232,7 @@ public class IIeeeBaseTsnStatusStreamTypeNode extends BaseInterfaceTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getListenerStatusNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ListenerStatus",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "ListenerStatus", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -248,8 +260,11 @@ public class IIeeeBaseTsnStatusStreamTypeNode extends BaseInterfaceTypeNode
   public TsnFailureCode readFailureCode() throws UaException {
     try {
       return readFailureCodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -257,8 +272,11 @@ public class IIeeeBaseTsnStatusStreamTypeNode extends BaseInterfaceTypeNode
   public void writeFailureCode(TsnFailureCode value) throws UaException {
     try {
       writeFailureCodeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -288,8 +306,11 @@ public class IIeeeBaseTsnStatusStreamTypeNode extends BaseInterfaceTypeNode
   public BaseDataVariableTypeNode getFailureCodeNode() throws UaException {
     try {
       return getFailureCodeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -297,10 +318,7 @@ public class IIeeeBaseTsnStatusStreamTypeNode extends BaseInterfaceTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getFailureCodeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "FailureCode",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "FailureCode", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -320,8 +338,11 @@ public class IIeeeBaseTsnStatusStreamTypeNode extends BaseInterfaceTypeNode
   public Object readFailureSystemIdentifier() throws UaException {
     try {
       return readFailureSystemIdentifierAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -329,8 +350,11 @@ public class IIeeeBaseTsnStatusStreamTypeNode extends BaseInterfaceTypeNode
   public void writeFailureSystemIdentifier(Object value) throws UaException {
     try {
       writeFailureSystemIdentifierAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -353,8 +377,11 @@ public class IIeeeBaseTsnStatusStreamTypeNode extends BaseInterfaceTypeNode
   public BaseDataVariableTypeNode getFailureSystemIdentifierNode() throws UaException {
     try {
       return getFailureSystemIdentifierNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -365,7 +392,7 @@ public class IIeeeBaseTsnStatusStreamTypeNode extends BaseInterfaceTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "FailureSystemIdentifier",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IIeeeBaseTsnStreamTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IIeeeBaseTsnStreamTypeNode.java
@@ -78,8 +78,11 @@ public class IIeeeBaseTsnStreamTypeNode extends BaseInterfaceTypeNode
   public UByte[] readStreamId() throws UaException {
     try {
       return readStreamIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -87,8 +90,11 @@ public class IIeeeBaseTsnStreamTypeNode extends BaseInterfaceTypeNode
   public void writeStreamId(UByte[] value) throws UaException {
     try {
       writeStreamIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -110,8 +116,11 @@ public class IIeeeBaseTsnStreamTypeNode extends BaseInterfaceTypeNode
   public BaseDataVariableTypeNode getStreamIdNode() throws UaException {
     try {
       return getStreamIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -119,7 +128,7 @@ public class IIeeeBaseTsnStreamTypeNode extends BaseInterfaceTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getStreamIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "StreamId", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "StreamId", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -139,8 +148,11 @@ public class IIeeeBaseTsnStreamTypeNode extends BaseInterfaceTypeNode
   public String readStreamName() throws UaException {
     try {
       return readStreamNameAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -148,8 +160,11 @@ public class IIeeeBaseTsnStreamTypeNode extends BaseInterfaceTypeNode
   public void writeStreamName(String value) throws UaException {
     try {
       writeStreamNameAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -171,8 +186,11 @@ public class IIeeeBaseTsnStreamTypeNode extends BaseInterfaceTypeNode
   public BaseDataVariableTypeNode getStreamNameNode() throws UaException {
     try {
       return getStreamNameNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -180,7 +198,7 @@ public class IIeeeBaseTsnStreamTypeNode extends BaseInterfaceTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getStreamNameNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "StreamName", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "StreamName", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -208,8 +226,11 @@ public class IIeeeBaseTsnStreamTypeNode extends BaseInterfaceTypeNode
   public TsnStreamState readState() throws UaException {
     try {
       return readStateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -217,8 +238,11 @@ public class IIeeeBaseTsnStreamTypeNode extends BaseInterfaceTypeNode
   public void writeState(TsnStreamState value) throws UaException {
     try {
       writeStateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -248,8 +272,11 @@ public class IIeeeBaseTsnStreamTypeNode extends BaseInterfaceTypeNode
   public BaseDataVariableTypeNode getStateNode() throws UaException {
     try {
       return getStateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -257,7 +284,7 @@ public class IIeeeBaseTsnStreamTypeNode extends BaseInterfaceTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getStateNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "State", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "State", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -277,8 +304,11 @@ public class IIeeeBaseTsnStreamTypeNode extends BaseInterfaceTypeNode
   public UInteger readAccumulatedLatency() throws UaException {
     try {
       return readAccumulatedLatencyAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -286,8 +316,11 @@ public class IIeeeBaseTsnStreamTypeNode extends BaseInterfaceTypeNode
   public void writeAccumulatedLatency(UInteger value) throws UaException {
     try {
       writeAccumulatedLatencyAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -309,8 +342,11 @@ public class IIeeeBaseTsnStreamTypeNode extends BaseInterfaceTypeNode
   public BaseDataVariableTypeNode getAccumulatedLatencyNode() throws UaException {
     try {
       return getAccumulatedLatencyNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -320,7 +356,7 @@ public class IIeeeBaseTsnStreamTypeNode extends BaseInterfaceTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "AccumulatedLatency",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -341,8 +377,11 @@ public class IIeeeBaseTsnStreamTypeNode extends BaseInterfaceTypeNode
   public UByte readSrClassId() throws UaException {
     try {
       return readSrClassIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -350,8 +389,11 @@ public class IIeeeBaseTsnStreamTypeNode extends BaseInterfaceTypeNode
   public void writeSrClassId(UByte value) throws UaException {
     try {
       writeSrClassIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -373,8 +415,11 @@ public class IIeeeBaseTsnStreamTypeNode extends BaseInterfaceTypeNode
   public BaseDataVariableTypeNode getSrClassIdNode() throws UaException {
     try {
       return getSrClassIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -382,7 +427,7 @@ public class IIeeeBaseTsnStreamTypeNode extends BaseInterfaceTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getSrClassIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "SrClassId", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "SrClassId", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IIeeeBaseTsnTrafficSpecificationTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IIeeeBaseTsnTrafficSpecificationTypeNode.java
@@ -80,8 +80,11 @@ public class IIeeeBaseTsnTrafficSpecificationTypeNode extends BaseInterfaceTypeN
   public UShort readMaxIntervalFrames() throws UaException {
     try {
       return readMaxIntervalFramesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -89,8 +92,11 @@ public class IIeeeBaseTsnTrafficSpecificationTypeNode extends BaseInterfaceTypeN
   public void writeMaxIntervalFrames(UShort value) throws UaException {
     try {
       writeMaxIntervalFramesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -112,8 +118,11 @@ public class IIeeeBaseTsnTrafficSpecificationTypeNode extends BaseInterfaceTypeN
   public BaseDataVariableTypeNode getMaxIntervalFramesNode() throws UaException {
     try {
       return getMaxIntervalFramesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -123,7 +132,7 @@ public class IIeeeBaseTsnTrafficSpecificationTypeNode extends BaseInterfaceTypeN
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaxIntervalFrames",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -144,8 +153,11 @@ public class IIeeeBaseTsnTrafficSpecificationTypeNode extends BaseInterfaceTypeN
   public UInteger readMaxFrameSize() throws UaException {
     try {
       return readMaxFrameSizeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -153,8 +165,11 @@ public class IIeeeBaseTsnTrafficSpecificationTypeNode extends BaseInterfaceTypeN
   public void writeMaxFrameSize(UInteger value) throws UaException {
     try {
       writeMaxFrameSizeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -176,8 +191,11 @@ public class IIeeeBaseTsnTrafficSpecificationTypeNode extends BaseInterfaceTypeN
   public BaseDataVariableTypeNode getMaxFrameSizeNode() throws UaException {
     try {
       return getMaxFrameSizeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -185,10 +203,7 @@ public class IIeeeBaseTsnTrafficSpecificationTypeNode extends BaseInterfaceTypeN
   public CompletableFuture<? extends BaseDataVariableTypeNode> getMaxFrameSizeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "MaxFrameSize",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "MaxFrameSize", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -209,8 +224,11 @@ public class IIeeeBaseTsnTrafficSpecificationTypeNode extends BaseInterfaceTypeN
   public UnsignedRationalNumber readInterval() throws UaException {
     try {
       return readIntervalAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -218,8 +236,11 @@ public class IIeeeBaseTsnTrafficSpecificationTypeNode extends BaseInterfaceTypeN
   public void writeInterval(UnsignedRationalNumber value) throws UaException {
     try {
       writeIntervalAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -242,8 +263,11 @@ public class IIeeeBaseTsnTrafficSpecificationTypeNode extends BaseInterfaceTypeN
   public BaseDataVariableTypeNode getIntervalNode() throws UaException {
     try {
       return getIntervalNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -251,7 +275,7 @@ public class IIeeeBaseTsnTrafficSpecificationTypeNode extends BaseInterfaceTypeN
   public CompletableFuture<? extends BaseDataVariableTypeNode> getIntervalNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Interval", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "Interval", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IIeeeTsnInterfaceConfigurationListenerTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IIeeeTsnInterfaceConfigurationListenerTypeNode.java
@@ -78,8 +78,11 @@ public class IIeeeTsnInterfaceConfigurationListenerTypeNode
   public UInteger readReceiveOffset() throws UaException {
     try {
       return readReceiveOffsetAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -87,8 +90,11 @@ public class IIeeeTsnInterfaceConfigurationListenerTypeNode
   public void writeReceiveOffset(UInteger value) throws UaException {
     try {
       writeReceiveOffsetAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -110,8 +116,11 @@ public class IIeeeTsnInterfaceConfigurationListenerTypeNode
   public BaseDataVariableTypeNode getReceiveOffsetNode() throws UaException {
     try {
       return getReceiveOffsetNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -119,10 +128,7 @@ public class IIeeeTsnInterfaceConfigurationListenerTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getReceiveOffsetNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ReceiveOffset",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "ReceiveOffset", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IIeeeTsnInterfaceConfigurationTalkerTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IIeeeTsnInterfaceConfigurationTalkerTypeNode.java
@@ -78,8 +78,11 @@ public class IIeeeTsnInterfaceConfigurationTalkerTypeNode
   public UInteger readTimeAwareOffset() throws UaException {
     try {
       return readTimeAwareOffsetAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -87,8 +90,11 @@ public class IIeeeTsnInterfaceConfigurationTalkerTypeNode
   public void writeTimeAwareOffset(UInteger value) throws UaException {
     try {
       writeTimeAwareOffsetAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -110,8 +116,11 @@ public class IIeeeTsnInterfaceConfigurationTalkerTypeNode
   public BaseDataVariableTypeNode getTimeAwareOffsetNode() throws UaException {
     try {
       return getTimeAwareOffsetNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -119,10 +128,7 @@ public class IIeeeTsnInterfaceConfigurationTalkerTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getTimeAwareOffsetNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "TimeAwareOffset",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "TimeAwareOffset", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IIeeeTsnInterfaceConfigurationTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IIeeeTsnInterfaceConfigurationTypeNode.java
@@ -77,8 +77,11 @@ public class IIeeeTsnInterfaceConfigurationTypeNode extends BaseInterfaceTypeNod
   public String readMacAddress() throws UaException {
     try {
       return readMacAddressAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class IIeeeTsnInterfaceConfigurationTypeNode extends BaseInterfaceTypeNod
   public void writeMacAddress(String value) throws UaException {
     try {
       writeMacAddressAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class IIeeeTsnInterfaceConfigurationTypeNode extends BaseInterfaceTypeNod
   public BaseDataVariableTypeNode getMacAddressNode() throws UaException {
     try {
       return getMacAddressNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -118,7 +127,7 @@ public class IIeeeTsnInterfaceConfigurationTypeNode extends BaseInterfaceTypeNod
   public CompletableFuture<? extends BaseDataVariableTypeNode> getMacAddressNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "MacAddress", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "MacAddress", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -138,8 +147,11 @@ public class IIeeeTsnInterfaceConfigurationTypeNode extends BaseInterfaceTypeNod
   public String readInterfaceName() throws UaException {
     try {
       return readInterfaceNameAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -147,8 +159,11 @@ public class IIeeeTsnInterfaceConfigurationTypeNode extends BaseInterfaceTypeNod
   public void writeInterfaceName(String value) throws UaException {
     try {
       writeInterfaceNameAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -170,8 +185,11 @@ public class IIeeeTsnInterfaceConfigurationTypeNode extends BaseInterfaceTypeNod
   public BaseDataVariableTypeNode getInterfaceNameNode() throws UaException {
     try {
       return getInterfaceNameNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -179,10 +197,7 @@ public class IIeeeTsnInterfaceConfigurationTypeNode extends BaseInterfaceTypeNod
   public CompletableFuture<? extends BaseDataVariableTypeNode> getInterfaceNameNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "InterfaceName",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "InterfaceName", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IIeeeTsnMacAddressTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IIeeeTsnMacAddressTypeNode.java
@@ -77,8 +77,11 @@ public class IIeeeTsnMacAddressTypeNode extends BaseInterfaceTypeNode
   public UByte[] readDestinationAddress() throws UaException {
     try {
       return readDestinationAddressAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class IIeeeTsnMacAddressTypeNode extends BaseInterfaceTypeNode
   public void writeDestinationAddress(UByte[] value) throws UaException {
     try {
       writeDestinationAddressAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class IIeeeTsnMacAddressTypeNode extends BaseInterfaceTypeNode
   public BaseDataVariableTypeNode getDestinationAddressNode() throws UaException {
     try {
       return getDestinationAddressNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -120,7 +129,7 @@ public class IIeeeTsnMacAddressTypeNode extends BaseInterfaceTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "DestinationAddress",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -141,8 +150,11 @@ public class IIeeeTsnMacAddressTypeNode extends BaseInterfaceTypeNode
   public UByte[] readSourceAddress() throws UaException {
     try {
       return readSourceAddressAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -150,8 +162,11 @@ public class IIeeeTsnMacAddressTypeNode extends BaseInterfaceTypeNode
   public void writeSourceAddress(UByte[] value) throws UaException {
     try {
       writeSourceAddressAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -173,8 +188,11 @@ public class IIeeeTsnMacAddressTypeNode extends BaseInterfaceTypeNode
   public BaseDataVariableTypeNode getSourceAddressNode() throws UaException {
     try {
       return getSourceAddressNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -182,10 +200,7 @@ public class IIeeeTsnMacAddressTypeNode extends BaseInterfaceTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getSourceAddressNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "SourceAddress",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "SourceAddress", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IIeeeTsnVlanTagTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IIeeeTsnVlanTagTypeNode.java
@@ -77,8 +77,11 @@ public class IIeeeTsnVlanTagTypeNode extends BaseInterfaceTypeNode implements II
   public UShort readVlanId() throws UaException {
     try {
       return readVlanIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class IIeeeTsnVlanTagTypeNode extends BaseInterfaceTypeNode implements II
   public void writeVlanId(UShort value) throws UaException {
     try {
       writeVlanIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class IIeeeTsnVlanTagTypeNode extends BaseInterfaceTypeNode implements II
   public BaseDataVariableTypeNode getVlanIdNode() throws UaException {
     try {
       return getVlanIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -118,7 +127,7 @@ public class IIeeeTsnVlanTagTypeNode extends BaseInterfaceTypeNode implements II
   public CompletableFuture<? extends BaseDataVariableTypeNode> getVlanIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "VlanId", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "VlanId", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -138,8 +147,11 @@ public class IIeeeTsnVlanTagTypeNode extends BaseInterfaceTypeNode implements II
   public UByte readPriorityCodePoint() throws UaException {
     try {
       return readPriorityCodePointAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -147,8 +159,11 @@ public class IIeeeTsnVlanTagTypeNode extends BaseInterfaceTypeNode implements II
   public void writePriorityCodePoint(UByte value) throws UaException {
     try {
       writePriorityCodePointAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -170,8 +185,11 @@ public class IIeeeTsnVlanTagTypeNode extends BaseInterfaceTypeNode implements II
   public BaseDataVariableTypeNode getPriorityCodePointNode() throws UaException {
     try {
       return getPriorityCodePointNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -181,7 +199,7 @@ public class IIeeeTsnVlanTagTypeNode extends BaseInterfaceTypeNode implements II
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "PriorityCodePoint",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IIetfBaseNetworkInterfaceTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IIetfBaseNetworkInterfaceTypeNode.java
@@ -89,8 +89,11 @@ public class IIetfBaseNetworkInterfaceTypeNode extends BaseInterfaceTypeNode
   public InterfaceAdminStatus readAdminStatus() throws UaException {
     try {
       return readAdminStatusAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -98,8 +101,11 @@ public class IIetfBaseNetworkInterfaceTypeNode extends BaseInterfaceTypeNode
   public void writeAdminStatus(InterfaceAdminStatus value) throws UaException {
     try {
       writeAdminStatusAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -129,8 +135,11 @@ public class IIetfBaseNetworkInterfaceTypeNode extends BaseInterfaceTypeNode
   public BaseDataVariableTypeNode getAdminStatusNode() throws UaException {
     try {
       return getAdminStatusNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -138,10 +147,7 @@ public class IIetfBaseNetworkInterfaceTypeNode extends BaseInterfaceTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getAdminStatusNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "AdminStatus",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "AdminStatus", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -169,8 +175,11 @@ public class IIetfBaseNetworkInterfaceTypeNode extends BaseInterfaceTypeNode
   public InterfaceOperStatus readOperStatus() throws UaException {
     try {
       return readOperStatusAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -178,8 +187,11 @@ public class IIetfBaseNetworkInterfaceTypeNode extends BaseInterfaceTypeNode
   public void writeOperStatus(InterfaceOperStatus value) throws UaException {
     try {
       writeOperStatusAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -209,8 +221,11 @@ public class IIetfBaseNetworkInterfaceTypeNode extends BaseInterfaceTypeNode
   public BaseDataVariableTypeNode getOperStatusNode() throws UaException {
     try {
       return getOperStatusNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -218,7 +233,7 @@ public class IIetfBaseNetworkInterfaceTypeNode extends BaseInterfaceTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getOperStatusNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "OperStatus", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "OperStatus", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -238,8 +253,11 @@ public class IIetfBaseNetworkInterfaceTypeNode extends BaseInterfaceTypeNode
   public String readPhysAddress() throws UaException {
     try {
       return readPhysAddressAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -247,8 +265,11 @@ public class IIetfBaseNetworkInterfaceTypeNode extends BaseInterfaceTypeNode
   public void writePhysAddress(String value) throws UaException {
     try {
       writePhysAddressAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -270,8 +291,11 @@ public class IIetfBaseNetworkInterfaceTypeNode extends BaseInterfaceTypeNode
   public BaseDataVariableTypeNode getPhysAddressNode() throws UaException {
     try {
       return getPhysAddressNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -279,10 +303,7 @@ public class IIetfBaseNetworkInterfaceTypeNode extends BaseInterfaceTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getPhysAddressNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "PhysAddress",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "PhysAddress", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -302,8 +323,11 @@ public class IIetfBaseNetworkInterfaceTypeNode extends BaseInterfaceTypeNode
   public ULong readSpeed() throws UaException {
     try {
       return readSpeedAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -311,8 +335,11 @@ public class IIetfBaseNetworkInterfaceTypeNode extends BaseInterfaceTypeNode
   public void writeSpeed(ULong value) throws UaException {
     try {
       writeSpeedAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -334,8 +361,11 @@ public class IIetfBaseNetworkInterfaceTypeNode extends BaseInterfaceTypeNode
   public AnalogUnitTypeNode getSpeedNode() throws UaException {
     try {
       return getSpeedNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -343,7 +373,7 @@ public class IIetfBaseNetworkInterfaceTypeNode extends BaseInterfaceTypeNode
   public CompletableFuture<? extends AnalogUnitTypeNode> getSpeedNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Speed", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "Speed", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (AnalogUnitTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IOrderedObjectTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IOrderedObjectTypeNode.java
@@ -76,8 +76,11 @@ public class IOrderedObjectTypeNode extends BaseInterfaceTypeNode implements IOr
   public Variant readNumberInList() throws UaException {
     try {
       return readNumberInListAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -85,8 +88,11 @@ public class IOrderedObjectTypeNode extends BaseInterfaceTypeNode implements IOr
   public void writeNumberInList(Variant value) throws UaException {
     try {
       writeNumberInListAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -108,8 +114,11 @@ public class IOrderedObjectTypeNode extends BaseInterfaceTypeNode implements IOr
   public PropertyTypeNode getNumberInListNode() throws UaException {
     try {
       return getNumberInListNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -117,10 +126,7 @@ public class IOrderedObjectTypeNode extends BaseInterfaceTypeNode implements IOr
   public CompletableFuture<? extends PropertyTypeNode> getNumberInListNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "NumberInList",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "NumberInList", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IPriorityMappingEntryTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IPriorityMappingEntryTypeNode.java
@@ -77,8 +77,11 @@ public class IPriorityMappingEntryTypeNode extends BaseInterfaceTypeNode
   public String readMappingUri() throws UaException {
     try {
       return readMappingUriAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class IPriorityMappingEntryTypeNode extends BaseInterfaceTypeNode
   public void writeMappingUri(String value) throws UaException {
     try {
       writeMappingUriAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class IPriorityMappingEntryTypeNode extends BaseInterfaceTypeNode
   public BaseDataVariableTypeNode getMappingUriNode() throws UaException {
     try {
       return getMappingUriNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -118,7 +127,7 @@ public class IPriorityMappingEntryTypeNode extends BaseInterfaceTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getMappingUriNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "MappingUri", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "MappingUri", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -138,8 +147,11 @@ public class IPriorityMappingEntryTypeNode extends BaseInterfaceTypeNode
   public String readPriorityLabel() throws UaException {
     try {
       return readPriorityLabelAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -147,8 +159,11 @@ public class IPriorityMappingEntryTypeNode extends BaseInterfaceTypeNode
   public void writePriorityLabel(String value) throws UaException {
     try {
       writePriorityLabelAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -170,8 +185,11 @@ public class IPriorityMappingEntryTypeNode extends BaseInterfaceTypeNode
   public BaseDataVariableTypeNode getPriorityLabelNode() throws UaException {
     try {
       return getPriorityLabelNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -179,10 +197,7 @@ public class IPriorityMappingEntryTypeNode extends BaseInterfaceTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getPriorityLabelNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "PriorityLabel",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "PriorityLabel", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -202,8 +217,11 @@ public class IPriorityMappingEntryTypeNode extends BaseInterfaceTypeNode
   public UByte readPriorityValuePcp() throws UaException {
     try {
       return readPriorityValuePcpAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -211,8 +229,11 @@ public class IPriorityMappingEntryTypeNode extends BaseInterfaceTypeNode
   public void writePriorityValuePcp(UByte value) throws UaException {
     try {
       writePriorityValuePcpAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -234,8 +255,11 @@ public class IPriorityMappingEntryTypeNode extends BaseInterfaceTypeNode
   public BaseDataVariableTypeNode getPriorityValuePcpNode() throws UaException {
     try {
       return getPriorityValuePcpNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -245,7 +269,7 @@ public class IPriorityMappingEntryTypeNode extends BaseInterfaceTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "PriorityValue_PCP",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -266,8 +290,11 @@ public class IPriorityMappingEntryTypeNode extends BaseInterfaceTypeNode
   public UInteger readPriorityValueDscp() throws UaException {
     try {
       return readPriorityValueDscpAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -275,8 +302,11 @@ public class IPriorityMappingEntryTypeNode extends BaseInterfaceTypeNode
   public void writePriorityValueDscp(UInteger value) throws UaException {
     try {
       writePriorityValueDscpAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -298,8 +328,11 @@ public class IPriorityMappingEntryTypeNode extends BaseInterfaceTypeNode
   public BaseDataVariableTypeNode getPriorityValueDscpNode() throws UaException {
     try {
       return getPriorityValueDscpNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -309,7 +342,7 @@ public class IPriorityMappingEntryTypeNode extends BaseInterfaceTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "PriorityValue_DSCP",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ISrClassTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ISrClassTypeNode.java
@@ -77,8 +77,11 @@ public class ISrClassTypeNode extends BaseInterfaceTypeNode implements ISrClassT
   public UByte readId() throws UaException {
     try {
       return readIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class ISrClassTypeNode extends BaseInterfaceTypeNode implements ISrClassT
   public void writeId(UByte value) throws UaException {
     try {
       writeIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -108,8 +114,11 @@ public class ISrClassTypeNode extends BaseInterfaceTypeNode implements ISrClassT
   public BaseDataVariableTypeNode getIdNode() throws UaException {
     try {
       return getIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -117,7 +126,7 @@ public class ISrClassTypeNode extends BaseInterfaceTypeNode implements ISrClassT
   public CompletableFuture<? extends BaseDataVariableTypeNode> getIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Id", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "Id", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -137,8 +146,11 @@ public class ISrClassTypeNode extends BaseInterfaceTypeNode implements ISrClassT
   public UByte readPriority() throws UaException {
     try {
       return readPriorityAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -146,8 +158,11 @@ public class ISrClassTypeNode extends BaseInterfaceTypeNode implements ISrClassT
   public void writePriority(UByte value) throws UaException {
     try {
       writePriorityAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -169,8 +184,11 @@ public class ISrClassTypeNode extends BaseInterfaceTypeNode implements ISrClassT
   public BaseDataVariableTypeNode getPriorityNode() throws UaException {
     try {
       return getPriorityNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -178,7 +196,7 @@ public class ISrClassTypeNode extends BaseInterfaceTypeNode implements ISrClassT
   public CompletableFuture<? extends BaseDataVariableTypeNode> getPriorityNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Priority", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "Priority", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -198,8 +216,11 @@ public class ISrClassTypeNode extends BaseInterfaceTypeNode implements ISrClassT
   public UShort readVid() throws UaException {
     try {
       return readVidAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -207,8 +228,11 @@ public class ISrClassTypeNode extends BaseInterfaceTypeNode implements ISrClassT
   public void writeVid(UShort value) throws UaException {
     try {
       writeVidAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -230,8 +254,11 @@ public class ISrClassTypeNode extends BaseInterfaceTypeNode implements ISrClassT
   public BaseDataVariableTypeNode getVidNode() throws UaException {
     try {
       return getVidNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -239,7 +266,7 @@ public class ISrClassTypeNode extends BaseInterfaceTypeNode implements ISrClassT
   public CompletableFuture<? extends BaseDataVariableTypeNode> getVidNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Vid", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "Vid", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IVlanIdTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IVlanIdTypeNode.java
@@ -77,8 +77,11 @@ public class IVlanIdTypeNode extends BaseInterfaceTypeNode implements IVlanIdTyp
   public UShort readVlanId() throws UaException {
     try {
       return readVlanIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class IVlanIdTypeNode extends BaseInterfaceTypeNode implements IVlanIdTyp
   public void writeVlanId(UShort value) throws UaException {
     try {
       writeVlanIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class IVlanIdTypeNode extends BaseInterfaceTypeNode implements IVlanIdTyp
   public BaseDataVariableTypeNode getVlanIdNode() throws UaException {
     try {
       return getVlanIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -118,7 +127,7 @@ public class IVlanIdTypeNode extends BaseInterfaceTypeNode implements IVlanIdTyp
   public CompletableFuture<? extends BaseDataVariableTypeNode> getVlanIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "VlanId", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "VlanId", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IetfBaseNetworkInterfaceTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IetfBaseNetworkInterfaceTypeNode.java
@@ -89,8 +89,11 @@ public class IetfBaseNetworkInterfaceTypeNode extends BaseObjectTypeNode
   public InterfaceAdminStatus readAdminStatus() throws UaException {
     try {
       return readAdminStatusAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -98,8 +101,11 @@ public class IetfBaseNetworkInterfaceTypeNode extends BaseObjectTypeNode
   public void writeAdminStatus(InterfaceAdminStatus value) throws UaException {
     try {
       writeAdminStatusAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -129,8 +135,11 @@ public class IetfBaseNetworkInterfaceTypeNode extends BaseObjectTypeNode
   public BaseDataVariableTypeNode getAdminStatusNode() throws UaException {
     try {
       return getAdminStatusNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -138,10 +147,7 @@ public class IetfBaseNetworkInterfaceTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getAdminStatusNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "AdminStatus",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "AdminStatus", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -169,8 +175,11 @@ public class IetfBaseNetworkInterfaceTypeNode extends BaseObjectTypeNode
   public InterfaceOperStatus readOperStatus() throws UaException {
     try {
       return readOperStatusAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -178,8 +187,11 @@ public class IetfBaseNetworkInterfaceTypeNode extends BaseObjectTypeNode
   public void writeOperStatus(InterfaceOperStatus value) throws UaException {
     try {
       writeOperStatusAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -209,8 +221,11 @@ public class IetfBaseNetworkInterfaceTypeNode extends BaseObjectTypeNode
   public BaseDataVariableTypeNode getOperStatusNode() throws UaException {
     try {
       return getOperStatusNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -218,7 +233,7 @@ public class IetfBaseNetworkInterfaceTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getOperStatusNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "OperStatus", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "OperStatus", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -238,8 +253,11 @@ public class IetfBaseNetworkInterfaceTypeNode extends BaseObjectTypeNode
   public String readPhysAddress() throws UaException {
     try {
       return readPhysAddressAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -247,8 +265,11 @@ public class IetfBaseNetworkInterfaceTypeNode extends BaseObjectTypeNode
   public void writePhysAddress(String value) throws UaException {
     try {
       writePhysAddressAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -270,8 +291,11 @@ public class IetfBaseNetworkInterfaceTypeNode extends BaseObjectTypeNode
   public BaseDataVariableTypeNode getPhysAddressNode() throws UaException {
     try {
       return getPhysAddressNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -279,10 +303,7 @@ public class IetfBaseNetworkInterfaceTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getPhysAddressNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "PhysAddress",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "PhysAddress", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -302,8 +323,11 @@ public class IetfBaseNetworkInterfaceTypeNode extends BaseObjectTypeNode
   public ULong readSpeed() throws UaException {
     try {
       return readSpeedAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -311,8 +335,11 @@ public class IetfBaseNetworkInterfaceTypeNode extends BaseObjectTypeNode
   public void writeSpeed(ULong value) throws UaException {
     try {
       writeSpeedAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -334,8 +361,11 @@ public class IetfBaseNetworkInterfaceTypeNode extends BaseObjectTypeNode
   public AnalogUnitTypeNode getSpeedNode() throws UaException {
     try {
       return getSpeedNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -343,7 +373,7 @@ public class IetfBaseNetworkInterfaceTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends AnalogUnitTypeNode> getSpeedNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Speed", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "Speed", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (AnalogUnitTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/JsonDataSetReaderMessageTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/JsonDataSetReaderMessageTypeNode.java
@@ -79,8 +79,11 @@ public class JsonDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
   public JsonNetworkMessageContentMask readNetworkMessageContentMask() throws UaException {
     try {
       return readNetworkMessageContentMaskAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -89,8 +92,11 @@ public class JsonDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
       throws UaException {
     try {
       writeNetworkMessageContentMaskAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -114,8 +120,11 @@ public class JsonDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
   public PropertyTypeNode getNetworkMessageContentMaskNode() throws UaException {
     try {
       return getNetworkMessageContentMaskNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -125,7 +134,7 @@ public class JsonDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "NetworkMessageContentMask",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -146,8 +155,11 @@ public class JsonDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
   public JsonDataSetMessageContentMask readDataSetMessageContentMask() throws UaException {
     try {
       return readDataSetMessageContentMaskAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -156,8 +168,11 @@ public class JsonDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
       throws UaException {
     try {
       writeDataSetMessageContentMaskAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -181,8 +196,11 @@ public class JsonDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
   public PropertyTypeNode getDataSetMessageContentMaskNode() throws UaException {
     try {
       return getDataSetMessageContentMaskNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -192,7 +210,7 @@ public class JsonDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "DataSetMessageContentMask",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/JsonDataSetWriterMessageTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/JsonDataSetWriterMessageTypeNode.java
@@ -78,8 +78,11 @@ public class JsonDataSetWriterMessageTypeNode extends DataSetWriterMessageTypeNo
   public JsonDataSetMessageContentMask readDataSetMessageContentMask() throws UaException {
     try {
       return readDataSetMessageContentMaskAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -88,8 +91,11 @@ public class JsonDataSetWriterMessageTypeNode extends DataSetWriterMessageTypeNo
       throws UaException {
     try {
       writeDataSetMessageContentMaskAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -113,8 +119,11 @@ public class JsonDataSetWriterMessageTypeNode extends DataSetWriterMessageTypeNo
   public PropertyTypeNode getDataSetMessageContentMaskNode() throws UaException {
     try {
       return getDataSetMessageContentMaskNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -124,7 +133,7 @@ public class JsonDataSetWriterMessageTypeNode extends DataSetWriterMessageTypeNo
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "DataSetMessageContentMask",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/JsonWriterGroupMessageTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/JsonWriterGroupMessageTypeNode.java
@@ -78,8 +78,11 @@ public class JsonWriterGroupMessageTypeNode extends WriterGroupMessageTypeNode
   public JsonNetworkMessageContentMask readNetworkMessageContentMask() throws UaException {
     try {
       return readNetworkMessageContentMaskAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -88,8 +91,11 @@ public class JsonWriterGroupMessageTypeNode extends WriterGroupMessageTypeNode
       throws UaException {
     try {
       writeNetworkMessageContentMaskAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -113,8 +119,11 @@ public class JsonWriterGroupMessageTypeNode extends WriterGroupMessageTypeNode
   public PropertyTypeNode getNetworkMessageContentMaskNode() throws UaException {
     try {
       return getNetworkMessageContentMaskNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -124,7 +133,7 @@ public class JsonWriterGroupMessageTypeNode extends WriterGroupMessageTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "NetworkMessageContentMask",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/KeyCredentialAuditEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/KeyCredentialAuditEventTypeNode.java
@@ -77,8 +77,11 @@ public class KeyCredentialAuditEventTypeNode extends AuditUpdateMethodEventTypeN
   public String readResourceUri() throws UaException {
     try {
       return readResourceUriAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class KeyCredentialAuditEventTypeNode extends AuditUpdateMethodEventTypeN
   public void writeResourceUri(String value) throws UaException {
     try {
       writeResourceUriAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class KeyCredentialAuditEventTypeNode extends AuditUpdateMethodEventTypeN
   public PropertyTypeNode getResourceUriNode() throws UaException {
     try {
       return getResourceUriNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -118,10 +127,7 @@ public class KeyCredentialAuditEventTypeNode extends AuditUpdateMethodEventTypeN
   public CompletableFuture<? extends PropertyTypeNode> getResourceUriNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ResourceUri",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "ResourceUri", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/KeyCredentialConfigurationTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/KeyCredentialConfigurationTypeNode.java
@@ -77,8 +77,11 @@ public class KeyCredentialConfigurationTypeNode extends BaseObjectTypeNode
   public String readResourceUri() throws UaException {
     try {
       return readResourceUriAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class KeyCredentialConfigurationTypeNode extends BaseObjectTypeNode
   public void writeResourceUri(String value) throws UaException {
     try {
       writeResourceUriAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class KeyCredentialConfigurationTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getResourceUriNode() throws UaException {
     try {
       return getResourceUriNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -118,10 +127,7 @@ public class KeyCredentialConfigurationTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getResourceUriNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ResourceUri",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "ResourceUri", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -141,8 +147,11 @@ public class KeyCredentialConfigurationTypeNode extends BaseObjectTypeNode
   public String readProfileUri() throws UaException {
     try {
       return readProfileUriAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -150,8 +159,11 @@ public class KeyCredentialConfigurationTypeNode extends BaseObjectTypeNode
   public void writeProfileUri(String value) throws UaException {
     try {
       writeProfileUriAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -173,8 +185,11 @@ public class KeyCredentialConfigurationTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getProfileUriNode() throws UaException {
     try {
       return getProfileUriNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -182,7 +197,7 @@ public class KeyCredentialConfigurationTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getProfileUriNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "ProfileUri", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "ProfileUri", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -202,8 +217,11 @@ public class KeyCredentialConfigurationTypeNode extends BaseObjectTypeNode
   public String[] readEndpointUrls() throws UaException {
     try {
       return readEndpointUrlsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -211,8 +229,11 @@ public class KeyCredentialConfigurationTypeNode extends BaseObjectTypeNode
   public void writeEndpointUrls(String[] value) throws UaException {
     try {
       writeEndpointUrlsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -234,8 +255,11 @@ public class KeyCredentialConfigurationTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getEndpointUrlsNode() throws UaException {
     try {
       return getEndpointUrlsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -243,10 +267,7 @@ public class KeyCredentialConfigurationTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getEndpointUrlsNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "EndpointUrls",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "EndpointUrls", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -266,8 +287,11 @@ public class KeyCredentialConfigurationTypeNode extends BaseObjectTypeNode
   public String readCredentialId() throws UaException {
     try {
       return readCredentialIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -275,8 +299,11 @@ public class KeyCredentialConfigurationTypeNode extends BaseObjectTypeNode
   public void writeCredentialId(String value) throws UaException {
     try {
       writeCredentialIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -298,8 +325,11 @@ public class KeyCredentialConfigurationTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getCredentialIdNode() throws UaException {
     try {
       return getCredentialIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -307,10 +337,7 @@ public class KeyCredentialConfigurationTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getCredentialIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "CredentialId",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "CredentialId", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -330,8 +357,11 @@ public class KeyCredentialConfigurationTypeNode extends BaseObjectTypeNode
   public StatusCode readServiceStatus() throws UaException {
     try {
       return readServiceStatusAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -339,8 +369,11 @@ public class KeyCredentialConfigurationTypeNode extends BaseObjectTypeNode
   public void writeServiceStatus(StatusCode value) throws UaException {
     try {
       writeServiceStatusAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -362,8 +395,11 @@ public class KeyCredentialConfigurationTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getServiceStatusNode() throws UaException {
     try {
       return getServiceStatusNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -371,10 +407,7 @@ public class KeyCredentialConfigurationTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getServiceStatusNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ServiceStatus",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "ServiceStatus", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/KeyCredentialDeletedAuditEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/KeyCredentialDeletedAuditEventTypeNode.java
@@ -77,8 +77,11 @@ public class KeyCredentialDeletedAuditEventTypeNode extends KeyCredentialAuditEv
   public String readResourceUri() throws UaException {
     try {
       return readResourceUriAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class KeyCredentialDeletedAuditEventTypeNode extends KeyCredentialAuditEv
   public void writeResourceUri(String value) throws UaException {
     try {
       writeResourceUriAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class KeyCredentialDeletedAuditEventTypeNode extends KeyCredentialAuditEv
   public PropertyTypeNode getResourceUriNode() throws UaException {
     try {
       return getResourceUriNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -118,10 +127,7 @@ public class KeyCredentialDeletedAuditEventTypeNode extends KeyCredentialAuditEv
   public CompletableFuture<? extends PropertyTypeNode> getResourceUriNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ResourceUri",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "ResourceUri", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/LimitAlarmTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/LimitAlarmTypeNode.java
@@ -77,8 +77,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public Double readHighHighLimit() throws UaException {
     try {
       return readHighHighLimitAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public void writeHighHighLimit(Double value) throws UaException {
     try {
       writeHighHighLimitAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public PropertyTypeNode getHighHighLimitNode() throws UaException {
     try {
       return getHighHighLimitNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -118,10 +127,7 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public CompletableFuture<? extends PropertyTypeNode> getHighHighLimitNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "HighHighLimit",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "HighHighLimit", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -141,8 +147,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public Double readHighLimit() throws UaException {
     try {
       return readHighLimitAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -150,8 +159,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public void writeHighLimit(Double value) throws UaException {
     try {
       writeHighLimitAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -173,8 +185,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public PropertyTypeNode getHighLimitNode() throws UaException {
     try {
       return getHighLimitNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -182,7 +197,7 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public CompletableFuture<? extends PropertyTypeNode> getHighLimitNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "HighLimit", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "HighLimit", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -202,8 +217,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public Double readLowLimit() throws UaException {
     try {
       return readLowLimitAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -211,8 +229,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public void writeLowLimit(Double value) throws UaException {
     try {
       writeLowLimitAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -234,8 +255,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public PropertyTypeNode getLowLimitNode() throws UaException {
     try {
       return getLowLimitNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -243,7 +267,7 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public CompletableFuture<? extends PropertyTypeNode> getLowLimitNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "LowLimit", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "LowLimit", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -263,8 +287,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public Double readLowLowLimit() throws UaException {
     try {
       return readLowLowLimitAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -272,8 +299,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public void writeLowLowLimit(Double value) throws UaException {
     try {
       writeLowLowLimitAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -295,8 +325,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public PropertyTypeNode getLowLowLimitNode() throws UaException {
     try {
       return getLowLowLimitNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -304,10 +337,7 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public CompletableFuture<? extends PropertyTypeNode> getLowLowLimitNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "LowLowLimit",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "LowLowLimit", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -327,8 +357,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public Double readBaseHighHighLimit() throws UaException {
     try {
       return readBaseHighHighLimitAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -336,8 +369,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public void writeBaseHighHighLimit(Double value) throws UaException {
     try {
       writeBaseHighHighLimitAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -359,8 +395,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public PropertyTypeNode getBaseHighHighLimitNode() throws UaException {
     try {
       return getBaseHighHighLimitNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -370,7 +409,7 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "BaseHighHighLimit",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -391,8 +430,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public Double readBaseHighLimit() throws UaException {
     try {
       return readBaseHighLimitAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -400,8 +442,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public void writeBaseHighLimit(Double value) throws UaException {
     try {
       writeBaseHighLimitAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -423,8 +468,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public PropertyTypeNode getBaseHighLimitNode() throws UaException {
     try {
       return getBaseHighLimitNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -432,10 +480,7 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public CompletableFuture<? extends PropertyTypeNode> getBaseHighLimitNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "BaseHighLimit",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "BaseHighLimit", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -455,8 +500,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public Double readBaseLowLimit() throws UaException {
     try {
       return readBaseLowLimitAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -464,8 +512,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public void writeBaseLowLimit(Double value) throws UaException {
     try {
       writeBaseLowLimitAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -487,8 +538,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public PropertyTypeNode getBaseLowLimitNode() throws UaException {
     try {
       return getBaseLowLimitNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -496,10 +550,7 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public CompletableFuture<? extends PropertyTypeNode> getBaseLowLimitNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "BaseLowLimit",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "BaseLowLimit", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -519,8 +570,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public Double readBaseLowLowLimit() throws UaException {
     try {
       return readBaseLowLowLimitAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -528,8 +582,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public void writeBaseLowLowLimit(Double value) throws UaException {
     try {
       writeBaseLowLowLimitAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -551,8 +608,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public PropertyTypeNode getBaseLowLowLimitNode() throws UaException {
     try {
       return getBaseLowLowLimitNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -560,10 +620,7 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public CompletableFuture<? extends PropertyTypeNode> getBaseLowLowLimitNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "BaseLowLowLimit",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "BaseLowLowLimit", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -583,8 +640,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public UShort readSeverityHighHigh() throws UaException {
     try {
       return readSeverityHighHighAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -592,8 +652,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public void writeSeverityHighHigh(UShort value) throws UaException {
     try {
       writeSeverityHighHighAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -615,8 +678,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public PropertyTypeNode getSeverityHighHighNode() throws UaException {
     try {
       return getSeverityHighHighNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -626,7 +692,7 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SeverityHighHigh",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -647,8 +713,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public UShort readSeverityHigh() throws UaException {
     try {
       return readSeverityHighAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -656,8 +725,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public void writeSeverityHigh(UShort value) throws UaException {
     try {
       writeSeverityHighAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -679,8 +751,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public PropertyTypeNode getSeverityHighNode() throws UaException {
     try {
       return getSeverityHighNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -688,10 +763,7 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public CompletableFuture<? extends PropertyTypeNode> getSeverityHighNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "SeverityHigh",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "SeverityHigh", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -711,8 +783,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public UShort readSeverityLow() throws UaException {
     try {
       return readSeverityLowAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -720,8 +795,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public void writeSeverityLow(UShort value) throws UaException {
     try {
       writeSeverityLowAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -743,8 +821,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public PropertyTypeNode getSeverityLowNode() throws UaException {
     try {
       return getSeverityLowNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -752,10 +833,7 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public CompletableFuture<? extends PropertyTypeNode> getSeverityLowNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "SeverityLow",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "SeverityLow", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -775,8 +853,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public UShort readSeverityLowLow() throws UaException {
     try {
       return readSeverityLowLowAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -784,8 +865,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public void writeSeverityLowLow(UShort value) throws UaException {
     try {
       writeSeverityLowLowAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -807,8 +891,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public PropertyTypeNode getSeverityLowLowNode() throws UaException {
     try {
       return getSeverityLowLowNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -816,10 +903,7 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public CompletableFuture<? extends PropertyTypeNode> getSeverityLowLowNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "SeverityLowLow",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "SeverityLowLow", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -839,8 +923,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public Double readHighHighDeadband() throws UaException {
     try {
       return readHighHighDeadbandAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -848,8 +935,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public void writeHighHighDeadband(Double value) throws UaException {
     try {
       writeHighHighDeadbandAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -871,8 +961,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public PropertyTypeNode getHighHighDeadbandNode() throws UaException {
     try {
       return getHighHighDeadbandNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -882,7 +975,7 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "HighHighDeadband",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -903,8 +996,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public Double readHighDeadband() throws UaException {
     try {
       return readHighDeadbandAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -912,8 +1008,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public void writeHighDeadband(Double value) throws UaException {
     try {
       writeHighDeadbandAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -935,8 +1034,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public PropertyTypeNode getHighDeadbandNode() throws UaException {
     try {
       return getHighDeadbandNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -944,10 +1046,7 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public CompletableFuture<? extends PropertyTypeNode> getHighDeadbandNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "HighDeadband",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "HighDeadband", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -967,8 +1066,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public Double readLowDeadband() throws UaException {
     try {
       return readLowDeadbandAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -976,8 +1078,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public void writeLowDeadband(Double value) throws UaException {
     try {
       writeLowDeadbandAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -999,8 +1104,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public PropertyTypeNode getLowDeadbandNode() throws UaException {
     try {
       return getLowDeadbandNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1008,10 +1116,7 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public CompletableFuture<? extends PropertyTypeNode> getLowDeadbandNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "LowDeadband",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "LowDeadband", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -1031,8 +1136,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public Double readLowLowDeadband() throws UaException {
     try {
       return readLowLowDeadbandAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1040,8 +1148,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public void writeLowLowDeadband(Double value) throws UaException {
     try {
       writeLowLowDeadbandAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1063,8 +1174,11 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public PropertyTypeNode getLowLowDeadbandNode() throws UaException {
     try {
       return getLowLowDeadbandNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1072,10 +1186,7 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   public CompletableFuture<? extends PropertyTypeNode> getLowLowDeadbandNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "LowLowDeadband",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "LowLowDeadband", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/LldpInformationTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/LldpInformationTypeNode.java
@@ -59,8 +59,11 @@ public class LldpInformationTypeNode extends BaseObjectTypeNode implements LldpI
   public LldpRemoteStatisticsTypeNode getRemoteStatisticsNode() throws UaException {
     try {
       return getRemoteStatisticsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -70,7 +73,7 @@ public class LldpInformationTypeNode extends BaseObjectTypeNode implements LldpI
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "RemoteStatistics",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (LldpRemoteStatisticsTypeNode) node);
   }
@@ -79,8 +82,11 @@ public class LldpInformationTypeNode extends BaseObjectTypeNode implements LldpI
   public LldpLocalSystemTypeNode getLocalSystemDataNode() throws UaException {
     try {
       return getLocalSystemDataNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -88,10 +94,7 @@ public class LldpInformationTypeNode extends BaseObjectTypeNode implements LldpI
   public CompletableFuture<? extends LldpLocalSystemTypeNode> getLocalSystemDataNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "LocalSystemData",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "LocalSystemData", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (LldpLocalSystemTypeNode) node);
   }
 
@@ -99,8 +102,11 @@ public class LldpInformationTypeNode extends BaseObjectTypeNode implements LldpI
   public FolderTypeNode getPortsNode() throws UaException {
     try {
       return getPortsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -108,7 +114,7 @@ public class LldpInformationTypeNode extends BaseObjectTypeNode implements LldpI
   public CompletableFuture<? extends FolderTypeNode> getPortsNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Ports", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "Ports", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (FolderTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/LldpLocalSystemTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/LldpLocalSystemTypeNode.java
@@ -86,8 +86,11 @@ public class LldpLocalSystemTypeNode extends BaseObjectTypeNode implements LldpL
   public ChassisIdSubtype readChassisIdSubtype() throws UaException {
     try {
       return readChassisIdSubtypeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -95,8 +98,11 @@ public class LldpLocalSystemTypeNode extends BaseObjectTypeNode implements LldpL
   public void writeChassisIdSubtype(ChassisIdSubtype value) throws UaException {
     try {
       writeChassisIdSubtypeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -127,8 +133,11 @@ public class LldpLocalSystemTypeNode extends BaseObjectTypeNode implements LldpL
   public PropertyTypeNode getChassisIdSubtypeNode() throws UaException {
     try {
       return getChassisIdSubtypeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -138,7 +147,7 @@ public class LldpLocalSystemTypeNode extends BaseObjectTypeNode implements LldpL
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ChassisIdSubtype",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -159,8 +168,11 @@ public class LldpLocalSystemTypeNode extends BaseObjectTypeNode implements LldpL
   public String readChassisId() throws UaException {
     try {
       return readChassisIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -168,8 +180,11 @@ public class LldpLocalSystemTypeNode extends BaseObjectTypeNode implements LldpL
   public void writeChassisId(String value) throws UaException {
     try {
       writeChassisIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -191,8 +206,11 @@ public class LldpLocalSystemTypeNode extends BaseObjectTypeNode implements LldpL
   public PropertyTypeNode getChassisIdNode() throws UaException {
     try {
       return getChassisIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -200,7 +218,7 @@ public class LldpLocalSystemTypeNode extends BaseObjectTypeNode implements LldpL
   public CompletableFuture<? extends PropertyTypeNode> getChassisIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "ChassisId", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "ChassisId", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -220,8 +238,11 @@ public class LldpLocalSystemTypeNode extends BaseObjectTypeNode implements LldpL
   public String readSystemName() throws UaException {
     try {
       return readSystemNameAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -229,8 +250,11 @@ public class LldpLocalSystemTypeNode extends BaseObjectTypeNode implements LldpL
   public void writeSystemName(String value) throws UaException {
     try {
       writeSystemNameAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -252,8 +276,11 @@ public class LldpLocalSystemTypeNode extends BaseObjectTypeNode implements LldpL
   public PropertyTypeNode getSystemNameNode() throws UaException {
     try {
       return getSystemNameNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -261,7 +288,7 @@ public class LldpLocalSystemTypeNode extends BaseObjectTypeNode implements LldpL
   public CompletableFuture<? extends PropertyTypeNode> getSystemNameNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "SystemName", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "SystemName", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -281,8 +308,11 @@ public class LldpLocalSystemTypeNode extends BaseObjectTypeNode implements LldpL
   public String readSystemDescription() throws UaException {
     try {
       return readSystemDescriptionAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -290,8 +320,11 @@ public class LldpLocalSystemTypeNode extends BaseObjectTypeNode implements LldpL
   public void writeSystemDescription(String value) throws UaException {
     try {
       writeSystemDescriptionAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -313,8 +346,11 @@ public class LldpLocalSystemTypeNode extends BaseObjectTypeNode implements LldpL
   public PropertyTypeNode getSystemDescriptionNode() throws UaException {
     try {
       return getSystemDescriptionNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -324,7 +360,7 @@ public class LldpLocalSystemTypeNode extends BaseObjectTypeNode implements LldpL
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SystemDescription",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -345,8 +381,11 @@ public class LldpLocalSystemTypeNode extends BaseObjectTypeNode implements LldpL
   public LldpSystemCapabilitiesMap readSystemCapabilitiesSupported() throws UaException {
     try {
       return readSystemCapabilitiesSupportedAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -354,8 +393,11 @@ public class LldpLocalSystemTypeNode extends BaseObjectTypeNode implements LldpL
   public void writeSystemCapabilitiesSupported(LldpSystemCapabilitiesMap value) throws UaException {
     try {
       writeSystemCapabilitiesSupportedAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -379,8 +421,11 @@ public class LldpLocalSystemTypeNode extends BaseObjectTypeNode implements LldpL
   public PropertyTypeNode getSystemCapabilitiesSupportedNode() throws UaException {
     try {
       return getSystemCapabilitiesSupportedNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -390,7 +435,7 @@ public class LldpLocalSystemTypeNode extends BaseObjectTypeNode implements LldpL
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SystemCapabilitiesSupported",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -411,8 +456,11 @@ public class LldpLocalSystemTypeNode extends BaseObjectTypeNode implements LldpL
   public LldpSystemCapabilitiesMap readSystemCapabilitiesEnabled() throws UaException {
     try {
       return readSystemCapabilitiesEnabledAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -420,8 +468,11 @@ public class LldpLocalSystemTypeNode extends BaseObjectTypeNode implements LldpL
   public void writeSystemCapabilitiesEnabled(LldpSystemCapabilitiesMap value) throws UaException {
     try {
       writeSystemCapabilitiesEnabledAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -445,8 +496,11 @@ public class LldpLocalSystemTypeNode extends BaseObjectTypeNode implements LldpL
   public PropertyTypeNode getSystemCapabilitiesEnabledNode() throws UaException {
     try {
       return getSystemCapabilitiesEnabledNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -456,7 +510,7 @@ public class LldpLocalSystemTypeNode extends BaseObjectTypeNode implements LldpL
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SystemCapabilitiesEnabled",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/LldpPortInformationTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/LldpPortInformationTypeNode.java
@@ -80,8 +80,11 @@ public class LldpPortInformationTypeNode extends BaseObjectTypeNode
   public String readIetfBaseNetworkInterfaceName() throws UaException {
     try {
       return readIetfBaseNetworkInterfaceNameAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -89,8 +92,11 @@ public class LldpPortInformationTypeNode extends BaseObjectTypeNode
   public void writeIetfBaseNetworkInterfaceName(String value) throws UaException {
     try {
       writeIetfBaseNetworkInterfaceNameAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -113,8 +119,11 @@ public class LldpPortInformationTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getIetfBaseNetworkInterfaceNameNode() throws UaException {
     try {
       return getIetfBaseNetworkInterfaceNameNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -124,7 +133,7 @@ public class LldpPortInformationTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "IetfBaseNetworkInterfaceName",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -145,8 +154,11 @@ public class LldpPortInformationTypeNode extends BaseObjectTypeNode
   public UByte[] readDestMacAddress() throws UaException {
     try {
       return readDestMacAddressAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -154,8 +166,11 @@ public class LldpPortInformationTypeNode extends BaseObjectTypeNode
   public void writeDestMacAddress(UByte[] value) throws UaException {
     try {
       writeDestMacAddressAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -177,8 +192,11 @@ public class LldpPortInformationTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getDestMacAddressNode() throws UaException {
     try {
       return getDestMacAddressNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -186,10 +204,7 @@ public class LldpPortInformationTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getDestMacAddressNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "DestMacAddress",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "DestMacAddress", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -217,8 +232,11 @@ public class LldpPortInformationTypeNode extends BaseObjectTypeNode
   public PortIdSubtype readPortIdSubtype() throws UaException {
     try {
       return readPortIdSubtypeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -226,8 +244,11 @@ public class LldpPortInformationTypeNode extends BaseObjectTypeNode
   public void writePortIdSubtype(PortIdSubtype value) throws UaException {
     try {
       writePortIdSubtypeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -257,8 +278,11 @@ public class LldpPortInformationTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getPortIdSubtypeNode() throws UaException {
     try {
       return getPortIdSubtypeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -266,10 +290,7 @@ public class LldpPortInformationTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getPortIdSubtypeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "PortIdSubtype",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "PortIdSubtype", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -289,8 +310,11 @@ public class LldpPortInformationTypeNode extends BaseObjectTypeNode
   public String readPortId() throws UaException {
     try {
       return readPortIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -298,8 +322,11 @@ public class LldpPortInformationTypeNode extends BaseObjectTypeNode
   public void writePortId(String value) throws UaException {
     try {
       writePortIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -321,8 +348,11 @@ public class LldpPortInformationTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getPortIdNode() throws UaException {
     try {
       return getPortIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -330,7 +360,7 @@ public class LldpPortInformationTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getPortIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "PortId", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "PortId", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -350,8 +380,11 @@ public class LldpPortInformationTypeNode extends BaseObjectTypeNode
   public String readPortDescription() throws UaException {
     try {
       return readPortDescriptionAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -359,8 +392,11 @@ public class LldpPortInformationTypeNode extends BaseObjectTypeNode
   public void writePortDescription(String value) throws UaException {
     try {
       writePortDescriptionAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -382,8 +418,11 @@ public class LldpPortInformationTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getPortDescriptionNode() throws UaException {
     try {
       return getPortDescriptionNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -391,10 +430,7 @@ public class LldpPortInformationTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getPortDescriptionNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "PortDescription",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "PortDescription", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -417,8 +453,11 @@ public class LldpPortInformationTypeNode extends BaseObjectTypeNode
   public LldpManagementAddressTxPortType[] readManagementAddressTxPort() throws UaException {
     try {
       return readManagementAddressTxPortAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -427,8 +466,11 @@ public class LldpPortInformationTypeNode extends BaseObjectTypeNode
       throws UaException {
     try {
       writeManagementAddressTxPortAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -454,8 +496,11 @@ public class LldpPortInformationTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getManagementAddressTxPortNode() throws UaException {
     try {
       return getManagementAddressTxPortNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -465,7 +510,7 @@ public class LldpPortInformationTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ManagementAddressTxPort",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -474,8 +519,11 @@ public class LldpPortInformationTypeNode extends BaseObjectTypeNode
   public FolderTypeNode getRemoteSystemsDataNode() throws UaException {
     try {
       return getRemoteSystemsDataNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -485,7 +533,7 @@ public class LldpPortInformationTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "RemoteSystemsData",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (FolderTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/LldpRemoteStatisticsTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/LldpRemoteStatisticsTypeNode.java
@@ -77,8 +77,11 @@ public class LldpRemoteStatisticsTypeNode extends BaseObjectTypeNode
   public UInteger readLastChangeTime() throws UaException {
     try {
       return readLastChangeTimeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class LldpRemoteStatisticsTypeNode extends BaseObjectTypeNode
   public void writeLastChangeTime(UInteger value) throws UaException {
     try {
       writeLastChangeTimeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class LldpRemoteStatisticsTypeNode extends BaseObjectTypeNode
   public BaseDataVariableTypeNode getLastChangeTimeNode() throws UaException {
     try {
       return getLastChangeTimeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -118,10 +127,7 @@ public class LldpRemoteStatisticsTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getLastChangeTimeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "LastChangeTime",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "LastChangeTime", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -141,8 +147,11 @@ public class LldpRemoteStatisticsTypeNode extends BaseObjectTypeNode
   public UInteger readRemoteInserts() throws UaException {
     try {
       return readRemoteInsertsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -150,8 +159,11 @@ public class LldpRemoteStatisticsTypeNode extends BaseObjectTypeNode
   public void writeRemoteInserts(UInteger value) throws UaException {
     try {
       writeRemoteInsertsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -173,8 +185,11 @@ public class LldpRemoteStatisticsTypeNode extends BaseObjectTypeNode
   public BaseDataVariableTypeNode getRemoteInsertsNode() throws UaException {
     try {
       return getRemoteInsertsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -182,10 +197,7 @@ public class LldpRemoteStatisticsTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getRemoteInsertsNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "RemoteInserts",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "RemoteInserts", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -205,8 +217,11 @@ public class LldpRemoteStatisticsTypeNode extends BaseObjectTypeNode
   public UInteger readRemoteDeletes() throws UaException {
     try {
       return readRemoteDeletesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -214,8 +229,11 @@ public class LldpRemoteStatisticsTypeNode extends BaseObjectTypeNode
   public void writeRemoteDeletes(UInteger value) throws UaException {
     try {
       writeRemoteDeletesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -237,8 +255,11 @@ public class LldpRemoteStatisticsTypeNode extends BaseObjectTypeNode
   public BaseDataVariableTypeNode getRemoteDeletesNode() throws UaException {
     try {
       return getRemoteDeletesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -246,10 +267,7 @@ public class LldpRemoteStatisticsTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getRemoteDeletesNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "RemoteDeletes",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "RemoteDeletes", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -269,8 +287,11 @@ public class LldpRemoteStatisticsTypeNode extends BaseObjectTypeNode
   public UInteger readRemoteDrops() throws UaException {
     try {
       return readRemoteDropsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -278,8 +299,11 @@ public class LldpRemoteStatisticsTypeNode extends BaseObjectTypeNode
   public void writeRemoteDrops(UInteger value) throws UaException {
     try {
       writeRemoteDropsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -301,8 +325,11 @@ public class LldpRemoteStatisticsTypeNode extends BaseObjectTypeNode
   public BaseDataVariableTypeNode getRemoteDropsNode() throws UaException {
     try {
       return getRemoteDropsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -310,10 +337,7 @@ public class LldpRemoteStatisticsTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getRemoteDropsNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "RemoteDrops",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "RemoteDrops", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -333,8 +357,11 @@ public class LldpRemoteStatisticsTypeNode extends BaseObjectTypeNode
   public UInteger readRemoteAgeouts() throws UaException {
     try {
       return readRemoteAgeoutsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -342,8 +369,11 @@ public class LldpRemoteStatisticsTypeNode extends BaseObjectTypeNode
   public void writeRemoteAgeouts(UInteger value) throws UaException {
     try {
       writeRemoteAgeoutsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -365,8 +395,11 @@ public class LldpRemoteStatisticsTypeNode extends BaseObjectTypeNode
   public BaseDataVariableTypeNode getRemoteAgeoutsNode() throws UaException {
     try {
       return getRemoteAgeoutsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -374,10 +407,7 @@ public class LldpRemoteStatisticsTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getRemoteAgeoutsNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "RemoteAgeouts",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "RemoteAgeouts", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/LldpRemoteSystemTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/LldpRemoteSystemTypeNode.java
@@ -82,8 +82,11 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public UInteger readTimeMark() throws UaException {
     try {
       return readTimeMarkAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -91,8 +94,11 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public void writeTimeMark(UInteger value) throws UaException {
     try {
       writeTimeMarkAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -114,8 +120,11 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public BaseDataVariableTypeNode getTimeMarkNode() throws UaException {
     try {
       return getTimeMarkNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -123,7 +132,7 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public CompletableFuture<? extends BaseDataVariableTypeNode> getTimeMarkNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "TimeMark", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "TimeMark", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -143,8 +152,11 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public UInteger readRemoteIndex() throws UaException {
     try {
       return readRemoteIndexAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -152,8 +164,11 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public void writeRemoteIndex(UInteger value) throws UaException {
     try {
       writeRemoteIndexAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -175,8 +190,11 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public BaseDataVariableTypeNode getRemoteIndexNode() throws UaException {
     try {
       return getRemoteIndexNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -184,10 +202,7 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public CompletableFuture<? extends BaseDataVariableTypeNode> getRemoteIndexNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "RemoteIndex",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "RemoteIndex", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -215,8 +230,11 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public ChassisIdSubtype readChassisIdSubtype() throws UaException {
     try {
       return readChassisIdSubtypeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -224,8 +242,11 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public void writeChassisIdSubtype(ChassisIdSubtype value) throws UaException {
     try {
       writeChassisIdSubtypeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -256,8 +277,11 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public BaseDataVariableTypeNode getChassisIdSubtypeNode() throws UaException {
     try {
       return getChassisIdSubtypeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -267,7 +291,7 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ChassisIdSubtype",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -288,8 +312,11 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public String readChassisId() throws UaException {
     try {
       return readChassisIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -297,8 +324,11 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public void writeChassisId(String value) throws UaException {
     try {
       writeChassisIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -320,8 +350,11 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public BaseDataVariableTypeNode getChassisIdNode() throws UaException {
     try {
       return getChassisIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -329,7 +362,7 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public CompletableFuture<? extends BaseDataVariableTypeNode> getChassisIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "ChassisId", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "ChassisId", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -357,8 +390,11 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public PortIdSubtype readPortIdSubtype() throws UaException {
     try {
       return readPortIdSubtypeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -366,8 +402,11 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public void writePortIdSubtype(PortIdSubtype value) throws UaException {
     try {
       writePortIdSubtypeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -397,8 +436,11 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public BaseDataVariableTypeNode getPortIdSubtypeNode() throws UaException {
     try {
       return getPortIdSubtypeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -406,10 +448,7 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public CompletableFuture<? extends BaseDataVariableTypeNode> getPortIdSubtypeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "PortIdSubtype",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "PortIdSubtype", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -429,8 +468,11 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public String readPortId() throws UaException {
     try {
       return readPortIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -438,8 +480,11 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public void writePortId(String value) throws UaException {
     try {
       writePortIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -461,8 +506,11 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public BaseDataVariableTypeNode getPortIdNode() throws UaException {
     try {
       return getPortIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -470,7 +518,7 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public CompletableFuture<? extends BaseDataVariableTypeNode> getPortIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "PortId", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "PortId", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -490,8 +538,11 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public String readPortDescription() throws UaException {
     try {
       return readPortDescriptionAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -499,8 +550,11 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public void writePortDescription(String value) throws UaException {
     try {
       writePortDescriptionAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -522,8 +576,11 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public BaseDataVariableTypeNode getPortDescriptionNode() throws UaException {
     try {
       return getPortDescriptionNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -531,10 +588,7 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public CompletableFuture<? extends BaseDataVariableTypeNode> getPortDescriptionNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "PortDescription",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "PortDescription", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -554,8 +608,11 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public String readSystemName() throws UaException {
     try {
       return readSystemNameAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -563,8 +620,11 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public void writeSystemName(String value) throws UaException {
     try {
       writeSystemNameAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -586,8 +646,11 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public BaseDataVariableTypeNode getSystemNameNode() throws UaException {
     try {
       return getSystemNameNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -595,7 +658,7 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public CompletableFuture<? extends BaseDataVariableTypeNode> getSystemNameNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "SystemName", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "SystemName", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -615,8 +678,11 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public String readSystemDescription() throws UaException {
     try {
       return readSystemDescriptionAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -624,8 +690,11 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public void writeSystemDescription(String value) throws UaException {
     try {
       writeSystemDescriptionAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -647,8 +716,11 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public BaseDataVariableTypeNode getSystemDescriptionNode() throws UaException {
     try {
       return getSystemDescriptionNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -658,7 +730,7 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SystemDescription",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -679,8 +751,11 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public LldpSystemCapabilitiesMap readSystemCapabilitiesSupported() throws UaException {
     try {
       return readSystemCapabilitiesSupportedAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -688,8 +763,11 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public void writeSystemCapabilitiesSupported(LldpSystemCapabilitiesMap value) throws UaException {
     try {
       writeSystemCapabilitiesSupportedAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -713,8 +791,11 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public BaseDataVariableTypeNode getSystemCapabilitiesSupportedNode() throws UaException {
     try {
       return getSystemCapabilitiesSupportedNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -725,7 +806,7 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SystemCapabilitiesSupported",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -746,8 +827,11 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public LldpSystemCapabilitiesMap readSystemCapabilitiesEnabled() throws UaException {
     try {
       return readSystemCapabilitiesEnabledAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -755,8 +839,11 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public void writeSystemCapabilitiesEnabled(LldpSystemCapabilitiesMap value) throws UaException {
     try {
       writeSystemCapabilitiesEnabledAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -780,8 +867,11 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public BaseDataVariableTypeNode getSystemCapabilitiesEnabledNode() throws UaException {
     try {
       return getSystemCapabilitiesEnabledNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -792,7 +882,7 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SystemCapabilitiesEnabled",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -813,8 +903,11 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public Boolean readRemoteChanges() throws UaException {
     try {
       return readRemoteChangesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -822,8 +915,11 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public void writeRemoteChanges(Boolean value) throws UaException {
     try {
       writeRemoteChangesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -845,8 +941,11 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public BaseDataVariableTypeNode getRemoteChangesNode() throws UaException {
     try {
       return getRemoteChangesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -854,10 +953,7 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public CompletableFuture<? extends BaseDataVariableTypeNode> getRemoteChangesNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "RemoteChanges",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "RemoteChanges", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -877,8 +973,11 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public Boolean readRemoteTooManyNeighbors() throws UaException {
     try {
       return readRemoteTooManyNeighborsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -886,8 +985,11 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public void writeRemoteTooManyNeighbors(Boolean value) throws UaException {
     try {
       writeRemoteTooManyNeighborsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -910,8 +1012,11 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public BaseDataVariableTypeNode getRemoteTooManyNeighborsNode() throws UaException {
     try {
       return getRemoteTooManyNeighborsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -922,7 +1027,7 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "RemoteTooManyNeighbors",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -945,8 +1050,11 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public LldpManagementAddressType[] readManagementAddress() throws UaException {
     try {
       return readManagementAddressAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -954,8 +1062,11 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public void writeManagementAddress(LldpManagementAddressType[] value) throws UaException {
     try {
       writeManagementAddressAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -980,8 +1091,11 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public BaseDataVariableTypeNode getManagementAddressNode() throws UaException {
     try {
       return getManagementAddressNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -991,7 +1105,7 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ManagementAddress",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -1014,8 +1128,11 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public LldpTlvType[] readRemoteUnknownTlv() throws UaException {
     try {
       return readRemoteUnknownTlvAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1023,8 +1140,11 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public void writeRemoteUnknownTlv(LldpTlvType[] value) throws UaException {
     try {
       writeRemoteUnknownTlvAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1048,8 +1168,11 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   public BaseDataVariableTypeNode getRemoteUnknownTlvNode() throws UaException {
     try {
       return getRemoteUnknownTlvNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1059,7 +1182,7 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "RemoteUnknownTlv",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/NamespaceMetadataTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/NamespaceMetadataTypeNode.java
@@ -79,8 +79,11 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   public String readNamespaceUri() throws UaException {
     try {
       return readNamespaceUriAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -88,8 +91,11 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   public void writeNamespaceUri(String value) throws UaException {
     try {
       writeNamespaceUriAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -111,8 +117,11 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   public PropertyTypeNode getNamespaceUriNode() throws UaException {
     try {
       return getNamespaceUriNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -120,10 +129,7 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   public CompletableFuture<? extends PropertyTypeNode> getNamespaceUriNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "NamespaceUri",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "NamespaceUri", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -143,8 +149,11 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   public String readNamespaceVersion() throws UaException {
     try {
       return readNamespaceVersionAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -152,8 +161,11 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   public void writeNamespaceVersion(String value) throws UaException {
     try {
       writeNamespaceVersionAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -175,8 +187,11 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   public PropertyTypeNode getNamespaceVersionNode() throws UaException {
     try {
       return getNamespaceVersionNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -186,7 +201,7 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "NamespaceVersion",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -207,8 +222,11 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   public DateTime readNamespacePublicationDate() throws UaException {
     try {
       return readNamespacePublicationDateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -216,8 +234,11 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   public void writeNamespacePublicationDate(DateTime value) throws UaException {
     try {
       writeNamespacePublicationDateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -240,8 +261,11 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   public PropertyTypeNode getNamespacePublicationDateNode() throws UaException {
     try {
       return getNamespacePublicationDateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -251,7 +275,7 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "NamespacePublicationDate",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -272,8 +296,11 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   public Boolean readIsNamespaceSubset() throws UaException {
     try {
       return readIsNamespaceSubsetAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -281,8 +308,11 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   public void writeIsNamespaceSubset(Boolean value) throws UaException {
     try {
       writeIsNamespaceSubsetAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -304,8 +334,11 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   public PropertyTypeNode getIsNamespaceSubsetNode() throws UaException {
     try {
       return getIsNamespaceSubsetNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -315,7 +348,7 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "IsNamespaceSubset",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -349,8 +382,11 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   public IdType[] readStaticNodeIdTypes() throws UaException {
     try {
       return readStaticNodeIdTypesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -358,8 +394,11 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   public void writeStaticNodeIdTypes(IdType[] value) throws UaException {
     try {
       writeStaticNodeIdTypesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -396,8 +435,11 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   public PropertyTypeNode getStaticNodeIdTypesNode() throws UaException {
     try {
       return getStaticNodeIdTypesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -407,7 +449,7 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "StaticNodeIdTypes",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -428,8 +470,11 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   public String[] readStaticNumericNodeIdRange() throws UaException {
     try {
       return readStaticNumericNodeIdRangeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -437,8 +482,11 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   public void writeStaticNumericNodeIdRange(String[] value) throws UaException {
     try {
       writeStaticNumericNodeIdRangeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -461,8 +509,11 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   public PropertyTypeNode getStaticNumericNodeIdRangeNode() throws UaException {
     try {
       return getStaticNumericNodeIdRangeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -472,7 +523,7 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "StaticNumericNodeIdRange",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -493,8 +544,11 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   public String readStaticStringNodeIdPattern() throws UaException {
     try {
       return readStaticStringNodeIdPatternAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -502,8 +556,11 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   public void writeStaticStringNodeIdPattern(String value) throws UaException {
     try {
       writeStaticStringNodeIdPatternAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -526,8 +583,11 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   public PropertyTypeNode getStaticStringNodeIdPatternNode() throws UaException {
     try {
       return getStaticStringNodeIdPatternNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -537,7 +597,7 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "StaticStringNodeIdPattern",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -560,8 +620,11 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   public RolePermissionType[] readDefaultRolePermissions() throws UaException {
     try {
       return readDefaultRolePermissionsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -569,8 +632,11 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   public void writeDefaultRolePermissions(RolePermissionType[] value) throws UaException {
     try {
       writeDefaultRolePermissionsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -595,8 +661,11 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   public PropertyTypeNode getDefaultRolePermissionsNode() throws UaException {
     try {
       return getDefaultRolePermissionsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -606,7 +675,7 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "DefaultRolePermissions",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -629,8 +698,11 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   public RolePermissionType[] readDefaultUserRolePermissions() throws UaException {
     try {
       return readDefaultUserRolePermissionsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -638,8 +710,11 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   public void writeDefaultUserRolePermissions(RolePermissionType[] value) throws UaException {
     try {
       writeDefaultUserRolePermissionsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -664,8 +739,11 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   public PropertyTypeNode getDefaultUserRolePermissionsNode() throws UaException {
     try {
       return getDefaultUserRolePermissionsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -675,7 +753,7 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "DefaultUserRolePermissions",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -696,8 +774,11 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   public AccessRestrictionType readDefaultAccessRestrictions() throws UaException {
     try {
       return readDefaultAccessRestrictionsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -705,8 +786,11 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   public void writeDefaultAccessRestrictions(AccessRestrictionType value) throws UaException {
     try {
       writeDefaultAccessRestrictionsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -729,8 +813,11 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   public PropertyTypeNode getDefaultAccessRestrictionsNode() throws UaException {
     try {
       return getDefaultAccessRestrictionsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -740,7 +827,7 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "DefaultAccessRestrictions",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -761,8 +848,11 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   public UInteger readConfigurationVersion() throws UaException {
     try {
       return readConfigurationVersionAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -770,8 +860,11 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   public void writeConfigurationVersion(UInteger value) throws UaException {
     try {
       writeConfigurationVersionAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -794,8 +887,11 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   public PropertyTypeNode getConfigurationVersionNode() throws UaException {
     try {
       return getConfigurationVersionNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -805,7 +901,7 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ConfigurationVersion",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -826,8 +922,11 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   public String readModelVersion() throws UaException {
     try {
       return readModelVersionAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -835,8 +934,11 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   public void writeModelVersion(String value) throws UaException {
     try {
       writeModelVersionAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -858,8 +960,11 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   public PropertyTypeNode getModelVersionNode() throws UaException {
     try {
       return getModelVersionNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -867,10 +972,7 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   public CompletableFuture<? extends PropertyTypeNode> getModelVersionNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ModelVersion",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "ModelVersion", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -878,8 +980,11 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   public AddressSpaceFileTypeNode getNamespaceFileNode() throws UaException {
     try {
       return getNamespaceFileNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -887,10 +992,7 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   public CompletableFuture<? extends AddressSpaceFileTypeNode> getNamespaceFileNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "NamespaceFile",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "NamespaceFile", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (AddressSpaceFileTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/NetworkAddressTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/NetworkAddressTypeNode.java
@@ -76,8 +76,11 @@ public class NetworkAddressTypeNode extends BaseObjectTypeNode implements Networ
   public String readNetworkInterface() throws UaException {
     try {
       return readNetworkInterfaceAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -85,8 +88,11 @@ public class NetworkAddressTypeNode extends BaseObjectTypeNode implements Networ
   public void writeNetworkInterface(String value) throws UaException {
     try {
       writeNetworkInterfaceAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -108,8 +114,11 @@ public class NetworkAddressTypeNode extends BaseObjectTypeNode implements Networ
   public SelectionListTypeNode getNetworkInterfaceNode() throws UaException {
     try {
       return getNetworkInterfaceNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -119,7 +128,7 @@ public class NetworkAddressTypeNode extends BaseObjectTypeNode implements Networ
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "NetworkInterface",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (SelectionListTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/NetworkAddressUrlTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/NetworkAddressUrlTypeNode.java
@@ -77,8 +77,11 @@ public class NetworkAddressUrlTypeNode extends NetworkAddressTypeNode
   public String readUrl() throws UaException {
     try {
       return readUrlAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class NetworkAddressUrlTypeNode extends NetworkAddressTypeNode
   public void writeUrl(String value) throws UaException {
     try {
       writeUrlAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class NetworkAddressUrlTypeNode extends NetworkAddressTypeNode
   public BaseDataVariableTypeNode getUrlNode() throws UaException {
     try {
       return getUrlNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -118,7 +127,7 @@ public class NetworkAddressUrlTypeNode extends NetworkAddressTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getUrlNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Url", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "Url", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/NonExclusiveDeviationAlarmTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/NonExclusiveDeviationAlarmTypeNode.java
@@ -77,8 +77,11 @@ public class NonExclusiveDeviationAlarmTypeNode extends NonExclusiveLimitAlarmTy
   public NodeId readSetpointNode() throws UaException {
     try {
       return readSetpointNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class NonExclusiveDeviationAlarmTypeNode extends NonExclusiveLimitAlarmTy
   public void writeSetpointNode(NodeId value) throws UaException {
     try {
       writeSetpointNodeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class NonExclusiveDeviationAlarmTypeNode extends NonExclusiveLimitAlarmTy
   public PropertyTypeNode getSetpointNodeNode() throws UaException {
     try {
       return getSetpointNodeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -118,10 +127,7 @@ public class NonExclusiveDeviationAlarmTypeNode extends NonExclusiveLimitAlarmTy
   public CompletableFuture<? extends PropertyTypeNode> getSetpointNodeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "SetpointNode",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "SetpointNode", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -141,8 +147,11 @@ public class NonExclusiveDeviationAlarmTypeNode extends NonExclusiveLimitAlarmTy
   public NodeId readBaseSetpointNode() throws UaException {
     try {
       return readBaseSetpointNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -150,8 +159,11 @@ public class NonExclusiveDeviationAlarmTypeNode extends NonExclusiveLimitAlarmTy
   public void writeBaseSetpointNode(NodeId value) throws UaException {
     try {
       writeBaseSetpointNodeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -173,8 +185,11 @@ public class NonExclusiveDeviationAlarmTypeNode extends NonExclusiveLimitAlarmTy
   public PropertyTypeNode getBaseSetpointNodeNode() throws UaException {
     try {
       return getBaseSetpointNodeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -184,7 +199,7 @@ public class NonExclusiveDeviationAlarmTypeNode extends NonExclusiveLimitAlarmTy
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "BaseSetpointNode",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/NonExclusiveLimitAlarmTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/NonExclusiveLimitAlarmTypeNode.java
@@ -77,8 +77,11 @@ public class NonExclusiveLimitAlarmTypeNode extends LimitAlarmTypeNode
   public LocalizedText readActiveState() throws UaException {
     try {
       return readActiveStateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class NonExclusiveLimitAlarmTypeNode extends LimitAlarmTypeNode
   public void writeActiveState(LocalizedText value) throws UaException {
     try {
       writeActiveStateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class NonExclusiveLimitAlarmTypeNode extends LimitAlarmTypeNode
   public TwoStateVariableTypeNode getActiveStateNode() throws UaException {
     try {
       return getActiveStateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -118,10 +127,7 @@ public class NonExclusiveLimitAlarmTypeNode extends LimitAlarmTypeNode
   public CompletableFuture<? extends TwoStateVariableTypeNode> getActiveStateNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ActiveState",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "ActiveState", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (TwoStateVariableTypeNode) node);
   }
 
@@ -141,8 +147,11 @@ public class NonExclusiveLimitAlarmTypeNode extends LimitAlarmTypeNode
   public LocalizedText readHighHighState() throws UaException {
     try {
       return readHighHighStateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -150,8 +159,11 @@ public class NonExclusiveLimitAlarmTypeNode extends LimitAlarmTypeNode
   public void writeHighHighState(LocalizedText value) throws UaException {
     try {
       writeHighHighStateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -173,8 +185,11 @@ public class NonExclusiveLimitAlarmTypeNode extends LimitAlarmTypeNode
   public TwoStateVariableTypeNode getHighHighStateNode() throws UaException {
     try {
       return getHighHighStateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -182,10 +197,7 @@ public class NonExclusiveLimitAlarmTypeNode extends LimitAlarmTypeNode
   public CompletableFuture<? extends TwoStateVariableTypeNode> getHighHighStateNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "HighHighState",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "HighHighState", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (TwoStateVariableTypeNode) node);
   }
 
@@ -205,8 +217,11 @@ public class NonExclusiveLimitAlarmTypeNode extends LimitAlarmTypeNode
   public LocalizedText readHighState() throws UaException {
     try {
       return readHighStateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -214,8 +229,11 @@ public class NonExclusiveLimitAlarmTypeNode extends LimitAlarmTypeNode
   public void writeHighState(LocalizedText value) throws UaException {
     try {
       writeHighStateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -237,8 +255,11 @@ public class NonExclusiveLimitAlarmTypeNode extends LimitAlarmTypeNode
   public TwoStateVariableTypeNode getHighStateNode() throws UaException {
     try {
       return getHighStateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -246,7 +267,7 @@ public class NonExclusiveLimitAlarmTypeNode extends LimitAlarmTypeNode
   public CompletableFuture<? extends TwoStateVariableTypeNode> getHighStateNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "HighState", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "HighState", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (TwoStateVariableTypeNode) node);
   }
 
@@ -266,8 +287,11 @@ public class NonExclusiveLimitAlarmTypeNode extends LimitAlarmTypeNode
   public LocalizedText readLowState() throws UaException {
     try {
       return readLowStateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -275,8 +299,11 @@ public class NonExclusiveLimitAlarmTypeNode extends LimitAlarmTypeNode
   public void writeLowState(LocalizedText value) throws UaException {
     try {
       writeLowStateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -298,8 +325,11 @@ public class NonExclusiveLimitAlarmTypeNode extends LimitAlarmTypeNode
   public TwoStateVariableTypeNode getLowStateNode() throws UaException {
     try {
       return getLowStateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -307,7 +337,7 @@ public class NonExclusiveLimitAlarmTypeNode extends LimitAlarmTypeNode
   public CompletableFuture<? extends TwoStateVariableTypeNode> getLowStateNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "LowState", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "LowState", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (TwoStateVariableTypeNode) node);
   }
 
@@ -327,8 +357,11 @@ public class NonExclusiveLimitAlarmTypeNode extends LimitAlarmTypeNode
   public LocalizedText readLowLowState() throws UaException {
     try {
       return readLowLowStateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -336,8 +369,11 @@ public class NonExclusiveLimitAlarmTypeNode extends LimitAlarmTypeNode
   public void writeLowLowState(LocalizedText value) throws UaException {
     try {
       writeLowLowStateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -359,8 +395,11 @@ public class NonExclusiveLimitAlarmTypeNode extends LimitAlarmTypeNode
   public TwoStateVariableTypeNode getLowLowStateNode() throws UaException {
     try {
       return getLowLowStateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -368,10 +407,7 @@ public class NonExclusiveLimitAlarmTypeNode extends LimitAlarmTypeNode
   public CompletableFuture<? extends TwoStateVariableTypeNode> getLowLowStateNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "LowLowState",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "LowLowState", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (TwoStateVariableTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/NonExclusiveRateOfChangeAlarmTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/NonExclusiveRateOfChangeAlarmTypeNode.java
@@ -80,8 +80,11 @@ public class NonExclusiveRateOfChangeAlarmTypeNode extends NonExclusiveLimitAlar
   public EUInformation readEngineeringUnits() throws UaException {
     try {
       return readEngineeringUnitsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -89,8 +92,11 @@ public class NonExclusiveRateOfChangeAlarmTypeNode extends NonExclusiveLimitAlar
   public void writeEngineeringUnits(EUInformation value) throws UaException {
     try {
       writeEngineeringUnitsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -114,8 +120,11 @@ public class NonExclusiveRateOfChangeAlarmTypeNode extends NonExclusiveLimitAlar
   public PropertyTypeNode getEngineeringUnitsNode() throws UaException {
     try {
       return getEngineeringUnitsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -125,7 +134,7 @@ public class NonExclusiveRateOfChangeAlarmTypeNode extends NonExclusiveLimitAlar
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "EngineeringUnits",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/NonTransparentBackupRedundancyTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/NonTransparentBackupRedundancyTypeNode.java
@@ -82,8 +82,11 @@ public class NonTransparentBackupRedundancyTypeNode extends NonTransparentRedund
   public RedundantServerDataType[] readRedundantServerArray() throws UaException {
     try {
       return readRedundantServerArrayAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -91,8 +94,11 @@ public class NonTransparentBackupRedundancyTypeNode extends NonTransparentRedund
   public void writeRedundantServerArray(RedundantServerDataType[] value) throws UaException {
     try {
       writeRedundantServerArrayAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -117,8 +123,11 @@ public class NonTransparentBackupRedundancyTypeNode extends NonTransparentRedund
   public PropertyTypeNode getRedundantServerArrayNode() throws UaException {
     try {
       return getRedundantServerArrayNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -128,7 +137,7 @@ public class NonTransparentBackupRedundancyTypeNode extends NonTransparentRedund
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "RedundantServerArray",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -157,8 +166,11 @@ public class NonTransparentBackupRedundancyTypeNode extends NonTransparentRedund
   public RedundantServerMode readMode() throws UaException {
     try {
       return readModeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -166,8 +178,11 @@ public class NonTransparentBackupRedundancyTypeNode extends NonTransparentRedund
   public void writeMode(RedundantServerMode value) throws UaException {
     try {
       writeModeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -197,8 +212,11 @@ public class NonTransparentBackupRedundancyTypeNode extends NonTransparentRedund
   public PropertyTypeNode getModeNode() throws UaException {
     try {
       return getModeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -206,7 +224,7 @@ public class NonTransparentBackupRedundancyTypeNode extends NonTransparentRedund
   public CompletableFuture<? extends PropertyTypeNode> getModeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Mode", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Mode", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/NonTransparentNetworkRedundancyTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/NonTransparentNetworkRedundancyTypeNode.java
@@ -81,8 +81,11 @@ public class NonTransparentNetworkRedundancyTypeNode extends NonTransparentRedun
   public NetworkGroupDataType[] readServerNetworkGroups() throws UaException {
     try {
       return readServerNetworkGroupsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -90,8 +93,11 @@ public class NonTransparentNetworkRedundancyTypeNode extends NonTransparentRedun
   public void writeServerNetworkGroups(NetworkGroupDataType[] value) throws UaException {
     try {
       writeServerNetworkGroupsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -116,8 +122,11 @@ public class NonTransparentNetworkRedundancyTypeNode extends NonTransparentRedun
   public PropertyTypeNode getServerNetworkGroupsNode() throws UaException {
     try {
       return getServerNetworkGroupsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -127,7 +136,7 @@ public class NonTransparentNetworkRedundancyTypeNode extends NonTransparentRedun
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ServerNetworkGroups",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/NonTransparentRedundancyTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/NonTransparentRedundancyTypeNode.java
@@ -77,8 +77,11 @@ public class NonTransparentRedundancyTypeNode extends ServerRedundancyTypeNode
   public String[] readServerUriArray() throws UaException {
     try {
       return readServerUriArrayAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class NonTransparentRedundancyTypeNode extends ServerRedundancyTypeNode
   public void writeServerUriArray(String[] value) throws UaException {
     try {
       writeServerUriArrayAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class NonTransparentRedundancyTypeNode extends ServerRedundancyTypeNode
   public PropertyTypeNode getServerUriArrayNode() throws UaException {
     try {
       return getServerUriArrayNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -118,10 +127,7 @@ public class NonTransparentRedundancyTypeNode extends ServerRedundancyTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getServerUriArrayNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ServerUriArray",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "ServerUriArray", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/OffNormalAlarmTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/OffNormalAlarmTypeNode.java
@@ -76,8 +76,11 @@ public class OffNormalAlarmTypeNode extends DiscreteAlarmTypeNode implements Off
   public NodeId readNormalState() throws UaException {
     try {
       return readNormalStateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -85,8 +88,11 @@ public class OffNormalAlarmTypeNode extends DiscreteAlarmTypeNode implements Off
   public void writeNormalState(NodeId value) throws UaException {
     try {
       writeNormalStateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -108,8 +114,11 @@ public class OffNormalAlarmTypeNode extends DiscreteAlarmTypeNode implements Off
   public PropertyTypeNode getNormalStateNode() throws UaException {
     try {
       return getNormalStateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -117,10 +126,7 @@ public class OffNormalAlarmTypeNode extends DiscreteAlarmTypeNode implements Off
   public CompletableFuture<? extends PropertyTypeNode> getNormalStateNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "NormalState",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "NormalState", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/OperationLimitsTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/OperationLimitsTypeNode.java
@@ -76,8 +76,11 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   public UInteger readMaxNodesPerRead() throws UaException {
     try {
       return readMaxNodesPerReadAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -85,8 +88,11 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   public void writeMaxNodesPerRead(UInteger value) throws UaException {
     try {
       writeMaxNodesPerReadAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -108,8 +114,11 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   public PropertyTypeNode getMaxNodesPerReadNode() throws UaException {
     try {
       return getMaxNodesPerReadNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -117,10 +126,7 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   public CompletableFuture<? extends PropertyTypeNode> getMaxNodesPerReadNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "MaxNodesPerRead",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "MaxNodesPerRead", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -140,8 +146,11 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   public UInteger readMaxNodesPerHistoryReadData() throws UaException {
     try {
       return readMaxNodesPerHistoryReadDataAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -149,8 +158,11 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   public void writeMaxNodesPerHistoryReadData(UInteger value) throws UaException {
     try {
       writeMaxNodesPerHistoryReadDataAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -173,8 +185,11 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   public PropertyTypeNode getMaxNodesPerHistoryReadDataNode() throws UaException {
     try {
       return getMaxNodesPerHistoryReadDataNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -184,7 +199,7 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaxNodesPerHistoryReadData",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -205,8 +220,11 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   public UInteger readMaxNodesPerHistoryReadEvents() throws UaException {
     try {
       return readMaxNodesPerHistoryReadEventsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -214,8 +232,11 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   public void writeMaxNodesPerHistoryReadEvents(UInteger value) throws UaException {
     try {
       writeMaxNodesPerHistoryReadEventsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -238,8 +259,11 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   public PropertyTypeNode getMaxNodesPerHistoryReadEventsNode() throws UaException {
     try {
       return getMaxNodesPerHistoryReadEventsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -249,7 +273,7 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaxNodesPerHistoryReadEvents",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -270,8 +294,11 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   public UInteger readMaxNodesPerWrite() throws UaException {
     try {
       return readMaxNodesPerWriteAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -279,8 +306,11 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   public void writeMaxNodesPerWrite(UInteger value) throws UaException {
     try {
       writeMaxNodesPerWriteAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -302,8 +332,11 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   public PropertyTypeNode getMaxNodesPerWriteNode() throws UaException {
     try {
       return getMaxNodesPerWriteNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -313,7 +346,7 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaxNodesPerWrite",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -334,8 +367,11 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   public UInteger readMaxNodesPerHistoryUpdateData() throws UaException {
     try {
       return readMaxNodesPerHistoryUpdateDataAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -343,8 +379,11 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   public void writeMaxNodesPerHistoryUpdateData(UInteger value) throws UaException {
     try {
       writeMaxNodesPerHistoryUpdateDataAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -367,8 +406,11 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   public PropertyTypeNode getMaxNodesPerHistoryUpdateDataNode() throws UaException {
     try {
       return getMaxNodesPerHistoryUpdateDataNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -378,7 +420,7 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaxNodesPerHistoryUpdateData",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -399,8 +441,11 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   public UInteger readMaxNodesPerHistoryUpdateEvents() throws UaException {
     try {
       return readMaxNodesPerHistoryUpdateEventsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -408,8 +453,11 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   public void writeMaxNodesPerHistoryUpdateEvents(UInteger value) throws UaException {
     try {
       writeMaxNodesPerHistoryUpdateEventsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -432,8 +480,11 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   public PropertyTypeNode getMaxNodesPerHistoryUpdateEventsNode() throws UaException {
     try {
       return getMaxNodesPerHistoryUpdateEventsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -444,7 +495,7 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaxNodesPerHistoryUpdateEvents",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -465,8 +516,11 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   public UInteger readMaxNodesPerMethodCall() throws UaException {
     try {
       return readMaxNodesPerMethodCallAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -474,8 +528,11 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   public void writeMaxNodesPerMethodCall(UInteger value) throws UaException {
     try {
       writeMaxNodesPerMethodCallAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -498,8 +555,11 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   public PropertyTypeNode getMaxNodesPerMethodCallNode() throws UaException {
     try {
       return getMaxNodesPerMethodCallNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -509,7 +569,7 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaxNodesPerMethodCall",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -530,8 +590,11 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   public UInteger readMaxNodesPerBrowse() throws UaException {
     try {
       return readMaxNodesPerBrowseAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -539,8 +602,11 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   public void writeMaxNodesPerBrowse(UInteger value) throws UaException {
     try {
       writeMaxNodesPerBrowseAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -562,8 +628,11 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   public PropertyTypeNode getMaxNodesPerBrowseNode() throws UaException {
     try {
       return getMaxNodesPerBrowseNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -573,7 +642,7 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaxNodesPerBrowse",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -594,8 +663,11 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   public UInteger readMaxNodesPerRegisterNodes() throws UaException {
     try {
       return readMaxNodesPerRegisterNodesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -603,8 +675,11 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   public void writeMaxNodesPerRegisterNodes(UInteger value) throws UaException {
     try {
       writeMaxNodesPerRegisterNodesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -627,8 +702,11 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   public PropertyTypeNode getMaxNodesPerRegisterNodesNode() throws UaException {
     try {
       return getMaxNodesPerRegisterNodesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -638,7 +716,7 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaxNodesPerRegisterNodes",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -659,8 +737,11 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   public UInteger readMaxNodesPerTranslateBrowsePathsToNodeIds() throws UaException {
     try {
       return readMaxNodesPerTranslateBrowsePathsToNodeIdsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -668,8 +749,11 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   public void writeMaxNodesPerTranslateBrowsePathsToNodeIds(UInteger value) throws UaException {
     try {
       writeMaxNodesPerTranslateBrowsePathsToNodeIdsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -692,8 +776,11 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   public PropertyTypeNode getMaxNodesPerTranslateBrowsePathsToNodeIdsNode() throws UaException {
     try {
       return getMaxNodesPerTranslateBrowsePathsToNodeIdsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -704,7 +791,7 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaxNodesPerTranslateBrowsePathsToNodeIds",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -725,8 +812,11 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   public UInteger readMaxNodesPerNodeManagement() throws UaException {
     try {
       return readMaxNodesPerNodeManagementAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -734,8 +824,11 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   public void writeMaxNodesPerNodeManagement(UInteger value) throws UaException {
     try {
       writeMaxNodesPerNodeManagementAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -758,8 +851,11 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   public PropertyTypeNode getMaxNodesPerNodeManagementNode() throws UaException {
     try {
       return getMaxNodesPerNodeManagementNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -769,7 +865,7 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaxNodesPerNodeManagement",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -790,8 +886,11 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   public UInteger readMaxMonitoredItemsPerCall() throws UaException {
     try {
       return readMaxMonitoredItemsPerCallAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -799,8 +898,11 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   public void writeMaxMonitoredItemsPerCall(UInteger value) throws UaException {
     try {
       writeMaxMonitoredItemsPerCallAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -823,8 +925,11 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   public PropertyTypeNode getMaxMonitoredItemsPerCallNode() throws UaException {
     try {
       return getMaxMonitoredItemsPerCallNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -834,7 +939,7 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaxMonitoredItemsPerCall",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/OrderedListTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/OrderedListTypeNode.java
@@ -76,8 +76,11 @@ public class OrderedListTypeNode extends BaseObjectTypeNode implements OrderedLi
   public String readNodeVersion() throws UaException {
     try {
       return readNodeVersionAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -85,8 +88,11 @@ public class OrderedListTypeNode extends BaseObjectTypeNode implements OrderedLi
   public void writeNodeVersion(String value) throws UaException {
     try {
       writeNodeVersionAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -108,8 +114,11 @@ public class OrderedListTypeNode extends BaseObjectTypeNode implements OrderedLi
   public PropertyTypeNode getNodeVersionNode() throws UaException {
     try {
       return getNodeVersionNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -117,10 +126,7 @@ public class OrderedListTypeNode extends BaseObjectTypeNode implements OrderedLi
   public CompletableFuture<? extends PropertyTypeNode> getNodeVersionNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "NodeVersion",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "NodeVersion", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PriorityMappingTableTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PriorityMappingTableTypeNode.java
@@ -81,8 +81,11 @@ public class PriorityMappingTableTypeNode extends BaseObjectTypeNode
   public PriorityMappingEntryType[] readPriorityMapppingEntries() throws UaException {
     try {
       return readPriorityMapppingEntriesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -90,8 +93,11 @@ public class PriorityMappingTableTypeNode extends BaseObjectTypeNode
   public void writePriorityMapppingEntries(PriorityMappingEntryType[] value) throws UaException {
     try {
       writePriorityMapppingEntriesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -117,8 +123,11 @@ public class PriorityMappingTableTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getPriorityMapppingEntriesNode() throws UaException {
     try {
       return getPriorityMapppingEntriesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -128,7 +137,7 @@ public class PriorityMappingTableTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "PriorityMapppingEntries",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ProgramStateMachineTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ProgramStateMachineTypeNode.java
@@ -82,8 +82,11 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public Boolean readCreatable() throws UaException {
     try {
       return readCreatableAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -91,8 +94,11 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public void writeCreatable(Boolean value) throws UaException {
     try {
       writeCreatableAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -114,8 +120,11 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public PropertyTypeNode getCreatableNode() throws UaException {
     try {
       return getCreatableNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -123,7 +132,7 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getCreatableNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Creatable", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Creatable", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -143,8 +152,11 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public Boolean readDeletable() throws UaException {
     try {
       return readDeletableAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -152,8 +164,11 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public void writeDeletable(Boolean value) throws UaException {
     try {
       writeDeletableAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -175,8 +190,11 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public PropertyTypeNode getDeletableNode() throws UaException {
     try {
       return getDeletableNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -184,7 +202,7 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getDeletableNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Deletable", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Deletable", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -204,8 +222,11 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public Boolean readAutoDelete() throws UaException {
     try {
       return readAutoDeleteAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -213,8 +234,11 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public void writeAutoDelete(Boolean value) throws UaException {
     try {
       writeAutoDeleteAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -236,8 +260,11 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public PropertyTypeNode getAutoDeleteNode() throws UaException {
     try {
       return getAutoDeleteNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -245,7 +272,7 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getAutoDeleteNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "AutoDelete", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "AutoDelete", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -265,8 +292,11 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public Integer readRecycleCount() throws UaException {
     try {
       return readRecycleCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -274,8 +304,11 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public void writeRecycleCount(Integer value) throws UaException {
     try {
       writeRecycleCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -297,8 +330,11 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public PropertyTypeNode getRecycleCountNode() throws UaException {
     try {
       return getRecycleCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -306,10 +342,7 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getRecycleCountNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "RecycleCount",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "RecycleCount", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -329,8 +362,11 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public UInteger readInstanceCount() throws UaException {
     try {
       return readInstanceCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -338,8 +374,11 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public void writeInstanceCount(UInteger value) throws UaException {
     try {
       writeInstanceCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -361,8 +400,11 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public PropertyTypeNode getInstanceCountNode() throws UaException {
     try {
       return getInstanceCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -370,10 +412,7 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getInstanceCountNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "InstanceCount",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "InstanceCount", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -393,8 +432,11 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public UInteger readMaxInstanceCount() throws UaException {
     try {
       return readMaxInstanceCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -402,8 +444,11 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public void writeMaxInstanceCount(UInteger value) throws UaException {
     try {
       writeMaxInstanceCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -425,8 +470,11 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public PropertyTypeNode getMaxInstanceCountNode() throws UaException {
     try {
       return getMaxInstanceCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -436,7 +484,7 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaxInstanceCount",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -457,8 +505,11 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public UInteger readMaxRecycleCount() throws UaException {
     try {
       return readMaxRecycleCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -466,8 +517,11 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public void writeMaxRecycleCount(UInteger value) throws UaException {
     try {
       writeMaxRecycleCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -489,8 +543,11 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public PropertyTypeNode getMaxRecycleCountNode() throws UaException {
     try {
       return getMaxRecycleCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -498,10 +555,7 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getMaxRecycleCountNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "MaxRecycleCount",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "MaxRecycleCount", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -521,8 +575,11 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public LocalizedText readCurrentState() throws UaException {
     try {
       return readCurrentStateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -530,8 +587,11 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public void writeCurrentState(LocalizedText value) throws UaException {
     try {
       writeCurrentStateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -553,8 +613,11 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public FiniteStateVariableTypeNode getCurrentStateNode() throws UaException {
     try {
       return getCurrentStateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -562,10 +625,7 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public CompletableFuture<? extends FiniteStateVariableTypeNode> getCurrentStateNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "CurrentState",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "CurrentState", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (FiniteStateVariableTypeNode) node);
   }
 
@@ -585,8 +645,11 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public LocalizedText readLastTransition() throws UaException {
     try {
       return readLastTransitionAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -594,8 +657,11 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public void writeLastTransition(LocalizedText value) throws UaException {
     try {
       writeLastTransitionAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -617,8 +683,11 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public FiniteTransitionVariableTypeNode getLastTransitionNode() throws UaException {
     try {
       return getLastTransitionNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -627,10 +696,7 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
       getLastTransitionNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "LastTransition",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "LastTransition", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (FiniteTransitionVariableTypeNode) node);
   }
 
@@ -651,8 +717,11 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public ProgramDiagnostic2DataType readProgramDiagnostic() throws UaException {
     try {
       return readProgramDiagnosticAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -660,8 +729,11 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public void writeProgramDiagnostic(ProgramDiagnostic2DataType value) throws UaException {
     try {
       writeProgramDiagnosticAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -686,8 +758,11 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public ProgramDiagnostic2TypeNode getProgramDiagnosticNode() throws UaException {
     try {
       return getProgramDiagnosticNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -697,7 +772,7 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ProgramDiagnostic",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (ProgramDiagnostic2TypeNode) node);
   }
@@ -706,8 +781,11 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public BaseObjectTypeNode getFinalResultDataNode() throws UaException {
     try {
       return getFinalResultDataNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -715,10 +793,7 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public CompletableFuture<? extends BaseObjectTypeNode> getFinalResultDataNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "FinalResultData",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "FinalResultData", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseObjectTypeNode) node);
   }
 
@@ -726,8 +801,11 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public StateTypeNode getHaltedNode() throws UaException {
     try {
       return getHaltedNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -735,7 +813,7 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public CompletableFuture<? extends StateTypeNode> getHaltedNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Halted", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "Halted", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (StateTypeNode) node);
   }
 
@@ -743,8 +821,11 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public StateTypeNode getReadyNode() throws UaException {
     try {
       return getReadyNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -752,7 +833,7 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public CompletableFuture<? extends StateTypeNode> getReadyNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Ready", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "Ready", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (StateTypeNode) node);
   }
 
@@ -760,8 +841,11 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public StateTypeNode getRunningNode() throws UaException {
     try {
       return getRunningNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -769,7 +853,7 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public CompletableFuture<? extends StateTypeNode> getRunningNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Running", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "Running", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (StateTypeNode) node);
   }
 
@@ -777,8 +861,11 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public StateTypeNode getSuspendedNode() throws UaException {
     try {
       return getSuspendedNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -786,7 +873,7 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public CompletableFuture<? extends StateTypeNode> getSuspendedNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Suspended", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "Suspended", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (StateTypeNode) node);
   }
 
@@ -794,8 +881,11 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public TransitionTypeNode getHaltedToReadyNode() throws UaException {
     try {
       return getHaltedToReadyNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -803,10 +893,7 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public CompletableFuture<? extends TransitionTypeNode> getHaltedToReadyNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "HaltedToReady",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "HaltedToReady", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (TransitionTypeNode) node);
   }
 
@@ -814,8 +901,11 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public TransitionTypeNode getReadyToRunningNode() throws UaException {
     try {
       return getReadyToRunningNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -823,10 +913,7 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public CompletableFuture<? extends TransitionTypeNode> getReadyToRunningNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ReadyToRunning",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "ReadyToRunning", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (TransitionTypeNode) node);
   }
 
@@ -834,8 +921,11 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public TransitionTypeNode getRunningToHaltedNode() throws UaException {
     try {
       return getRunningToHaltedNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -843,10 +933,7 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public CompletableFuture<? extends TransitionTypeNode> getRunningToHaltedNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "RunningToHalted",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "RunningToHalted", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (TransitionTypeNode) node);
   }
 
@@ -854,8 +941,11 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public TransitionTypeNode getRunningToReadyNode() throws UaException {
     try {
       return getRunningToReadyNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -863,10 +953,7 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public CompletableFuture<? extends TransitionTypeNode> getRunningToReadyNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "RunningToReady",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "RunningToReady", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (TransitionTypeNode) node);
   }
 
@@ -874,8 +961,11 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public TransitionTypeNode getRunningToSuspendedNode() throws UaException {
     try {
       return getRunningToSuspendedNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -885,7 +975,7 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "RunningToSuspended",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (TransitionTypeNode) node);
   }
@@ -894,8 +984,11 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public TransitionTypeNode getSuspendedToRunningNode() throws UaException {
     try {
       return getSuspendedToRunningNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -905,7 +998,7 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SuspendedToRunning",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (TransitionTypeNode) node);
   }
@@ -914,8 +1007,11 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public TransitionTypeNode getSuspendedToHaltedNode() throws UaException {
     try {
       return getSuspendedToHaltedNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -925,7 +1021,7 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SuspendedToHalted",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (TransitionTypeNode) node);
   }
@@ -934,8 +1030,11 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public TransitionTypeNode getSuspendedToReadyNode() throws UaException {
     try {
       return getSuspendedToReadyNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -945,7 +1044,7 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SuspendedToReady",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (TransitionTypeNode) node);
   }
@@ -954,8 +1053,11 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public TransitionTypeNode getReadyToHaltedNode() throws UaException {
     try {
       return getReadyToHaltedNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -963,10 +1065,7 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   public CompletableFuture<? extends TransitionTypeNode> getReadyToHaltedNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ReadyToHalted",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "ReadyToHalted", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (TransitionTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ProgramTransitionAuditEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ProgramTransitionAuditEventTypeNode.java
@@ -77,8 +77,11 @@ public class ProgramTransitionAuditEventTypeNode extends AuditUpdateStateEventTy
   public LocalizedText readTransition() throws UaException {
     try {
       return readTransitionAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class ProgramTransitionAuditEventTypeNode extends AuditUpdateStateEventTy
   public void writeTransition(LocalizedText value) throws UaException {
     try {
       writeTransitionAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class ProgramTransitionAuditEventTypeNode extends AuditUpdateStateEventTy
   public FiniteTransitionVariableTypeNode getTransitionNode() throws UaException {
     try {
       return getTransitionNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -118,7 +127,7 @@ public class ProgramTransitionAuditEventTypeNode extends AuditUpdateStateEventTy
   public CompletableFuture<? extends FiniteTransitionVariableTypeNode> getTransitionNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Transition", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "Transition", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (FiniteTransitionVariableTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ProgramTransitionEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ProgramTransitionEventTypeNode.java
@@ -77,8 +77,11 @@ public class ProgramTransitionEventTypeNode extends TransitionEventTypeNode
   public Object readIntermediateResult() throws UaException {
     try {
       return readIntermediateResultAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class ProgramTransitionEventTypeNode extends TransitionEventTypeNode
   public void writeIntermediateResult(Object value) throws UaException {
     try {
       writeIntermediateResultAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class ProgramTransitionEventTypeNode extends TransitionEventTypeNode
   public BaseDataVariableTypeNode getIntermediateResultNode() throws UaException {
     try {
       return getIntermediateResultNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -120,7 +129,7 @@ public class ProgramTransitionEventTypeNode extends TransitionEventTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "IntermediateResult",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ProgressEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ProgressEventTypeNode.java
@@ -77,8 +77,11 @@ public class ProgressEventTypeNode extends BaseEventTypeNode implements Progress
   public Object readContext() throws UaException {
     try {
       return readContextAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class ProgressEventTypeNode extends BaseEventTypeNode implements Progress
   public void writeContext(Object value) throws UaException {
     try {
       writeContextAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class ProgressEventTypeNode extends BaseEventTypeNode implements Progress
   public PropertyTypeNode getContextNode() throws UaException {
     try {
       return getContextNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -118,7 +127,7 @@ public class ProgressEventTypeNode extends BaseEventTypeNode implements Progress
   public CompletableFuture<? extends PropertyTypeNode> getContextNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Context", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Context", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -138,8 +147,11 @@ public class ProgressEventTypeNode extends BaseEventTypeNode implements Progress
   public UShort readProgress() throws UaException {
     try {
       return readProgressAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -147,8 +159,11 @@ public class ProgressEventTypeNode extends BaseEventTypeNode implements Progress
   public void writeProgress(UShort value) throws UaException {
     try {
       writeProgressAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -170,8 +185,11 @@ public class ProgressEventTypeNode extends BaseEventTypeNode implements Progress
   public PropertyTypeNode getProgressNode() throws UaException {
     try {
       return getProgressNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -179,7 +197,7 @@ public class ProgressEventTypeNode extends BaseEventTypeNode implements Progress
   public CompletableFuture<? extends PropertyTypeNode> getProgressNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Progress", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Progress", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ProvisionableDeviceTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ProvisionableDeviceTypeNode.java
@@ -77,8 +77,11 @@ public class ProvisionableDeviceTypeNode extends BaseObjectTypeNode
   public Boolean readIsSingleton() throws UaException {
     try {
       return readIsSingletonAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class ProvisionableDeviceTypeNode extends BaseObjectTypeNode
   public void writeIsSingleton(Boolean value) throws UaException {
     try {
       writeIsSingletonAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class ProvisionableDeviceTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getIsSingletonNode() throws UaException {
     try {
       return getIsSingletonNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -118,10 +127,7 @@ public class ProvisionableDeviceTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getIsSingletonNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "IsSingleton",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "IsSingleton", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubCapabilitiesTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubCapabilitiesTypeNode.java
@@ -77,8 +77,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public UInteger readMaxPubSubConnections() throws UaException {
     try {
       return readMaxPubSubConnectionsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeMaxPubSubConnections(UInteger value) throws UaException {
     try {
       writeMaxPubSubConnectionsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -110,8 +116,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getMaxPubSubConnectionsNode() throws UaException {
     try {
       return getMaxPubSubConnectionsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -121,7 +130,7 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaxPubSubConnections",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -142,8 +151,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public UInteger readMaxWriterGroups() throws UaException {
     try {
       return readMaxWriterGroupsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -151,8 +163,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeMaxWriterGroups(UInteger value) throws UaException {
     try {
       writeMaxWriterGroupsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -174,8 +189,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getMaxWriterGroupsNode() throws UaException {
     try {
       return getMaxWriterGroupsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -183,10 +201,7 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getMaxWriterGroupsNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "MaxWriterGroups",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "MaxWriterGroups", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -206,8 +221,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public UInteger readMaxReaderGroups() throws UaException {
     try {
       return readMaxReaderGroupsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -215,8 +233,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeMaxReaderGroups(UInteger value) throws UaException {
     try {
       writeMaxReaderGroupsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -238,8 +259,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getMaxReaderGroupsNode() throws UaException {
     try {
       return getMaxReaderGroupsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -247,10 +271,7 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getMaxReaderGroupsNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "MaxReaderGroups",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "MaxReaderGroups", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -270,8 +291,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public UInteger readMaxDataSetWriters() throws UaException {
     try {
       return readMaxDataSetWritersAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -279,8 +303,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeMaxDataSetWriters(UInteger value) throws UaException {
     try {
       writeMaxDataSetWritersAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -302,8 +329,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getMaxDataSetWritersNode() throws UaException {
     try {
       return getMaxDataSetWritersNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -313,7 +343,7 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaxDataSetWriters",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -334,8 +364,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public UInteger readMaxDataSetReaders() throws UaException {
     try {
       return readMaxDataSetReadersAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -343,8 +376,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeMaxDataSetReaders(UInteger value) throws UaException {
     try {
       writeMaxDataSetReadersAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -366,8 +402,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getMaxDataSetReadersNode() throws UaException {
     try {
       return getMaxDataSetReadersNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -377,7 +416,7 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaxDataSetReaders",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -398,8 +437,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public UInteger readMaxFieldsPerDataSet() throws UaException {
     try {
       return readMaxFieldsPerDataSetAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -407,8 +449,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeMaxFieldsPerDataSet(UInteger value) throws UaException {
     try {
       writeMaxFieldsPerDataSetAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -430,8 +475,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getMaxFieldsPerDataSetNode() throws UaException {
     try {
       return getMaxFieldsPerDataSetNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -441,7 +489,7 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaxFieldsPerDataSet",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -462,8 +510,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public UInteger readMaxDataSetWritersPerGroup() throws UaException {
     try {
       return readMaxDataSetWritersPerGroupAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -471,8 +522,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeMaxDataSetWritersPerGroup(UInteger value) throws UaException {
     try {
       writeMaxDataSetWritersPerGroupAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -495,8 +549,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getMaxDataSetWritersPerGroupNode() throws UaException {
     try {
       return getMaxDataSetWritersPerGroupNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -506,7 +563,7 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaxDataSetWritersPerGroup",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -527,8 +584,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public UInteger readMaxSecurityGroups() throws UaException {
     try {
       return readMaxSecurityGroupsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -536,8 +596,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeMaxSecurityGroups(UInteger value) throws UaException {
     try {
       writeMaxSecurityGroupsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -559,8 +622,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getMaxSecurityGroupsNode() throws UaException {
     try {
       return getMaxSecurityGroupsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -570,7 +636,7 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaxSecurityGroups",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -591,8 +657,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public UInteger readMaxPushTargets() throws UaException {
     try {
       return readMaxPushTargetsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -600,8 +669,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeMaxPushTargets(UInteger value) throws UaException {
     try {
       writeMaxPushTargetsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -623,8 +695,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getMaxPushTargetsNode() throws UaException {
     try {
       return getMaxPushTargetsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -632,10 +707,7 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getMaxPushTargetsNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "MaxPushTargets",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "MaxPushTargets", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -655,8 +727,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public UInteger readMaxPublishedDataSets() throws UaException {
     try {
       return readMaxPublishedDataSetsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -664,8 +739,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeMaxPublishedDataSets(UInteger value) throws UaException {
     try {
       writeMaxPublishedDataSetsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -688,8 +766,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getMaxPublishedDataSetsNode() throws UaException {
     try {
       return getMaxPublishedDataSetsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -699,7 +780,7 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaxPublishedDataSets",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -720,8 +801,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public UInteger readMaxStandaloneSubscribedDataSets() throws UaException {
     try {
       return readMaxStandaloneSubscribedDataSetsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -729,8 +813,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeMaxStandaloneSubscribedDataSets(UInteger value) throws UaException {
     try {
       writeMaxStandaloneSubscribedDataSetsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -753,8 +840,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getMaxStandaloneSubscribedDataSetsNode() throws UaException {
     try {
       return getMaxStandaloneSubscribedDataSetsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -765,7 +855,7 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaxStandaloneSubscribedDataSets",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -786,8 +876,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public UInteger readMaxNetworkMessageSizeDatagram() throws UaException {
     try {
       return readMaxNetworkMessageSizeDatagramAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -795,8 +888,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeMaxNetworkMessageSizeDatagram(UInteger value) throws UaException {
     try {
       writeMaxNetworkMessageSizeDatagramAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -819,8 +915,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getMaxNetworkMessageSizeDatagramNode() throws UaException {
     try {
       return getMaxNetworkMessageSizeDatagramNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -830,7 +929,7 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaxNetworkMessageSizeDatagram",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -851,8 +950,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public UInteger readMaxNetworkMessageSizeBroker() throws UaException {
     try {
       return readMaxNetworkMessageSizeBrokerAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -860,8 +962,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeMaxNetworkMessageSizeBroker(UInteger value) throws UaException {
     try {
       writeMaxNetworkMessageSizeBrokerAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -884,8 +989,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getMaxNetworkMessageSizeBrokerNode() throws UaException {
     try {
       return getMaxNetworkMessageSizeBrokerNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -895,7 +1003,7 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaxNetworkMessageSizeBroker",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -916,8 +1024,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public Boolean readSupportSecurityKeyPull() throws UaException {
     try {
       return readSupportSecurityKeyPullAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -925,8 +1036,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeSupportSecurityKeyPull(Boolean value) throws UaException {
     try {
       writeSupportSecurityKeyPullAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -949,8 +1063,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getSupportSecurityKeyPullNode() throws UaException {
     try {
       return getSupportSecurityKeyPullNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -960,7 +1077,7 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SupportSecurityKeyPull",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -981,8 +1098,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public Boolean readSupportSecurityKeyPush() throws UaException {
     try {
       return readSupportSecurityKeyPushAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -990,8 +1110,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeSupportSecurityKeyPush(Boolean value) throws UaException {
     try {
       writeSupportSecurityKeyPushAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1014,8 +1137,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getSupportSecurityKeyPushNode() throws UaException {
     try {
       return getSupportSecurityKeyPushNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1025,7 +1151,7 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SupportSecurityKeyPush",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -1046,8 +1172,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public Boolean readSupportSecurityKeyServer() throws UaException {
     try {
       return readSupportSecurityKeyServerAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1055,8 +1184,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeSupportSecurityKeyServer(Boolean value) throws UaException {
     try {
       writeSupportSecurityKeyServerAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1079,8 +1211,11 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getSupportSecurityKeyServerNode() throws UaException {
     try {
       return getSupportSecurityKeyServerNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1090,7 +1225,7 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SupportSecurityKeyServer",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubCommunicationFailureEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubCommunicationFailureEventTypeNode.java
@@ -77,8 +77,11 @@ public class PubSubCommunicationFailureEventTypeNode extends PubSubStatusEventTy
   public StatusCode readError() throws UaException {
     try {
       return readErrorAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class PubSubCommunicationFailureEventTypeNode extends PubSubStatusEventTy
   public void writeError(StatusCode value) throws UaException {
     try {
       writeErrorAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class PubSubCommunicationFailureEventTypeNode extends PubSubStatusEventTy
   public PropertyTypeNode getErrorNode() throws UaException {
     try {
       return getErrorNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -118,7 +127,7 @@ public class PubSubCommunicationFailureEventTypeNode extends PubSubStatusEventTy
   public CompletableFuture<? extends PropertyTypeNode> getErrorNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Error", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Error", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubConnectionTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubConnectionTypeNode.java
@@ -79,8 +79,11 @@ public class PubSubConnectionTypeNode extends BaseObjectTypeNode implements PubS
   public Object readPublisherId() throws UaException {
     try {
       return readPublisherIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -88,8 +91,11 @@ public class PubSubConnectionTypeNode extends BaseObjectTypeNode implements PubS
   public void writePublisherId(Object value) throws UaException {
     try {
       writePublisherIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -111,8 +117,11 @@ public class PubSubConnectionTypeNode extends BaseObjectTypeNode implements PubS
   public PropertyTypeNode getPublisherIdNode() throws UaException {
     try {
       return getPublisherIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -120,10 +129,7 @@ public class PubSubConnectionTypeNode extends BaseObjectTypeNode implements PubS
   public CompletableFuture<? extends PropertyTypeNode> getPublisherIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "PublisherId",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "PublisherId", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -145,8 +151,11 @@ public class PubSubConnectionTypeNode extends BaseObjectTypeNode implements PubS
   public KeyValuePair[] readConnectionProperties() throws UaException {
     try {
       return readConnectionPropertiesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -154,8 +163,11 @@ public class PubSubConnectionTypeNode extends BaseObjectTypeNode implements PubS
   public void writeConnectionProperties(KeyValuePair[] value) throws UaException {
     try {
       writeConnectionPropertiesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -180,8 +192,11 @@ public class PubSubConnectionTypeNode extends BaseObjectTypeNode implements PubS
   public PropertyTypeNode getConnectionPropertiesNode() throws UaException {
     try {
       return getConnectionPropertiesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -191,7 +206,7 @@ public class PubSubConnectionTypeNode extends BaseObjectTypeNode implements PubS
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ConnectionProperties",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -212,8 +227,11 @@ public class PubSubConnectionTypeNode extends BaseObjectTypeNode implements PubS
   public String readTransportProfileUri() throws UaException {
     try {
       return readTransportProfileUriAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -221,8 +239,11 @@ public class PubSubConnectionTypeNode extends BaseObjectTypeNode implements PubS
   public void writeTransportProfileUri(String value) throws UaException {
     try {
       writeTransportProfileUriAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -244,8 +265,11 @@ public class PubSubConnectionTypeNode extends BaseObjectTypeNode implements PubS
   public SelectionListTypeNode getTransportProfileUriNode() throws UaException {
     try {
       return getTransportProfileUriNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -255,7 +279,7 @@ public class PubSubConnectionTypeNode extends BaseObjectTypeNode implements PubS
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "TransportProfileUri",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (SelectionListTypeNode) node);
   }
@@ -264,8 +288,11 @@ public class PubSubConnectionTypeNode extends BaseObjectTypeNode implements PubS
   public NetworkAddressTypeNode getAddressNode() throws UaException {
     try {
       return getAddressNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -273,7 +300,7 @@ public class PubSubConnectionTypeNode extends BaseObjectTypeNode implements PubS
   public CompletableFuture<? extends NetworkAddressTypeNode> getAddressNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Address", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "Address", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (NetworkAddressTypeNode) node);
   }
 
@@ -281,8 +308,11 @@ public class PubSubConnectionTypeNode extends BaseObjectTypeNode implements PubS
   public ConnectionTransportTypeNode getTransportSettingsNode() throws UaException {
     try {
       return getTransportSettingsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -292,7 +322,7 @@ public class PubSubConnectionTypeNode extends BaseObjectTypeNode implements PubS
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "TransportSettings",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (ConnectionTransportTypeNode) node);
   }
@@ -301,8 +331,11 @@ public class PubSubConnectionTypeNode extends BaseObjectTypeNode implements PubS
   public PubSubStatusTypeNode getStatusNode() throws UaException {
     try {
       return getStatusNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -310,7 +343,7 @@ public class PubSubConnectionTypeNode extends BaseObjectTypeNode implements PubS
   public CompletableFuture<? extends PubSubStatusTypeNode> getStatusNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Status", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "Status", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (PubSubStatusTypeNode) node);
   }
 
@@ -318,8 +351,11 @@ public class PubSubConnectionTypeNode extends BaseObjectTypeNode implements PubS
   public PubSubDiagnosticsConnectionTypeNode getDiagnosticsNode() throws UaException {
     try {
       return getDiagnosticsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -328,10 +364,7 @@ public class PubSubConnectionTypeNode extends BaseObjectTypeNode implements PubS
       getDiagnosticsNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "Diagnostics",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "Diagnostics", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (PubSubDiagnosticsConnectionTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubDiagnosticsConnectionTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubDiagnosticsConnectionTypeNode.java
@@ -60,8 +60,11 @@ public class PubSubDiagnosticsConnectionTypeNode extends PubSubDiagnosticsTypeNo
   public BaseObjectTypeNode getLiveValuesNode() throws UaException {
     try {
       return getLiveValuesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -69,7 +72,7 @@ public class PubSubDiagnosticsConnectionTypeNode extends PubSubDiagnosticsTypeNo
   public CompletableFuture<? extends BaseObjectTypeNode> getLiveValuesNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "LiveValues", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "LiveValues", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseObjectTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubDiagnosticsDataSetReaderTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubDiagnosticsDataSetReaderTypeNode.java
@@ -60,8 +60,11 @@ public class PubSubDiagnosticsDataSetReaderTypeNode extends PubSubDiagnosticsTyp
   public BaseObjectTypeNode getCountersNode() throws UaException {
     try {
       return getCountersNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -69,7 +72,7 @@ public class PubSubDiagnosticsDataSetReaderTypeNode extends PubSubDiagnosticsTyp
   public CompletableFuture<? extends BaseObjectTypeNode> getCountersNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Counters", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "Counters", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseObjectTypeNode) node);
   }
 
@@ -77,8 +80,11 @@ public class PubSubDiagnosticsDataSetReaderTypeNode extends PubSubDiagnosticsTyp
   public BaseObjectTypeNode getLiveValuesNode() throws UaException {
     try {
       return getLiveValuesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,7 +92,7 @@ public class PubSubDiagnosticsDataSetReaderTypeNode extends PubSubDiagnosticsTyp
   public CompletableFuture<? extends BaseObjectTypeNode> getLiveValuesNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "LiveValues", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "LiveValues", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseObjectTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubDiagnosticsDataSetWriterTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubDiagnosticsDataSetWriterTypeNode.java
@@ -60,8 +60,11 @@ public class PubSubDiagnosticsDataSetWriterTypeNode extends PubSubDiagnosticsTyp
   public BaseObjectTypeNode getCountersNode() throws UaException {
     try {
       return getCountersNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -69,7 +72,7 @@ public class PubSubDiagnosticsDataSetWriterTypeNode extends PubSubDiagnosticsTyp
   public CompletableFuture<? extends BaseObjectTypeNode> getCountersNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Counters", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "Counters", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseObjectTypeNode) node);
   }
 
@@ -77,8 +80,11 @@ public class PubSubDiagnosticsDataSetWriterTypeNode extends PubSubDiagnosticsTyp
   public BaseObjectTypeNode getLiveValuesNode() throws UaException {
     try {
       return getLiveValuesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,7 +92,7 @@ public class PubSubDiagnosticsDataSetWriterTypeNode extends PubSubDiagnosticsTyp
   public CompletableFuture<? extends BaseObjectTypeNode> getLiveValuesNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "LiveValues", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "LiveValues", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseObjectTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubDiagnosticsReaderGroupTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubDiagnosticsReaderGroupTypeNode.java
@@ -60,8 +60,11 @@ public class PubSubDiagnosticsReaderGroupTypeNode extends PubSubDiagnosticsTypeN
   public BaseObjectTypeNode getCountersNode() throws UaException {
     try {
       return getCountersNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -69,7 +72,7 @@ public class PubSubDiagnosticsReaderGroupTypeNode extends PubSubDiagnosticsTypeN
   public CompletableFuture<? extends BaseObjectTypeNode> getCountersNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Counters", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "Counters", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseObjectTypeNode) node);
   }
 
@@ -77,8 +80,11 @@ public class PubSubDiagnosticsReaderGroupTypeNode extends PubSubDiagnosticsTypeN
   public BaseObjectTypeNode getLiveValuesNode() throws UaException {
     try {
       return getLiveValuesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,7 +92,7 @@ public class PubSubDiagnosticsReaderGroupTypeNode extends PubSubDiagnosticsTypeN
   public CompletableFuture<? extends BaseObjectTypeNode> getLiveValuesNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "LiveValues", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "LiveValues", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseObjectTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubDiagnosticsRootTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubDiagnosticsRootTypeNode.java
@@ -60,8 +60,11 @@ public class PubSubDiagnosticsRootTypeNode extends PubSubDiagnosticsTypeNode
   public BaseObjectTypeNode getLiveValuesNode() throws UaException {
     try {
       return getLiveValuesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -69,7 +72,7 @@ public class PubSubDiagnosticsRootTypeNode extends PubSubDiagnosticsTypeNode
   public CompletableFuture<? extends BaseObjectTypeNode> getLiveValuesNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "LiveValues", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "LiveValues", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseObjectTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubDiagnosticsTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubDiagnosticsTypeNode.java
@@ -86,8 +86,11 @@ public class PubSubDiagnosticsTypeNode extends BaseObjectTypeNode implements Pub
   public DiagnosticsLevel readDiagnosticsLevel() throws UaException {
     try {
       return readDiagnosticsLevelAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -95,8 +98,11 @@ public class PubSubDiagnosticsTypeNode extends BaseObjectTypeNode implements Pub
   public void writeDiagnosticsLevel(DiagnosticsLevel value) throws UaException {
     try {
       writeDiagnosticsLevelAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -127,8 +133,11 @@ public class PubSubDiagnosticsTypeNode extends BaseObjectTypeNode implements Pub
   public BaseDataVariableTypeNode getDiagnosticsLevelNode() throws UaException {
     try {
       return getDiagnosticsLevelNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -138,7 +147,7 @@ public class PubSubDiagnosticsTypeNode extends BaseObjectTypeNode implements Pub
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "DiagnosticsLevel",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -159,8 +168,11 @@ public class PubSubDiagnosticsTypeNode extends BaseObjectTypeNode implements Pub
   public UInteger readTotalInformation() throws UaException {
     try {
       return readTotalInformationAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -168,8 +180,11 @@ public class PubSubDiagnosticsTypeNode extends BaseObjectTypeNode implements Pub
   public void writeTotalInformation(UInteger value) throws UaException {
     try {
       writeTotalInformationAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -191,8 +206,11 @@ public class PubSubDiagnosticsTypeNode extends BaseObjectTypeNode implements Pub
   public PubSubDiagnosticsCounterTypeNode getTotalInformationNode() throws UaException {
     try {
       return getTotalInformationNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -203,7 +221,7 @@ public class PubSubDiagnosticsTypeNode extends BaseObjectTypeNode implements Pub
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "TotalInformation",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (PubSubDiagnosticsCounterTypeNode) node);
   }
@@ -224,8 +242,11 @@ public class PubSubDiagnosticsTypeNode extends BaseObjectTypeNode implements Pub
   public UInteger readTotalError() throws UaException {
     try {
       return readTotalErrorAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -233,8 +254,11 @@ public class PubSubDiagnosticsTypeNode extends BaseObjectTypeNode implements Pub
   public void writeTotalError(UInteger value) throws UaException {
     try {
       writeTotalErrorAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -256,8 +280,11 @@ public class PubSubDiagnosticsTypeNode extends BaseObjectTypeNode implements Pub
   public PubSubDiagnosticsCounterTypeNode getTotalErrorNode() throws UaException {
     try {
       return getTotalErrorNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -265,7 +292,7 @@ public class PubSubDiagnosticsTypeNode extends BaseObjectTypeNode implements Pub
   public CompletableFuture<? extends PubSubDiagnosticsCounterTypeNode> getTotalErrorNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "TotalError", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "TotalError", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (PubSubDiagnosticsCounterTypeNode) node);
   }
 
@@ -285,8 +312,11 @@ public class PubSubDiagnosticsTypeNode extends BaseObjectTypeNode implements Pub
   public Boolean readSubError() throws UaException {
     try {
       return readSubErrorAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -294,8 +324,11 @@ public class PubSubDiagnosticsTypeNode extends BaseObjectTypeNode implements Pub
   public void writeSubError(Boolean value) throws UaException {
     try {
       writeSubErrorAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -317,8 +350,11 @@ public class PubSubDiagnosticsTypeNode extends BaseObjectTypeNode implements Pub
   public BaseDataVariableTypeNode getSubErrorNode() throws UaException {
     try {
       return getSubErrorNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -326,7 +362,7 @@ public class PubSubDiagnosticsTypeNode extends BaseObjectTypeNode implements Pub
   public CompletableFuture<? extends BaseDataVariableTypeNode> getSubErrorNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "SubError", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "SubError", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -334,8 +370,11 @@ public class PubSubDiagnosticsTypeNode extends BaseObjectTypeNode implements Pub
   public BaseObjectTypeNode getCountersNode() throws UaException {
     try {
       return getCountersNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -343,7 +382,7 @@ public class PubSubDiagnosticsTypeNode extends BaseObjectTypeNode implements Pub
   public CompletableFuture<? extends BaseObjectTypeNode> getCountersNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Counters", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "Counters", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseObjectTypeNode) node);
   }
 
@@ -351,8 +390,11 @@ public class PubSubDiagnosticsTypeNode extends BaseObjectTypeNode implements Pub
   public BaseObjectTypeNode getLiveValuesNode() throws UaException {
     try {
       return getLiveValuesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -360,7 +402,7 @@ public class PubSubDiagnosticsTypeNode extends BaseObjectTypeNode implements Pub
   public CompletableFuture<? extends BaseObjectTypeNode> getLiveValuesNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "LiveValues", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "LiveValues", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseObjectTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubDiagnosticsWriterGroupTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubDiagnosticsWriterGroupTypeNode.java
@@ -60,8 +60,11 @@ public class PubSubDiagnosticsWriterGroupTypeNode extends PubSubDiagnosticsTypeN
   public BaseObjectTypeNode getCountersNode() throws UaException {
     try {
       return getCountersNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -69,7 +72,7 @@ public class PubSubDiagnosticsWriterGroupTypeNode extends PubSubDiagnosticsTypeN
   public CompletableFuture<? extends BaseObjectTypeNode> getCountersNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Counters", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "Counters", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseObjectTypeNode) node);
   }
 
@@ -77,8 +80,11 @@ public class PubSubDiagnosticsWriterGroupTypeNode extends PubSubDiagnosticsTypeN
   public BaseObjectTypeNode getLiveValuesNode() throws UaException {
     try {
       return getLiveValuesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,7 +92,7 @@ public class PubSubDiagnosticsWriterGroupTypeNode extends PubSubDiagnosticsTypeN
   public CompletableFuture<? extends BaseObjectTypeNode> getLiveValuesNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "LiveValues", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "LiveValues", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseObjectTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubGroupTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubGroupTypeNode.java
@@ -88,8 +88,11 @@ public class PubSubGroupTypeNode extends BaseObjectTypeNode implements PubSubGro
   public MessageSecurityMode readSecurityMode() throws UaException {
     try {
       return readSecurityModeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -97,8 +100,11 @@ public class PubSubGroupTypeNode extends BaseObjectTypeNode implements PubSubGro
   public void writeSecurityMode(MessageSecurityMode value) throws UaException {
     try {
       writeSecurityModeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -128,8 +134,11 @@ public class PubSubGroupTypeNode extends BaseObjectTypeNode implements PubSubGro
   public PropertyTypeNode getSecurityModeNode() throws UaException {
     try {
       return getSecurityModeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -137,10 +146,7 @@ public class PubSubGroupTypeNode extends BaseObjectTypeNode implements PubSubGro
   public CompletableFuture<? extends PropertyTypeNode> getSecurityModeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "SecurityMode",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "SecurityMode", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -160,8 +166,11 @@ public class PubSubGroupTypeNode extends BaseObjectTypeNode implements PubSubGro
   public String readSecurityGroupId() throws UaException {
     try {
       return readSecurityGroupIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -169,8 +178,11 @@ public class PubSubGroupTypeNode extends BaseObjectTypeNode implements PubSubGro
   public void writeSecurityGroupId(String value) throws UaException {
     try {
       writeSecurityGroupIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -192,8 +204,11 @@ public class PubSubGroupTypeNode extends BaseObjectTypeNode implements PubSubGro
   public PropertyTypeNode getSecurityGroupIdNode() throws UaException {
     try {
       return getSecurityGroupIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -201,10 +216,7 @@ public class PubSubGroupTypeNode extends BaseObjectTypeNode implements PubSubGro
   public CompletableFuture<? extends PropertyTypeNode> getSecurityGroupIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "SecurityGroupId",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "SecurityGroupId", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -226,8 +238,11 @@ public class PubSubGroupTypeNode extends BaseObjectTypeNode implements PubSubGro
   public EndpointDescription[] readSecurityKeyServices() throws UaException {
     try {
       return readSecurityKeyServicesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -235,8 +250,11 @@ public class PubSubGroupTypeNode extends BaseObjectTypeNode implements PubSubGro
   public void writeSecurityKeyServices(EndpointDescription[] value) throws UaException {
     try {
       writeSecurityKeyServicesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -261,8 +279,11 @@ public class PubSubGroupTypeNode extends BaseObjectTypeNode implements PubSubGro
   public PropertyTypeNode getSecurityKeyServicesNode() throws UaException {
     try {
       return getSecurityKeyServicesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -272,7 +293,7 @@ public class PubSubGroupTypeNode extends BaseObjectTypeNode implements PubSubGro
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SecurityKeyServices",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -293,8 +314,11 @@ public class PubSubGroupTypeNode extends BaseObjectTypeNode implements PubSubGro
   public UInteger readMaxNetworkMessageSize() throws UaException {
     try {
       return readMaxNetworkMessageSizeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -302,8 +326,11 @@ public class PubSubGroupTypeNode extends BaseObjectTypeNode implements PubSubGro
   public void writeMaxNetworkMessageSize(UInteger value) throws UaException {
     try {
       writeMaxNetworkMessageSizeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -326,8 +353,11 @@ public class PubSubGroupTypeNode extends BaseObjectTypeNode implements PubSubGro
   public PropertyTypeNode getMaxNetworkMessageSizeNode() throws UaException {
     try {
       return getMaxNetworkMessageSizeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -337,7 +367,7 @@ public class PubSubGroupTypeNode extends BaseObjectTypeNode implements PubSubGro
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaxNetworkMessageSize",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -360,8 +390,11 @@ public class PubSubGroupTypeNode extends BaseObjectTypeNode implements PubSubGro
   public KeyValuePair[] readGroupProperties() throws UaException {
     try {
       return readGroupPropertiesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -369,8 +402,11 @@ public class PubSubGroupTypeNode extends BaseObjectTypeNode implements PubSubGro
   public void writeGroupProperties(KeyValuePair[] value) throws UaException {
     try {
       writeGroupPropertiesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -394,8 +430,11 @@ public class PubSubGroupTypeNode extends BaseObjectTypeNode implements PubSubGro
   public PropertyTypeNode getGroupPropertiesNode() throws UaException {
     try {
       return getGroupPropertiesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -403,10 +442,7 @@ public class PubSubGroupTypeNode extends BaseObjectTypeNode implements PubSubGro
   public CompletableFuture<? extends PropertyTypeNode> getGroupPropertiesNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "GroupProperties",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "GroupProperties", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -414,8 +450,11 @@ public class PubSubGroupTypeNode extends BaseObjectTypeNode implements PubSubGro
   public PubSubStatusTypeNode getStatusNode() throws UaException {
     try {
       return getStatusNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -423,7 +462,7 @@ public class PubSubGroupTypeNode extends BaseObjectTypeNode implements PubSubGro
   public CompletableFuture<? extends PubSubStatusTypeNode> getStatusNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Status", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "Status", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (PubSubStatusTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubKeyPushTargetTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubKeyPushTargetTypeNode.java
@@ -81,8 +81,11 @@ public class PubSubKeyPushTargetTypeNode extends BaseObjectTypeNode
   public String readApplicationUri() throws UaException {
     try {
       return readApplicationUriAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -90,8 +93,11 @@ public class PubSubKeyPushTargetTypeNode extends BaseObjectTypeNode
   public void writeApplicationUri(String value) throws UaException {
     try {
       writeApplicationUriAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -113,8 +119,11 @@ public class PubSubKeyPushTargetTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getApplicationUriNode() throws UaException {
     try {
       return getApplicationUriNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -122,10 +131,7 @@ public class PubSubKeyPushTargetTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getApplicationUriNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ApplicationUri",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "ApplicationUri", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -145,8 +151,11 @@ public class PubSubKeyPushTargetTypeNode extends BaseObjectTypeNode
   public String readEndpointUrl() throws UaException {
     try {
       return readEndpointUrlAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -154,8 +163,11 @@ public class PubSubKeyPushTargetTypeNode extends BaseObjectTypeNode
   public void writeEndpointUrl(String value) throws UaException {
     try {
       writeEndpointUrlAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -177,8 +189,11 @@ public class PubSubKeyPushTargetTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getEndpointUrlNode() throws UaException {
     try {
       return getEndpointUrlNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -186,10 +201,7 @@ public class PubSubKeyPushTargetTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getEndpointUrlNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "EndpointUrl",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "EndpointUrl", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -209,8 +221,11 @@ public class PubSubKeyPushTargetTypeNode extends BaseObjectTypeNode
   public String readSecurityPolicyUri() throws UaException {
     try {
       return readSecurityPolicyUriAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -218,8 +233,11 @@ public class PubSubKeyPushTargetTypeNode extends BaseObjectTypeNode
   public void writeSecurityPolicyUri(String value) throws UaException {
     try {
       writeSecurityPolicyUriAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -241,8 +259,11 @@ public class PubSubKeyPushTargetTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getSecurityPolicyUriNode() throws UaException {
     try {
       return getSecurityPolicyUriNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -252,7 +273,7 @@ public class PubSubKeyPushTargetTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SecurityPolicyUri",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -274,8 +295,11 @@ public class PubSubKeyPushTargetTypeNode extends BaseObjectTypeNode
   public UserTokenPolicy readUserTokenType() throws UaException {
     try {
       return readUserTokenTypeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -283,8 +307,11 @@ public class PubSubKeyPushTargetTypeNode extends BaseObjectTypeNode
   public void writeUserTokenType(UserTokenPolicy value) throws UaException {
     try {
       writeUserTokenTypeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -308,8 +335,11 @@ public class PubSubKeyPushTargetTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getUserTokenTypeNode() throws UaException {
     try {
       return getUserTokenTypeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -317,10 +347,7 @@ public class PubSubKeyPushTargetTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getUserTokenTypeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "UserTokenType",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "UserTokenType", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -340,8 +367,11 @@ public class PubSubKeyPushTargetTypeNode extends BaseObjectTypeNode
   public UShort readRequestedKeyCount() throws UaException {
     try {
       return readRequestedKeyCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -349,8 +379,11 @@ public class PubSubKeyPushTargetTypeNode extends BaseObjectTypeNode
   public void writeRequestedKeyCount(UShort value) throws UaException {
     try {
       writeRequestedKeyCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -372,8 +405,11 @@ public class PubSubKeyPushTargetTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getRequestedKeyCountNode() throws UaException {
     try {
       return getRequestedKeyCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -383,7 +419,7 @@ public class PubSubKeyPushTargetTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "RequestedKeyCount",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -404,8 +440,11 @@ public class PubSubKeyPushTargetTypeNode extends BaseObjectTypeNode
   public Double readRetryInterval() throws UaException {
     try {
       return readRetryIntervalAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -413,8 +452,11 @@ public class PubSubKeyPushTargetTypeNode extends BaseObjectTypeNode
   public void writeRetryInterval(Double value) throws UaException {
     try {
       writeRetryIntervalAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -436,8 +478,11 @@ public class PubSubKeyPushTargetTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getRetryIntervalNode() throws UaException {
     try {
       return getRetryIntervalNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -445,10 +490,7 @@ public class PubSubKeyPushTargetTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getRetryIntervalNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "RetryInterval",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "RetryInterval", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -468,8 +510,11 @@ public class PubSubKeyPushTargetTypeNode extends BaseObjectTypeNode
   public DateTime readLastPushExecutionTime() throws UaException {
     try {
       return readLastPushExecutionTimeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -477,8 +522,11 @@ public class PubSubKeyPushTargetTypeNode extends BaseObjectTypeNode
   public void writeLastPushExecutionTime(DateTime value) throws UaException {
     try {
       writeLastPushExecutionTimeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -501,8 +549,11 @@ public class PubSubKeyPushTargetTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getLastPushExecutionTimeNode() throws UaException {
     try {
       return getLastPushExecutionTimeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -512,7 +563,7 @@ public class PubSubKeyPushTargetTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "LastPushExecutionTime",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -533,8 +584,11 @@ public class PubSubKeyPushTargetTypeNode extends BaseObjectTypeNode
   public DateTime readLastPushErrorTime() throws UaException {
     try {
       return readLastPushErrorTimeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -542,8 +596,11 @@ public class PubSubKeyPushTargetTypeNode extends BaseObjectTypeNode
   public void writeLastPushErrorTime(DateTime value) throws UaException {
     try {
       writeLastPushErrorTimeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -565,8 +622,11 @@ public class PubSubKeyPushTargetTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getLastPushErrorTimeNode() throws UaException {
     try {
       return getLastPushErrorTimeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -576,7 +636,7 @@ public class PubSubKeyPushTargetTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "LastPushErrorTime",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubKeyServiceTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubKeyServiceTypeNode.java
@@ -59,8 +59,11 @@ public class PubSubKeyServiceTypeNode extends BaseObjectTypeNode implements PubS
   public SecurityGroupFolderTypeNode getSecurityGroupsNode() throws UaException {
     try {
       return getSecurityGroupsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -68,10 +71,7 @@ public class PubSubKeyServiceTypeNode extends BaseObjectTypeNode implements PubS
   public CompletableFuture<? extends SecurityGroupFolderTypeNode> getSecurityGroupsNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "SecurityGroups",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "SecurityGroups", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (SecurityGroupFolderTypeNode) node);
   }
 
@@ -79,8 +79,11 @@ public class PubSubKeyServiceTypeNode extends BaseObjectTypeNode implements PubS
   public PubSubKeyPushTargetFolderTypeNode getKeyPushTargetsNode() throws UaException {
     try {
       return getKeyPushTargetsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -89,10 +92,7 @@ public class PubSubKeyServiceTypeNode extends BaseObjectTypeNode implements PubS
       getKeyPushTargetsNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "KeyPushTargets",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "KeyPushTargets", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (PubSubKeyPushTargetFolderTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubStatusEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubStatusEventTypeNode.java
@@ -78,8 +78,11 @@ public class PubSubStatusEventTypeNode extends SystemEventTypeNode
   public NodeId readConnectionId() throws UaException {
     try {
       return readConnectionIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -87,8 +90,11 @@ public class PubSubStatusEventTypeNode extends SystemEventTypeNode
   public void writeConnectionId(NodeId value) throws UaException {
     try {
       writeConnectionIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -110,8 +116,11 @@ public class PubSubStatusEventTypeNode extends SystemEventTypeNode
   public PropertyTypeNode getConnectionIdNode() throws UaException {
     try {
       return getConnectionIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -119,10 +128,7 @@ public class PubSubStatusEventTypeNode extends SystemEventTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getConnectionIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ConnectionId",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "ConnectionId", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -142,8 +148,11 @@ public class PubSubStatusEventTypeNode extends SystemEventTypeNode
   public NodeId readGroupId() throws UaException {
     try {
       return readGroupIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -151,8 +160,11 @@ public class PubSubStatusEventTypeNode extends SystemEventTypeNode
   public void writeGroupId(NodeId value) throws UaException {
     try {
       writeGroupIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -174,8 +186,11 @@ public class PubSubStatusEventTypeNode extends SystemEventTypeNode
   public PropertyTypeNode getGroupIdNode() throws UaException {
     try {
       return getGroupIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -183,7 +198,7 @@ public class PubSubStatusEventTypeNode extends SystemEventTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getGroupIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "GroupId", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "GroupId", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -211,8 +226,11 @@ public class PubSubStatusEventTypeNode extends SystemEventTypeNode
   public PubSubState readState() throws UaException {
     try {
       return readStateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -220,8 +238,11 @@ public class PubSubStatusEventTypeNode extends SystemEventTypeNode
   public void writeState(PubSubState value) throws UaException {
     try {
       writeStateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -251,8 +272,11 @@ public class PubSubStatusEventTypeNode extends SystemEventTypeNode
   public PropertyTypeNode getStateNode() throws UaException {
     try {
       return getStateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -260,7 +284,7 @@ public class PubSubStatusEventTypeNode extends SystemEventTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getStateNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "State", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "State", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubStatusTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubStatusTypeNode.java
@@ -85,8 +85,11 @@ public class PubSubStatusTypeNode extends BaseObjectTypeNode implements PubSubSt
   public PubSubState readState() throws UaException {
     try {
       return readStateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -94,8 +97,11 @@ public class PubSubStatusTypeNode extends BaseObjectTypeNode implements PubSubSt
   public void writeState(PubSubState value) throws UaException {
     try {
       writeStateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -125,8 +131,11 @@ public class PubSubStatusTypeNode extends BaseObjectTypeNode implements PubSubSt
   public BaseDataVariableTypeNode getStateNode() throws UaException {
     try {
       return getStateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -134,7 +143,7 @@ public class PubSubStatusTypeNode extends BaseObjectTypeNode implements PubSubSt
   public CompletableFuture<? extends BaseDataVariableTypeNode> getStateNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "State", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "State", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubTransportLimitsExceedEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubTransportLimitsExceedEventTypeNode.java
@@ -77,8 +77,11 @@ public class PubSubTransportLimitsExceedEventTypeNode extends PubSubStatusEventT
   public UInteger readActual() throws UaException {
     try {
       return readActualAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class PubSubTransportLimitsExceedEventTypeNode extends PubSubStatusEventT
   public void writeActual(UInteger value) throws UaException {
     try {
       writeActualAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class PubSubTransportLimitsExceedEventTypeNode extends PubSubStatusEventT
   public PropertyTypeNode getActualNode() throws UaException {
     try {
       return getActualNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -118,7 +127,7 @@ public class PubSubTransportLimitsExceedEventTypeNode extends PubSubStatusEventT
   public CompletableFuture<? extends PropertyTypeNode> getActualNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Actual", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Actual", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -138,8 +147,11 @@ public class PubSubTransportLimitsExceedEventTypeNode extends PubSubStatusEventT
   public UInteger readMaximum() throws UaException {
     try {
       return readMaximumAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -147,8 +159,11 @@ public class PubSubTransportLimitsExceedEventTypeNode extends PubSubStatusEventT
   public void writeMaximum(UInteger value) throws UaException {
     try {
       writeMaximumAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -170,8 +185,11 @@ public class PubSubTransportLimitsExceedEventTypeNode extends PubSubStatusEventT
   public PropertyTypeNode getMaximumNode() throws UaException {
     try {
       return getMaximumNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -179,7 +197,7 @@ public class PubSubTransportLimitsExceedEventTypeNode extends PubSubStatusEventT
   public CompletableFuture<? extends PropertyTypeNode> getMaximumNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Maximum", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Maximum", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PublishSubscribeTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PublishSubscribeTypeNode.java
@@ -81,8 +81,11 @@ public class PublishSubscribeTypeNode extends PubSubKeyServiceTypeNode
   public String[] readSupportedTransportProfiles() throws UaException {
     try {
       return readSupportedTransportProfilesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -90,8 +93,11 @@ public class PublishSubscribeTypeNode extends PubSubKeyServiceTypeNode
   public void writeSupportedTransportProfiles(String[] value) throws UaException {
     try {
       writeSupportedTransportProfilesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -114,8 +120,11 @@ public class PublishSubscribeTypeNode extends PubSubKeyServiceTypeNode
   public PropertyTypeNode getSupportedTransportProfilesNode() throws UaException {
     try {
       return getSupportedTransportProfilesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -125,7 +134,7 @@ public class PublishSubscribeTypeNode extends PubSubKeyServiceTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SupportedTransportProfiles",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -146,8 +155,11 @@ public class PublishSubscribeTypeNode extends PubSubKeyServiceTypeNode
   public ULong readDefaultDatagramPublisherId() throws UaException {
     try {
       return readDefaultDatagramPublisherIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -155,8 +167,11 @@ public class PublishSubscribeTypeNode extends PubSubKeyServiceTypeNode
   public void writeDefaultDatagramPublisherId(ULong value) throws UaException {
     try {
       writeDefaultDatagramPublisherIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -179,8 +194,11 @@ public class PublishSubscribeTypeNode extends PubSubKeyServiceTypeNode
   public PropertyTypeNode getDefaultDatagramPublisherIdNode() throws UaException {
     try {
       return getDefaultDatagramPublisherIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -190,7 +208,7 @@ public class PublishSubscribeTypeNode extends PubSubKeyServiceTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "DefaultDatagramPublisherId",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -211,8 +229,11 @@ public class PublishSubscribeTypeNode extends PubSubKeyServiceTypeNode
   public UInteger readConfigurationVersion() throws UaException {
     try {
       return readConfigurationVersionAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -220,8 +241,11 @@ public class PublishSubscribeTypeNode extends PubSubKeyServiceTypeNode
   public void writeConfigurationVersion(UInteger value) throws UaException {
     try {
       writeConfigurationVersionAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -244,8 +268,11 @@ public class PublishSubscribeTypeNode extends PubSubKeyServiceTypeNode
   public PropertyTypeNode getConfigurationVersionNode() throws UaException {
     try {
       return getConfigurationVersionNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -255,7 +282,7 @@ public class PublishSubscribeTypeNode extends PubSubKeyServiceTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ConfigurationVersion",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -278,8 +305,11 @@ public class PublishSubscribeTypeNode extends PubSubKeyServiceTypeNode
   public EndpointDescription[] readDefaultSecurityKeyServices() throws UaException {
     try {
       return readDefaultSecurityKeyServicesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -287,8 +317,11 @@ public class PublishSubscribeTypeNode extends PubSubKeyServiceTypeNode
   public void writeDefaultSecurityKeyServices(EndpointDescription[] value) throws UaException {
     try {
       writeDefaultSecurityKeyServicesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -313,8 +346,11 @@ public class PublishSubscribeTypeNode extends PubSubKeyServiceTypeNode
   public PropertyTypeNode getDefaultSecurityKeyServicesNode() throws UaException {
     try {
       return getDefaultSecurityKeyServicesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -324,7 +360,7 @@ public class PublishSubscribeTypeNode extends PubSubKeyServiceTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "DefaultSecurityKeyServices",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -347,8 +383,11 @@ public class PublishSubscribeTypeNode extends PubSubKeyServiceTypeNode
   public KeyValuePair[] readConfigurationProperties() throws UaException {
     try {
       return readConfigurationPropertiesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -356,8 +395,11 @@ public class PublishSubscribeTypeNode extends PubSubKeyServiceTypeNode
   public void writeConfigurationProperties(KeyValuePair[] value) throws UaException {
     try {
       writeConfigurationPropertiesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -382,8 +424,11 @@ public class PublishSubscribeTypeNode extends PubSubKeyServiceTypeNode
   public PropertyTypeNode getConfigurationPropertiesNode() throws UaException {
     try {
       return getConfigurationPropertiesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -393,7 +438,7 @@ public class PublishSubscribeTypeNode extends PubSubKeyServiceTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ConfigurationProperties",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -402,8 +447,11 @@ public class PublishSubscribeTypeNode extends PubSubKeyServiceTypeNode
   public DataSetFolderTypeNode getPublishedDataSetsNode() throws UaException {
     try {
       return getPublishedDataSetsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -413,7 +461,7 @@ public class PublishSubscribeTypeNode extends PubSubKeyServiceTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "PublishedDataSets",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (DataSetFolderTypeNode) node);
   }
@@ -422,8 +470,11 @@ public class PublishSubscribeTypeNode extends PubSubKeyServiceTypeNode
   public SubscribedDataSetFolderTypeNode getSubscribedDataSetsNode() throws UaException {
     try {
       return getSubscribedDataSetsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -434,7 +485,7 @@ public class PublishSubscribeTypeNode extends PubSubKeyServiceTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SubscribedDataSets",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (SubscribedDataSetFolderTypeNode) node);
   }
@@ -443,8 +494,11 @@ public class PublishSubscribeTypeNode extends PubSubKeyServiceTypeNode
   public PubSubConfigurationTypeNode getPubSubConfigurationNode() throws UaException {
     try {
       return getPubSubConfigurationNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -455,7 +509,7 @@ public class PublishSubscribeTypeNode extends PubSubKeyServiceTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "PubSubConfiguration",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (PubSubConfigurationTypeNode) node);
   }
@@ -464,8 +518,11 @@ public class PublishSubscribeTypeNode extends PubSubKeyServiceTypeNode
   public PubSubStatusTypeNode getStatusNode() throws UaException {
     try {
       return getStatusNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -473,7 +530,7 @@ public class PublishSubscribeTypeNode extends PubSubKeyServiceTypeNode
   public CompletableFuture<? extends PubSubStatusTypeNode> getStatusNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Status", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "Status", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (PubSubStatusTypeNode) node);
   }
 
@@ -481,8 +538,11 @@ public class PublishSubscribeTypeNode extends PubSubKeyServiceTypeNode
   public PubSubDiagnosticsRootTypeNode getDiagnosticsNode() throws UaException {
     try {
       return getDiagnosticsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -490,10 +550,7 @@ public class PublishSubscribeTypeNode extends PubSubKeyServiceTypeNode
   public CompletableFuture<? extends PubSubDiagnosticsRootTypeNode> getDiagnosticsNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "Diagnostics",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "Diagnostics", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (PubSubDiagnosticsRootTypeNode) node);
   }
 
@@ -501,8 +558,11 @@ public class PublishSubscribeTypeNode extends PubSubKeyServiceTypeNode
   public PubSubCapabilitiesTypeNode getPubSubCapablitiesNode() throws UaException {
     try {
       return getPubSubCapablitiesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -512,7 +572,7 @@ public class PublishSubscribeTypeNode extends PubSubKeyServiceTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "PubSubCapablities",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (PubSubCapabilitiesTypeNode) node);
   }
@@ -521,8 +581,11 @@ public class PublishSubscribeTypeNode extends PubSubKeyServiceTypeNode
   public FolderTypeNode getDataSetClassesNode() throws UaException {
     try {
       return getDataSetClassesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -530,10 +593,7 @@ public class PublishSubscribeTypeNode extends PubSubKeyServiceTypeNode
   public CompletableFuture<? extends FolderTypeNode> getDataSetClassesNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "DataSetClasses",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "DataSetClasses", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (FolderTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PublishedDataItemsTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PublishedDataItemsTypeNode.java
@@ -81,8 +81,11 @@ public class PublishedDataItemsTypeNode extends PublishedDataSetTypeNode
   public PublishedVariableDataType[] readPublishedData() throws UaException {
     try {
       return readPublishedDataAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -90,8 +93,11 @@ public class PublishedDataItemsTypeNode extends PublishedDataSetTypeNode
   public void writePublishedData(PublishedVariableDataType[] value) throws UaException {
     try {
       writePublishedDataAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -116,8 +122,11 @@ public class PublishedDataItemsTypeNode extends PublishedDataSetTypeNode
   public PropertyTypeNode getPublishedDataNode() throws UaException {
     try {
       return getPublishedDataNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -125,10 +134,7 @@ public class PublishedDataItemsTypeNode extends PublishedDataSetTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getPublishedDataNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "PublishedData",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "PublishedData", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PublishedDataSetTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PublishedDataSetTypeNode.java
@@ -81,8 +81,11 @@ public class PublishedDataSetTypeNode extends BaseObjectTypeNode implements Publ
   public ConfigurationVersionDataType readConfigurationVersion() throws UaException {
     try {
       return readConfigurationVersionAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -90,8 +93,11 @@ public class PublishedDataSetTypeNode extends BaseObjectTypeNode implements Publ
   public void writeConfigurationVersion(ConfigurationVersionDataType value) throws UaException {
     try {
       writeConfigurationVersionAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -116,8 +122,11 @@ public class PublishedDataSetTypeNode extends BaseObjectTypeNode implements Publ
   public PropertyTypeNode getConfigurationVersionNode() throws UaException {
     try {
       return getConfigurationVersionNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -127,7 +136,7 @@ public class PublishedDataSetTypeNode extends BaseObjectTypeNode implements Publ
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ConfigurationVersion",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -149,8 +158,11 @@ public class PublishedDataSetTypeNode extends BaseObjectTypeNode implements Publ
   public DataSetMetaDataType readDataSetMetaData() throws UaException {
     try {
       return readDataSetMetaDataAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -158,8 +170,11 @@ public class PublishedDataSetTypeNode extends BaseObjectTypeNode implements Publ
   public void writeDataSetMetaData(DataSetMetaDataType value) throws UaException {
     try {
       writeDataSetMetaDataAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -184,8 +199,11 @@ public class PublishedDataSetTypeNode extends BaseObjectTypeNode implements Publ
   public PropertyTypeNode getDataSetMetaDataNode() throws UaException {
     try {
       return getDataSetMetaDataNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -193,10 +211,7 @@ public class PublishedDataSetTypeNode extends BaseObjectTypeNode implements Publ
   public CompletableFuture<? extends PropertyTypeNode> getDataSetMetaDataNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "DataSetMetaData",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "DataSetMetaData", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -216,8 +231,11 @@ public class PublishedDataSetTypeNode extends BaseObjectTypeNode implements Publ
   public UUID readDataSetClassId() throws UaException {
     try {
       return readDataSetClassIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -225,8 +243,11 @@ public class PublishedDataSetTypeNode extends BaseObjectTypeNode implements Publ
   public void writeDataSetClassId(UUID value) throws UaException {
     try {
       writeDataSetClassIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -248,8 +269,11 @@ public class PublishedDataSetTypeNode extends BaseObjectTypeNode implements Publ
   public PropertyTypeNode getDataSetClassIdNode() throws UaException {
     try {
       return getDataSetClassIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -257,10 +281,7 @@ public class PublishedDataSetTypeNode extends BaseObjectTypeNode implements Publ
   public CompletableFuture<? extends PropertyTypeNode> getDataSetClassIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "DataSetClassId",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "DataSetClassId", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -280,8 +301,11 @@ public class PublishedDataSetTypeNode extends BaseObjectTypeNode implements Publ
   public Boolean readCyclicDataSet() throws UaException {
     try {
       return readCyclicDataSetAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -289,8 +313,11 @@ public class PublishedDataSetTypeNode extends BaseObjectTypeNode implements Publ
   public void writeCyclicDataSet(Boolean value) throws UaException {
     try {
       writeCyclicDataSetAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -312,8 +339,11 @@ public class PublishedDataSetTypeNode extends BaseObjectTypeNode implements Publ
   public PropertyTypeNode getCyclicDataSetNode() throws UaException {
     try {
       return getCyclicDataSetNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -321,10 +351,7 @@ public class PublishedDataSetTypeNode extends BaseObjectTypeNode implements Publ
   public CompletableFuture<? extends PropertyTypeNode> getCyclicDataSetNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "CyclicDataSet",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "CyclicDataSet", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -332,8 +359,11 @@ public class PublishedDataSetTypeNode extends BaseObjectTypeNode implements Publ
   public ExtensionFieldsTypeNode getExtensionFieldsNode() throws UaException {
     try {
       return getExtensionFieldsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -341,10 +371,7 @@ public class PublishedDataSetTypeNode extends BaseObjectTypeNode implements Publ
   public CompletableFuture<? extends ExtensionFieldsTypeNode> getExtensionFieldsNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ExtensionFields",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "ExtensionFields", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (ExtensionFieldsTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PublishedEventsTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PublishedEventsTypeNode.java
@@ -80,8 +80,11 @@ public class PublishedEventsTypeNode extends PublishedDataSetTypeNode
   public NodeId readPubSubEventNotifier() throws UaException {
     try {
       return readPubSubEventNotifierAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -89,8 +92,11 @@ public class PublishedEventsTypeNode extends PublishedDataSetTypeNode
   public void writePubSubEventNotifier(NodeId value) throws UaException {
     try {
       writePubSubEventNotifierAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -112,8 +118,11 @@ public class PublishedEventsTypeNode extends PublishedDataSetTypeNode
   public PropertyTypeNode getPubSubEventNotifierNode() throws UaException {
     try {
       return getPubSubEventNotifierNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -123,7 +132,7 @@ public class PublishedEventsTypeNode extends PublishedDataSetTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "PubSubEventNotifier",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -146,8 +155,11 @@ public class PublishedEventsTypeNode extends PublishedDataSetTypeNode
   public SimpleAttributeOperand[] readSelectedFields() throws UaException {
     try {
       return readSelectedFieldsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -155,8 +167,11 @@ public class PublishedEventsTypeNode extends PublishedDataSetTypeNode
   public void writeSelectedFields(SimpleAttributeOperand[] value) throws UaException {
     try {
       writeSelectedFieldsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -181,8 +196,11 @@ public class PublishedEventsTypeNode extends PublishedDataSetTypeNode
   public PropertyTypeNode getSelectedFieldsNode() throws UaException {
     try {
       return getSelectedFieldsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -190,10 +208,7 @@ public class PublishedEventsTypeNode extends PublishedDataSetTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getSelectedFieldsNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "SelectedFields",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "SelectedFields", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -214,8 +229,11 @@ public class PublishedEventsTypeNode extends PublishedDataSetTypeNode
   public ContentFilter readFilter() throws UaException {
     try {
       return readFilterAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -223,8 +241,11 @@ public class PublishedEventsTypeNode extends PublishedDataSetTypeNode
   public void writeFilter(ContentFilter value) throws UaException {
     try {
       writeFilterAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -247,8 +268,11 @@ public class PublishedEventsTypeNode extends PublishedDataSetTypeNode
   public PropertyTypeNode getFilterNode() throws UaException {
     try {
       return getFilterNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -256,7 +280,7 @@ public class PublishedEventsTypeNode extends PublishedDataSetTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getFilterNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Filter", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Filter", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/QuantityTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/QuantityTypeNode.java
@@ -79,8 +79,11 @@ public class QuantityTypeNode extends BaseObjectTypeNode implements QuantityType
   public LocalizedText readSymbol() throws UaException {
     try {
       return readSymbolAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -88,8 +91,11 @@ public class QuantityTypeNode extends BaseObjectTypeNode implements QuantityType
   public void writeSymbol(LocalizedText value) throws UaException {
     try {
       writeSymbolAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -111,8 +117,11 @@ public class QuantityTypeNode extends BaseObjectTypeNode implements QuantityType
   public PropertyTypeNode getSymbolNode() throws UaException {
     try {
       return getSymbolNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -120,7 +129,7 @@ public class QuantityTypeNode extends BaseObjectTypeNode implements QuantityType
   public CompletableFuture<? extends PropertyTypeNode> getSymbolNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Symbol", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Symbol", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -142,8 +151,11 @@ public class QuantityTypeNode extends BaseObjectTypeNode implements QuantityType
   public AnnotationDataType[] readAnnotation() throws UaException {
     try {
       return readAnnotationAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -151,8 +163,11 @@ public class QuantityTypeNode extends BaseObjectTypeNode implements QuantityType
   public void writeAnnotation(AnnotationDataType[] value) throws UaException {
     try {
       writeAnnotationAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -176,8 +191,11 @@ public class QuantityTypeNode extends BaseObjectTypeNode implements QuantityType
   public PropertyTypeNode getAnnotationNode() throws UaException {
     try {
       return getAnnotationNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -185,7 +203,7 @@ public class QuantityTypeNode extends BaseObjectTypeNode implements QuantityType
   public CompletableFuture<? extends PropertyTypeNode> getAnnotationNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Annotation", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Annotation", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -205,8 +223,11 @@ public class QuantityTypeNode extends BaseObjectTypeNode implements QuantityType
   public String readConversionService() throws UaException {
     try {
       return readConversionServiceAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -214,8 +235,11 @@ public class QuantityTypeNode extends BaseObjectTypeNode implements QuantityType
   public void writeConversionService(String value) throws UaException {
     try {
       writeConversionServiceAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -237,8 +261,11 @@ public class QuantityTypeNode extends BaseObjectTypeNode implements QuantityType
   public PropertyTypeNode getConversionServiceNode() throws UaException {
     try {
       return getConversionServiceNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -248,7 +275,7 @@ public class QuantityTypeNode extends BaseObjectTypeNode implements QuantityType
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ConversionService",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -270,8 +297,11 @@ public class QuantityTypeNode extends BaseObjectTypeNode implements QuantityType
   public QuantityDimension readDimension() throws UaException {
     try {
       return readDimensionAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -279,8 +309,11 @@ public class QuantityTypeNode extends BaseObjectTypeNode implements QuantityType
   public void writeDimension(QuantityDimension value) throws UaException {
     try {
       writeDimensionAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -303,8 +336,11 @@ public class QuantityTypeNode extends BaseObjectTypeNode implements QuantityType
   public PropertyTypeNode getDimensionNode() throws UaException {
     try {
       return getDimensionNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -312,7 +348,7 @@ public class QuantityTypeNode extends BaseObjectTypeNode implements QuantityType
   public CompletableFuture<? extends PropertyTypeNode> getDimensionNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Dimension", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Dimension", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -320,8 +356,11 @@ public class QuantityTypeNode extends BaseObjectTypeNode implements QuantityType
   public BaseObjectTypeNode getServerUnitsNode() throws UaException {
     try {
       return getServerUnitsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -329,10 +368,7 @@ public class QuantityTypeNode extends BaseObjectTypeNode implements QuantityType
   public CompletableFuture<? extends BaseObjectTypeNode> getServerUnitsNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ServerUnits",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "ServerUnits", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseObjectTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ReaderGroupTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ReaderGroupTypeNode.java
@@ -59,8 +59,11 @@ public class ReaderGroupTypeNode extends PubSubGroupTypeNode implements ReaderGr
   public PubSubDiagnosticsReaderGroupTypeNode getDiagnosticsNode() throws UaException {
     try {
       return getDiagnosticsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -69,10 +72,7 @@ public class ReaderGroupTypeNode extends PubSubGroupTypeNode implements ReaderGr
       getDiagnosticsNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "Diagnostics",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "Diagnostics", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (PubSubDiagnosticsReaderGroupTypeNode) node);
   }
 
@@ -80,8 +80,11 @@ public class ReaderGroupTypeNode extends PubSubGroupTypeNode implements ReaderGr
   public ReaderGroupTransportTypeNode getTransportSettingsNode() throws UaException {
     try {
       return getTransportSettingsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -91,7 +94,7 @@ public class ReaderGroupTypeNode extends PubSubGroupTypeNode implements ReaderGr
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "TransportSettings",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (ReaderGroupTransportTypeNode) node);
   }
@@ -100,8 +103,11 @@ public class ReaderGroupTypeNode extends PubSubGroupTypeNode implements ReaderGr
   public ReaderGroupMessageTypeNode getMessageSettingsNode() throws UaException {
     try {
       return getMessageSettingsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,10 +115,7 @@ public class ReaderGroupTypeNode extends PubSubGroupTypeNode implements ReaderGr
   public CompletableFuture<? extends ReaderGroupMessageTypeNode> getMessageSettingsNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "MessageSettings",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "MessageSettings", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (ReaderGroupMessageTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/RoleTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/RoleTypeNode.java
@@ -81,8 +81,11 @@ public class RoleTypeNode extends BaseObjectTypeNode implements RoleType {
   public IdentityMappingRuleType[] readIdentities() throws UaException {
     try {
       return readIdentitiesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -90,8 +93,11 @@ public class RoleTypeNode extends BaseObjectTypeNode implements RoleType {
   public void writeIdentities(IdentityMappingRuleType[] value) throws UaException {
     try {
       writeIdentitiesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -115,8 +121,11 @@ public class RoleTypeNode extends BaseObjectTypeNode implements RoleType {
   public PropertyTypeNode getIdentitiesNode() throws UaException {
     try {
       return getIdentitiesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -124,7 +133,7 @@ public class RoleTypeNode extends BaseObjectTypeNode implements RoleType {
   public CompletableFuture<? extends PropertyTypeNode> getIdentitiesNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Identities", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Identities", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -144,8 +153,11 @@ public class RoleTypeNode extends BaseObjectTypeNode implements RoleType {
   public Boolean readApplicationsExclude() throws UaException {
     try {
       return readApplicationsExcludeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -153,8 +165,11 @@ public class RoleTypeNode extends BaseObjectTypeNode implements RoleType {
   public void writeApplicationsExclude(Boolean value) throws UaException {
     try {
       writeApplicationsExcludeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -176,8 +191,11 @@ public class RoleTypeNode extends BaseObjectTypeNode implements RoleType {
   public PropertyTypeNode getApplicationsExcludeNode() throws UaException {
     try {
       return getApplicationsExcludeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -187,7 +205,7 @@ public class RoleTypeNode extends BaseObjectTypeNode implements RoleType {
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ApplicationsExclude",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -208,8 +226,11 @@ public class RoleTypeNode extends BaseObjectTypeNode implements RoleType {
   public String[] readApplications() throws UaException {
     try {
       return readApplicationsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -217,8 +238,11 @@ public class RoleTypeNode extends BaseObjectTypeNode implements RoleType {
   public void writeApplications(String[] value) throws UaException {
     try {
       writeApplicationsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -240,8 +264,11 @@ public class RoleTypeNode extends BaseObjectTypeNode implements RoleType {
   public PropertyTypeNode getApplicationsNode() throws UaException {
     try {
       return getApplicationsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -249,10 +276,7 @@ public class RoleTypeNode extends BaseObjectTypeNode implements RoleType {
   public CompletableFuture<? extends PropertyTypeNode> getApplicationsNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "Applications",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "Applications", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -272,8 +296,11 @@ public class RoleTypeNode extends BaseObjectTypeNode implements RoleType {
   public Boolean readEndpointsExclude() throws UaException {
     try {
       return readEndpointsExcludeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -281,8 +308,11 @@ public class RoleTypeNode extends BaseObjectTypeNode implements RoleType {
   public void writeEndpointsExclude(Boolean value) throws UaException {
     try {
       writeEndpointsExcludeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -304,8 +334,11 @@ public class RoleTypeNode extends BaseObjectTypeNode implements RoleType {
   public PropertyTypeNode getEndpointsExcludeNode() throws UaException {
     try {
       return getEndpointsExcludeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -315,7 +348,7 @@ public class RoleTypeNode extends BaseObjectTypeNode implements RoleType {
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "EndpointsExclude",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -338,8 +371,11 @@ public class RoleTypeNode extends BaseObjectTypeNode implements RoleType {
   public EndpointType[] readEndpoints() throws UaException {
     try {
       return readEndpointsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -347,8 +383,11 @@ public class RoleTypeNode extends BaseObjectTypeNode implements RoleType {
   public void writeEndpoints(EndpointType[] value) throws UaException {
     try {
       writeEndpointsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -372,8 +411,11 @@ public class RoleTypeNode extends BaseObjectTypeNode implements RoleType {
   public PropertyTypeNode getEndpointsNode() throws UaException {
     try {
       return getEndpointsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -381,7 +423,7 @@ public class RoleTypeNode extends BaseObjectTypeNode implements RoleType {
   public CompletableFuture<? extends PropertyTypeNode> getEndpointsNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Endpoints", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Endpoints", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -401,8 +443,11 @@ public class RoleTypeNode extends BaseObjectTypeNode implements RoleType {
   public Boolean readCustomConfiguration() throws UaException {
     try {
       return readCustomConfigurationAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -410,8 +455,11 @@ public class RoleTypeNode extends BaseObjectTypeNode implements RoleType {
   public void writeCustomConfiguration(Boolean value) throws UaException {
     try {
       writeCustomConfigurationAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -433,8 +481,11 @@ public class RoleTypeNode extends BaseObjectTypeNode implements RoleType {
   public PropertyTypeNode getCustomConfigurationNode() throws UaException {
     try {
       return getCustomConfigurationNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -444,7 +495,7 @@ public class RoleTypeNode extends BaseObjectTypeNode implements RoleType {
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "CustomConfiguration",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/SecurityGroupFolderTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/SecurityGroupFolderTypeNode.java
@@ -76,8 +76,11 @@ public class SecurityGroupFolderTypeNode extends FolderTypeNode implements Secur
   public String[] readSupportedSecurityPolicyUris() throws UaException {
     try {
       return readSupportedSecurityPolicyUrisAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -85,8 +88,11 @@ public class SecurityGroupFolderTypeNode extends FolderTypeNode implements Secur
   public void writeSupportedSecurityPolicyUris(String[] value) throws UaException {
     try {
       writeSupportedSecurityPolicyUrisAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class SecurityGroupFolderTypeNode extends FolderTypeNode implements Secur
   public PropertyTypeNode getSupportedSecurityPolicyUrisNode() throws UaException {
     try {
       return getSupportedSecurityPolicyUrisNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -120,7 +129,7 @@ public class SecurityGroupFolderTypeNode extends FolderTypeNode implements Secur
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SupportedSecurityPolicyUris",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/SecurityGroupTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/SecurityGroupTypeNode.java
@@ -76,8 +76,11 @@ public class SecurityGroupTypeNode extends BaseObjectTypeNode implements Securit
   public String readSecurityGroupId() throws UaException {
     try {
       return readSecurityGroupIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -85,8 +88,11 @@ public class SecurityGroupTypeNode extends BaseObjectTypeNode implements Securit
   public void writeSecurityGroupId(String value) throws UaException {
     try {
       writeSecurityGroupIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -108,8 +114,11 @@ public class SecurityGroupTypeNode extends BaseObjectTypeNode implements Securit
   public PropertyTypeNode getSecurityGroupIdNode() throws UaException {
     try {
       return getSecurityGroupIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -117,10 +126,7 @@ public class SecurityGroupTypeNode extends BaseObjectTypeNode implements Securit
   public CompletableFuture<? extends PropertyTypeNode> getSecurityGroupIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "SecurityGroupId",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "SecurityGroupId", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -140,8 +146,11 @@ public class SecurityGroupTypeNode extends BaseObjectTypeNode implements Securit
   public Double readKeyLifetime() throws UaException {
     try {
       return readKeyLifetimeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -149,8 +158,11 @@ public class SecurityGroupTypeNode extends BaseObjectTypeNode implements Securit
   public void writeKeyLifetime(Double value) throws UaException {
     try {
       writeKeyLifetimeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -172,8 +184,11 @@ public class SecurityGroupTypeNode extends BaseObjectTypeNode implements Securit
   public PropertyTypeNode getKeyLifetimeNode() throws UaException {
     try {
       return getKeyLifetimeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -181,10 +196,7 @@ public class SecurityGroupTypeNode extends BaseObjectTypeNode implements Securit
   public CompletableFuture<? extends PropertyTypeNode> getKeyLifetimeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "KeyLifetime",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "KeyLifetime", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -204,8 +216,11 @@ public class SecurityGroupTypeNode extends BaseObjectTypeNode implements Securit
   public String readSecurityPolicyUri() throws UaException {
     try {
       return readSecurityPolicyUriAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -213,8 +228,11 @@ public class SecurityGroupTypeNode extends BaseObjectTypeNode implements Securit
   public void writeSecurityPolicyUri(String value) throws UaException {
     try {
       writeSecurityPolicyUriAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -236,8 +254,11 @@ public class SecurityGroupTypeNode extends BaseObjectTypeNode implements Securit
   public PropertyTypeNode getSecurityPolicyUriNode() throws UaException {
     try {
       return getSecurityPolicyUriNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -247,7 +268,7 @@ public class SecurityGroupTypeNode extends BaseObjectTypeNode implements Securit
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SecurityPolicyUri",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -268,8 +289,11 @@ public class SecurityGroupTypeNode extends BaseObjectTypeNode implements Securit
   public UInteger readMaxFutureKeyCount() throws UaException {
     try {
       return readMaxFutureKeyCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -277,8 +301,11 @@ public class SecurityGroupTypeNode extends BaseObjectTypeNode implements Securit
   public void writeMaxFutureKeyCount(UInteger value) throws UaException {
     try {
       writeMaxFutureKeyCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -300,8 +327,11 @@ public class SecurityGroupTypeNode extends BaseObjectTypeNode implements Securit
   public PropertyTypeNode getMaxFutureKeyCountNode() throws UaException {
     try {
       return getMaxFutureKeyCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -311,7 +341,7 @@ public class SecurityGroupTypeNode extends BaseObjectTypeNode implements Securit
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaxFutureKeyCount",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -332,8 +362,11 @@ public class SecurityGroupTypeNode extends BaseObjectTypeNode implements Securit
   public UInteger readMaxPastKeyCount() throws UaException {
     try {
       return readMaxPastKeyCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -341,8 +374,11 @@ public class SecurityGroupTypeNode extends BaseObjectTypeNode implements Securit
   public void writeMaxPastKeyCount(UInteger value) throws UaException {
     try {
       writeMaxPastKeyCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -364,8 +400,11 @@ public class SecurityGroupTypeNode extends BaseObjectTypeNode implements Securit
   public PropertyTypeNode getMaxPastKeyCountNode() throws UaException {
     try {
       return getMaxPastKeyCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -373,10 +412,7 @@ public class SecurityGroupTypeNode extends BaseObjectTypeNode implements Securit
   public CompletableFuture<? extends PropertyTypeNode> getMaxPastKeyCountNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "MaxPastKeyCount",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "MaxPastKeyCount", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/SemanticChangeEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/SemanticChangeEventTypeNode.java
@@ -81,8 +81,11 @@ public class SemanticChangeEventTypeNode extends BaseEventTypeNode
   public SemanticChangeStructureDataType[] readChanges() throws UaException {
     try {
       return readChangesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -90,8 +93,11 @@ public class SemanticChangeEventTypeNode extends BaseEventTypeNode
   public void writeChanges(SemanticChangeStructureDataType[] value) throws UaException {
     try {
       writeChangesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -116,8 +122,11 @@ public class SemanticChangeEventTypeNode extends BaseEventTypeNode
   public PropertyTypeNode getChangesNode() throws UaException {
     try {
       return getChangesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -125,7 +134,7 @@ public class SemanticChangeEventTypeNode extends BaseEventTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getChangesNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Changes", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Changes", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ServerCapabilitiesTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ServerCapabilitiesTypeNode.java
@@ -80,8 +80,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public String[] readServerProfileArray() throws UaException {
     try {
       return readServerProfileArrayAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -89,8 +92,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeServerProfileArray(String[] value) throws UaException {
     try {
       writeServerProfileArrayAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -112,8 +118,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getServerProfileArrayNode() throws UaException {
     try {
       return getServerProfileArrayNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -123,7 +132,7 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ServerProfileArray",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -144,8 +153,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public String[] readLocaleIdArray() throws UaException {
     try {
       return readLocaleIdArrayAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -153,8 +165,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeLocaleIdArray(String[] value) throws UaException {
     try {
       writeLocaleIdArrayAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -176,8 +191,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getLocaleIdArrayNode() throws UaException {
     try {
       return getLocaleIdArrayNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -185,10 +203,7 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getLocaleIdArrayNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "LocaleIdArray",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "LocaleIdArray", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -208,8 +223,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public Double readMinSupportedSampleRate() throws UaException {
     try {
       return readMinSupportedSampleRateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -217,8 +235,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeMinSupportedSampleRate(Double value) throws UaException {
     try {
       writeMinSupportedSampleRateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -241,8 +262,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getMinSupportedSampleRateNode() throws UaException {
     try {
       return getMinSupportedSampleRateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -252,7 +276,7 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MinSupportedSampleRate",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -273,8 +297,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public UShort readMaxBrowseContinuationPoints() throws UaException {
     try {
       return readMaxBrowseContinuationPointsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -282,8 +309,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeMaxBrowseContinuationPoints(UShort value) throws UaException {
     try {
       writeMaxBrowseContinuationPointsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -306,8 +336,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getMaxBrowseContinuationPointsNode() throws UaException {
     try {
       return getMaxBrowseContinuationPointsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -317,7 +350,7 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaxBrowseContinuationPoints",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -338,8 +371,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public UShort readMaxQueryContinuationPoints() throws UaException {
     try {
       return readMaxQueryContinuationPointsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -347,8 +383,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeMaxQueryContinuationPoints(UShort value) throws UaException {
     try {
       writeMaxQueryContinuationPointsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -371,8 +410,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getMaxQueryContinuationPointsNode() throws UaException {
     try {
       return getMaxQueryContinuationPointsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -382,7 +424,7 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaxQueryContinuationPoints",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -403,8 +445,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public UShort readMaxHistoryContinuationPoints() throws UaException {
     try {
       return readMaxHistoryContinuationPointsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -412,8 +457,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeMaxHistoryContinuationPoints(UShort value) throws UaException {
     try {
       writeMaxHistoryContinuationPointsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -436,8 +484,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getMaxHistoryContinuationPointsNode() throws UaException {
     try {
       return getMaxHistoryContinuationPointsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -447,7 +498,7 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaxHistoryContinuationPoints",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -470,8 +521,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public SignedSoftwareCertificate[] readSoftwareCertificates() throws UaException {
     try {
       return readSoftwareCertificatesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -479,8 +533,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeSoftwareCertificates(SignedSoftwareCertificate[] value) throws UaException {
     try {
       writeSoftwareCertificatesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -505,8 +562,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getSoftwareCertificatesNode() throws UaException {
     try {
       return getSoftwareCertificatesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -516,7 +576,7 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SoftwareCertificates",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -537,8 +597,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public UInteger readMaxArrayLength() throws UaException {
     try {
       return readMaxArrayLengthAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -546,8 +609,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeMaxArrayLength(UInteger value) throws UaException {
     try {
       writeMaxArrayLengthAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -569,8 +635,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getMaxArrayLengthNode() throws UaException {
     try {
       return getMaxArrayLengthNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -578,10 +647,7 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getMaxArrayLengthNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "MaxArrayLength",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "MaxArrayLength", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -601,8 +667,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public UInteger readMaxStringLength() throws UaException {
     try {
       return readMaxStringLengthAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -610,8 +679,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeMaxStringLength(UInteger value) throws UaException {
     try {
       writeMaxStringLengthAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -633,8 +705,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getMaxStringLengthNode() throws UaException {
     try {
       return getMaxStringLengthNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -642,10 +717,7 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getMaxStringLengthNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "MaxStringLength",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "MaxStringLength", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -665,8 +737,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public UInteger readMaxByteStringLength() throws UaException {
     try {
       return readMaxByteStringLengthAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -674,8 +749,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeMaxByteStringLength(UInteger value) throws UaException {
     try {
       writeMaxByteStringLengthAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -697,8 +775,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getMaxByteStringLengthNode() throws UaException {
     try {
       return getMaxByteStringLengthNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -708,7 +789,7 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaxByteStringLength",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -729,8 +810,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public UInteger readMaxSessions() throws UaException {
     try {
       return readMaxSessionsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -738,8 +822,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeMaxSessions(UInteger value) throws UaException {
     try {
       writeMaxSessionsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -761,8 +848,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getMaxSessionsNode() throws UaException {
     try {
       return getMaxSessionsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -770,10 +860,7 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getMaxSessionsNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "MaxSessions",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "MaxSessions", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -793,8 +880,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public UInteger readMaxSubscriptions() throws UaException {
     try {
       return readMaxSubscriptionsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -802,8 +892,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeMaxSubscriptions(UInteger value) throws UaException {
     try {
       writeMaxSubscriptionsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -825,8 +918,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getMaxSubscriptionsNode() throws UaException {
     try {
       return getMaxSubscriptionsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -836,7 +932,7 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaxSubscriptions",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -857,8 +953,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public UInteger readMaxMonitoredItems() throws UaException {
     try {
       return readMaxMonitoredItemsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -866,8 +965,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeMaxMonitoredItems(UInteger value) throws UaException {
     try {
       writeMaxMonitoredItemsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -889,8 +991,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getMaxMonitoredItemsNode() throws UaException {
     try {
       return getMaxMonitoredItemsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -900,7 +1005,7 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaxMonitoredItems",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -921,8 +1026,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public UInteger readMaxSubscriptionsPerSession() throws UaException {
     try {
       return readMaxSubscriptionsPerSessionAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -930,8 +1038,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeMaxSubscriptionsPerSession(UInteger value) throws UaException {
     try {
       writeMaxSubscriptionsPerSessionAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -954,8 +1065,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getMaxSubscriptionsPerSessionNode() throws UaException {
     try {
       return getMaxSubscriptionsPerSessionNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -965,7 +1079,7 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaxSubscriptionsPerSession",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -986,8 +1100,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public UInteger readMaxMonitoredItemsPerSubscription() throws UaException {
     try {
       return readMaxMonitoredItemsPerSubscriptionAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -995,8 +1112,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeMaxMonitoredItemsPerSubscription(UInteger value) throws UaException {
     try {
       writeMaxMonitoredItemsPerSubscriptionAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1019,8 +1139,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getMaxMonitoredItemsPerSubscriptionNode() throws UaException {
     try {
       return getMaxMonitoredItemsPerSubscriptionNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1031,7 +1154,7 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaxMonitoredItemsPerSubscription",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -1052,8 +1175,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public UInteger readMaxSelectClauseParameters() throws UaException {
     try {
       return readMaxSelectClauseParametersAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1061,8 +1187,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeMaxSelectClauseParameters(UInteger value) throws UaException {
     try {
       writeMaxSelectClauseParametersAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1085,8 +1214,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getMaxSelectClauseParametersNode() throws UaException {
     try {
       return getMaxSelectClauseParametersNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1096,7 +1228,7 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaxSelectClauseParameters",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -1117,8 +1249,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public UInteger readMaxWhereClauseParameters() throws UaException {
     try {
       return readMaxWhereClauseParametersAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1126,8 +1261,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeMaxWhereClauseParameters(UInteger value) throws UaException {
     try {
       writeMaxWhereClauseParametersAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1150,8 +1288,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getMaxWhereClauseParametersNode() throws UaException {
     try {
       return getMaxWhereClauseParametersNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1161,7 +1302,7 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaxWhereClauseParameters",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -1182,8 +1323,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public UInteger readMaxMonitoredItemsQueueSize() throws UaException {
     try {
       return readMaxMonitoredItemsQueueSizeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1191,8 +1335,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeMaxMonitoredItemsQueueSize(UInteger value) throws UaException {
     try {
       writeMaxMonitoredItemsQueueSizeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1215,8 +1362,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getMaxMonitoredItemsQueueSizeNode() throws UaException {
     try {
       return getMaxMonitoredItemsQueueSizeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1226,7 +1376,7 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaxMonitoredItemsQueueSize",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -1247,8 +1397,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public QualifiedName[] readConformanceUnits() throws UaException {
     try {
       return readConformanceUnitsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1256,8 +1409,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public void writeConformanceUnits(QualifiedName[] value) throws UaException {
     try {
       writeConformanceUnitsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1280,8 +1436,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getConformanceUnitsNode() throws UaException {
     try {
       return getConformanceUnitsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1291,7 +1450,7 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ConformanceUnits",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -1300,8 +1459,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public OperationLimitsTypeNode getOperationLimitsNode() throws UaException {
     try {
       return getOperationLimitsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1309,10 +1471,7 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends OperationLimitsTypeNode> getOperationLimitsNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "OperationLimits",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "OperationLimits", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (OperationLimitsTypeNode) node);
   }
 
@@ -1320,8 +1479,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public FolderTypeNode getModellingRulesNode() throws UaException {
     try {
       return getModellingRulesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1329,10 +1491,7 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends FolderTypeNode> getModellingRulesNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ModellingRules",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "ModellingRules", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (FolderTypeNode) node);
   }
 
@@ -1340,8 +1499,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public FolderTypeNode getAggregateFunctionsNode() throws UaException {
     try {
       return getAggregateFunctionsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1351,7 +1513,7 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "AggregateFunctions",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (FolderTypeNode) node);
   }
@@ -1360,8 +1522,11 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public RoleSetTypeNode getRoleSetNode() throws UaException {
     try {
       return getRoleSetNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1369,7 +1534,7 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends RoleSetTypeNode> getRoleSetNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "RoleSet", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "RoleSet", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (RoleSetTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ServerConfigurationTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ServerConfigurationTypeNode.java
@@ -78,8 +78,11 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   public String readApplicationUri() throws UaException {
     try {
       return readApplicationUriAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -87,8 +90,11 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   public void writeApplicationUri(String value) throws UaException {
     try {
       writeApplicationUriAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -110,8 +116,11 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getApplicationUriNode() throws UaException {
     try {
       return getApplicationUriNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -119,10 +128,7 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getApplicationUriNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ApplicationUri",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "ApplicationUri", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -142,8 +148,11 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   public String readProductUri() throws UaException {
     try {
       return readProductUriAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -151,8 +160,11 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   public void writeProductUri(String value) throws UaException {
     try {
       writeProductUriAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -174,8 +186,11 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getProductUriNode() throws UaException {
     try {
       return getProductUriNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -183,7 +198,7 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getProductUriNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "ProductUri", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "ProductUri", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -211,8 +226,11 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   public ApplicationType readApplicationType() throws UaException {
     try {
       return readApplicationTypeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -220,8 +238,11 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   public void writeApplicationType(ApplicationType value) throws UaException {
     try {
       writeApplicationTypeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -251,8 +272,11 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getApplicationTypeNode() throws UaException {
     try {
       return getApplicationTypeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -260,10 +284,7 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getApplicationTypeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ApplicationType",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "ApplicationType", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -283,8 +304,11 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   public LocalizedText[] readApplicationNames() throws UaException {
     try {
       return readApplicationNamesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -292,8 +316,11 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   public void writeApplicationNames(LocalizedText[] value) throws UaException {
     try {
       writeApplicationNamesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -316,8 +343,11 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getApplicationNamesNode() throws UaException {
     try {
       return getApplicationNamesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -327,7 +357,7 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ApplicationNames",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -348,8 +378,11 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   public String[] readServerCapabilities() throws UaException {
     try {
       return readServerCapabilitiesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -357,8 +390,11 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   public void writeServerCapabilities(String[] value) throws UaException {
     try {
       writeServerCapabilitiesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -380,8 +416,11 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getServerCapabilitiesNode() throws UaException {
     try {
       return getServerCapabilitiesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -391,7 +430,7 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ServerCapabilities",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -412,8 +451,11 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   public String[] readSupportedPrivateKeyFormats() throws UaException {
     try {
       return readSupportedPrivateKeyFormatsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -421,8 +463,11 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   public void writeSupportedPrivateKeyFormats(String[] value) throws UaException {
     try {
       writeSupportedPrivateKeyFormatsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -445,8 +490,11 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getSupportedPrivateKeyFormatsNode() throws UaException {
     try {
       return getSupportedPrivateKeyFormatsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -456,7 +504,7 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SupportedPrivateKeyFormats",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -477,8 +525,11 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   public UInteger readMaxTrustListSize() throws UaException {
     try {
       return readMaxTrustListSizeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -486,8 +537,11 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   public void writeMaxTrustListSize(UInteger value) throws UaException {
     try {
       writeMaxTrustListSizeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -509,8 +563,11 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getMaxTrustListSizeNode() throws UaException {
     try {
       return getMaxTrustListSizeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -520,7 +577,7 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaxTrustListSize",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -541,8 +598,11 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   public Boolean readMulticastDnsEnabled() throws UaException {
     try {
       return readMulticastDnsEnabledAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -550,8 +610,11 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   public void writeMulticastDnsEnabled(Boolean value) throws UaException {
     try {
       writeMulticastDnsEnabledAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -573,8 +636,11 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getMulticastDnsEnabledNode() throws UaException {
     try {
       return getMulticastDnsEnabledNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -584,7 +650,7 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MulticastDnsEnabled",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -605,8 +671,11 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   public Boolean readHasSecureElement() throws UaException {
     try {
       return readHasSecureElementAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -614,8 +683,11 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   public void writeHasSecureElement(Boolean value) throws UaException {
     try {
       writeHasSecureElementAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -637,8 +709,11 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getHasSecureElementNode() throws UaException {
     try {
       return getHasSecureElementNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -648,7 +723,7 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "HasSecureElement",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -669,8 +744,11 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   public Boolean readSupportsTransactions() throws UaException {
     try {
       return readSupportsTransactionsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -678,8 +756,11 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   public void writeSupportsTransactions(Boolean value) throws UaException {
     try {
       writeSupportsTransactionsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -702,8 +783,11 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getSupportsTransactionsNode() throws UaException {
     try {
       return getSupportsTransactionsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -713,7 +797,7 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SupportsTransactions",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -734,8 +818,11 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   public Boolean readInApplicationSetup() throws UaException {
     try {
       return readInApplicationSetupAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -743,8 +830,11 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   public void writeInApplicationSetup(Boolean value) throws UaException {
     try {
       writeInApplicationSetupAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -766,8 +856,11 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getInApplicationSetupNode() throws UaException {
     try {
       return getInApplicationSetupNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -777,7 +870,7 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "InApplicationSetup",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -786,8 +879,11 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   public CertificateGroupFolderTypeNode getCertificateGroupsNode() throws UaException {
     try {
       return getCertificateGroupsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -798,7 +894,7 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "CertificateGroups",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (CertificateGroupFolderTypeNode) node);
   }
@@ -807,8 +903,11 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   public TransactionDiagnosticsTypeNode getTransactionDiagnosticsNode() throws UaException {
     try {
       return getTransactionDiagnosticsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -819,7 +918,7 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "TransactionDiagnostics",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (TransactionDiagnosticsTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ServerDiagnosticsTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ServerDiagnosticsTypeNode.java
@@ -83,8 +83,11 @@ public class ServerDiagnosticsTypeNode extends BaseObjectTypeNode implements Ser
   public Boolean readEnabledFlag() throws UaException {
     try {
       return readEnabledFlagAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -92,8 +95,11 @@ public class ServerDiagnosticsTypeNode extends BaseObjectTypeNode implements Ser
   public void writeEnabledFlag(Boolean value) throws UaException {
     try {
       writeEnabledFlagAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -115,8 +121,11 @@ public class ServerDiagnosticsTypeNode extends BaseObjectTypeNode implements Ser
   public PropertyTypeNode getEnabledFlagNode() throws UaException {
     try {
       return getEnabledFlagNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -124,10 +133,7 @@ public class ServerDiagnosticsTypeNode extends BaseObjectTypeNode implements Ser
   public CompletableFuture<? extends PropertyTypeNode> getEnabledFlagNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "EnabledFlag",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "EnabledFlag", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -149,8 +155,11 @@ public class ServerDiagnosticsTypeNode extends BaseObjectTypeNode implements Ser
   public ServerDiagnosticsSummaryDataType readServerDiagnosticsSummary() throws UaException {
     try {
       return readServerDiagnosticsSummaryAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -159,8 +168,11 @@ public class ServerDiagnosticsTypeNode extends BaseObjectTypeNode implements Ser
       throws UaException {
     try {
       writeServerDiagnosticsSummaryAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -186,8 +198,11 @@ public class ServerDiagnosticsTypeNode extends BaseObjectTypeNode implements Ser
   public ServerDiagnosticsSummaryTypeNode getServerDiagnosticsSummaryNode() throws UaException {
     try {
       return getServerDiagnosticsSummaryNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -198,7 +213,7 @@ public class ServerDiagnosticsTypeNode extends BaseObjectTypeNode implements Ser
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ServerDiagnosticsSummary",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (ServerDiagnosticsSummaryTypeNode) node);
   }
@@ -224,8 +239,11 @@ public class ServerDiagnosticsTypeNode extends BaseObjectTypeNode implements Ser
       throws UaException {
     try {
       return readSamplingIntervalDiagnosticsArrayAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -234,8 +252,11 @@ public class ServerDiagnosticsTypeNode extends BaseObjectTypeNode implements Ser
       throws UaException {
     try {
       writeSamplingIntervalDiagnosticsArrayAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -263,8 +284,11 @@ public class ServerDiagnosticsTypeNode extends BaseObjectTypeNode implements Ser
       throws UaException {
     try {
       return getSamplingIntervalDiagnosticsArrayNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -275,7 +299,7 @@ public class ServerDiagnosticsTypeNode extends BaseObjectTypeNode implements Ser
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SamplingIntervalDiagnosticsArray",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (SamplingIntervalDiagnosticsArrayTypeNode) node);
   }
@@ -299,8 +323,11 @@ public class ServerDiagnosticsTypeNode extends BaseObjectTypeNode implements Ser
   public SubscriptionDiagnosticsDataType[] readSubscriptionDiagnosticsArray() throws UaException {
     try {
       return readSubscriptionDiagnosticsArrayAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -309,8 +336,11 @@ public class ServerDiagnosticsTypeNode extends BaseObjectTypeNode implements Ser
       throws UaException {
     try {
       writeSubscriptionDiagnosticsArrayAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -338,8 +368,11 @@ public class ServerDiagnosticsTypeNode extends BaseObjectTypeNode implements Ser
       throws UaException {
     try {
       return getSubscriptionDiagnosticsArrayNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -350,7 +383,7 @@ public class ServerDiagnosticsTypeNode extends BaseObjectTypeNode implements Ser
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SubscriptionDiagnosticsArray",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (SubscriptionDiagnosticsArrayTypeNode) node);
   }
@@ -359,8 +392,11 @@ public class ServerDiagnosticsTypeNode extends BaseObjectTypeNode implements Ser
   public SessionsDiagnosticsSummaryTypeNode getSessionsDiagnosticsSummaryNode() throws UaException {
     try {
       return getSessionsDiagnosticsSummaryNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -371,7 +407,7 @@ public class ServerDiagnosticsTypeNode extends BaseObjectTypeNode implements Ser
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SessionsDiagnosticsSummary",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (SessionsDiagnosticsSummaryTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ServerRedundancyTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ServerRedundancyTypeNode.java
@@ -87,8 +87,11 @@ public class ServerRedundancyTypeNode extends BaseObjectTypeNode implements Serv
   public RedundancySupport readRedundancySupport() throws UaException {
     try {
       return readRedundancySupportAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -96,8 +99,11 @@ public class ServerRedundancyTypeNode extends BaseObjectTypeNode implements Serv
   public void writeRedundancySupport(RedundancySupport value) throws UaException {
     try {
       writeRedundancySupportAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -128,8 +134,11 @@ public class ServerRedundancyTypeNode extends BaseObjectTypeNode implements Serv
   public PropertyTypeNode getRedundancySupportNode() throws UaException {
     try {
       return getRedundancySupportNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -139,7 +148,7 @@ public class ServerRedundancyTypeNode extends BaseObjectTypeNode implements Serv
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "RedundancySupport",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -162,8 +171,11 @@ public class ServerRedundancyTypeNode extends BaseObjectTypeNode implements Serv
   public RedundantServerDataType[] readRedundantServerArray() throws UaException {
     try {
       return readRedundantServerArrayAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -171,8 +183,11 @@ public class ServerRedundancyTypeNode extends BaseObjectTypeNode implements Serv
   public void writeRedundantServerArray(RedundantServerDataType[] value) throws UaException {
     try {
       writeRedundantServerArrayAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -197,8 +212,11 @@ public class ServerRedundancyTypeNode extends BaseObjectTypeNode implements Serv
   public PropertyTypeNode getRedundantServerArrayNode() throws UaException {
     try {
       return getRedundantServerArrayNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -208,7 +226,7 @@ public class ServerRedundancyTypeNode extends BaseObjectTypeNode implements Serv
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "RedundantServerArray",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ServerTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ServerTypeNode.java
@@ -81,8 +81,11 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
   public String[] readServerArray() throws UaException {
     try {
       return readServerArrayAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -90,8 +93,11 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
   public void writeServerArray(String[] value) throws UaException {
     try {
       writeServerArrayAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -113,8 +119,11 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
   public PropertyTypeNode getServerArrayNode() throws UaException {
     try {
       return getServerArrayNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -122,10 +131,7 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
   public CompletableFuture<? extends PropertyTypeNode> getServerArrayNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ServerArray",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "ServerArray", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -145,8 +151,11 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
   public String[] readNamespaceArray() throws UaException {
     try {
       return readNamespaceArrayAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -154,8 +163,11 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
   public void writeNamespaceArray(String[] value) throws UaException {
     try {
       writeNamespaceArrayAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -177,8 +189,11 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
   public PropertyTypeNode getNamespaceArrayNode() throws UaException {
     try {
       return getNamespaceArrayNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -186,10 +201,7 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
   public CompletableFuture<? extends PropertyTypeNode> getNamespaceArrayNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "NamespaceArray",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "NamespaceArray", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -209,8 +221,11 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
   public UInteger readUrisVersion() throws UaException {
     try {
       return readUrisVersionAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -218,8 +233,11 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
   public void writeUrisVersion(UInteger value) throws UaException {
     try {
       writeUrisVersionAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -241,8 +259,11 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
   public PropertyTypeNode getUrisVersionNode() throws UaException {
     try {
       return getUrisVersionNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -250,10 +271,7 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
   public CompletableFuture<? extends PropertyTypeNode> getUrisVersionNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "UrisVersion",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "UrisVersion", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -273,8 +291,11 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
   public UByte readServiceLevel() throws UaException {
     try {
       return readServiceLevelAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -282,8 +303,11 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
   public void writeServiceLevel(UByte value) throws UaException {
     try {
       writeServiceLevelAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -305,8 +329,11 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
   public PropertyTypeNode getServiceLevelNode() throws UaException {
     try {
       return getServiceLevelNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -314,10 +341,7 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
   public CompletableFuture<? extends PropertyTypeNode> getServiceLevelNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ServiceLevel",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "ServiceLevel", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -337,8 +361,11 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
   public Boolean readAuditing() throws UaException {
     try {
       return readAuditingAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -346,8 +373,11 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
   public void writeAuditing(Boolean value) throws UaException {
     try {
       writeAuditingAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -369,8 +399,11 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
   public PropertyTypeNode getAuditingNode() throws UaException {
     try {
       return getAuditingNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -378,7 +411,7 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
   public CompletableFuture<? extends PropertyTypeNode> getAuditingNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Auditing", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Auditing", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -398,8 +431,11 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
   public DateTime readEstimatedReturnTime() throws UaException {
     try {
       return readEstimatedReturnTimeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -407,8 +443,11 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
   public void writeEstimatedReturnTime(DateTime value) throws UaException {
     try {
       writeEstimatedReturnTimeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -430,8 +469,11 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
   public PropertyTypeNode getEstimatedReturnTimeNode() throws UaException {
     try {
       return getEstimatedReturnTimeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -441,7 +483,7 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "EstimatedReturnTime",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -463,8 +505,11 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
   public TimeZoneDataType readLocalTime() throws UaException {
     try {
       return readLocalTimeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -472,8 +517,11 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
   public void writeLocalTime(TimeZoneDataType value) throws UaException {
     try {
       writeLocalTimeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -496,8 +544,11 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
   public PropertyTypeNode getLocalTimeNode() throws UaException {
     try {
       return getLocalTimeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -505,7 +556,7 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
   public CompletableFuture<? extends PropertyTypeNode> getLocalTimeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "LocalTime", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "LocalTime", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -526,8 +577,11 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
   public ServerStatusDataType readServerStatus() throws UaException {
     try {
       return readServerStatusAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -535,8 +589,11 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
   public void writeServerStatus(ServerStatusDataType value) throws UaException {
     try {
       writeServerStatusAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -560,8 +617,11 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
   public ServerStatusTypeNode getServerStatusNode() throws UaException {
     try {
       return getServerStatusNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -569,10 +629,7 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
   public CompletableFuture<? extends ServerStatusTypeNode> getServerStatusNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ServerStatus",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "ServerStatus", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (ServerStatusTypeNode) node);
   }
 
@@ -580,8 +637,11 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
   public ServerCapabilitiesTypeNode getServerCapabilitiesNode() throws UaException {
     try {
       return getServerCapabilitiesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -591,7 +651,7 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ServerCapabilities",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (ServerCapabilitiesTypeNode) node);
   }
@@ -600,8 +660,11 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
   public ServerDiagnosticsTypeNode getServerDiagnosticsNode() throws UaException {
     try {
       return getServerDiagnosticsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -611,7 +674,7 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ServerDiagnostics",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (ServerDiagnosticsTypeNode) node);
   }
@@ -620,8 +683,11 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
   public VendorServerInfoTypeNode getVendorServerInfoNode() throws UaException {
     try {
       return getVendorServerInfoNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -631,7 +697,7 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "VendorServerInfo",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (VendorServerInfoTypeNode) node);
   }
@@ -640,8 +706,11 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
   public ServerRedundancyTypeNode getServerRedundancyNode() throws UaException {
     try {
       return getServerRedundancyNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -651,7 +720,7 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ServerRedundancy",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (ServerRedundancyTypeNode) node);
   }
@@ -660,8 +729,11 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
   public NamespacesTypeNode getNamespacesNode() throws UaException {
     try {
       return getNamespacesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -669,7 +741,7 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
   public CompletableFuture<? extends NamespacesTypeNode> getNamespacesNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Namespaces", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "Namespaces", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (NamespacesTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ServerUnitTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ServerUnitTypeNode.java
@@ -85,8 +85,11 @@ public class ServerUnitTypeNode extends UnitTypeNode implements ServerUnitType {
   public ConversionLimitEnum readConversionLimit() throws UaException {
     try {
       return readConversionLimitAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -94,8 +97,11 @@ public class ServerUnitTypeNode extends UnitTypeNode implements ServerUnitType {
   public void writeConversionLimit(ConversionLimitEnum value) throws UaException {
     try {
       writeConversionLimitAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -126,8 +132,11 @@ public class ServerUnitTypeNode extends UnitTypeNode implements ServerUnitType {
   public PropertyTypeNode getConversionLimitNode() throws UaException {
     try {
       return getConversionLimitNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -135,10 +144,7 @@ public class ServerUnitTypeNode extends UnitTypeNode implements ServerUnitType {
   public CompletableFuture<? extends PropertyTypeNode> getConversionLimitNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ConversionLimit",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "ConversionLimit", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -146,8 +152,11 @@ public class ServerUnitTypeNode extends UnitTypeNode implements ServerUnitType {
   public BaseObjectTypeNode getAlternativeUnitsNode() throws UaException {
     try {
       return getAlternativeUnitsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -157,7 +166,7 @@ public class ServerUnitTypeNode extends UnitTypeNode implements ServerUnitType {
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "AlternativeUnits",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseObjectTypeNode) node);
   }
@@ -166,8 +175,11 @@ public class ServerUnitTypeNode extends UnitTypeNode implements ServerUnitType {
   public UnitTypeNode getCoherentUnitNode() throws UaException {
     try {
       return getCoherentUnitNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -175,10 +187,7 @@ public class ServerUnitTypeNode extends UnitTypeNode implements ServerUnitType {
   public CompletableFuture<? extends UnitTypeNode> getCoherentUnitNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "CoherentUnit",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "CoherentUnit", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (UnitTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/SessionDiagnosticsObjectTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/SessionDiagnosticsObjectTypeNode.java
@@ -84,8 +84,11 @@ public class SessionDiagnosticsObjectTypeNode extends BaseObjectTypeNode
   public NodeId[] readCurrentRoleIds() throws UaException {
     try {
       return readCurrentRoleIdsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -93,8 +96,11 @@ public class SessionDiagnosticsObjectTypeNode extends BaseObjectTypeNode
   public void writeCurrentRoleIds(NodeId[] value) throws UaException {
     try {
       writeCurrentRoleIdsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -116,8 +122,11 @@ public class SessionDiagnosticsObjectTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getCurrentRoleIdsNode() throws UaException {
     try {
       return getCurrentRoleIdsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -125,10 +134,7 @@ public class SessionDiagnosticsObjectTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getCurrentRoleIdsNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "CurrentRoleIds",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "CurrentRoleIds", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -149,8 +155,11 @@ public class SessionDiagnosticsObjectTypeNode extends BaseObjectTypeNode
   public SessionDiagnosticsDataType readSessionDiagnostics() throws UaException {
     try {
       return readSessionDiagnosticsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -158,8 +167,11 @@ public class SessionDiagnosticsObjectTypeNode extends BaseObjectTypeNode
   public void writeSessionDiagnostics(SessionDiagnosticsDataType value) throws UaException {
     try {
       writeSessionDiagnosticsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -184,8 +196,11 @@ public class SessionDiagnosticsObjectTypeNode extends BaseObjectTypeNode
   public SessionDiagnosticsVariableTypeNode getSessionDiagnosticsNode() throws UaException {
     try {
       return getSessionDiagnosticsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -196,7 +211,7 @@ public class SessionDiagnosticsObjectTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SessionDiagnostics",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (SessionDiagnosticsVariableTypeNode) node);
   }
@@ -219,8 +234,11 @@ public class SessionDiagnosticsObjectTypeNode extends BaseObjectTypeNode
   public SessionSecurityDiagnosticsDataType readSessionSecurityDiagnostics() throws UaException {
     try {
       return readSessionSecurityDiagnosticsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -229,8 +247,11 @@ public class SessionDiagnosticsObjectTypeNode extends BaseObjectTypeNode
       throws UaException {
     try {
       writeSessionSecurityDiagnosticsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -256,8 +277,11 @@ public class SessionDiagnosticsObjectTypeNode extends BaseObjectTypeNode
   public SessionSecurityDiagnosticsTypeNode getSessionSecurityDiagnosticsNode() throws UaException {
     try {
       return getSessionSecurityDiagnosticsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -268,7 +292,7 @@ public class SessionDiagnosticsObjectTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SessionSecurityDiagnostics",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (SessionSecurityDiagnosticsTypeNode) node);
   }
@@ -292,8 +316,11 @@ public class SessionDiagnosticsObjectTypeNode extends BaseObjectTypeNode
   public SubscriptionDiagnosticsDataType[] readSubscriptionDiagnosticsArray() throws UaException {
     try {
       return readSubscriptionDiagnosticsArrayAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -302,8 +329,11 @@ public class SessionDiagnosticsObjectTypeNode extends BaseObjectTypeNode
       throws UaException {
     try {
       writeSubscriptionDiagnosticsArrayAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -331,8 +361,11 @@ public class SessionDiagnosticsObjectTypeNode extends BaseObjectTypeNode
       throws UaException {
     try {
       return getSubscriptionDiagnosticsArrayNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -343,7 +376,7 @@ public class SessionDiagnosticsObjectTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SubscriptionDiagnosticsArray",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (SubscriptionDiagnosticsArrayTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/SessionsDiagnosticsSummaryTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/SessionsDiagnosticsSummaryTypeNode.java
@@ -83,8 +83,11 @@ public class SessionsDiagnosticsSummaryTypeNode extends BaseObjectTypeNode
   public SessionDiagnosticsDataType[] readSessionDiagnosticsArray() throws UaException {
     try {
       return readSessionDiagnosticsArrayAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -92,8 +95,11 @@ public class SessionsDiagnosticsSummaryTypeNode extends BaseObjectTypeNode
   public void writeSessionDiagnosticsArray(SessionDiagnosticsDataType[] value) throws UaException {
     try {
       writeSessionDiagnosticsArrayAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -119,8 +125,11 @@ public class SessionsDiagnosticsSummaryTypeNode extends BaseObjectTypeNode
   public SessionDiagnosticsArrayTypeNode getSessionDiagnosticsArrayNode() throws UaException {
     try {
       return getSessionDiagnosticsArrayNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -131,7 +140,7 @@ public class SessionsDiagnosticsSummaryTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SessionDiagnosticsArray",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (SessionDiagnosticsArrayTypeNode) node);
   }
@@ -157,8 +166,11 @@ public class SessionsDiagnosticsSummaryTypeNode extends BaseObjectTypeNode
       throws UaException {
     try {
       return readSessionSecurityDiagnosticsArrayAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -167,8 +179,11 @@ public class SessionsDiagnosticsSummaryTypeNode extends BaseObjectTypeNode
       throws UaException {
     try {
       writeSessionSecurityDiagnosticsArrayAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -196,8 +211,11 @@ public class SessionsDiagnosticsSummaryTypeNode extends BaseObjectTypeNode
       throws UaException {
     try {
       return getSessionSecurityDiagnosticsArrayNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -208,7 +226,7 @@ public class SessionsDiagnosticsSummaryTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SessionSecurityDiagnosticsArray",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (SessionSecurityDiagnosticsArrayTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ShelvedStateMachineTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ShelvedStateMachineTypeNode.java
@@ -77,8 +77,11 @@ public class ShelvedStateMachineTypeNode extends FiniteStateMachineTypeNode
   public Double readUnshelveTime() throws UaException {
     try {
       return readUnshelveTimeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class ShelvedStateMachineTypeNode extends FiniteStateMachineTypeNode
   public void writeUnshelveTime(Double value) throws UaException {
     try {
       writeUnshelveTimeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class ShelvedStateMachineTypeNode extends FiniteStateMachineTypeNode
   public PropertyTypeNode getUnshelveTimeNode() throws UaException {
     try {
       return getUnshelveTimeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -118,10 +127,7 @@ public class ShelvedStateMachineTypeNode extends FiniteStateMachineTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getUnshelveTimeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "UnshelveTime",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "UnshelveTime", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -129,8 +135,11 @@ public class ShelvedStateMachineTypeNode extends FiniteStateMachineTypeNode
   public StateTypeNode getUnshelvedNode() throws UaException {
     try {
       return getUnshelvedNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -138,7 +147,7 @@ public class ShelvedStateMachineTypeNode extends FiniteStateMachineTypeNode
   public CompletableFuture<? extends StateTypeNode> getUnshelvedNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Unshelved", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "Unshelved", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (StateTypeNode) node);
   }
 
@@ -146,8 +155,11 @@ public class ShelvedStateMachineTypeNode extends FiniteStateMachineTypeNode
   public StateTypeNode getTimedShelvedNode() throws UaException {
     try {
       return getTimedShelvedNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -155,10 +167,7 @@ public class ShelvedStateMachineTypeNode extends FiniteStateMachineTypeNode
   public CompletableFuture<? extends StateTypeNode> getTimedShelvedNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "TimedShelved",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "TimedShelved", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (StateTypeNode) node);
   }
 
@@ -166,8 +175,11 @@ public class ShelvedStateMachineTypeNode extends FiniteStateMachineTypeNode
   public StateTypeNode getOneShotShelvedNode() throws UaException {
     try {
       return getOneShotShelvedNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -175,10 +187,7 @@ public class ShelvedStateMachineTypeNode extends FiniteStateMachineTypeNode
   public CompletableFuture<? extends StateTypeNode> getOneShotShelvedNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "OneShotShelved",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "OneShotShelved", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (StateTypeNode) node);
   }
 
@@ -186,8 +195,11 @@ public class ShelvedStateMachineTypeNode extends FiniteStateMachineTypeNode
   public TransitionTypeNode getUnshelvedToTimedShelvedNode() throws UaException {
     try {
       return getUnshelvedToTimedShelvedNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -197,7 +209,7 @@ public class ShelvedStateMachineTypeNode extends FiniteStateMachineTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "UnshelvedToTimedShelved",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (TransitionTypeNode) node);
   }
@@ -206,8 +218,11 @@ public class ShelvedStateMachineTypeNode extends FiniteStateMachineTypeNode
   public TransitionTypeNode getUnshelvedToOneShotShelvedNode() throws UaException {
     try {
       return getUnshelvedToOneShotShelvedNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -217,7 +232,7 @@ public class ShelvedStateMachineTypeNode extends FiniteStateMachineTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "UnshelvedToOneShotShelved",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (TransitionTypeNode) node);
   }
@@ -226,8 +241,11 @@ public class ShelvedStateMachineTypeNode extends FiniteStateMachineTypeNode
   public TransitionTypeNode getTimedShelvedToUnshelvedNode() throws UaException {
     try {
       return getTimedShelvedToUnshelvedNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -237,7 +255,7 @@ public class ShelvedStateMachineTypeNode extends FiniteStateMachineTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "TimedShelvedToUnshelved",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (TransitionTypeNode) node);
   }
@@ -246,8 +264,11 @@ public class ShelvedStateMachineTypeNode extends FiniteStateMachineTypeNode
   public TransitionTypeNode getTimedShelvedToOneShotShelvedNode() throws UaException {
     try {
       return getTimedShelvedToOneShotShelvedNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -258,7 +279,7 @@ public class ShelvedStateMachineTypeNode extends FiniteStateMachineTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "TimedShelvedToOneShotShelved",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (TransitionTypeNode) node);
   }
@@ -267,8 +288,11 @@ public class ShelvedStateMachineTypeNode extends FiniteStateMachineTypeNode
   public TransitionTypeNode getOneShotShelvedToUnshelvedNode() throws UaException {
     try {
       return getOneShotShelvedToUnshelvedNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -278,7 +302,7 @@ public class ShelvedStateMachineTypeNode extends FiniteStateMachineTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "OneShotShelvedToUnshelved",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (TransitionTypeNode) node);
   }
@@ -287,8 +311,11 @@ public class ShelvedStateMachineTypeNode extends FiniteStateMachineTypeNode
   public TransitionTypeNode getOneShotShelvedToTimedShelvedNode() throws UaException {
     try {
       return getOneShotShelvedToTimedShelvedNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -299,7 +326,7 @@ public class ShelvedStateMachineTypeNode extends FiniteStateMachineTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "OneShotShelvedToTimedShelved",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (TransitionTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/StandaloneSubscribedDataSetTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/StandaloneSubscribedDataSetTypeNode.java
@@ -80,8 +80,11 @@ public class StandaloneSubscribedDataSetTypeNode extends BaseObjectTypeNode
   public DataSetMetaDataType readDataSetMetaData() throws UaException {
     try {
       return readDataSetMetaDataAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -89,8 +92,11 @@ public class StandaloneSubscribedDataSetTypeNode extends BaseObjectTypeNode
   public void writeDataSetMetaData(DataSetMetaDataType value) throws UaException {
     try {
       writeDataSetMetaDataAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -115,8 +121,11 @@ public class StandaloneSubscribedDataSetTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getDataSetMetaDataNode() throws UaException {
     try {
       return getDataSetMetaDataNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -124,10 +133,7 @@ public class StandaloneSubscribedDataSetTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getDataSetMetaDataNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "DataSetMetaData",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "DataSetMetaData", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -147,8 +153,11 @@ public class StandaloneSubscribedDataSetTypeNode extends BaseObjectTypeNode
   public Boolean readIsConnected() throws UaException {
     try {
       return readIsConnectedAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -156,8 +165,11 @@ public class StandaloneSubscribedDataSetTypeNode extends BaseObjectTypeNode
   public void writeIsConnected(Boolean value) throws UaException {
     try {
       writeIsConnectedAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -179,8 +191,11 @@ public class StandaloneSubscribedDataSetTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getIsConnectedNode() throws UaException {
     try {
       return getIsConnectedNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -188,10 +203,7 @@ public class StandaloneSubscribedDataSetTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getIsConnectedNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "IsConnected",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "IsConnected", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -199,8 +211,11 @@ public class StandaloneSubscribedDataSetTypeNode extends BaseObjectTypeNode
   public SubscribedDataSetTypeNode getSubscribedDataSetNode() throws UaException {
     try {
       return getSubscribedDataSetNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -210,7 +225,7 @@ public class StandaloneSubscribedDataSetTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SubscribedDataSet",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (SubscribedDataSetTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/StateMachineTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/StateMachineTypeNode.java
@@ -77,8 +77,11 @@ public class StateMachineTypeNode extends BaseObjectTypeNode implements StateMac
   public LocalizedText readCurrentState() throws UaException {
     try {
       return readCurrentStateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class StateMachineTypeNode extends BaseObjectTypeNode implements StateMac
   public void writeCurrentState(LocalizedText value) throws UaException {
     try {
       writeCurrentStateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class StateMachineTypeNode extends BaseObjectTypeNode implements StateMac
   public StateVariableTypeNode getCurrentStateNode() throws UaException {
     try {
       return getCurrentStateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -118,10 +127,7 @@ public class StateMachineTypeNode extends BaseObjectTypeNode implements StateMac
   public CompletableFuture<? extends StateVariableTypeNode> getCurrentStateNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "CurrentState",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "CurrentState", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (StateVariableTypeNode) node);
   }
 
@@ -141,8 +147,11 @@ public class StateMachineTypeNode extends BaseObjectTypeNode implements StateMac
   public LocalizedText readLastTransition() throws UaException {
     try {
       return readLastTransitionAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -150,8 +159,11 @@ public class StateMachineTypeNode extends BaseObjectTypeNode implements StateMac
   public void writeLastTransition(LocalizedText value) throws UaException {
     try {
       writeLastTransitionAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -173,8 +185,11 @@ public class StateMachineTypeNode extends BaseObjectTypeNode implements StateMac
   public TransitionVariableTypeNode getLastTransitionNode() throws UaException {
     try {
       return getLastTransitionNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -182,10 +197,7 @@ public class StateMachineTypeNode extends BaseObjectTypeNode implements StateMac
   public CompletableFuture<? extends TransitionVariableTypeNode> getLastTransitionNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "LastTransition",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "LastTransition", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (TransitionVariableTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/StateTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/StateTypeNode.java
@@ -76,8 +76,11 @@ public class StateTypeNode extends BaseObjectTypeNode implements StateType {
   public UInteger readStateNumber() throws UaException {
     try {
       return readStateNumberAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -85,8 +88,11 @@ public class StateTypeNode extends BaseObjectTypeNode implements StateType {
   public void writeStateNumber(UInteger value) throws UaException {
     try {
       writeStateNumberAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -108,8 +114,11 @@ public class StateTypeNode extends BaseObjectTypeNode implements StateType {
   public PropertyTypeNode getStateNumberNode() throws UaException {
     try {
       return getStateNumberNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -117,10 +126,7 @@ public class StateTypeNode extends BaseObjectTypeNode implements StateType {
   public CompletableFuture<? extends PropertyTypeNode> getStateNumberNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "StateNumber",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "StateNumber", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/SyntaxReferenceEntryTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/SyntaxReferenceEntryTypeNode.java
@@ -77,8 +77,11 @@ public class SyntaxReferenceEntryTypeNode extends DictionaryEntryTypeNode
   public String readCommonName() throws UaException {
     try {
       return readCommonNameAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class SyntaxReferenceEntryTypeNode extends DictionaryEntryTypeNode
   public void writeCommonName(String value) throws UaException {
     try {
       writeCommonNameAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class SyntaxReferenceEntryTypeNode extends DictionaryEntryTypeNode
   public PropertyTypeNode getCommonNameNode() throws UaException {
     try {
       return getCommonNameNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -118,7 +127,7 @@ public class SyntaxReferenceEntryTypeNode extends DictionaryEntryTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getCommonNameNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "CommonName", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "CommonName", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/SystemStatusChangeEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/SystemStatusChangeEventTypeNode.java
@@ -86,8 +86,11 @@ public class SystemStatusChangeEventTypeNode extends SystemEventTypeNode
   public ServerState readSystemState() throws UaException {
     try {
       return readSystemStateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -95,8 +98,11 @@ public class SystemStatusChangeEventTypeNode extends SystemEventTypeNode
   public void writeSystemState(ServerState value) throws UaException {
     try {
       writeSystemStateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -126,8 +132,11 @@ public class SystemStatusChangeEventTypeNode extends SystemEventTypeNode
   public PropertyTypeNode getSystemStateNode() throws UaException {
     try {
       return getSystemStateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -135,10 +144,7 @@ public class SystemStatusChangeEventTypeNode extends SystemEventTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getSystemStateNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "SystemState",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "SystemState", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/TargetVariablesTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/TargetVariablesTypeNode.java
@@ -81,8 +81,11 @@ public class TargetVariablesTypeNode extends SubscribedDataSetTypeNode
   public FieldTargetDataType[] readTargetVariables() throws UaException {
     try {
       return readTargetVariablesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -90,8 +93,11 @@ public class TargetVariablesTypeNode extends SubscribedDataSetTypeNode
   public void writeTargetVariables(FieldTargetDataType[] value) throws UaException {
     try {
       writeTargetVariablesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -116,8 +122,11 @@ public class TargetVariablesTypeNode extends SubscribedDataSetTypeNode
   public PropertyTypeNode getTargetVariablesNode() throws UaException {
     try {
       return getTargetVariablesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -125,10 +134,7 @@ public class TargetVariablesTypeNode extends SubscribedDataSetTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getTargetVariablesNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "TargetVariables",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "TargetVariables", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/TemporaryFileTransferTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/TemporaryFileTransferTypeNode.java
@@ -77,8 +77,11 @@ public class TemporaryFileTransferTypeNode extends BaseObjectTypeNode
   public Double readClientProcessingTimeout() throws UaException {
     try {
       return readClientProcessingTimeoutAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class TemporaryFileTransferTypeNode extends BaseObjectTypeNode
   public void writeClientProcessingTimeout(Double value) throws UaException {
     try {
       writeClientProcessingTimeoutAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -110,8 +116,11 @@ public class TemporaryFileTransferTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getClientProcessingTimeoutNode() throws UaException {
     try {
       return getClientProcessingTimeoutNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -121,7 +130,7 @@ public class TemporaryFileTransferTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ClientProcessingTimeout",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/TransactionDiagnosticsTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/TransactionDiagnosticsTypeNode.java
@@ -80,8 +80,11 @@ public class TransactionDiagnosticsTypeNode extends BaseObjectTypeNode
   public DateTime readStartTime() throws UaException {
     try {
       return readStartTimeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -89,8 +92,11 @@ public class TransactionDiagnosticsTypeNode extends BaseObjectTypeNode
   public void writeStartTime(DateTime value) throws UaException {
     try {
       writeStartTimeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -112,8 +118,11 @@ public class TransactionDiagnosticsTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getStartTimeNode() throws UaException {
     try {
       return getStartTimeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -121,7 +130,7 @@ public class TransactionDiagnosticsTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getStartTimeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "StartTime", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "StartTime", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -141,8 +150,11 @@ public class TransactionDiagnosticsTypeNode extends BaseObjectTypeNode
   public DateTime readEndTime() throws UaException {
     try {
       return readEndTimeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -150,8 +162,11 @@ public class TransactionDiagnosticsTypeNode extends BaseObjectTypeNode
   public void writeEndTime(DateTime value) throws UaException {
     try {
       writeEndTimeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -173,8 +188,11 @@ public class TransactionDiagnosticsTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getEndTimeNode() throws UaException {
     try {
       return getEndTimeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -182,7 +200,7 @@ public class TransactionDiagnosticsTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getEndTimeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "EndTime", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "EndTime", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -202,8 +220,11 @@ public class TransactionDiagnosticsTypeNode extends BaseObjectTypeNode
   public StatusCode readResult() throws UaException {
     try {
       return readResultAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -211,8 +232,11 @@ public class TransactionDiagnosticsTypeNode extends BaseObjectTypeNode
   public void writeResult(StatusCode value) throws UaException {
     try {
       writeResultAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -234,8 +258,11 @@ public class TransactionDiagnosticsTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getResultNode() throws UaException {
     try {
       return getResultNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -243,7 +270,7 @@ public class TransactionDiagnosticsTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getResultNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Result", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Result", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -263,8 +290,11 @@ public class TransactionDiagnosticsTypeNode extends BaseObjectTypeNode
   public NodeId[] readAffectedTrustLists() throws UaException {
     try {
       return readAffectedTrustListsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -272,8 +302,11 @@ public class TransactionDiagnosticsTypeNode extends BaseObjectTypeNode
   public void writeAffectedTrustLists(NodeId[] value) throws UaException {
     try {
       writeAffectedTrustListsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -295,8 +328,11 @@ public class TransactionDiagnosticsTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getAffectedTrustListsNode() throws UaException {
     try {
       return getAffectedTrustListsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -306,7 +342,7 @@ public class TransactionDiagnosticsTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "AffectedTrustLists",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -327,8 +363,11 @@ public class TransactionDiagnosticsTypeNode extends BaseObjectTypeNode
   public NodeId[] readAffectedCertificateGroups() throws UaException {
     try {
       return readAffectedCertificateGroupsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -336,8 +375,11 @@ public class TransactionDiagnosticsTypeNode extends BaseObjectTypeNode
   public void writeAffectedCertificateGroups(NodeId[] value) throws UaException {
     try {
       writeAffectedCertificateGroupsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -360,8 +402,11 @@ public class TransactionDiagnosticsTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getAffectedCertificateGroupsNode() throws UaException {
     try {
       return getAffectedCertificateGroupsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -371,7 +416,7 @@ public class TransactionDiagnosticsTypeNode extends BaseObjectTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "AffectedCertificateGroups",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -394,8 +439,11 @@ public class TransactionDiagnosticsTypeNode extends BaseObjectTypeNode
   public TransactionErrorType[] readErrors() throws UaException {
     try {
       return readErrorsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -403,8 +451,11 @@ public class TransactionDiagnosticsTypeNode extends BaseObjectTypeNode
   public void writeErrors(TransactionErrorType[] value) throws UaException {
     try {
       writeErrorsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -428,8 +479,11 @@ public class TransactionDiagnosticsTypeNode extends BaseObjectTypeNode
   public PropertyTypeNode getErrorsNode() throws UaException {
     try {
       return getErrorsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -437,7 +491,7 @@ public class TransactionDiagnosticsTypeNode extends BaseObjectTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getErrorsNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Errors", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Errors", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/TransitionEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/TransitionEventTypeNode.java
@@ -77,8 +77,11 @@ public class TransitionEventTypeNode extends BaseEventTypeNode implements Transi
   public LocalizedText readTransition() throws UaException {
     try {
       return readTransitionAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class TransitionEventTypeNode extends BaseEventTypeNode implements Transi
   public void writeTransition(LocalizedText value) throws UaException {
     try {
       writeTransitionAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class TransitionEventTypeNode extends BaseEventTypeNode implements Transi
   public TransitionVariableTypeNode getTransitionNode() throws UaException {
     try {
       return getTransitionNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -118,7 +127,7 @@ public class TransitionEventTypeNode extends BaseEventTypeNode implements Transi
   public CompletableFuture<? extends TransitionVariableTypeNode> getTransitionNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Transition", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "Transition", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (TransitionVariableTypeNode) node);
   }
 
@@ -138,8 +147,11 @@ public class TransitionEventTypeNode extends BaseEventTypeNode implements Transi
   public LocalizedText readFromState() throws UaException {
     try {
       return readFromStateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -147,8 +159,11 @@ public class TransitionEventTypeNode extends BaseEventTypeNode implements Transi
   public void writeFromState(LocalizedText value) throws UaException {
     try {
       writeFromStateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -170,8 +185,11 @@ public class TransitionEventTypeNode extends BaseEventTypeNode implements Transi
   public StateVariableTypeNode getFromStateNode() throws UaException {
     try {
       return getFromStateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -179,7 +197,7 @@ public class TransitionEventTypeNode extends BaseEventTypeNode implements Transi
   public CompletableFuture<? extends StateVariableTypeNode> getFromStateNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "FromState", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "FromState", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (StateVariableTypeNode) node);
   }
 
@@ -199,8 +217,11 @@ public class TransitionEventTypeNode extends BaseEventTypeNode implements Transi
   public LocalizedText readToState() throws UaException {
     try {
       return readToStateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -208,8 +229,11 @@ public class TransitionEventTypeNode extends BaseEventTypeNode implements Transi
   public void writeToState(LocalizedText value) throws UaException {
     try {
       writeToStateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -231,8 +255,11 @@ public class TransitionEventTypeNode extends BaseEventTypeNode implements Transi
   public StateVariableTypeNode getToStateNode() throws UaException {
     try {
       return getToStateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -240,7 +267,7 @@ public class TransitionEventTypeNode extends BaseEventTypeNode implements Transi
   public CompletableFuture<? extends StateVariableTypeNode> getToStateNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "ToState", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "ToState", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (StateVariableTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/TransitionTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/TransitionTypeNode.java
@@ -76,8 +76,11 @@ public class TransitionTypeNode extends BaseObjectTypeNode implements Transition
   public UInteger readTransitionNumber() throws UaException {
     try {
       return readTransitionNumberAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -85,8 +88,11 @@ public class TransitionTypeNode extends BaseObjectTypeNode implements Transition
   public void writeTransitionNumber(UInteger value) throws UaException {
     try {
       writeTransitionNumberAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -108,8 +114,11 @@ public class TransitionTypeNode extends BaseObjectTypeNode implements Transition
   public PropertyTypeNode getTransitionNumberNode() throws UaException {
     try {
       return getTransitionNumberNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -119,7 +128,7 @@ public class TransitionTypeNode extends BaseObjectTypeNode implements Transition
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "TransitionNumber",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/TransparentRedundancyTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/TransparentRedundancyTypeNode.java
@@ -81,8 +81,11 @@ public class TransparentRedundancyTypeNode extends ServerRedundancyTypeNode
   public RedundantServerDataType[] readRedundantServerArray() throws UaException {
     try {
       return readRedundantServerArrayAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -90,8 +93,11 @@ public class TransparentRedundancyTypeNode extends ServerRedundancyTypeNode
   public void writeRedundantServerArray(RedundantServerDataType[] value) throws UaException {
     try {
       writeRedundantServerArrayAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -116,8 +122,11 @@ public class TransparentRedundancyTypeNode extends ServerRedundancyTypeNode
   public PropertyTypeNode getRedundantServerArrayNode() throws UaException {
     try {
       return getRedundantServerArrayNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -127,7 +136,7 @@ public class TransparentRedundancyTypeNode extends ServerRedundancyTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "RedundantServerArray",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -148,8 +157,11 @@ public class TransparentRedundancyTypeNode extends ServerRedundancyTypeNode
   public String readCurrentServerId() throws UaException {
     try {
       return readCurrentServerIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -157,8 +169,11 @@ public class TransparentRedundancyTypeNode extends ServerRedundancyTypeNode
   public void writeCurrentServerId(String value) throws UaException {
     try {
       writeCurrentServerIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -180,8 +195,11 @@ public class TransparentRedundancyTypeNode extends ServerRedundancyTypeNode
   public PropertyTypeNode getCurrentServerIdNode() throws UaException {
     try {
       return getCurrentServerIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -189,10 +207,7 @@ public class TransparentRedundancyTypeNode extends ServerRedundancyTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getCurrentServerIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "CurrentServerId",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "CurrentServerId", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/TrustListOutOfDateAlarmTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/TrustListOutOfDateAlarmTypeNode.java
@@ -78,8 +78,11 @@ public class TrustListOutOfDateAlarmTypeNode extends SystemOffNormalAlarmTypeNod
   public NodeId readTrustListId() throws UaException {
     try {
       return readTrustListIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -87,8 +90,11 @@ public class TrustListOutOfDateAlarmTypeNode extends SystemOffNormalAlarmTypeNod
   public void writeTrustListId(NodeId value) throws UaException {
     try {
       writeTrustListIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -110,8 +116,11 @@ public class TrustListOutOfDateAlarmTypeNode extends SystemOffNormalAlarmTypeNod
   public PropertyTypeNode getTrustListIdNode() throws UaException {
     try {
       return getTrustListIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -119,10 +128,7 @@ public class TrustListOutOfDateAlarmTypeNode extends SystemOffNormalAlarmTypeNod
   public CompletableFuture<? extends PropertyTypeNode> getTrustListIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "TrustListId",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "TrustListId", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -142,8 +148,11 @@ public class TrustListOutOfDateAlarmTypeNode extends SystemOffNormalAlarmTypeNod
   public DateTime readLastUpdateTime() throws UaException {
     try {
       return readLastUpdateTimeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -151,8 +160,11 @@ public class TrustListOutOfDateAlarmTypeNode extends SystemOffNormalAlarmTypeNod
   public void writeLastUpdateTime(DateTime value) throws UaException {
     try {
       writeLastUpdateTimeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -174,8 +186,11 @@ public class TrustListOutOfDateAlarmTypeNode extends SystemOffNormalAlarmTypeNod
   public PropertyTypeNode getLastUpdateTimeNode() throws UaException {
     try {
       return getLastUpdateTimeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -183,10 +198,7 @@ public class TrustListOutOfDateAlarmTypeNode extends SystemOffNormalAlarmTypeNod
   public CompletableFuture<? extends PropertyTypeNode> getLastUpdateTimeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "LastUpdateTime",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "LastUpdateTime", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -206,8 +218,11 @@ public class TrustListOutOfDateAlarmTypeNode extends SystemOffNormalAlarmTypeNod
   public Double readUpdateFrequency() throws UaException {
     try {
       return readUpdateFrequencyAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -215,8 +230,11 @@ public class TrustListOutOfDateAlarmTypeNode extends SystemOffNormalAlarmTypeNod
   public void writeUpdateFrequency(Double value) throws UaException {
     try {
       writeUpdateFrequencyAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -238,8 +256,11 @@ public class TrustListOutOfDateAlarmTypeNode extends SystemOffNormalAlarmTypeNod
   public PropertyTypeNode getUpdateFrequencyNode() throws UaException {
     try {
       return getUpdateFrequencyNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -247,10 +268,7 @@ public class TrustListOutOfDateAlarmTypeNode extends SystemOffNormalAlarmTypeNod
   public CompletableFuture<? extends PropertyTypeNode> getUpdateFrequencyNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "UpdateFrequency",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "UpdateFrequency", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/TrustListTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/TrustListTypeNode.java
@@ -78,8 +78,11 @@ public class TrustListTypeNode extends FileTypeNode implements TrustListType {
   public DateTime readLastUpdateTime() throws UaException {
     try {
       return readLastUpdateTimeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -87,8 +90,11 @@ public class TrustListTypeNode extends FileTypeNode implements TrustListType {
   public void writeLastUpdateTime(DateTime value) throws UaException {
     try {
       writeLastUpdateTimeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -110,8 +116,11 @@ public class TrustListTypeNode extends FileTypeNode implements TrustListType {
   public PropertyTypeNode getLastUpdateTimeNode() throws UaException {
     try {
       return getLastUpdateTimeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -119,10 +128,7 @@ public class TrustListTypeNode extends FileTypeNode implements TrustListType {
   public CompletableFuture<? extends PropertyTypeNode> getLastUpdateTimeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "LastUpdateTime",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "LastUpdateTime", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -142,8 +148,11 @@ public class TrustListTypeNode extends FileTypeNode implements TrustListType {
   public Double readUpdateFrequency() throws UaException {
     try {
       return readUpdateFrequencyAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -151,8 +160,11 @@ public class TrustListTypeNode extends FileTypeNode implements TrustListType {
   public void writeUpdateFrequency(Double value) throws UaException {
     try {
       writeUpdateFrequencyAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -174,8 +186,11 @@ public class TrustListTypeNode extends FileTypeNode implements TrustListType {
   public PropertyTypeNode getUpdateFrequencyNode() throws UaException {
     try {
       return getUpdateFrequencyNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -183,10 +198,7 @@ public class TrustListTypeNode extends FileTypeNode implements TrustListType {
   public CompletableFuture<? extends PropertyTypeNode> getUpdateFrequencyNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "UpdateFrequency",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "UpdateFrequency", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -206,8 +218,11 @@ public class TrustListTypeNode extends FileTypeNode implements TrustListType {
   public Double readActivityTimeout() throws UaException {
     try {
       return readActivityTimeoutAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -215,8 +230,11 @@ public class TrustListTypeNode extends FileTypeNode implements TrustListType {
   public void writeActivityTimeout(Double value) throws UaException {
     try {
       writeActivityTimeoutAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -238,8 +256,11 @@ public class TrustListTypeNode extends FileTypeNode implements TrustListType {
   public PropertyTypeNode getActivityTimeoutNode() throws UaException {
     try {
       return getActivityTimeoutNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -247,10 +268,7 @@ public class TrustListTypeNode extends FileTypeNode implements TrustListType {
   public CompletableFuture<? extends PropertyTypeNode> getActivityTimeoutNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ActivityTimeout",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "ActivityTimeout", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -270,8 +288,11 @@ public class TrustListTypeNode extends FileTypeNode implements TrustListType {
   public TrustListValidationOptions readDefaultValidationOptions() throws UaException {
     try {
       return readDefaultValidationOptionsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -279,8 +300,11 @@ public class TrustListTypeNode extends FileTypeNode implements TrustListType {
   public void writeDefaultValidationOptions(TrustListValidationOptions value) throws UaException {
     try {
       writeDefaultValidationOptionsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -304,8 +328,11 @@ public class TrustListTypeNode extends FileTypeNode implements TrustListType {
   public PropertyTypeNode getDefaultValidationOptionsNode() throws UaException {
     try {
       return getDefaultValidationOptionsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -315,7 +342,7 @@ public class TrustListTypeNode extends FileTypeNode implements TrustListType {
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "DefaultValidationOptions",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/TrustListUpdatedAuditEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/TrustListUpdatedAuditEventTypeNode.java
@@ -77,8 +77,11 @@ public class TrustListUpdatedAuditEventTypeNode extends AuditUpdateMethodEventTy
   public NodeId readTrustListId() throws UaException {
     try {
       return readTrustListIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class TrustListUpdatedAuditEventTypeNode extends AuditUpdateMethodEventTy
   public void writeTrustListId(NodeId value) throws UaException {
     try {
       writeTrustListIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class TrustListUpdatedAuditEventTypeNode extends AuditUpdateMethodEventTy
   public PropertyTypeNode getTrustListIdNode() throws UaException {
     try {
       return getTrustListIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -118,10 +127,7 @@ public class TrustListUpdatedAuditEventTypeNode extends AuditUpdateMethodEventTy
   public CompletableFuture<? extends PropertyTypeNode> getTrustListIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "TrustListId",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "TrustListId", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/UadpDataSetReaderMessageTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/UadpDataSetReaderMessageTypeNode.java
@@ -81,8 +81,11 @@ public class UadpDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
   public UInteger readGroupVersion() throws UaException {
     try {
       return readGroupVersionAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -90,8 +93,11 @@ public class UadpDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
   public void writeGroupVersion(UInteger value) throws UaException {
     try {
       writeGroupVersionAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -113,8 +119,11 @@ public class UadpDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
   public PropertyTypeNode getGroupVersionNode() throws UaException {
     try {
       return getGroupVersionNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -122,10 +131,7 @@ public class UadpDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
   public CompletableFuture<? extends PropertyTypeNode> getGroupVersionNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "GroupVersion",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "GroupVersion", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -145,8 +151,11 @@ public class UadpDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
   public UShort readNetworkMessageNumber() throws UaException {
     try {
       return readNetworkMessageNumberAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -154,8 +163,11 @@ public class UadpDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
   public void writeNetworkMessageNumber(UShort value) throws UaException {
     try {
       writeNetworkMessageNumberAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -177,8 +189,11 @@ public class UadpDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
   public PropertyTypeNode getNetworkMessageNumberNode() throws UaException {
     try {
       return getNetworkMessageNumberNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -188,7 +203,7 @@ public class UadpDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "NetworkMessageNumber",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -209,8 +224,11 @@ public class UadpDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
   public UShort readDataSetOffset() throws UaException {
     try {
       return readDataSetOffsetAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -218,8 +236,11 @@ public class UadpDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
   public void writeDataSetOffset(UShort value) throws UaException {
     try {
       writeDataSetOffsetAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -241,8 +262,11 @@ public class UadpDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
   public PropertyTypeNode getDataSetOffsetNode() throws UaException {
     try {
       return getDataSetOffsetNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -250,10 +274,7 @@ public class UadpDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
   public CompletableFuture<? extends PropertyTypeNode> getDataSetOffsetNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "DataSetOffset",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "DataSetOffset", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -273,8 +294,11 @@ public class UadpDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
   public UUID readDataSetClassId() throws UaException {
     try {
       return readDataSetClassIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -282,8 +306,11 @@ public class UadpDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
   public void writeDataSetClassId(UUID value) throws UaException {
     try {
       writeDataSetClassIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -305,8 +332,11 @@ public class UadpDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
   public PropertyTypeNode getDataSetClassIdNode() throws UaException {
     try {
       return getDataSetClassIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -314,10 +344,7 @@ public class UadpDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
   public CompletableFuture<? extends PropertyTypeNode> getDataSetClassIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "DataSetClassId",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "DataSetClassId", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -337,8 +364,11 @@ public class UadpDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
   public UadpNetworkMessageContentMask readNetworkMessageContentMask() throws UaException {
     try {
       return readNetworkMessageContentMaskAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -347,8 +377,11 @@ public class UadpDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
       throws UaException {
     try {
       writeNetworkMessageContentMaskAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -372,8 +405,11 @@ public class UadpDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
   public PropertyTypeNode getNetworkMessageContentMaskNode() throws UaException {
     try {
       return getNetworkMessageContentMaskNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -383,7 +419,7 @@ public class UadpDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "NetworkMessageContentMask",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -404,8 +440,11 @@ public class UadpDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
   public UadpDataSetMessageContentMask readDataSetMessageContentMask() throws UaException {
     try {
       return readDataSetMessageContentMaskAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -414,8 +453,11 @@ public class UadpDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
       throws UaException {
     try {
       writeDataSetMessageContentMaskAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -439,8 +481,11 @@ public class UadpDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
   public PropertyTypeNode getDataSetMessageContentMaskNode() throws UaException {
     try {
       return getDataSetMessageContentMaskNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -450,7 +495,7 @@ public class UadpDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "DataSetMessageContentMask",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -471,8 +516,11 @@ public class UadpDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
   public Double readPublishingInterval() throws UaException {
     try {
       return readPublishingIntervalAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -480,8 +528,11 @@ public class UadpDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
   public void writePublishingInterval(Double value) throws UaException {
     try {
       writePublishingIntervalAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -503,8 +554,11 @@ public class UadpDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
   public PropertyTypeNode getPublishingIntervalNode() throws UaException {
     try {
       return getPublishingIntervalNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -514,7 +568,7 @@ public class UadpDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "PublishingInterval",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -535,8 +589,11 @@ public class UadpDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
   public Double readProcessingOffset() throws UaException {
     try {
       return readProcessingOffsetAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -544,8 +601,11 @@ public class UadpDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
   public void writeProcessingOffset(Double value) throws UaException {
     try {
       writeProcessingOffsetAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -567,8 +627,11 @@ public class UadpDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
   public PropertyTypeNode getProcessingOffsetNode() throws UaException {
     try {
       return getProcessingOffsetNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -578,7 +641,7 @@ public class UadpDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ProcessingOffset",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -599,8 +662,11 @@ public class UadpDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
   public Double readReceiveOffset() throws UaException {
     try {
       return readReceiveOffsetAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -608,8 +674,11 @@ public class UadpDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
   public void writeReceiveOffset(Double value) throws UaException {
     try {
       writeReceiveOffsetAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -631,8 +700,11 @@ public class UadpDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
   public PropertyTypeNode getReceiveOffsetNode() throws UaException {
     try {
       return getReceiveOffsetNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -640,10 +712,7 @@ public class UadpDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
   public CompletableFuture<? extends PropertyTypeNode> getReceiveOffsetNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ReceiveOffset",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "ReceiveOffset", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/UadpDataSetWriterMessageTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/UadpDataSetWriterMessageTypeNode.java
@@ -79,8 +79,11 @@ public class UadpDataSetWriterMessageTypeNode extends DataSetWriterMessageTypeNo
   public UadpDataSetMessageContentMask readDataSetMessageContentMask() throws UaException {
     try {
       return readDataSetMessageContentMaskAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -89,8 +92,11 @@ public class UadpDataSetWriterMessageTypeNode extends DataSetWriterMessageTypeNo
       throws UaException {
     try {
       writeDataSetMessageContentMaskAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -114,8 +120,11 @@ public class UadpDataSetWriterMessageTypeNode extends DataSetWriterMessageTypeNo
   public PropertyTypeNode getDataSetMessageContentMaskNode() throws UaException {
     try {
       return getDataSetMessageContentMaskNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -125,7 +134,7 @@ public class UadpDataSetWriterMessageTypeNode extends DataSetWriterMessageTypeNo
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "DataSetMessageContentMask",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -146,8 +155,11 @@ public class UadpDataSetWriterMessageTypeNode extends DataSetWriterMessageTypeNo
   public UShort readConfiguredSize() throws UaException {
     try {
       return readConfiguredSizeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -155,8 +167,11 @@ public class UadpDataSetWriterMessageTypeNode extends DataSetWriterMessageTypeNo
   public void writeConfiguredSize(UShort value) throws UaException {
     try {
       writeConfiguredSizeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -178,8 +193,11 @@ public class UadpDataSetWriterMessageTypeNode extends DataSetWriterMessageTypeNo
   public PropertyTypeNode getConfiguredSizeNode() throws UaException {
     try {
       return getConfiguredSizeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -187,10 +205,7 @@ public class UadpDataSetWriterMessageTypeNode extends DataSetWriterMessageTypeNo
   public CompletableFuture<? extends PropertyTypeNode> getConfiguredSizeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ConfiguredSize",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "ConfiguredSize", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -210,8 +225,11 @@ public class UadpDataSetWriterMessageTypeNode extends DataSetWriterMessageTypeNo
   public UShort readNetworkMessageNumber() throws UaException {
     try {
       return readNetworkMessageNumberAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -219,8 +237,11 @@ public class UadpDataSetWriterMessageTypeNode extends DataSetWriterMessageTypeNo
   public void writeNetworkMessageNumber(UShort value) throws UaException {
     try {
       writeNetworkMessageNumberAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -242,8 +263,11 @@ public class UadpDataSetWriterMessageTypeNode extends DataSetWriterMessageTypeNo
   public PropertyTypeNode getNetworkMessageNumberNode() throws UaException {
     try {
       return getNetworkMessageNumberNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -253,7 +277,7 @@ public class UadpDataSetWriterMessageTypeNode extends DataSetWriterMessageTypeNo
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "NetworkMessageNumber",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -274,8 +298,11 @@ public class UadpDataSetWriterMessageTypeNode extends DataSetWriterMessageTypeNo
   public UShort readDataSetOffset() throws UaException {
     try {
       return readDataSetOffsetAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -283,8 +310,11 @@ public class UadpDataSetWriterMessageTypeNode extends DataSetWriterMessageTypeNo
   public void writeDataSetOffset(UShort value) throws UaException {
     try {
       writeDataSetOffsetAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -306,8 +336,11 @@ public class UadpDataSetWriterMessageTypeNode extends DataSetWriterMessageTypeNo
   public PropertyTypeNode getDataSetOffsetNode() throws UaException {
     try {
       return getDataSetOffsetNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -315,10 +348,7 @@ public class UadpDataSetWriterMessageTypeNode extends DataSetWriterMessageTypeNo
   public CompletableFuture<? extends PropertyTypeNode> getDataSetOffsetNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "DataSetOffset",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "DataSetOffset", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/UadpWriterGroupMessageTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/UadpWriterGroupMessageTypeNode.java
@@ -79,8 +79,11 @@ public class UadpWriterGroupMessageTypeNode extends WriterGroupMessageTypeNode
   public UInteger readGroupVersion() throws UaException {
     try {
       return readGroupVersionAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -88,8 +91,11 @@ public class UadpWriterGroupMessageTypeNode extends WriterGroupMessageTypeNode
   public void writeGroupVersion(UInteger value) throws UaException {
     try {
       writeGroupVersionAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -111,8 +117,11 @@ public class UadpWriterGroupMessageTypeNode extends WriterGroupMessageTypeNode
   public PropertyTypeNode getGroupVersionNode() throws UaException {
     try {
       return getGroupVersionNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -120,10 +129,7 @@ public class UadpWriterGroupMessageTypeNode extends WriterGroupMessageTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getGroupVersionNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "GroupVersion",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "GroupVersion", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -151,8 +157,11 @@ public class UadpWriterGroupMessageTypeNode extends WriterGroupMessageTypeNode
   public DataSetOrderingType readDataSetOrdering() throws UaException {
     try {
       return readDataSetOrderingAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -160,8 +169,11 @@ public class UadpWriterGroupMessageTypeNode extends WriterGroupMessageTypeNode
   public void writeDataSetOrdering(DataSetOrderingType value) throws UaException {
     try {
       writeDataSetOrderingAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -192,8 +204,11 @@ public class UadpWriterGroupMessageTypeNode extends WriterGroupMessageTypeNode
   public PropertyTypeNode getDataSetOrderingNode() throws UaException {
     try {
       return getDataSetOrderingNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -201,10 +216,7 @@ public class UadpWriterGroupMessageTypeNode extends WriterGroupMessageTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getDataSetOrderingNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "DataSetOrdering",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "DataSetOrdering", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -224,8 +236,11 @@ public class UadpWriterGroupMessageTypeNode extends WriterGroupMessageTypeNode
   public UadpNetworkMessageContentMask readNetworkMessageContentMask() throws UaException {
     try {
       return readNetworkMessageContentMaskAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -234,8 +249,11 @@ public class UadpWriterGroupMessageTypeNode extends WriterGroupMessageTypeNode
       throws UaException {
     try {
       writeNetworkMessageContentMaskAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -259,8 +277,11 @@ public class UadpWriterGroupMessageTypeNode extends WriterGroupMessageTypeNode
   public PropertyTypeNode getNetworkMessageContentMaskNode() throws UaException {
     try {
       return getNetworkMessageContentMaskNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -270,7 +291,7 @@ public class UadpWriterGroupMessageTypeNode extends WriterGroupMessageTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "NetworkMessageContentMask",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -291,8 +312,11 @@ public class UadpWriterGroupMessageTypeNode extends WriterGroupMessageTypeNode
   public Double readSamplingOffset() throws UaException {
     try {
       return readSamplingOffsetAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -300,8 +324,11 @@ public class UadpWriterGroupMessageTypeNode extends WriterGroupMessageTypeNode
   public void writeSamplingOffset(Double value) throws UaException {
     try {
       writeSamplingOffsetAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -323,8 +350,11 @@ public class UadpWriterGroupMessageTypeNode extends WriterGroupMessageTypeNode
   public PropertyTypeNode getSamplingOffsetNode() throws UaException {
     try {
       return getSamplingOffsetNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -332,10 +362,7 @@ public class UadpWriterGroupMessageTypeNode extends WriterGroupMessageTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getSamplingOffsetNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "SamplingOffset",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "SamplingOffset", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -355,8 +382,11 @@ public class UadpWriterGroupMessageTypeNode extends WriterGroupMessageTypeNode
   public Double[] readPublishingOffset() throws UaException {
     try {
       return readPublishingOffsetAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -364,8 +394,11 @@ public class UadpWriterGroupMessageTypeNode extends WriterGroupMessageTypeNode
   public void writePublishingOffset(Double[] value) throws UaException {
     try {
       writePublishingOffsetAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -387,8 +420,11 @@ public class UadpWriterGroupMessageTypeNode extends WriterGroupMessageTypeNode
   public PropertyTypeNode getPublishingOffsetNode() throws UaException {
     try {
       return getPublishingOffsetNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -398,7 +434,7 @@ public class UadpWriterGroupMessageTypeNode extends WriterGroupMessageTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "PublishingOffset",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/UnitTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/UnitTypeNode.java
@@ -76,8 +76,11 @@ public class UnitTypeNode extends BaseObjectTypeNode implements UnitType {
   public LocalizedText readSymbol() throws UaException {
     try {
       return readSymbolAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -85,8 +88,11 @@ public class UnitTypeNode extends BaseObjectTypeNode implements UnitType {
   public void writeSymbol(LocalizedText value) throws UaException {
     try {
       writeSymbolAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -108,8 +114,11 @@ public class UnitTypeNode extends BaseObjectTypeNode implements UnitType {
   public PropertyTypeNode getSymbolNode() throws UaException {
     try {
       return getSymbolNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -117,7 +126,7 @@ public class UnitTypeNode extends BaseObjectTypeNode implements UnitType {
   public CompletableFuture<? extends PropertyTypeNode> getSymbolNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Symbol", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Symbol", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -137,8 +146,11 @@ public class UnitTypeNode extends BaseObjectTypeNode implements UnitType {
   public String readUnitSystem() throws UaException {
     try {
       return readUnitSystemAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -146,8 +158,11 @@ public class UnitTypeNode extends BaseObjectTypeNode implements UnitType {
   public void writeUnitSystem(String value) throws UaException {
     try {
       writeUnitSystemAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -169,8 +184,11 @@ public class UnitTypeNode extends BaseObjectTypeNode implements UnitType {
   public PropertyTypeNode getUnitSystemNode() throws UaException {
     try {
       return getUnitSystemNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -178,7 +196,7 @@ public class UnitTypeNode extends BaseObjectTypeNode implements UnitType {
   public CompletableFuture<? extends PropertyTypeNode> getUnitSystemNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "UnitSystem", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "UnitSystem", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -198,8 +216,11 @@ public class UnitTypeNode extends BaseObjectTypeNode implements UnitType {
   public String readDiscipline() throws UaException {
     try {
       return readDisciplineAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -207,8 +228,11 @@ public class UnitTypeNode extends BaseObjectTypeNode implements UnitType {
   public void writeDiscipline(String value) throws UaException {
     try {
       writeDisciplineAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -230,8 +254,11 @@ public class UnitTypeNode extends BaseObjectTypeNode implements UnitType {
   public PropertyTypeNode getDisciplineNode() throws UaException {
     try {
       return getDisciplineNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -239,7 +266,7 @@ public class UnitTypeNode extends BaseObjectTypeNode implements UnitType {
   public CompletableFuture<? extends PropertyTypeNode> getDisciplineNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Discipline", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Discipline", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/UserManagementTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/UserManagementTypeNode.java
@@ -82,8 +82,11 @@ public class UserManagementTypeNode extends BaseObjectTypeNode implements UserMa
   public UserManagementDataType[] readUsers() throws UaException {
     try {
       return readUsersAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -91,8 +94,11 @@ public class UserManagementTypeNode extends BaseObjectTypeNode implements UserMa
   public void writeUsers(UserManagementDataType[] value) throws UaException {
     try {
       writeUsersAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -116,8 +122,11 @@ public class UserManagementTypeNode extends BaseObjectTypeNode implements UserMa
   public PropertyTypeNode getUsersNode() throws UaException {
     try {
       return getUsersNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -125,7 +134,7 @@ public class UserManagementTypeNode extends BaseObjectTypeNode implements UserMa
   public CompletableFuture<? extends PropertyTypeNode> getUsersNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Users", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Users", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -146,8 +155,11 @@ public class UserManagementTypeNode extends BaseObjectTypeNode implements UserMa
   public Range readPasswordLength() throws UaException {
     try {
       return readPasswordLengthAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -155,8 +167,11 @@ public class UserManagementTypeNode extends BaseObjectTypeNode implements UserMa
   public void writePasswordLength(Range value) throws UaException {
     try {
       writePasswordLengthAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -180,8 +195,11 @@ public class UserManagementTypeNode extends BaseObjectTypeNode implements UserMa
   public PropertyTypeNode getPasswordLengthNode() throws UaException {
     try {
       return getPasswordLengthNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -189,10 +207,7 @@ public class UserManagementTypeNode extends BaseObjectTypeNode implements UserMa
   public CompletableFuture<? extends PropertyTypeNode> getPasswordLengthNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "PasswordLength",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "PasswordLength", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -212,8 +227,11 @@ public class UserManagementTypeNode extends BaseObjectTypeNode implements UserMa
   public PasswordOptionsMask readPasswordOptions() throws UaException {
     try {
       return readPasswordOptionsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -221,8 +239,11 @@ public class UserManagementTypeNode extends BaseObjectTypeNode implements UserMa
   public void writePasswordOptions(PasswordOptionsMask value) throws UaException {
     try {
       writePasswordOptionsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -245,8 +266,11 @@ public class UserManagementTypeNode extends BaseObjectTypeNode implements UserMa
   public PropertyTypeNode getPasswordOptionsNode() throws UaException {
     try {
       return getPasswordOptionsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -254,10 +278,7 @@ public class UserManagementTypeNode extends BaseObjectTypeNode implements UserMa
   public CompletableFuture<? extends PropertyTypeNode> getPasswordOptionsNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "PasswordOptions",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "PasswordOptions", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -277,8 +298,11 @@ public class UserManagementTypeNode extends BaseObjectTypeNode implements UserMa
   public LocalizedText readPasswordRestrictions() throws UaException {
     try {
       return readPasswordRestrictionsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -286,8 +310,11 @@ public class UserManagementTypeNode extends BaseObjectTypeNode implements UserMa
   public void writePasswordRestrictions(LocalizedText value) throws UaException {
     try {
       writePasswordRestrictionsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -310,8 +337,11 @@ public class UserManagementTypeNode extends BaseObjectTypeNode implements UserMa
   public PropertyTypeNode getPasswordRestrictionsNode() throws UaException {
     try {
       return getPasswordRestrictionsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -321,7 +351,7 @@ public class UserManagementTypeNode extends BaseObjectTypeNode implements UserMa
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "PasswordRestrictions",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/WriterGroupTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/WriterGroupTypeNode.java
@@ -77,8 +77,11 @@ public class WriterGroupTypeNode extends PubSubGroupTypeNode implements WriterGr
   public UShort readWriterGroupId() throws UaException {
     try {
       return readWriterGroupIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -86,8 +89,11 @@ public class WriterGroupTypeNode extends PubSubGroupTypeNode implements WriterGr
   public void writeWriterGroupId(UShort value) throws UaException {
     try {
       writeWriterGroupIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -109,8 +115,11 @@ public class WriterGroupTypeNode extends PubSubGroupTypeNode implements WriterGr
   public PropertyTypeNode getWriterGroupIdNode() throws UaException {
     try {
       return getWriterGroupIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -118,10 +127,7 @@ public class WriterGroupTypeNode extends PubSubGroupTypeNode implements WriterGr
   public CompletableFuture<? extends PropertyTypeNode> getWriterGroupIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "WriterGroupId",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "WriterGroupId", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -141,8 +147,11 @@ public class WriterGroupTypeNode extends PubSubGroupTypeNode implements WriterGr
   public Double readPublishingInterval() throws UaException {
     try {
       return readPublishingIntervalAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -150,8 +159,11 @@ public class WriterGroupTypeNode extends PubSubGroupTypeNode implements WriterGr
   public void writePublishingInterval(Double value) throws UaException {
     try {
       writePublishingIntervalAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -173,8 +185,11 @@ public class WriterGroupTypeNode extends PubSubGroupTypeNode implements WriterGr
   public PropertyTypeNode getPublishingIntervalNode() throws UaException {
     try {
       return getPublishingIntervalNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -184,7 +199,7 @@ public class WriterGroupTypeNode extends PubSubGroupTypeNode implements WriterGr
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "PublishingInterval",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -205,8 +220,11 @@ public class WriterGroupTypeNode extends PubSubGroupTypeNode implements WriterGr
   public Double readKeepAliveTime() throws UaException {
     try {
       return readKeepAliveTimeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -214,8 +232,11 @@ public class WriterGroupTypeNode extends PubSubGroupTypeNode implements WriterGr
   public void writeKeepAliveTime(Double value) throws UaException {
     try {
       writeKeepAliveTimeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -237,8 +258,11 @@ public class WriterGroupTypeNode extends PubSubGroupTypeNode implements WriterGr
   public PropertyTypeNode getKeepAliveTimeNode() throws UaException {
     try {
       return getKeepAliveTimeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -246,10 +270,7 @@ public class WriterGroupTypeNode extends PubSubGroupTypeNode implements WriterGr
   public CompletableFuture<? extends PropertyTypeNode> getKeepAliveTimeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "KeepAliveTime",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "KeepAliveTime", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -269,8 +290,11 @@ public class WriterGroupTypeNode extends PubSubGroupTypeNode implements WriterGr
   public UByte readPriority() throws UaException {
     try {
       return readPriorityAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -278,8 +302,11 @@ public class WriterGroupTypeNode extends PubSubGroupTypeNode implements WriterGr
   public void writePriority(UByte value) throws UaException {
     try {
       writePriorityAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -301,8 +328,11 @@ public class WriterGroupTypeNode extends PubSubGroupTypeNode implements WriterGr
   public PropertyTypeNode getPriorityNode() throws UaException {
     try {
       return getPriorityNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -310,7 +340,7 @@ public class WriterGroupTypeNode extends PubSubGroupTypeNode implements WriterGr
   public CompletableFuture<? extends PropertyTypeNode> getPriorityNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Priority", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Priority", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -330,8 +360,11 @@ public class WriterGroupTypeNode extends PubSubGroupTypeNode implements WriterGr
   public String[] readLocaleIds() throws UaException {
     try {
       return readLocaleIdsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -339,8 +372,11 @@ public class WriterGroupTypeNode extends PubSubGroupTypeNode implements WriterGr
   public void writeLocaleIds(String[] value) throws UaException {
     try {
       writeLocaleIdsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -362,8 +398,11 @@ public class WriterGroupTypeNode extends PubSubGroupTypeNode implements WriterGr
   public PropertyTypeNode getLocaleIdsNode() throws UaException {
     try {
       return getLocaleIdsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -371,7 +410,7 @@ public class WriterGroupTypeNode extends PubSubGroupTypeNode implements WriterGr
   public CompletableFuture<? extends PropertyTypeNode> getLocaleIdsNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "LocaleIds", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "LocaleIds", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -391,8 +430,11 @@ public class WriterGroupTypeNode extends PubSubGroupTypeNode implements WriterGr
   public String readHeaderLayoutUri() throws UaException {
     try {
       return readHeaderLayoutUriAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -400,8 +442,11 @@ public class WriterGroupTypeNode extends PubSubGroupTypeNode implements WriterGr
   public void writeHeaderLayoutUri(String value) throws UaException {
     try {
       writeHeaderLayoutUriAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -423,8 +468,11 @@ public class WriterGroupTypeNode extends PubSubGroupTypeNode implements WriterGr
   public PropertyTypeNode getHeaderLayoutUriNode() throws UaException {
     try {
       return getHeaderLayoutUriNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -432,10 +480,7 @@ public class WriterGroupTypeNode extends PubSubGroupTypeNode implements WriterGr
   public CompletableFuture<? extends PropertyTypeNode> getHeaderLayoutUriNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "HeaderLayoutUri",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "HeaderLayoutUri", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -443,8 +488,11 @@ public class WriterGroupTypeNode extends PubSubGroupTypeNode implements WriterGr
   public WriterGroupTransportTypeNode getTransportSettingsNode() throws UaException {
     try {
       return getTransportSettingsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -454,7 +502,7 @@ public class WriterGroupTypeNode extends PubSubGroupTypeNode implements WriterGr
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "TransportSettings",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (WriterGroupTransportTypeNode) node);
   }
@@ -463,8 +511,11 @@ public class WriterGroupTypeNode extends PubSubGroupTypeNode implements WriterGr
   public WriterGroupMessageTypeNode getMessageSettingsNode() throws UaException {
     try {
       return getMessageSettingsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -472,10 +523,7 @@ public class WriterGroupTypeNode extends PubSubGroupTypeNode implements WriterGr
   public CompletableFuture<? extends WriterGroupMessageTypeNode> getMessageSettingsNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "MessageSettings",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "MessageSettings", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (WriterGroupMessageTypeNode) node);
   }
 
@@ -483,8 +531,11 @@ public class WriterGroupTypeNode extends PubSubGroupTypeNode implements WriterGr
   public PubSubDiagnosticsWriterGroupTypeNode getDiagnosticsNode() throws UaException {
     try {
       return getDiagnosticsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -493,10 +544,7 @@ public class WriterGroupTypeNode extends PubSubGroupTypeNode implements WriterGr
       getDiagnosticsNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "Diagnostics",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "Diagnostics", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (PubSubDiagnosticsWriterGroupTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/AlarmRateVariableTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/AlarmRateVariableTypeNode.java
@@ -94,8 +94,11 @@ public class AlarmRateVariableTypeNode extends BaseDataVariableTypeNode
   public UShort readRate() throws UaException {
     try {
       return readRateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -103,8 +106,11 @@ public class AlarmRateVariableTypeNode extends BaseDataVariableTypeNode
   public void writeRate(UShort value) throws UaException {
     try {
       writeRateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -126,8 +132,11 @@ public class AlarmRateVariableTypeNode extends BaseDataVariableTypeNode
   public PropertyTypeNode getRateNode() throws UaException {
     try {
       return getRateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -135,7 +144,7 @@ public class AlarmRateVariableTypeNode extends BaseDataVariableTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getRateNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Rate", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Rate", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/AlarmStateVariableTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/AlarmStateVariableTypeNode.java
@@ -96,8 +96,11 @@ public class AlarmStateVariableTypeNode extends BaseDataVariableTypeNode
   public UShort readHighestActiveSeverity() throws UaException {
     try {
       return readHighestActiveSeverityAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -105,8 +108,11 @@ public class AlarmStateVariableTypeNode extends BaseDataVariableTypeNode
   public void writeHighestActiveSeverity(UShort value) throws UaException {
     try {
       writeHighestActiveSeverityAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -129,8 +135,11 @@ public class AlarmStateVariableTypeNode extends BaseDataVariableTypeNode
   public PropertyTypeNode getHighestActiveSeverityNode() throws UaException {
     try {
       return getHighestActiveSeverityNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -140,7 +149,7 @@ public class AlarmStateVariableTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "HighestActiveSeverity",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -161,8 +170,11 @@ public class AlarmStateVariableTypeNode extends BaseDataVariableTypeNode
   public UShort readHighestUnackSeverity() throws UaException {
     try {
       return readHighestUnackSeverityAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -170,8 +182,11 @@ public class AlarmStateVariableTypeNode extends BaseDataVariableTypeNode
   public void writeHighestUnackSeverity(UShort value) throws UaException {
     try {
       writeHighestUnackSeverityAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -193,8 +208,11 @@ public class AlarmStateVariableTypeNode extends BaseDataVariableTypeNode
   public PropertyTypeNode getHighestUnackSeverityNode() throws UaException {
     try {
       return getHighestUnackSeverityNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -204,7 +222,7 @@ public class AlarmStateVariableTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "HighestUnackSeverity",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -225,8 +243,11 @@ public class AlarmStateVariableTypeNode extends BaseDataVariableTypeNode
   public UInteger readActiveCount() throws UaException {
     try {
       return readActiveCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -234,8 +255,11 @@ public class AlarmStateVariableTypeNode extends BaseDataVariableTypeNode
   public void writeActiveCount(UInteger value) throws UaException {
     try {
       writeActiveCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -257,8 +281,11 @@ public class AlarmStateVariableTypeNode extends BaseDataVariableTypeNode
   public PropertyTypeNode getActiveCountNode() throws UaException {
     try {
       return getActiveCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -266,10 +293,7 @@ public class AlarmStateVariableTypeNode extends BaseDataVariableTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getActiveCountNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ActiveCount",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "ActiveCount", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -289,8 +313,11 @@ public class AlarmStateVariableTypeNode extends BaseDataVariableTypeNode
   public UInteger readUnacknowledgedCount() throws UaException {
     try {
       return readUnacknowledgedCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -298,8 +325,11 @@ public class AlarmStateVariableTypeNode extends BaseDataVariableTypeNode
   public void writeUnacknowledgedCount(UInteger value) throws UaException {
     try {
       writeUnacknowledgedCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -321,8 +351,11 @@ public class AlarmStateVariableTypeNode extends BaseDataVariableTypeNode
   public PropertyTypeNode getUnacknowledgedCountNode() throws UaException {
     try {
       return getUnacknowledgedCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -332,7 +365,7 @@ public class AlarmStateVariableTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "UnacknowledgedCount",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -353,8 +386,11 @@ public class AlarmStateVariableTypeNode extends BaseDataVariableTypeNode
   public UInteger readUnconfirmedCount() throws UaException {
     try {
       return readUnconfirmedCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -362,8 +398,11 @@ public class AlarmStateVariableTypeNode extends BaseDataVariableTypeNode
   public void writeUnconfirmedCount(UInteger value) throws UaException {
     try {
       writeUnconfirmedCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -385,8 +424,11 @@ public class AlarmStateVariableTypeNode extends BaseDataVariableTypeNode
   public PropertyTypeNode getUnconfirmedCountNode() throws UaException {
     try {
       return getUnconfirmedCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -396,7 +438,7 @@ public class AlarmStateVariableTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "UnconfirmedCount",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -418,8 +460,11 @@ public class AlarmStateVariableTypeNode extends BaseDataVariableTypeNode
   public ContentFilter readFilter() throws UaException {
     try {
       return readFilterAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -427,8 +472,11 @@ public class AlarmStateVariableTypeNode extends BaseDataVariableTypeNode
   public void writeFilter(ContentFilter value) throws UaException {
     try {
       writeFilterAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -451,8 +499,11 @@ public class AlarmStateVariableTypeNode extends BaseDataVariableTypeNode
   public PropertyTypeNode getFilterNode() throws UaException {
     try {
       return getFilterNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -460,7 +511,7 @@ public class AlarmStateVariableTypeNode extends BaseDataVariableTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getFilterNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Filter", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Filter", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/AnalogItemTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/AnalogItemTypeNode.java
@@ -95,8 +95,11 @@ public class AnalogItemTypeNode extends BaseAnalogTypeNode implements AnalogItem
   public Range readEuRange() throws UaException {
     try {
       return readEuRangeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -104,8 +107,11 @@ public class AnalogItemTypeNode extends BaseAnalogTypeNode implements AnalogItem
   public void writeEuRange(Range value) throws UaException {
     try {
       writeEuRangeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -128,8 +134,11 @@ public class AnalogItemTypeNode extends BaseAnalogTypeNode implements AnalogItem
   public PropertyTypeNode getEuRangeNode() throws UaException {
     try {
       return getEuRangeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -137,7 +146,7 @@ public class AnalogItemTypeNode extends BaseAnalogTypeNode implements AnalogItem
   public CompletableFuture<? extends PropertyTypeNode> getEuRangeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "EURange", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "EURange", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/AnalogUnitRangeTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/AnalogUnitRangeTypeNode.java
@@ -95,8 +95,11 @@ public class AnalogUnitRangeTypeNode extends AnalogItemTypeNode implements Analo
   public EUInformation readEngineeringUnits() throws UaException {
     try {
       return readEngineeringUnitsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -104,8 +107,11 @@ public class AnalogUnitRangeTypeNode extends AnalogItemTypeNode implements Analo
   public void writeEngineeringUnits(EUInformation value) throws UaException {
     try {
       writeEngineeringUnitsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -129,8 +135,11 @@ public class AnalogUnitRangeTypeNode extends AnalogItemTypeNode implements Analo
   public PropertyTypeNode getEngineeringUnitsNode() throws UaException {
     try {
       return getEngineeringUnitsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -140,7 +149,7 @@ public class AnalogUnitRangeTypeNode extends AnalogItemTypeNode implements Analo
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "EngineeringUnits",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/AnalogUnitTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/AnalogUnitTypeNode.java
@@ -95,8 +95,11 @@ public class AnalogUnitTypeNode extends BaseAnalogTypeNode implements AnalogUnit
   public EUInformation readEngineeringUnits() throws UaException {
     try {
       return readEngineeringUnitsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -104,8 +107,11 @@ public class AnalogUnitTypeNode extends BaseAnalogTypeNode implements AnalogUnit
   public void writeEngineeringUnits(EUInformation value) throws UaException {
     try {
       writeEngineeringUnitsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -129,8 +135,11 @@ public class AnalogUnitTypeNode extends BaseAnalogTypeNode implements AnalogUnit
   public PropertyTypeNode getEngineeringUnitsNode() throws UaException {
     try {
       return getEngineeringUnitsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -140,7 +149,7 @@ public class AnalogUnitTypeNode extends BaseAnalogTypeNode implements AnalogUnit
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "EngineeringUnits",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ArrayItemTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ArrayItemTypeNode.java
@@ -97,8 +97,11 @@ public class ArrayItemTypeNode extends DataItemTypeNode implements ArrayItemType
   public Range readInstrumentRange() throws UaException {
     try {
       return readInstrumentRangeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -106,8 +109,11 @@ public class ArrayItemTypeNode extends DataItemTypeNode implements ArrayItemType
   public void writeInstrumentRange(Range value) throws UaException {
     try {
       writeInstrumentRangeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -131,8 +137,11 @@ public class ArrayItemTypeNode extends DataItemTypeNode implements ArrayItemType
   public PropertyTypeNode getInstrumentRangeNode() throws UaException {
     try {
       return getInstrumentRangeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -140,10 +149,7 @@ public class ArrayItemTypeNode extends DataItemTypeNode implements ArrayItemType
   public CompletableFuture<? extends PropertyTypeNode> getInstrumentRangeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "InstrumentRange",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "InstrumentRange", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -164,8 +170,11 @@ public class ArrayItemTypeNode extends DataItemTypeNode implements ArrayItemType
   public Range readEuRange() throws UaException {
     try {
       return readEuRangeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -173,8 +182,11 @@ public class ArrayItemTypeNode extends DataItemTypeNode implements ArrayItemType
   public void writeEuRange(Range value) throws UaException {
     try {
       writeEuRangeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -197,8 +209,11 @@ public class ArrayItemTypeNode extends DataItemTypeNode implements ArrayItemType
   public PropertyTypeNode getEuRangeNode() throws UaException {
     try {
       return getEuRangeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -206,7 +221,7 @@ public class ArrayItemTypeNode extends DataItemTypeNode implements ArrayItemType
   public CompletableFuture<? extends PropertyTypeNode> getEuRangeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "EURange", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "EURange", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -227,8 +242,11 @@ public class ArrayItemTypeNode extends DataItemTypeNode implements ArrayItemType
   public EUInformation readEngineeringUnits() throws UaException {
     try {
       return readEngineeringUnitsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -236,8 +254,11 @@ public class ArrayItemTypeNode extends DataItemTypeNode implements ArrayItemType
   public void writeEngineeringUnits(EUInformation value) throws UaException {
     try {
       writeEngineeringUnitsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -261,8 +282,11 @@ public class ArrayItemTypeNode extends DataItemTypeNode implements ArrayItemType
   public PropertyTypeNode getEngineeringUnitsNode() throws UaException {
     try {
       return getEngineeringUnitsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -272,7 +296,7 @@ public class ArrayItemTypeNode extends DataItemTypeNode implements ArrayItemType
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "EngineeringUnits",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -293,8 +317,11 @@ public class ArrayItemTypeNode extends DataItemTypeNode implements ArrayItemType
   public LocalizedText readTitle() throws UaException {
     try {
       return readTitleAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -302,8 +329,11 @@ public class ArrayItemTypeNode extends DataItemTypeNode implements ArrayItemType
   public void writeTitle(LocalizedText value) throws UaException {
     try {
       writeTitleAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -325,8 +355,11 @@ public class ArrayItemTypeNode extends DataItemTypeNode implements ArrayItemType
   public PropertyTypeNode getTitleNode() throws UaException {
     try {
       return getTitleNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -334,7 +367,7 @@ public class ArrayItemTypeNode extends DataItemTypeNode implements ArrayItemType
   public CompletableFuture<? extends PropertyTypeNode> getTitleNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Title", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Title", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -362,8 +395,11 @@ public class ArrayItemTypeNode extends DataItemTypeNode implements ArrayItemType
   public AxisScaleEnumeration readAxisScaleType() throws UaException {
     try {
       return readAxisScaleTypeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -371,8 +407,11 @@ public class ArrayItemTypeNode extends DataItemTypeNode implements ArrayItemType
   public void writeAxisScaleType(AxisScaleEnumeration value) throws UaException {
     try {
       writeAxisScaleTypeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -402,8 +441,11 @@ public class ArrayItemTypeNode extends DataItemTypeNode implements ArrayItemType
   public PropertyTypeNode getAxisScaleTypeNode() throws UaException {
     try {
       return getAxisScaleTypeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -411,10 +453,7 @@ public class ArrayItemTypeNode extends DataItemTypeNode implements ArrayItemType
   public CompletableFuture<? extends PropertyTypeNode> getAxisScaleTypeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "AxisScaleType",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "AxisScaleType", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/AudioVariableTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/AudioVariableTypeNode.java
@@ -92,8 +92,11 @@ public class AudioVariableTypeNode extends BaseDataVariableTypeNode implements A
   public String readListId() throws UaException {
     try {
       return readListIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -101,8 +104,11 @@ public class AudioVariableTypeNode extends BaseDataVariableTypeNode implements A
   public void writeListId(String value) throws UaException {
     try {
       writeListIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -124,8 +130,11 @@ public class AudioVariableTypeNode extends BaseDataVariableTypeNode implements A
   public PropertyTypeNode getListIdNode() throws UaException {
     try {
       return getListIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -133,7 +142,7 @@ public class AudioVariableTypeNode extends BaseDataVariableTypeNode implements A
   public CompletableFuture<? extends PropertyTypeNode> getListIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "ListId", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "ListId", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -153,8 +162,11 @@ public class AudioVariableTypeNode extends BaseDataVariableTypeNode implements A
   public String readAgencyId() throws UaException {
     try {
       return readAgencyIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -162,8 +174,11 @@ public class AudioVariableTypeNode extends BaseDataVariableTypeNode implements A
   public void writeAgencyId(String value) throws UaException {
     try {
       writeAgencyIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -185,8 +200,11 @@ public class AudioVariableTypeNode extends BaseDataVariableTypeNode implements A
   public PropertyTypeNode getAgencyIdNode() throws UaException {
     try {
       return getAgencyIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -194,7 +212,7 @@ public class AudioVariableTypeNode extends BaseDataVariableTypeNode implements A
   public CompletableFuture<? extends PropertyTypeNode> getAgencyIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "AgencyId", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "AgencyId", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -214,8 +232,11 @@ public class AudioVariableTypeNode extends BaseDataVariableTypeNode implements A
   public String readVersionId() throws UaException {
     try {
       return readVersionIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -223,8 +244,11 @@ public class AudioVariableTypeNode extends BaseDataVariableTypeNode implements A
   public void writeVersionId(String value) throws UaException {
     try {
       writeVersionIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -246,8 +270,11 @@ public class AudioVariableTypeNode extends BaseDataVariableTypeNode implements A
   public PropertyTypeNode getVersionIdNode() throws UaException {
     try {
       return getVersionIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -255,7 +282,7 @@ public class AudioVariableTypeNode extends BaseDataVariableTypeNode implements A
   public CompletableFuture<? extends PropertyTypeNode> getVersionIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "VersionId", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "VersionId", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/BaseAnalogTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/BaseAnalogTypeNode.java
@@ -96,8 +96,11 @@ public class BaseAnalogTypeNode extends DataItemTypeNode implements BaseAnalogTy
   public Range readInstrumentRange() throws UaException {
     try {
       return readInstrumentRangeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -105,8 +108,11 @@ public class BaseAnalogTypeNode extends DataItemTypeNode implements BaseAnalogTy
   public void writeInstrumentRange(Range value) throws UaException {
     try {
       writeInstrumentRangeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -130,8 +136,11 @@ public class BaseAnalogTypeNode extends DataItemTypeNode implements BaseAnalogTy
   public PropertyTypeNode getInstrumentRangeNode() throws UaException {
     try {
       return getInstrumentRangeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -139,10 +148,7 @@ public class BaseAnalogTypeNode extends DataItemTypeNode implements BaseAnalogTy
   public CompletableFuture<? extends PropertyTypeNode> getInstrumentRangeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "InstrumentRange",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "InstrumentRange", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -163,8 +169,11 @@ public class BaseAnalogTypeNode extends DataItemTypeNode implements BaseAnalogTy
   public Range readEuRange() throws UaException {
     try {
       return readEuRangeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -172,8 +181,11 @@ public class BaseAnalogTypeNode extends DataItemTypeNode implements BaseAnalogTy
   public void writeEuRange(Range value) throws UaException {
     try {
       writeEuRangeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -196,8 +208,11 @@ public class BaseAnalogTypeNode extends DataItemTypeNode implements BaseAnalogTy
   public PropertyTypeNode getEuRangeNode() throws UaException {
     try {
       return getEuRangeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -205,7 +220,7 @@ public class BaseAnalogTypeNode extends DataItemTypeNode implements BaseAnalogTy
   public CompletableFuture<? extends PropertyTypeNode> getEuRangeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "EURange", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "EURange", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -226,8 +241,11 @@ public class BaseAnalogTypeNode extends DataItemTypeNode implements BaseAnalogTy
   public EUInformation readEngineeringUnits() throws UaException {
     try {
       return readEngineeringUnitsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -235,8 +253,11 @@ public class BaseAnalogTypeNode extends DataItemTypeNode implements BaseAnalogTy
   public void writeEngineeringUnits(EUInformation value) throws UaException {
     try {
       writeEngineeringUnitsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -260,8 +281,11 @@ public class BaseAnalogTypeNode extends DataItemTypeNode implements BaseAnalogTy
   public PropertyTypeNode getEngineeringUnitsNode() throws UaException {
     try {
       return getEngineeringUnitsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -271,7 +295,7 @@ public class BaseAnalogTypeNode extends DataItemTypeNode implements BaseAnalogTy
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "EngineeringUnits",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/BitFieldTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/BitFieldTypeNode.java
@@ -96,8 +96,11 @@ public class BitFieldTypeNode extends BaseDataVariableTypeNode implements BitFie
   public BitFieldDefinition[] readBitFieldsDefinitions() throws UaException {
     try {
       return readBitFieldsDefinitionsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -105,8 +108,11 @@ public class BitFieldTypeNode extends BaseDataVariableTypeNode implements BitFie
   public void writeBitFieldsDefinitions(BitFieldDefinition[] value) throws UaException {
     try {
       writeBitFieldsDefinitionsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -131,8 +137,11 @@ public class BitFieldTypeNode extends BaseDataVariableTypeNode implements BitFie
   public PropertyTypeNode getBitFieldsDefinitionsNode() throws UaException {
     try {
       return getBitFieldsDefinitionsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -142,7 +151,7 @@ public class BitFieldTypeNode extends BaseDataVariableTypeNode implements BitFie
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "BitFieldsDefinitions",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/BuildInfoTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/BuildInfoTypeNode.java
@@ -93,8 +93,11 @@ public class BuildInfoTypeNode extends BaseDataVariableTypeNode implements Build
   public String readProductUri() throws UaException {
     try {
       return readProductUriAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -102,8 +105,11 @@ public class BuildInfoTypeNode extends BaseDataVariableTypeNode implements Build
   public void writeProductUri(String value) throws UaException {
     try {
       writeProductUriAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -125,8 +131,11 @@ public class BuildInfoTypeNode extends BaseDataVariableTypeNode implements Build
   public BaseDataVariableTypeNode getProductUriNode() throws UaException {
     try {
       return getProductUriNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -134,7 +143,7 @@ public class BuildInfoTypeNode extends BaseDataVariableTypeNode implements Build
   public CompletableFuture<? extends BaseDataVariableTypeNode> getProductUriNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "ProductUri", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "ProductUri", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -154,8 +163,11 @@ public class BuildInfoTypeNode extends BaseDataVariableTypeNode implements Build
   public String readManufacturerName() throws UaException {
     try {
       return readManufacturerNameAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -163,8 +175,11 @@ public class BuildInfoTypeNode extends BaseDataVariableTypeNode implements Build
   public void writeManufacturerName(String value) throws UaException {
     try {
       writeManufacturerNameAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -186,8 +201,11 @@ public class BuildInfoTypeNode extends BaseDataVariableTypeNode implements Build
   public BaseDataVariableTypeNode getManufacturerNameNode() throws UaException {
     try {
       return getManufacturerNameNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -197,7 +215,7 @@ public class BuildInfoTypeNode extends BaseDataVariableTypeNode implements Build
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ManufacturerName",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -218,8 +236,11 @@ public class BuildInfoTypeNode extends BaseDataVariableTypeNode implements Build
   public String readProductName() throws UaException {
     try {
       return readProductNameAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -227,8 +248,11 @@ public class BuildInfoTypeNode extends BaseDataVariableTypeNode implements Build
   public void writeProductName(String value) throws UaException {
     try {
       writeProductNameAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -250,8 +274,11 @@ public class BuildInfoTypeNode extends BaseDataVariableTypeNode implements Build
   public BaseDataVariableTypeNode getProductNameNode() throws UaException {
     try {
       return getProductNameNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -259,10 +286,7 @@ public class BuildInfoTypeNode extends BaseDataVariableTypeNode implements Build
   public CompletableFuture<? extends BaseDataVariableTypeNode> getProductNameNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ProductName",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "ProductName", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -282,8 +306,11 @@ public class BuildInfoTypeNode extends BaseDataVariableTypeNode implements Build
   public String readSoftwareVersion() throws UaException {
     try {
       return readSoftwareVersionAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -291,8 +318,11 @@ public class BuildInfoTypeNode extends BaseDataVariableTypeNode implements Build
   public void writeSoftwareVersion(String value) throws UaException {
     try {
       writeSoftwareVersionAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -314,8 +344,11 @@ public class BuildInfoTypeNode extends BaseDataVariableTypeNode implements Build
   public BaseDataVariableTypeNode getSoftwareVersionNode() throws UaException {
     try {
       return getSoftwareVersionNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -323,10 +356,7 @@ public class BuildInfoTypeNode extends BaseDataVariableTypeNode implements Build
   public CompletableFuture<? extends BaseDataVariableTypeNode> getSoftwareVersionNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "SoftwareVersion",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "SoftwareVersion", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -346,8 +376,11 @@ public class BuildInfoTypeNode extends BaseDataVariableTypeNode implements Build
   public String readBuildNumber() throws UaException {
     try {
       return readBuildNumberAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -355,8 +388,11 @@ public class BuildInfoTypeNode extends BaseDataVariableTypeNode implements Build
   public void writeBuildNumber(String value) throws UaException {
     try {
       writeBuildNumberAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -378,8 +414,11 @@ public class BuildInfoTypeNode extends BaseDataVariableTypeNode implements Build
   public BaseDataVariableTypeNode getBuildNumberNode() throws UaException {
     try {
       return getBuildNumberNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -387,10 +426,7 @@ public class BuildInfoTypeNode extends BaseDataVariableTypeNode implements Build
   public CompletableFuture<? extends BaseDataVariableTypeNode> getBuildNumberNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "BuildNumber",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "BuildNumber", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -410,8 +446,11 @@ public class BuildInfoTypeNode extends BaseDataVariableTypeNode implements Build
   public DateTime readBuildDate() throws UaException {
     try {
       return readBuildDateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -419,8 +458,11 @@ public class BuildInfoTypeNode extends BaseDataVariableTypeNode implements Build
   public void writeBuildDate(DateTime value) throws UaException {
     try {
       writeBuildDateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -442,8 +484,11 @@ public class BuildInfoTypeNode extends BaseDataVariableTypeNode implements Build
   public BaseDataVariableTypeNode getBuildDateNode() throws UaException {
     try {
       return getBuildDateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -451,7 +496,7 @@ public class BuildInfoTypeNode extends BaseDataVariableTypeNode implements Build
   public CompletableFuture<? extends BaseDataVariableTypeNode> getBuildDateNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "BuildDate", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "BuildDate", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/CartesianCoordinatesTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/CartesianCoordinatesTypeNode.java
@@ -96,8 +96,11 @@ public class CartesianCoordinatesTypeNode extends BaseDataVariableTypeNode
   public EUInformation readLengthUnit() throws UaException {
     try {
       return readLengthUnitAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -105,8 +108,11 @@ public class CartesianCoordinatesTypeNode extends BaseDataVariableTypeNode
   public void writeLengthUnit(EUInformation value) throws UaException {
     try {
       writeLengthUnitAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -129,8 +135,11 @@ public class CartesianCoordinatesTypeNode extends BaseDataVariableTypeNode
   public PropertyTypeNode getLengthUnitNode() throws UaException {
     try {
       return getLengthUnitNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -138,7 +147,7 @@ public class CartesianCoordinatesTypeNode extends BaseDataVariableTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getLengthUnitNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "LengthUnit", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "LengthUnit", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ConditionVariableTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ConditionVariableTypeNode.java
@@ -94,8 +94,11 @@ public class ConditionVariableTypeNode extends BaseDataVariableTypeNode
   public DateTime readSourceTimestamp() throws UaException {
     try {
       return readSourceTimestampAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -103,8 +106,11 @@ public class ConditionVariableTypeNode extends BaseDataVariableTypeNode
   public void writeSourceTimestamp(DateTime value) throws UaException {
     try {
       writeSourceTimestampAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -126,8 +132,11 @@ public class ConditionVariableTypeNode extends BaseDataVariableTypeNode
   public PropertyTypeNode getSourceTimestampNode() throws UaException {
     try {
       return getSourceTimestampNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -135,10 +144,7 @@ public class ConditionVariableTypeNode extends BaseDataVariableTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getSourceTimestampNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "SourceTimestamp",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "SourceTimestamp", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/CubeItemTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/CubeItemTypeNode.java
@@ -95,8 +95,11 @@ public class CubeItemTypeNode extends ArrayItemTypeNode implements CubeItemType 
   public AxisInformation readXAxisDefinition() throws UaException {
     try {
       return readXAxisDefinitionAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -104,8 +107,11 @@ public class CubeItemTypeNode extends ArrayItemTypeNode implements CubeItemType 
   public void writeXAxisDefinition(AxisInformation value) throws UaException {
     try {
       writeXAxisDefinitionAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -129,8 +135,11 @@ public class CubeItemTypeNode extends ArrayItemTypeNode implements CubeItemType 
   public PropertyTypeNode getXAxisDefinitionNode() throws UaException {
     try {
       return getXAxisDefinitionNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -138,10 +147,7 @@ public class CubeItemTypeNode extends ArrayItemTypeNode implements CubeItemType 
   public CompletableFuture<? extends PropertyTypeNode> getXAxisDefinitionNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "XAxisDefinition",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "XAxisDefinition", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -162,8 +168,11 @@ public class CubeItemTypeNode extends ArrayItemTypeNode implements CubeItemType 
   public AxisInformation readYAxisDefinition() throws UaException {
     try {
       return readYAxisDefinitionAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -171,8 +180,11 @@ public class CubeItemTypeNode extends ArrayItemTypeNode implements CubeItemType 
   public void writeYAxisDefinition(AxisInformation value) throws UaException {
     try {
       writeYAxisDefinitionAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -196,8 +208,11 @@ public class CubeItemTypeNode extends ArrayItemTypeNode implements CubeItemType 
   public PropertyTypeNode getYAxisDefinitionNode() throws UaException {
     try {
       return getYAxisDefinitionNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -205,10 +220,7 @@ public class CubeItemTypeNode extends ArrayItemTypeNode implements CubeItemType 
   public CompletableFuture<? extends PropertyTypeNode> getYAxisDefinitionNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "YAxisDefinition",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "YAxisDefinition", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -229,8 +241,11 @@ public class CubeItemTypeNode extends ArrayItemTypeNode implements CubeItemType 
   public AxisInformation readZAxisDefinition() throws UaException {
     try {
       return readZAxisDefinitionAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -238,8 +253,11 @@ public class CubeItemTypeNode extends ArrayItemTypeNode implements CubeItemType 
   public void writeZAxisDefinition(AxisInformation value) throws UaException {
     try {
       writeZAxisDefinitionAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -263,8 +281,11 @@ public class CubeItemTypeNode extends ArrayItemTypeNode implements CubeItemType 
   public PropertyTypeNode getZAxisDefinitionNode() throws UaException {
     try {
       return getZAxisDefinitionNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -272,10 +293,7 @@ public class CubeItemTypeNode extends ArrayItemTypeNode implements CubeItemType 
   public CompletableFuture<? extends PropertyTypeNode> getZAxisDefinitionNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ZAxisDefinition",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "ZAxisDefinition", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/DataItemTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/DataItemTypeNode.java
@@ -92,8 +92,11 @@ public class DataItemTypeNode extends BaseDataVariableTypeNode implements DataIt
   public String readDefinition() throws UaException {
     try {
       return readDefinitionAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -101,8 +104,11 @@ public class DataItemTypeNode extends BaseDataVariableTypeNode implements DataIt
   public void writeDefinition(String value) throws UaException {
     try {
       writeDefinitionAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -124,8 +130,11 @@ public class DataItemTypeNode extends BaseDataVariableTypeNode implements DataIt
   public PropertyTypeNode getDefinitionNode() throws UaException {
     try {
       return getDefinitionNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -133,7 +142,7 @@ public class DataItemTypeNode extends BaseDataVariableTypeNode implements DataIt
   public CompletableFuture<? extends PropertyTypeNode> getDefinitionNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Definition", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Definition", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -153,8 +162,11 @@ public class DataItemTypeNode extends BaseDataVariableTypeNode implements DataIt
   public Double readValuePrecision() throws UaException {
     try {
       return readValuePrecisionAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -162,8 +174,11 @@ public class DataItemTypeNode extends BaseDataVariableTypeNode implements DataIt
   public void writeValuePrecision(Double value) throws UaException {
     try {
       writeValuePrecisionAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -185,8 +200,11 @@ public class DataItemTypeNode extends BaseDataVariableTypeNode implements DataIt
   public PropertyTypeNode getValuePrecisionNode() throws UaException {
     try {
       return getValuePrecisionNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -194,10 +212,7 @@ public class DataItemTypeNode extends BaseDataVariableTypeNode implements DataIt
   public CompletableFuture<? extends PropertyTypeNode> getValuePrecisionNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ValuePrecision",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "ValuePrecision", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/DataTypeDescriptionTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/DataTypeDescriptionTypeNode.java
@@ -94,8 +94,11 @@ public class DataTypeDescriptionTypeNode extends BaseDataVariableTypeNode
   public String readDataTypeVersion() throws UaException {
     try {
       return readDataTypeVersionAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -103,8 +106,11 @@ public class DataTypeDescriptionTypeNode extends BaseDataVariableTypeNode
   public void writeDataTypeVersion(String value) throws UaException {
     try {
       writeDataTypeVersionAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -126,8 +132,11 @@ public class DataTypeDescriptionTypeNode extends BaseDataVariableTypeNode
   public PropertyTypeNode getDataTypeVersionNode() throws UaException {
     try {
       return getDataTypeVersionNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -135,10 +144,7 @@ public class DataTypeDescriptionTypeNode extends BaseDataVariableTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getDataTypeVersionNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "DataTypeVersion",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "DataTypeVersion", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -158,8 +164,11 @@ public class DataTypeDescriptionTypeNode extends BaseDataVariableTypeNode
   public ByteString readDictionaryFragment() throws UaException {
     try {
       return readDictionaryFragmentAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -167,8 +176,11 @@ public class DataTypeDescriptionTypeNode extends BaseDataVariableTypeNode
   public void writeDictionaryFragment(ByteString value) throws UaException {
     try {
       writeDictionaryFragmentAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -190,8 +202,11 @@ public class DataTypeDescriptionTypeNode extends BaseDataVariableTypeNode
   public PropertyTypeNode getDictionaryFragmentNode() throws UaException {
     try {
       return getDictionaryFragmentNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -201,7 +216,7 @@ public class DataTypeDescriptionTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "DictionaryFragment",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/DataTypeDictionaryTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/DataTypeDictionaryTypeNode.java
@@ -93,8 +93,11 @@ public class DataTypeDictionaryTypeNode extends BaseDataVariableTypeNode
   public String readDataTypeVersion() throws UaException {
     try {
       return readDataTypeVersionAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -102,8 +105,11 @@ public class DataTypeDictionaryTypeNode extends BaseDataVariableTypeNode
   public void writeDataTypeVersion(String value) throws UaException {
     try {
       writeDataTypeVersionAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -125,8 +131,11 @@ public class DataTypeDictionaryTypeNode extends BaseDataVariableTypeNode
   public PropertyTypeNode getDataTypeVersionNode() throws UaException {
     try {
       return getDataTypeVersionNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -134,10 +143,7 @@ public class DataTypeDictionaryTypeNode extends BaseDataVariableTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getDataTypeVersionNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "DataTypeVersion",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "DataTypeVersion", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -157,8 +163,11 @@ public class DataTypeDictionaryTypeNode extends BaseDataVariableTypeNode
   public String readNamespaceUri() throws UaException {
     try {
       return readNamespaceUriAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -166,8 +175,11 @@ public class DataTypeDictionaryTypeNode extends BaseDataVariableTypeNode
   public void writeNamespaceUri(String value) throws UaException {
     try {
       writeNamespaceUriAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -189,8 +201,11 @@ public class DataTypeDictionaryTypeNode extends BaseDataVariableTypeNode
   public PropertyTypeNode getNamespaceUriNode() throws UaException {
     try {
       return getNamespaceUriNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -198,10 +213,7 @@ public class DataTypeDictionaryTypeNode extends BaseDataVariableTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getNamespaceUriNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "NamespaceUri",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "NamespaceUri", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -221,8 +233,11 @@ public class DataTypeDictionaryTypeNode extends BaseDataVariableTypeNode
   public Boolean readDeprecated() throws UaException {
     try {
       return readDeprecatedAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -230,8 +245,11 @@ public class DataTypeDictionaryTypeNode extends BaseDataVariableTypeNode
   public void writeDeprecated(Boolean value) throws UaException {
     try {
       writeDeprecatedAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -253,8 +271,11 @@ public class DataTypeDictionaryTypeNode extends BaseDataVariableTypeNode
   public PropertyTypeNode getDeprecatedNode() throws UaException {
     try {
       return getDeprecatedNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -262,7 +283,7 @@ public class DataTypeDictionaryTypeNode extends BaseDataVariableTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getDeprecatedNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Deprecated", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Deprecated", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ExpressionGuardVariableTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ExpressionGuardVariableTypeNode.java
@@ -96,8 +96,11 @@ public class ExpressionGuardVariableTypeNode extends GuardVariableTypeNode
   public ContentFilter readExpression() throws UaException {
     try {
       return readExpressionAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -105,8 +108,11 @@ public class ExpressionGuardVariableTypeNode extends GuardVariableTypeNode
   public void writeExpression(ContentFilter value) throws UaException {
     try {
       writeExpressionAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -129,8 +135,11 @@ public class ExpressionGuardVariableTypeNode extends GuardVariableTypeNode
   public PropertyTypeNode getExpressionNode() throws UaException {
     try {
       return getExpressionNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -138,7 +147,7 @@ public class ExpressionGuardVariableTypeNode extends GuardVariableTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getExpressionNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Expression", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Expression", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/FiniteStateVariableTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/FiniteStateVariableTypeNode.java
@@ -93,8 +93,11 @@ public class FiniteStateVariableTypeNode extends StateVariableTypeNode
   public NodeId readId() throws UaException {
     try {
       return readIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -102,8 +105,11 @@ public class FiniteStateVariableTypeNode extends StateVariableTypeNode
   public void writeId(NodeId value) throws UaException {
     try {
       writeIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -124,8 +130,11 @@ public class FiniteStateVariableTypeNode extends StateVariableTypeNode
   public PropertyTypeNode getIdNode() throws UaException {
     try {
       return getIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -133,7 +142,7 @@ public class FiniteStateVariableTypeNode extends StateVariableTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Id", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Id", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/FiniteTransitionVariableTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/FiniteTransitionVariableTypeNode.java
@@ -93,8 +93,11 @@ public class FiniteTransitionVariableTypeNode extends TransitionVariableTypeNode
   public NodeId readId() throws UaException {
     try {
       return readIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -102,8 +105,11 @@ public class FiniteTransitionVariableTypeNode extends TransitionVariableTypeNode
   public void writeId(NodeId value) throws UaException {
     try {
       writeIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -124,8 +130,11 @@ public class FiniteTransitionVariableTypeNode extends TransitionVariableTypeNode
   public PropertyTypeNode getIdNode() throws UaException {
     try {
       return getIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -133,7 +142,7 @@ public class FiniteTransitionVariableTypeNode extends TransitionVariableTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Id", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Id", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/FrameTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/FrameTypeNode.java
@@ -95,8 +95,11 @@ public class FrameTypeNode extends BaseDataVariableTypeNode implements FrameType
   public Boolean readConstant() throws UaException {
     try {
       return readConstantAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -104,8 +107,11 @@ public class FrameTypeNode extends BaseDataVariableTypeNode implements FrameType
   public void writeConstant(Boolean value) throws UaException {
     try {
       writeConstantAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -127,8 +133,11 @@ public class FrameTypeNode extends BaseDataVariableTypeNode implements FrameType
   public PropertyTypeNode getConstantNode() throws UaException {
     try {
       return getConstantNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -136,7 +145,7 @@ public class FrameTypeNode extends BaseDataVariableTypeNode implements FrameType
   public CompletableFuture<? extends PropertyTypeNode> getConstantNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Constant", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Constant", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -156,8 +165,11 @@ public class FrameTypeNode extends BaseDataVariableTypeNode implements FrameType
   public Boolean readFixedBase() throws UaException {
     try {
       return readFixedBaseAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -165,8 +177,11 @@ public class FrameTypeNode extends BaseDataVariableTypeNode implements FrameType
   public void writeFixedBase(Boolean value) throws UaException {
     try {
       writeFixedBaseAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -188,8 +203,11 @@ public class FrameTypeNode extends BaseDataVariableTypeNode implements FrameType
   public PropertyTypeNode getFixedBaseNode() throws UaException {
     try {
       return getFixedBaseNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -197,7 +215,7 @@ public class FrameTypeNode extends BaseDataVariableTypeNode implements FrameType
   public CompletableFuture<? extends PropertyTypeNode> getFixedBaseNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "FixedBase", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "FixedBase", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -218,8 +236,11 @@ public class FrameTypeNode extends BaseDataVariableTypeNode implements FrameType
   public CartesianCoordinates readCartesianCoordinates() throws UaException {
     try {
       return readCartesianCoordinatesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -227,8 +248,11 @@ public class FrameTypeNode extends BaseDataVariableTypeNode implements FrameType
   public void writeCartesianCoordinates(CartesianCoordinates value) throws UaException {
     try {
       writeCartesianCoordinatesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -253,8 +277,11 @@ public class FrameTypeNode extends BaseDataVariableTypeNode implements FrameType
   public CartesianCoordinatesTypeNode getCartesianCoordinatesNode() throws UaException {
     try {
       return getCartesianCoordinatesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -265,7 +292,7 @@ public class FrameTypeNode extends BaseDataVariableTypeNode implements FrameType
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "CartesianCoordinates",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (CartesianCoordinatesTypeNode) node);
   }
@@ -287,8 +314,11 @@ public class FrameTypeNode extends BaseDataVariableTypeNode implements FrameType
   public Orientation readOrientation() throws UaException {
     try {
       return readOrientationAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -296,8 +326,11 @@ public class FrameTypeNode extends BaseDataVariableTypeNode implements FrameType
   public void writeOrientation(Orientation value) throws UaException {
     try {
       writeOrientationAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -321,8 +354,11 @@ public class FrameTypeNode extends BaseDataVariableTypeNode implements FrameType
   public OrientationTypeNode getOrientationNode() throws UaException {
     try {
       return getOrientationNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -330,10 +366,7 @@ public class FrameTypeNode extends BaseDataVariableTypeNode implements FrameType
   public CompletableFuture<? extends OrientationTypeNode> getOrientationNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "Orientation",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "Orientation", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (OrientationTypeNode) node);
   }
 
@@ -353,8 +386,11 @@ public class FrameTypeNode extends BaseDataVariableTypeNode implements FrameType
   public NodeId readBaseFrame() throws UaException {
     try {
       return readBaseFrameAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -362,8 +398,11 @@ public class FrameTypeNode extends BaseDataVariableTypeNode implements FrameType
   public void writeBaseFrame(NodeId value) throws UaException {
     try {
       writeBaseFrameAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -385,8 +424,11 @@ public class FrameTypeNode extends BaseDataVariableTypeNode implements FrameType
   public BaseDataVariableTypeNode getBaseFrameNode() throws UaException {
     try {
       return getBaseFrameNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -394,7 +436,7 @@ public class FrameTypeNode extends BaseDataVariableTypeNode implements FrameType
   public CompletableFuture<? extends BaseDataVariableTypeNode> getBaseFrameNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "BaseFrame", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "BaseFrame", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ImageItemTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ImageItemTypeNode.java
@@ -95,8 +95,11 @@ public class ImageItemTypeNode extends ArrayItemTypeNode implements ImageItemTyp
   public AxisInformation readXAxisDefinition() throws UaException {
     try {
       return readXAxisDefinitionAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -104,8 +107,11 @@ public class ImageItemTypeNode extends ArrayItemTypeNode implements ImageItemTyp
   public void writeXAxisDefinition(AxisInformation value) throws UaException {
     try {
       writeXAxisDefinitionAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -129,8 +135,11 @@ public class ImageItemTypeNode extends ArrayItemTypeNode implements ImageItemTyp
   public PropertyTypeNode getXAxisDefinitionNode() throws UaException {
     try {
       return getXAxisDefinitionNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -138,10 +147,7 @@ public class ImageItemTypeNode extends ArrayItemTypeNode implements ImageItemTyp
   public CompletableFuture<? extends PropertyTypeNode> getXAxisDefinitionNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "XAxisDefinition",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "XAxisDefinition", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -162,8 +168,11 @@ public class ImageItemTypeNode extends ArrayItemTypeNode implements ImageItemTyp
   public AxisInformation readYAxisDefinition() throws UaException {
     try {
       return readYAxisDefinitionAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -171,8 +180,11 @@ public class ImageItemTypeNode extends ArrayItemTypeNode implements ImageItemTyp
   public void writeYAxisDefinition(AxisInformation value) throws UaException {
     try {
       writeYAxisDefinitionAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -196,8 +208,11 @@ public class ImageItemTypeNode extends ArrayItemTypeNode implements ImageItemTyp
   public PropertyTypeNode getYAxisDefinitionNode() throws UaException {
     try {
       return getYAxisDefinitionNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -205,10 +220,7 @@ public class ImageItemTypeNode extends ArrayItemTypeNode implements ImageItemTyp
   public CompletableFuture<? extends PropertyTypeNode> getYAxisDefinitionNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "YAxisDefinition",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "YAxisDefinition", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/MultiStateDictionaryEntryDiscreteBaseTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/MultiStateDictionaryEntryDiscreteBaseTypeNode.java
@@ -93,8 +93,11 @@ public class MultiStateDictionaryEntryDiscreteBaseTypeNode extends MultiStateVal
   public Object readEnumDictionaryEntries() throws UaException {
     try {
       return readEnumDictionaryEntriesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -102,8 +105,11 @@ public class MultiStateDictionaryEntryDiscreteBaseTypeNode extends MultiStateVal
   public void writeEnumDictionaryEntries(Object value) throws UaException {
     try {
       writeEnumDictionaryEntriesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -126,8 +132,11 @@ public class MultiStateDictionaryEntryDiscreteBaseTypeNode extends MultiStateVal
   public PropertyTypeNode getEnumDictionaryEntriesNode() throws UaException {
     try {
       return getEnumDictionaryEntriesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -137,7 +146,7 @@ public class MultiStateDictionaryEntryDiscreteBaseTypeNode extends MultiStateVal
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "EnumDictionaryEntries",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -158,8 +167,11 @@ public class MultiStateDictionaryEntryDiscreteBaseTypeNode extends MultiStateVal
   public NodeId[] readValueAsDictionaryEntries() throws UaException {
     try {
       return readValueAsDictionaryEntriesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -167,8 +179,11 @@ public class MultiStateDictionaryEntryDiscreteBaseTypeNode extends MultiStateVal
   public void writeValueAsDictionaryEntries(NodeId[] value) throws UaException {
     try {
       writeValueAsDictionaryEntriesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -191,8 +206,11 @@ public class MultiStateDictionaryEntryDiscreteBaseTypeNode extends MultiStateVal
   public PropertyTypeNode getValueAsDictionaryEntriesNode() throws UaException {
     try {
       return getValueAsDictionaryEntriesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -202,7 +220,7 @@ public class MultiStateDictionaryEntryDiscreteBaseTypeNode extends MultiStateVal
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ValueAsDictionaryEntries",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/MultiStateDictionaryEntryDiscreteTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/MultiStateDictionaryEntryDiscreteTypeNode.java
@@ -94,8 +94,11 @@ public class MultiStateDictionaryEntryDiscreteTypeNode
   public NodeId[] readValueAsDictionaryEntries() throws UaException {
     try {
       return readValueAsDictionaryEntriesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -103,8 +106,11 @@ public class MultiStateDictionaryEntryDiscreteTypeNode
   public void writeValueAsDictionaryEntries(NodeId[] value) throws UaException {
     try {
       writeValueAsDictionaryEntriesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -127,8 +133,11 @@ public class MultiStateDictionaryEntryDiscreteTypeNode
   public PropertyTypeNode getValueAsDictionaryEntriesNode() throws UaException {
     try {
       return getValueAsDictionaryEntriesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -138,7 +147,7 @@ public class MultiStateDictionaryEntryDiscreteTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ValueAsDictionaryEntries",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/MultiStateDiscreteTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/MultiStateDiscreteTypeNode.java
@@ -93,8 +93,11 @@ public class MultiStateDiscreteTypeNode extends DiscreteItemTypeNode
   public LocalizedText[] readEnumStrings() throws UaException {
     try {
       return readEnumStringsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -102,8 +105,11 @@ public class MultiStateDiscreteTypeNode extends DiscreteItemTypeNode
   public void writeEnumStrings(LocalizedText[] value) throws UaException {
     try {
       writeEnumStringsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -125,8 +131,11 @@ public class MultiStateDiscreteTypeNode extends DiscreteItemTypeNode
   public PropertyTypeNode getEnumStringsNode() throws UaException {
     try {
       return getEnumStringsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -134,10 +143,7 @@ public class MultiStateDiscreteTypeNode extends DiscreteItemTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getEnumStringsNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "EnumStrings",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "EnumStrings", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/MultiStateValueDiscreteTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/MultiStateValueDiscreteTypeNode.java
@@ -97,8 +97,11 @@ public class MultiStateValueDiscreteTypeNode extends DiscreteItemTypeNode
   public EnumValueType[] readEnumValues() throws UaException {
     try {
       return readEnumValuesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -106,8 +109,11 @@ public class MultiStateValueDiscreteTypeNode extends DiscreteItemTypeNode
   public void writeEnumValues(EnumValueType[] value) throws UaException {
     try {
       writeEnumValuesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -131,8 +137,11 @@ public class MultiStateValueDiscreteTypeNode extends DiscreteItemTypeNode
   public PropertyTypeNode getEnumValuesNode() throws UaException {
     try {
       return getEnumValuesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -140,7 +149,7 @@ public class MultiStateValueDiscreteTypeNode extends DiscreteItemTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getEnumValuesNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "EnumValues", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "EnumValues", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -160,8 +169,11 @@ public class MultiStateValueDiscreteTypeNode extends DiscreteItemTypeNode
   public LocalizedText readValueAsText() throws UaException {
     try {
       return readValueAsTextAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -169,8 +181,11 @@ public class MultiStateValueDiscreteTypeNode extends DiscreteItemTypeNode
   public void writeValueAsText(LocalizedText value) throws UaException {
     try {
       writeValueAsTextAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -192,8 +207,11 @@ public class MultiStateValueDiscreteTypeNode extends DiscreteItemTypeNode
   public PropertyTypeNode getValueAsTextNode() throws UaException {
     try {
       return getValueAsTextNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -201,10 +219,7 @@ public class MultiStateValueDiscreteTypeNode extends DiscreteItemTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getValueAsTextNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ValueAsText",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "ValueAsText", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/NDimensionArrayItemTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/NDimensionArrayItemTypeNode.java
@@ -97,8 +97,11 @@ public class NDimensionArrayItemTypeNode extends ArrayItemTypeNode
   public AxisInformation[] readAxisDefinition() throws UaException {
     try {
       return readAxisDefinitionAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -106,8 +109,11 @@ public class NDimensionArrayItemTypeNode extends ArrayItemTypeNode
   public void writeAxisDefinition(AxisInformation[] value) throws UaException {
     try {
       writeAxisDefinitionAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -131,8 +137,11 @@ public class NDimensionArrayItemTypeNode extends ArrayItemTypeNode
   public PropertyTypeNode getAxisDefinitionNode() throws UaException {
     try {
       return getAxisDefinitionNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -140,10 +149,7 @@ public class NDimensionArrayItemTypeNode extends ArrayItemTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getAxisDefinitionNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "AxisDefinition",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "AxisDefinition", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/OptionSetTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/OptionSetTypeNode.java
@@ -92,8 +92,11 @@ public class OptionSetTypeNode extends BaseDataVariableTypeNode implements Optio
   public LocalizedText[] readOptionSetValues() throws UaException {
     try {
       return readOptionSetValuesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -101,8 +104,11 @@ public class OptionSetTypeNode extends BaseDataVariableTypeNode implements Optio
   public void writeOptionSetValues(LocalizedText[] value) throws UaException {
     try {
       writeOptionSetValuesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -124,8 +130,11 @@ public class OptionSetTypeNode extends BaseDataVariableTypeNode implements Optio
   public PropertyTypeNode getOptionSetValuesNode() throws UaException {
     try {
       return getOptionSetValuesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -133,10 +142,7 @@ public class OptionSetTypeNode extends BaseDataVariableTypeNode implements Optio
   public CompletableFuture<? extends PropertyTypeNode> getOptionSetValuesNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "OptionSetValues",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "OptionSetValues", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -156,8 +162,11 @@ public class OptionSetTypeNode extends BaseDataVariableTypeNode implements Optio
   public Boolean[] readBitMask() throws UaException {
     try {
       return readBitMaskAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -165,8 +174,11 @@ public class OptionSetTypeNode extends BaseDataVariableTypeNode implements Optio
   public void writeBitMask(Boolean[] value) throws UaException {
     try {
       writeBitMaskAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -188,8 +200,11 @@ public class OptionSetTypeNode extends BaseDataVariableTypeNode implements Optio
   public PropertyTypeNode getBitMaskNode() throws UaException {
     try {
       return getBitMaskNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -197,7 +212,7 @@ public class OptionSetTypeNode extends BaseDataVariableTypeNode implements Optio
   public CompletableFuture<? extends PropertyTypeNode> getBitMaskNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "BitMask", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "BitMask", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/OrientationTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/OrientationTypeNode.java
@@ -95,8 +95,11 @@ public class OrientationTypeNode extends BaseDataVariableTypeNode implements Ori
   public EUInformation readAngleUnit() throws UaException {
     try {
       return readAngleUnitAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -104,8 +107,11 @@ public class OrientationTypeNode extends BaseDataVariableTypeNode implements Ori
   public void writeAngleUnit(EUInformation value) throws UaException {
     try {
       writeAngleUnitAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -128,8 +134,11 @@ public class OrientationTypeNode extends BaseDataVariableTypeNode implements Ori
   public PropertyTypeNode getAngleUnitNode() throws UaException {
     try {
       return getAngleUnitNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -137,7 +146,7 @@ public class OrientationTypeNode extends BaseDataVariableTypeNode implements Ori
   public CompletableFuture<? extends PropertyTypeNode> getAngleUnitNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "AngleUnit", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "AngleUnit", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ProgramDiagnostic2TypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ProgramDiagnostic2TypeNode.java
@@ -96,8 +96,11 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   public DateTime readLastTransitionTime() throws UaException {
     try {
       return readLastTransitionTimeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -105,8 +108,11 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   public void writeLastTransitionTime(DateTime value) throws UaException {
     try {
       writeLastTransitionTimeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -128,8 +134,11 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   public PropertyTypeNode getLastTransitionTimeNode() throws UaException {
     try {
       return getLastTransitionTimeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -139,7 +148,7 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "LastTransitionTime",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -160,8 +169,11 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   public NodeId readCreateSessionId() throws UaException {
     try {
       return readCreateSessionIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -169,8 +181,11 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   public void writeCreateSessionId(NodeId value) throws UaException {
     try {
       writeCreateSessionIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -192,8 +207,11 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getCreateSessionIdNode() throws UaException {
     try {
       return getCreateSessionIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -201,10 +219,7 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getCreateSessionIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "CreateSessionId",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "CreateSessionId", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -224,8 +239,11 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   public String readCreateClientName() throws UaException {
     try {
       return readCreateClientNameAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -233,8 +251,11 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   public void writeCreateClientName(String value) throws UaException {
     try {
       writeCreateClientNameAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -256,8 +277,11 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getCreateClientNameNode() throws UaException {
     try {
       return getCreateClientNameNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -267,7 +291,7 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "CreateClientName",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -288,8 +312,11 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   public DateTime readInvocationCreationTime() throws UaException {
     try {
       return readInvocationCreationTimeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -297,8 +324,11 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   public void writeInvocationCreationTime(DateTime value) throws UaException {
     try {
       writeInvocationCreationTimeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -321,8 +351,11 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getInvocationCreationTimeNode() throws UaException {
     try {
       return getInvocationCreationTimeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -333,7 +366,7 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "InvocationCreationTime",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -354,8 +387,11 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   public String readLastMethodCall() throws UaException {
     try {
       return readLastMethodCallAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -363,8 +399,11 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   public void writeLastMethodCall(String value) throws UaException {
     try {
       writeLastMethodCallAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -386,8 +425,11 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getLastMethodCallNode() throws UaException {
     try {
       return getLastMethodCallNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -395,10 +437,7 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getLastMethodCallNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "LastMethodCall",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "LastMethodCall", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -418,8 +457,11 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   public NodeId readLastMethodSessionId() throws UaException {
     try {
       return readLastMethodSessionIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -427,8 +469,11 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   public void writeLastMethodSessionId(NodeId value) throws UaException {
     try {
       writeLastMethodSessionIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -450,8 +495,11 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getLastMethodSessionIdNode() throws UaException {
     try {
       return getLastMethodSessionIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -461,7 +509,7 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "LastMethodSessionId",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -484,8 +532,11 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   public Argument[] readLastMethodInputArguments() throws UaException {
     try {
       return readLastMethodInputArgumentsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -493,8 +544,11 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   public void writeLastMethodInputArguments(Argument[] value) throws UaException {
     try {
       writeLastMethodInputArgumentsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -519,8 +573,11 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getLastMethodInputArgumentsNode() throws UaException {
     try {
       return getLastMethodInputArgumentsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -531,7 +588,7 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "LastMethodInputArguments",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -554,8 +611,11 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   public Argument[] readLastMethodOutputArguments() throws UaException {
     try {
       return readLastMethodOutputArgumentsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -563,8 +623,11 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   public void writeLastMethodOutputArguments(Argument[] value) throws UaException {
     try {
       writeLastMethodOutputArgumentsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -589,8 +652,11 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getLastMethodOutputArgumentsNode() throws UaException {
     try {
       return getLastMethodOutputArgumentsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -601,7 +667,7 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "LastMethodOutputArguments",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -622,8 +688,11 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   public Object[] readLastMethodInputValues() throws UaException {
     try {
       return readLastMethodInputValuesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -631,8 +700,11 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   public void writeLastMethodInputValues(Object[] value) throws UaException {
     try {
       writeLastMethodInputValuesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -655,8 +727,11 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getLastMethodInputValuesNode() throws UaException {
     try {
       return getLastMethodInputValuesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -666,7 +741,7 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "LastMethodInputValues",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -687,8 +762,11 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   public Object[] readLastMethodOutputValues() throws UaException {
     try {
       return readLastMethodOutputValuesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -696,8 +774,11 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   public void writeLastMethodOutputValues(Object[] value) throws UaException {
     try {
       writeLastMethodOutputValuesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -720,8 +801,11 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getLastMethodOutputValuesNode() throws UaException {
     try {
       return getLastMethodOutputValuesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -732,7 +816,7 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "LastMethodOutputValues",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -753,8 +837,11 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   public DateTime readLastMethodCallTime() throws UaException {
     try {
       return readLastMethodCallTimeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -762,8 +849,11 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   public void writeLastMethodCallTime(DateTime value) throws UaException {
     try {
       writeLastMethodCallTimeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -785,8 +875,11 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getLastMethodCallTimeNode() throws UaException {
     try {
       return getLastMethodCallTimeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -796,7 +889,7 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "LastMethodCallTime",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -817,8 +910,11 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   public StatusCode readLastMethodReturnStatus() throws UaException {
     try {
       return readLastMethodReturnStatusAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -826,8 +922,11 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   public void writeLastMethodReturnStatus(StatusCode value) throws UaException {
     try {
       writeLastMethodReturnStatusAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -850,8 +949,11 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getLastMethodReturnStatusNode() throws UaException {
     try {
       return getLastMethodReturnStatusNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -862,7 +964,7 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "LastMethodReturnStatus",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ProgramDiagnosticTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ProgramDiagnosticTypeNode.java
@@ -96,8 +96,11 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
   public NodeId readCreateSessionId() throws UaException {
     try {
       return readCreateSessionIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -105,8 +108,11 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
   public void writeCreateSessionId(NodeId value) throws UaException {
     try {
       writeCreateSessionIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -128,8 +134,11 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
   public PropertyTypeNode getCreateSessionIdNode() throws UaException {
     try {
       return getCreateSessionIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -137,10 +146,7 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getCreateSessionIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "CreateSessionId",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "CreateSessionId", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -160,8 +166,11 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
   public String readCreateClientName() throws UaException {
     try {
       return readCreateClientNameAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -169,8 +178,11 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
   public void writeCreateClientName(String value) throws UaException {
     try {
       writeCreateClientNameAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -192,8 +204,11 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
   public PropertyTypeNode getCreateClientNameNode() throws UaException {
     try {
       return getCreateClientNameNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -203,7 +218,7 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "CreateClientName",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -224,8 +239,11 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
   public DateTime readInvocationCreationTime() throws UaException {
     try {
       return readInvocationCreationTimeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -233,8 +251,11 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
   public void writeInvocationCreationTime(DateTime value) throws UaException {
     try {
       writeInvocationCreationTimeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -257,8 +278,11 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
   public PropertyTypeNode getInvocationCreationTimeNode() throws UaException {
     try {
       return getInvocationCreationTimeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -268,7 +292,7 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "InvocationCreationTime",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -289,8 +313,11 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
   public DateTime readLastTransitionTime() throws UaException {
     try {
       return readLastTransitionTimeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -298,8 +325,11 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
   public void writeLastTransitionTime(DateTime value) throws UaException {
     try {
       writeLastTransitionTimeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -321,8 +351,11 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
   public PropertyTypeNode getLastTransitionTimeNode() throws UaException {
     try {
       return getLastTransitionTimeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -332,7 +365,7 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "LastTransitionTime",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -353,8 +386,11 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
   public String readLastMethodCall() throws UaException {
     try {
       return readLastMethodCallAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -362,8 +398,11 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
   public void writeLastMethodCall(String value) throws UaException {
     try {
       writeLastMethodCallAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -385,8 +424,11 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
   public PropertyTypeNode getLastMethodCallNode() throws UaException {
     try {
       return getLastMethodCallNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -394,10 +436,7 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getLastMethodCallNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "LastMethodCall",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "LastMethodCall", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -417,8 +456,11 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
   public NodeId readLastMethodSessionId() throws UaException {
     try {
       return readLastMethodSessionIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -426,8 +468,11 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
   public void writeLastMethodSessionId(NodeId value) throws UaException {
     try {
       writeLastMethodSessionIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -449,8 +494,11 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
   public PropertyTypeNode getLastMethodSessionIdNode() throws UaException {
     try {
       return getLastMethodSessionIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -460,7 +508,7 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "LastMethodSessionId",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -481,8 +529,11 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
   public Object[] readLastMethodInputArguments() throws UaException {
     try {
       return readLastMethodInputArgumentsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -490,8 +541,11 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
   public void writeLastMethodInputArguments(Object[] value) throws UaException {
     try {
       writeLastMethodInputArgumentsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -514,8 +568,11 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
   public PropertyTypeNode getLastMethodInputArgumentsNode() throws UaException {
     try {
       return getLastMethodInputArgumentsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -525,7 +582,7 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "LastMethodInputArguments",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -546,8 +603,11 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
   public Object[] readLastMethodOutputArguments() throws UaException {
     try {
       return readLastMethodOutputArgumentsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -555,8 +615,11 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
   public void writeLastMethodOutputArguments(Object[] value) throws UaException {
     try {
       writeLastMethodOutputArgumentsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -579,8 +642,11 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
   public PropertyTypeNode getLastMethodOutputArgumentsNode() throws UaException {
     try {
       return getLastMethodOutputArgumentsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -590,7 +656,7 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "LastMethodOutputArguments",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -611,8 +677,11 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
   public DateTime readLastMethodCallTime() throws UaException {
     try {
       return readLastMethodCallTimeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -620,8 +689,11 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
   public void writeLastMethodCallTime(DateTime value) throws UaException {
     try {
       writeLastMethodCallTimeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -643,8 +715,11 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
   public PropertyTypeNode getLastMethodCallTimeNode() throws UaException {
     try {
       return getLastMethodCallTimeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -654,7 +729,7 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "LastMethodCallTime",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -676,8 +751,11 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
   public StatusResult readLastMethodReturnStatus() throws UaException {
     try {
       return readLastMethodReturnStatusAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -685,8 +763,11 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
   public void writeLastMethodReturnStatus(StatusResult value) throws UaException {
     try {
       writeLastMethodReturnStatusAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -711,8 +792,11 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
   public PropertyTypeNode getLastMethodReturnStatusNode() throws UaException {
     try {
       return getLastMethodReturnStatusNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -722,7 +806,7 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "LastMethodReturnStatus",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/PubSubDiagnosticsCounterTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/PubSubDiagnosticsCounterTypeNode.java
@@ -96,8 +96,11 @@ public class PubSubDiagnosticsCounterTypeNode extends BaseDataVariableTypeNode
   public Boolean readActive() throws UaException {
     try {
       return readActiveAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -105,8 +108,11 @@ public class PubSubDiagnosticsCounterTypeNode extends BaseDataVariableTypeNode
   public void writeActive(Boolean value) throws UaException {
     try {
       writeActiveAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -128,8 +134,11 @@ public class PubSubDiagnosticsCounterTypeNode extends BaseDataVariableTypeNode
   public PropertyTypeNode getActiveNode() throws UaException {
     try {
       return getActiveNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -137,7 +146,7 @@ public class PubSubDiagnosticsCounterTypeNode extends BaseDataVariableTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getActiveNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Active", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Active", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -165,8 +174,11 @@ public class PubSubDiagnosticsCounterTypeNode extends BaseDataVariableTypeNode
   public PubSubDiagnosticsCounterClassification readClassification() throws UaException {
     try {
       return readClassificationAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -174,8 +186,11 @@ public class PubSubDiagnosticsCounterTypeNode extends BaseDataVariableTypeNode
   public void writeClassification(PubSubDiagnosticsCounterClassification value) throws UaException {
     try {
       writeClassificationAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -207,8 +222,11 @@ public class PubSubDiagnosticsCounterTypeNode extends BaseDataVariableTypeNode
   public PropertyTypeNode getClassificationNode() throws UaException {
     try {
       return getClassificationNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -216,10 +234,7 @@ public class PubSubDiagnosticsCounterTypeNode extends BaseDataVariableTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getClassificationNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "Classification",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "Classification", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -247,8 +262,11 @@ public class PubSubDiagnosticsCounterTypeNode extends BaseDataVariableTypeNode
   public DiagnosticsLevel readDiagnosticsLevel() throws UaException {
     try {
       return readDiagnosticsLevelAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -256,8 +274,11 @@ public class PubSubDiagnosticsCounterTypeNode extends BaseDataVariableTypeNode
   public void writeDiagnosticsLevel(DiagnosticsLevel value) throws UaException {
     try {
       writeDiagnosticsLevelAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -288,8 +309,11 @@ public class PubSubDiagnosticsCounterTypeNode extends BaseDataVariableTypeNode
   public PropertyTypeNode getDiagnosticsLevelNode() throws UaException {
     try {
       return getDiagnosticsLevelNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -299,7 +323,7 @@ public class PubSubDiagnosticsCounterTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "DiagnosticsLevel",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -320,8 +344,11 @@ public class PubSubDiagnosticsCounterTypeNode extends BaseDataVariableTypeNode
   public DateTime readTimeFirstChange() throws UaException {
     try {
       return readTimeFirstChangeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -329,8 +356,11 @@ public class PubSubDiagnosticsCounterTypeNode extends BaseDataVariableTypeNode
   public void writeTimeFirstChange(DateTime value) throws UaException {
     try {
       writeTimeFirstChangeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -352,8 +382,11 @@ public class PubSubDiagnosticsCounterTypeNode extends BaseDataVariableTypeNode
   public PropertyTypeNode getTimeFirstChangeNode() throws UaException {
     try {
       return getTimeFirstChangeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -361,10 +394,7 @@ public class PubSubDiagnosticsCounterTypeNode extends BaseDataVariableTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getTimeFirstChangeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "TimeFirstChange",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "TimeFirstChange", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/RationalNumberTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/RationalNumberTypeNode.java
@@ -92,8 +92,11 @@ public class RationalNumberTypeNode extends BaseDataVariableTypeNode implements 
   public Integer readNumerator() throws UaException {
     try {
       return readNumeratorAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -101,8 +104,11 @@ public class RationalNumberTypeNode extends BaseDataVariableTypeNode implements 
   public void writeNumerator(Integer value) throws UaException {
     try {
       writeNumeratorAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -124,8 +130,11 @@ public class RationalNumberTypeNode extends BaseDataVariableTypeNode implements 
   public BaseDataVariableTypeNode getNumeratorNode() throws UaException {
     try {
       return getNumeratorNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -133,7 +142,7 @@ public class RationalNumberTypeNode extends BaseDataVariableTypeNode implements 
   public CompletableFuture<? extends BaseDataVariableTypeNode> getNumeratorNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Numerator", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "Numerator", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -153,8 +162,11 @@ public class RationalNumberTypeNode extends BaseDataVariableTypeNode implements 
   public UInteger readDenominator() throws UaException {
     try {
       return readDenominatorAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -162,8 +174,11 @@ public class RationalNumberTypeNode extends BaseDataVariableTypeNode implements 
   public void writeDenominator(UInteger value) throws UaException {
     try {
       writeDenominatorAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -185,8 +200,11 @@ public class RationalNumberTypeNode extends BaseDataVariableTypeNode implements 
   public BaseDataVariableTypeNode getDenominatorNode() throws UaException {
     try {
       return getDenominatorNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -194,10 +212,7 @@ public class RationalNumberTypeNode extends BaseDataVariableTypeNode implements 
   public CompletableFuture<? extends BaseDataVariableTypeNode> getDenominatorNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "Denominator",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "Denominator", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ReferenceDescriptionVariableTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ReferenceDescriptionVariableTypeNode.java
@@ -97,8 +97,11 @@ public class ReferenceDescriptionVariableTypeNode extends BaseDataVariableTypeNo
   public ReferenceListEntryDataType[] readReferenceRefinement() throws UaException {
     try {
       return readReferenceRefinementAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -106,8 +109,11 @@ public class ReferenceDescriptionVariableTypeNode extends BaseDataVariableTypeNo
   public void writeReferenceRefinement(ReferenceListEntryDataType[] value) throws UaException {
     try {
       writeReferenceRefinementAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -132,8 +138,11 @@ public class ReferenceDescriptionVariableTypeNode extends BaseDataVariableTypeNo
   public PropertyTypeNode getReferenceRefinementNode() throws UaException {
     try {
       return getReferenceRefinementNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -143,7 +152,7 @@ public class ReferenceDescriptionVariableTypeNode extends BaseDataVariableTypeNo
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ReferenceRefinement",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/SamplingIntervalDiagnosticsArrayTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/SamplingIntervalDiagnosticsArrayTypeNode.java
@@ -97,8 +97,11 @@ public class SamplingIntervalDiagnosticsArrayTypeNode extends BaseDataVariableTy
   public SamplingIntervalDiagnosticsDataType readSamplingIntervalDiagnostics() throws UaException {
     try {
       return readSamplingIntervalDiagnosticsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -107,8 +110,11 @@ public class SamplingIntervalDiagnosticsArrayTypeNode extends BaseDataVariableTy
       throws UaException {
     try {
       writeSamplingIntervalDiagnosticsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -135,8 +141,11 @@ public class SamplingIntervalDiagnosticsArrayTypeNode extends BaseDataVariableTy
       throws UaException {
     try {
       return getSamplingIntervalDiagnosticsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -147,7 +156,7 @@ public class SamplingIntervalDiagnosticsArrayTypeNode extends BaseDataVariableTy
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SamplingIntervalDiagnostics",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (SamplingIntervalDiagnosticsTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/SamplingIntervalDiagnosticsTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/SamplingIntervalDiagnosticsTypeNode.java
@@ -93,8 +93,11 @@ public class SamplingIntervalDiagnosticsTypeNode extends BaseDataVariableTypeNod
   public Double readSamplingInterval() throws UaException {
     try {
       return readSamplingIntervalAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -102,8 +105,11 @@ public class SamplingIntervalDiagnosticsTypeNode extends BaseDataVariableTypeNod
   public void writeSamplingInterval(Double value) throws UaException {
     try {
       writeSamplingIntervalAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -125,8 +131,11 @@ public class SamplingIntervalDiagnosticsTypeNode extends BaseDataVariableTypeNod
   public BaseDataVariableTypeNode getSamplingIntervalNode() throws UaException {
     try {
       return getSamplingIntervalNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -136,7 +145,7 @@ public class SamplingIntervalDiagnosticsTypeNode extends BaseDataVariableTypeNod
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SamplingInterval",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -157,8 +166,11 @@ public class SamplingIntervalDiagnosticsTypeNode extends BaseDataVariableTypeNod
   public UInteger readSampledMonitoredItemsCount() throws UaException {
     try {
       return readSampledMonitoredItemsCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -166,8 +178,11 @@ public class SamplingIntervalDiagnosticsTypeNode extends BaseDataVariableTypeNod
   public void writeSampledMonitoredItemsCount(UInteger value) throws UaException {
     try {
       writeSampledMonitoredItemsCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -190,8 +205,11 @@ public class SamplingIntervalDiagnosticsTypeNode extends BaseDataVariableTypeNod
   public BaseDataVariableTypeNode getSampledMonitoredItemsCountNode() throws UaException {
     try {
       return getSampledMonitoredItemsCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -202,7 +220,7 @@ public class SamplingIntervalDiagnosticsTypeNode extends BaseDataVariableTypeNod
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SampledMonitoredItemsCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -223,8 +241,11 @@ public class SamplingIntervalDiagnosticsTypeNode extends BaseDataVariableTypeNod
   public UInteger readMaxSampledMonitoredItemsCount() throws UaException {
     try {
       return readMaxSampledMonitoredItemsCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -232,8 +253,11 @@ public class SamplingIntervalDiagnosticsTypeNode extends BaseDataVariableTypeNod
   public void writeMaxSampledMonitoredItemsCount(UInteger value) throws UaException {
     try {
       writeMaxSampledMonitoredItemsCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -256,8 +280,11 @@ public class SamplingIntervalDiagnosticsTypeNode extends BaseDataVariableTypeNod
   public BaseDataVariableTypeNode getMaxSampledMonitoredItemsCountNode() throws UaException {
     try {
       return getMaxSampledMonitoredItemsCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -268,7 +295,7 @@ public class SamplingIntervalDiagnosticsTypeNode extends BaseDataVariableTypeNod
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaxSampledMonitoredItemsCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -289,8 +316,11 @@ public class SamplingIntervalDiagnosticsTypeNode extends BaseDataVariableTypeNod
   public UInteger readDisabledMonitoredItemsSamplingCount() throws UaException {
     try {
       return readDisabledMonitoredItemsSamplingCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -298,8 +328,11 @@ public class SamplingIntervalDiagnosticsTypeNode extends BaseDataVariableTypeNod
   public void writeDisabledMonitoredItemsSamplingCount(UInteger value) throws UaException {
     try {
       writeDisabledMonitoredItemsSamplingCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -322,8 +355,11 @@ public class SamplingIntervalDiagnosticsTypeNode extends BaseDataVariableTypeNod
   public BaseDataVariableTypeNode getDisabledMonitoredItemsSamplingCountNode() throws UaException {
     try {
       return getDisabledMonitoredItemsSamplingCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -334,7 +370,7 @@ public class SamplingIntervalDiagnosticsTypeNode extends BaseDataVariableTypeNod
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "DisabledMonitoredItemsSamplingCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/SelectionListTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/SelectionListTypeNode.java
@@ -92,8 +92,11 @@ public class SelectionListTypeNode extends BaseDataVariableTypeNode implements S
   public Object[] readSelections() throws UaException {
     try {
       return readSelectionsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -101,8 +104,11 @@ public class SelectionListTypeNode extends BaseDataVariableTypeNode implements S
   public void writeSelections(Object[] value) throws UaException {
     try {
       writeSelectionsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -124,8 +130,11 @@ public class SelectionListTypeNode extends BaseDataVariableTypeNode implements S
   public PropertyTypeNode getSelectionsNode() throws UaException {
     try {
       return getSelectionsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -133,7 +142,7 @@ public class SelectionListTypeNode extends BaseDataVariableTypeNode implements S
   public CompletableFuture<? extends PropertyTypeNode> getSelectionsNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Selections", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Selections", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -153,8 +162,11 @@ public class SelectionListTypeNode extends BaseDataVariableTypeNode implements S
   public LocalizedText[] readSelectionDescriptions() throws UaException {
     try {
       return readSelectionDescriptionsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -162,8 +174,11 @@ public class SelectionListTypeNode extends BaseDataVariableTypeNode implements S
   public void writeSelectionDescriptions(LocalizedText[] value) throws UaException {
     try {
       writeSelectionDescriptionsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -186,8 +201,11 @@ public class SelectionListTypeNode extends BaseDataVariableTypeNode implements S
   public PropertyTypeNode getSelectionDescriptionsNode() throws UaException {
     try {
       return getSelectionDescriptionsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -197,7 +215,7 @@ public class SelectionListTypeNode extends BaseDataVariableTypeNode implements S
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SelectionDescriptions",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -218,8 +236,11 @@ public class SelectionListTypeNode extends BaseDataVariableTypeNode implements S
   public Boolean readRestrictToList() throws UaException {
     try {
       return readRestrictToListAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -227,8 +248,11 @@ public class SelectionListTypeNode extends BaseDataVariableTypeNode implements S
   public void writeRestrictToList(Boolean value) throws UaException {
     try {
       writeRestrictToListAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -250,8 +274,11 @@ public class SelectionListTypeNode extends BaseDataVariableTypeNode implements S
   public PropertyTypeNode getRestrictToListNode() throws UaException {
     try {
       return getRestrictToListNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -259,10 +286,7 @@ public class SelectionListTypeNode extends BaseDataVariableTypeNode implements S
   public CompletableFuture<? extends PropertyTypeNode> getRestrictToListNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "RestrictToList",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "RestrictToList", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ServerDiagnosticsSummaryTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ServerDiagnosticsSummaryTypeNode.java
@@ -93,8 +93,11 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   public UInteger readServerViewCount() throws UaException {
     try {
       return readServerViewCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -102,8 +105,11 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   public void writeServerViewCount(UInteger value) throws UaException {
     try {
       writeServerViewCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -125,8 +131,11 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getServerViewCountNode() throws UaException {
     try {
       return getServerViewCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -134,10 +143,7 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getServerViewCountNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ServerViewCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "ServerViewCount", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -157,8 +163,11 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   public UInteger readCurrentSessionCount() throws UaException {
     try {
       return readCurrentSessionCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -166,8 +175,11 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   public void writeCurrentSessionCount(UInteger value) throws UaException {
     try {
       writeCurrentSessionCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -189,8 +201,11 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getCurrentSessionCountNode() throws UaException {
     try {
       return getCurrentSessionCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -200,7 +215,7 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "CurrentSessionCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -221,8 +236,11 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   public UInteger readCumulatedSessionCount() throws UaException {
     try {
       return readCumulatedSessionCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -230,8 +248,11 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   public void writeCumulatedSessionCount(UInteger value) throws UaException {
     try {
       writeCumulatedSessionCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -254,8 +275,11 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getCumulatedSessionCountNode() throws UaException {
     try {
       return getCumulatedSessionCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -265,7 +289,7 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "CumulatedSessionCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -286,8 +310,11 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   public UInteger readSecurityRejectedSessionCount() throws UaException {
     try {
       return readSecurityRejectedSessionCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -295,8 +322,11 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   public void writeSecurityRejectedSessionCount(UInteger value) throws UaException {
     try {
       writeSecurityRejectedSessionCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -319,8 +349,11 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getSecurityRejectedSessionCountNode() throws UaException {
     try {
       return getSecurityRejectedSessionCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -331,7 +364,7 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SecurityRejectedSessionCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -352,8 +385,11 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   public UInteger readRejectedSessionCount() throws UaException {
     try {
       return readRejectedSessionCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -361,8 +397,11 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   public void writeRejectedSessionCount(UInteger value) throws UaException {
     try {
       writeRejectedSessionCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -385,8 +424,11 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getRejectedSessionCountNode() throws UaException {
     try {
       return getRejectedSessionCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -396,7 +438,7 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "RejectedSessionCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -417,8 +459,11 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   public UInteger readSessionTimeoutCount() throws UaException {
     try {
       return readSessionTimeoutCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -426,8 +471,11 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   public void writeSessionTimeoutCount(UInteger value) throws UaException {
     try {
       writeSessionTimeoutCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -449,8 +497,11 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getSessionTimeoutCountNode() throws UaException {
     try {
       return getSessionTimeoutCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -460,7 +511,7 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SessionTimeoutCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -481,8 +532,11 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   public UInteger readSessionAbortCount() throws UaException {
     try {
       return readSessionAbortCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -490,8 +544,11 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   public void writeSessionAbortCount(UInteger value) throws UaException {
     try {
       writeSessionAbortCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -513,8 +570,11 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getSessionAbortCountNode() throws UaException {
     try {
       return getSessionAbortCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -524,7 +584,7 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SessionAbortCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -545,8 +605,11 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   public UInteger readPublishingIntervalCount() throws UaException {
     try {
       return readPublishingIntervalCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -554,8 +617,11 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   public void writePublishingIntervalCount(UInteger value) throws UaException {
     try {
       writePublishingIntervalCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -578,8 +644,11 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getPublishingIntervalCountNode() throws UaException {
     try {
       return getPublishingIntervalCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -590,7 +659,7 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "PublishingIntervalCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -611,8 +680,11 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   public UInteger readCurrentSubscriptionCount() throws UaException {
     try {
       return readCurrentSubscriptionCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -620,8 +692,11 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   public void writeCurrentSubscriptionCount(UInteger value) throws UaException {
     try {
       writeCurrentSubscriptionCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -644,8 +719,11 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getCurrentSubscriptionCountNode() throws UaException {
     try {
       return getCurrentSubscriptionCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -656,7 +734,7 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "CurrentSubscriptionCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -677,8 +755,11 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   public UInteger readCumulatedSubscriptionCount() throws UaException {
     try {
       return readCumulatedSubscriptionCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -686,8 +767,11 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   public void writeCumulatedSubscriptionCount(UInteger value) throws UaException {
     try {
       writeCumulatedSubscriptionCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -710,8 +794,11 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getCumulatedSubscriptionCountNode() throws UaException {
     try {
       return getCumulatedSubscriptionCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -722,7 +809,7 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "CumulatedSubscriptionCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -743,8 +830,11 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   public UInteger readSecurityRejectedRequestsCount() throws UaException {
     try {
       return readSecurityRejectedRequestsCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -752,8 +842,11 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   public void writeSecurityRejectedRequestsCount(UInteger value) throws UaException {
     try {
       writeSecurityRejectedRequestsCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -776,8 +869,11 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getSecurityRejectedRequestsCountNode() throws UaException {
     try {
       return getSecurityRejectedRequestsCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -788,7 +884,7 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SecurityRejectedRequestsCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -809,8 +905,11 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   public UInteger readRejectedRequestsCount() throws UaException {
     try {
       return readRejectedRequestsCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -818,8 +917,11 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   public void writeRejectedRequestsCount(UInteger value) throws UaException {
     try {
       writeRejectedRequestsCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -842,8 +944,11 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getRejectedRequestsCountNode() throws UaException {
     try {
       return getRejectedRequestsCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -853,7 +958,7 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "RejectedRequestsCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ServerStatusTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ServerStatusTypeNode.java
@@ -96,8 +96,11 @@ public class ServerStatusTypeNode extends BaseDataVariableTypeNode implements Se
   public DateTime readStartTime() throws UaException {
     try {
       return readStartTimeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -105,8 +108,11 @@ public class ServerStatusTypeNode extends BaseDataVariableTypeNode implements Se
   public void writeStartTime(DateTime value) throws UaException {
     try {
       writeStartTimeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -128,8 +134,11 @@ public class ServerStatusTypeNode extends BaseDataVariableTypeNode implements Se
   public BaseDataVariableTypeNode getStartTimeNode() throws UaException {
     try {
       return getStartTimeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -137,7 +146,7 @@ public class ServerStatusTypeNode extends BaseDataVariableTypeNode implements Se
   public CompletableFuture<? extends BaseDataVariableTypeNode> getStartTimeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "StartTime", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "StartTime", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -157,8 +166,11 @@ public class ServerStatusTypeNode extends BaseDataVariableTypeNode implements Se
   public DateTime readCurrentTime() throws UaException {
     try {
       return readCurrentTimeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -166,8 +178,11 @@ public class ServerStatusTypeNode extends BaseDataVariableTypeNode implements Se
   public void writeCurrentTime(DateTime value) throws UaException {
     try {
       writeCurrentTimeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -189,8 +204,11 @@ public class ServerStatusTypeNode extends BaseDataVariableTypeNode implements Se
   public BaseDataVariableTypeNode getCurrentTimeNode() throws UaException {
     try {
       return getCurrentTimeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -198,10 +216,7 @@ public class ServerStatusTypeNode extends BaseDataVariableTypeNode implements Se
   public CompletableFuture<? extends BaseDataVariableTypeNode> getCurrentTimeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "CurrentTime",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "CurrentTime", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -229,8 +244,11 @@ public class ServerStatusTypeNode extends BaseDataVariableTypeNode implements Se
   public ServerState readState() throws UaException {
     try {
       return readStateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -238,8 +256,11 @@ public class ServerStatusTypeNode extends BaseDataVariableTypeNode implements Se
   public void writeState(ServerState value) throws UaException {
     try {
       writeStateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -269,8 +290,11 @@ public class ServerStatusTypeNode extends BaseDataVariableTypeNode implements Se
   public BaseDataVariableTypeNode getStateNode() throws UaException {
     try {
       return getStateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -278,7 +302,7 @@ public class ServerStatusTypeNode extends BaseDataVariableTypeNode implements Se
   public CompletableFuture<? extends BaseDataVariableTypeNode> getStateNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "State", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "State", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -299,8 +323,11 @@ public class ServerStatusTypeNode extends BaseDataVariableTypeNode implements Se
   public BuildInfo readBuildInfo() throws UaException {
     try {
       return readBuildInfoAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -308,8 +335,11 @@ public class ServerStatusTypeNode extends BaseDataVariableTypeNode implements Se
   public void writeBuildInfo(BuildInfo value) throws UaException {
     try {
       writeBuildInfoAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -332,8 +362,11 @@ public class ServerStatusTypeNode extends BaseDataVariableTypeNode implements Se
   public BuildInfoTypeNode getBuildInfoNode() throws UaException {
     try {
       return getBuildInfoNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -341,7 +374,7 @@ public class ServerStatusTypeNode extends BaseDataVariableTypeNode implements Se
   public CompletableFuture<? extends BuildInfoTypeNode> getBuildInfoNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "BuildInfo", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "BuildInfo", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BuildInfoTypeNode) node);
   }
 
@@ -361,8 +394,11 @@ public class ServerStatusTypeNode extends BaseDataVariableTypeNode implements Se
   public UInteger readSecondsTillShutdown() throws UaException {
     try {
       return readSecondsTillShutdownAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -370,8 +406,11 @@ public class ServerStatusTypeNode extends BaseDataVariableTypeNode implements Se
   public void writeSecondsTillShutdown(UInteger value) throws UaException {
     try {
       writeSecondsTillShutdownAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -393,8 +432,11 @@ public class ServerStatusTypeNode extends BaseDataVariableTypeNode implements Se
   public BaseDataVariableTypeNode getSecondsTillShutdownNode() throws UaException {
     try {
       return getSecondsTillShutdownNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -404,7 +446,7 @@ public class ServerStatusTypeNode extends BaseDataVariableTypeNode implements Se
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SecondsTillShutdown",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -425,8 +467,11 @@ public class ServerStatusTypeNode extends BaseDataVariableTypeNode implements Se
   public LocalizedText readShutdownReason() throws UaException {
     try {
       return readShutdownReasonAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -434,8 +479,11 @@ public class ServerStatusTypeNode extends BaseDataVariableTypeNode implements Se
   public void writeShutdownReason(LocalizedText value) throws UaException {
     try {
       writeShutdownReasonAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -457,8 +505,11 @@ public class ServerStatusTypeNode extends BaseDataVariableTypeNode implements Se
   public BaseDataVariableTypeNode getShutdownReasonNode() throws UaException {
     try {
       return getShutdownReasonNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -466,10 +517,7 @@ public class ServerStatusTypeNode extends BaseDataVariableTypeNode implements Se
   public CompletableFuture<? extends BaseDataVariableTypeNode> getShutdownReasonNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ShutdownReason",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "ShutdownReason", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/SessionDiagnosticsArrayTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/SessionDiagnosticsArrayTypeNode.java
@@ -96,8 +96,11 @@ public class SessionDiagnosticsArrayTypeNode extends BaseDataVariableTypeNode
   public SessionDiagnosticsDataType readSessionDiagnostics() throws UaException {
     try {
       return readSessionDiagnosticsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -105,8 +108,11 @@ public class SessionDiagnosticsArrayTypeNode extends BaseDataVariableTypeNode
   public void writeSessionDiagnostics(SessionDiagnosticsDataType value) throws UaException {
     try {
       writeSessionDiagnosticsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -131,8 +137,11 @@ public class SessionDiagnosticsArrayTypeNode extends BaseDataVariableTypeNode
   public SessionDiagnosticsVariableTypeNode getSessionDiagnosticsNode() throws UaException {
     try {
       return getSessionDiagnosticsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -143,7 +152,7 @@ public class SessionDiagnosticsArrayTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SessionDiagnostics",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (SessionDiagnosticsVariableTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/SessionDiagnosticsVariableTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/SessionDiagnosticsVariableTypeNode.java
@@ -97,8 +97,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public NodeId readSessionId() throws UaException {
     try {
       return readSessionIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -106,8 +109,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public void writeSessionId(NodeId value) throws UaException {
     try {
       writeSessionIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -129,8 +135,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getSessionIdNode() throws UaException {
     try {
       return getSessionIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -138,7 +147,7 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getSessionIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "SessionId", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "SessionId", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -158,8 +167,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public String readSessionName() throws UaException {
     try {
       return readSessionNameAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -167,8 +179,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public void writeSessionName(String value) throws UaException {
     try {
       writeSessionNameAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -190,8 +205,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getSessionNameNode() throws UaException {
     try {
       return getSessionNameNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -199,10 +217,7 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getSessionNameNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "SessionName",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "SessionName", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -223,8 +238,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public ApplicationDescription readClientDescription() throws UaException {
     try {
       return readClientDescriptionAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -232,8 +250,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public void writeClientDescription(ApplicationDescription value) throws UaException {
     try {
       writeClientDescriptionAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -258,8 +279,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getClientDescriptionNode() throws UaException {
     try {
       return getClientDescriptionNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -269,7 +293,7 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ClientDescription",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -290,8 +314,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public String readServerUri() throws UaException {
     try {
       return readServerUriAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -299,8 +326,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public void writeServerUri(String value) throws UaException {
     try {
       writeServerUriAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -322,8 +352,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getServerUriNode() throws UaException {
     try {
       return getServerUriNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -331,7 +364,7 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getServerUriNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "ServerUri", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "ServerUri", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -351,8 +384,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public String readEndpointUrl() throws UaException {
     try {
       return readEndpointUrlAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -360,8 +396,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public void writeEndpointUrl(String value) throws UaException {
     try {
       writeEndpointUrlAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -383,8 +422,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getEndpointUrlNode() throws UaException {
     try {
       return getEndpointUrlNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -392,10 +434,7 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getEndpointUrlNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "EndpointUrl",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "EndpointUrl", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -415,8 +454,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public String[] readLocaleIds() throws UaException {
     try {
       return readLocaleIdsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -424,8 +466,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public void writeLocaleIds(String[] value) throws UaException {
     try {
       writeLocaleIdsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -447,8 +492,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getLocaleIdsNode() throws UaException {
     try {
       return getLocaleIdsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -456,7 +504,7 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getLocaleIdsNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "LocaleIds", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "LocaleIds", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -476,8 +524,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public Double readActualSessionTimeout() throws UaException {
     try {
       return readActualSessionTimeoutAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -485,8 +536,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public void writeActualSessionTimeout(Double value) throws UaException {
     try {
       writeActualSessionTimeoutAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -508,8 +562,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getActualSessionTimeoutNode() throws UaException {
     try {
       return getActualSessionTimeoutNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -519,7 +576,7 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ActualSessionTimeout",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -540,8 +597,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public UInteger readMaxResponseMessageSize() throws UaException {
     try {
       return readMaxResponseMessageSizeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -549,8 +609,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public void writeMaxResponseMessageSize(UInteger value) throws UaException {
     try {
       writeMaxResponseMessageSizeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -573,8 +636,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getMaxResponseMessageSizeNode() throws UaException {
     try {
       return getMaxResponseMessageSizeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -585,7 +651,7 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaxResponseMessageSize",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -606,8 +672,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public DateTime readClientConnectionTime() throws UaException {
     try {
       return readClientConnectionTimeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -615,8 +684,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public void writeClientConnectionTime(DateTime value) throws UaException {
     try {
       writeClientConnectionTimeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -639,8 +711,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getClientConnectionTimeNode() throws UaException {
     try {
       return getClientConnectionTimeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -650,7 +725,7 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ClientConnectionTime",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -671,8 +746,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public DateTime readClientLastContactTime() throws UaException {
     try {
       return readClientLastContactTimeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -680,8 +758,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public void writeClientLastContactTime(DateTime value) throws UaException {
     try {
       writeClientLastContactTimeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -704,8 +785,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getClientLastContactTimeNode() throws UaException {
     try {
       return getClientLastContactTimeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -715,7 +799,7 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ClientLastContactTime",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -736,8 +820,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public UInteger readCurrentSubscriptionsCount() throws UaException {
     try {
       return readCurrentSubscriptionsCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -745,8 +832,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public void writeCurrentSubscriptionsCount(UInteger value) throws UaException {
     try {
       writeCurrentSubscriptionsCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -769,8 +859,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getCurrentSubscriptionsCountNode() throws UaException {
     try {
       return getCurrentSubscriptionsCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -781,7 +874,7 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "CurrentSubscriptionsCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -802,8 +895,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public UInteger readCurrentMonitoredItemsCount() throws UaException {
     try {
       return readCurrentMonitoredItemsCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -811,8 +907,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public void writeCurrentMonitoredItemsCount(UInteger value) throws UaException {
     try {
       writeCurrentMonitoredItemsCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -835,8 +934,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getCurrentMonitoredItemsCountNode() throws UaException {
     try {
       return getCurrentMonitoredItemsCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -847,7 +949,7 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "CurrentMonitoredItemsCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -868,8 +970,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public UInteger readCurrentPublishRequestsInQueue() throws UaException {
     try {
       return readCurrentPublishRequestsInQueueAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -877,8 +982,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public void writeCurrentPublishRequestsInQueue(UInteger value) throws UaException {
     try {
       writeCurrentPublishRequestsInQueueAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -901,8 +1009,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getCurrentPublishRequestsInQueueNode() throws UaException {
     try {
       return getCurrentPublishRequestsInQueueNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -913,7 +1024,7 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "CurrentPublishRequestsInQueue",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -935,8 +1046,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public ServiceCounterDataType readTotalRequestCount() throws UaException {
     try {
       return readTotalRequestCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -944,8 +1058,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public void writeTotalRequestCount(ServiceCounterDataType value) throws UaException {
     try {
       writeTotalRequestCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -970,8 +1087,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getTotalRequestCountNode() throws UaException {
     try {
       return getTotalRequestCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -981,7 +1101,7 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "TotalRequestCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -1002,8 +1122,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public UInteger readUnauthorizedRequestCount() throws UaException {
     try {
       return readUnauthorizedRequestCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1011,8 +1134,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public void writeUnauthorizedRequestCount(UInteger value) throws UaException {
     try {
       writeUnauthorizedRequestCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1035,8 +1161,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getUnauthorizedRequestCountNode() throws UaException {
     try {
       return getUnauthorizedRequestCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1047,7 +1176,7 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "UnauthorizedRequestCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -1069,8 +1198,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public ServiceCounterDataType readReadCount() throws UaException {
     try {
       return readReadCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1078,8 +1210,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public void writeReadCount(ServiceCounterDataType value) throws UaException {
     try {
       writeReadCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1102,8 +1237,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getReadCountNode() throws UaException {
     try {
       return getReadCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1111,7 +1249,7 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getReadCountNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "ReadCount", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "ReadCount", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -1132,8 +1270,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public ServiceCounterDataType readHistoryReadCount() throws UaException {
     try {
       return readHistoryReadCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1141,8 +1282,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public void writeHistoryReadCount(ServiceCounterDataType value) throws UaException {
     try {
       writeHistoryReadCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1167,8 +1311,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getHistoryReadCountNode() throws UaException {
     try {
       return getHistoryReadCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1178,7 +1325,7 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "HistoryReadCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -1200,8 +1347,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public ServiceCounterDataType readWriteCount() throws UaException {
     try {
       return readWriteCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1209,8 +1359,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public void writeWriteCount(ServiceCounterDataType value) throws UaException {
     try {
       writeWriteCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1233,8 +1386,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getWriteCountNode() throws UaException {
     try {
       return getWriteCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1242,7 +1398,7 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getWriteCountNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "WriteCount", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "WriteCount", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -1263,8 +1419,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public ServiceCounterDataType readHistoryUpdateCount() throws UaException {
     try {
       return readHistoryUpdateCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1272,8 +1431,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public void writeHistoryUpdateCount(ServiceCounterDataType value) throws UaException {
     try {
       writeHistoryUpdateCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1298,8 +1460,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getHistoryUpdateCountNode() throws UaException {
     try {
       return getHistoryUpdateCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1309,7 +1474,7 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "HistoryUpdateCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -1331,8 +1496,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public ServiceCounterDataType readCallCount() throws UaException {
     try {
       return readCallCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1340,8 +1508,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public void writeCallCount(ServiceCounterDataType value) throws UaException {
     try {
       writeCallCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1364,8 +1535,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getCallCountNode() throws UaException {
     try {
       return getCallCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1373,7 +1547,7 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getCallCountNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "CallCount", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "CallCount", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -1394,8 +1568,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public ServiceCounterDataType readCreateMonitoredItemsCount() throws UaException {
     try {
       return readCreateMonitoredItemsCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1403,8 +1580,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public void writeCreateMonitoredItemsCount(ServiceCounterDataType value) throws UaException {
     try {
       writeCreateMonitoredItemsCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1429,8 +1609,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getCreateMonitoredItemsCountNode() throws UaException {
     try {
       return getCreateMonitoredItemsCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1441,7 +1624,7 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "CreateMonitoredItemsCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -1463,8 +1646,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public ServiceCounterDataType readModifyMonitoredItemsCount() throws UaException {
     try {
       return readModifyMonitoredItemsCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1472,8 +1658,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public void writeModifyMonitoredItemsCount(ServiceCounterDataType value) throws UaException {
     try {
       writeModifyMonitoredItemsCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1498,8 +1687,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getModifyMonitoredItemsCountNode() throws UaException {
     try {
       return getModifyMonitoredItemsCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1510,7 +1702,7 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ModifyMonitoredItemsCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -1532,8 +1724,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public ServiceCounterDataType readSetMonitoringModeCount() throws UaException {
     try {
       return readSetMonitoringModeCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1541,8 +1736,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public void writeSetMonitoringModeCount(ServiceCounterDataType value) throws UaException {
     try {
       writeSetMonitoringModeCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1567,8 +1765,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getSetMonitoringModeCountNode() throws UaException {
     try {
       return getSetMonitoringModeCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1579,7 +1780,7 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SetMonitoringModeCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -1601,8 +1802,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public ServiceCounterDataType readSetTriggeringCount() throws UaException {
     try {
       return readSetTriggeringCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1610,8 +1814,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public void writeSetTriggeringCount(ServiceCounterDataType value) throws UaException {
     try {
       writeSetTriggeringCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1636,8 +1843,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getSetTriggeringCountNode() throws UaException {
     try {
       return getSetTriggeringCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1647,7 +1857,7 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SetTriggeringCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -1669,8 +1879,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public ServiceCounterDataType readDeleteMonitoredItemsCount() throws UaException {
     try {
       return readDeleteMonitoredItemsCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1678,8 +1891,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public void writeDeleteMonitoredItemsCount(ServiceCounterDataType value) throws UaException {
     try {
       writeDeleteMonitoredItemsCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1704,8 +1920,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getDeleteMonitoredItemsCountNode() throws UaException {
     try {
       return getDeleteMonitoredItemsCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1716,7 +1935,7 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "DeleteMonitoredItemsCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -1738,8 +1957,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public ServiceCounterDataType readCreateSubscriptionCount() throws UaException {
     try {
       return readCreateSubscriptionCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1747,8 +1969,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public void writeCreateSubscriptionCount(ServiceCounterDataType value) throws UaException {
     try {
       writeCreateSubscriptionCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1773,8 +1998,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getCreateSubscriptionCountNode() throws UaException {
     try {
       return getCreateSubscriptionCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1785,7 +2013,7 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "CreateSubscriptionCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -1807,8 +2035,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public ServiceCounterDataType readModifySubscriptionCount() throws UaException {
     try {
       return readModifySubscriptionCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1816,8 +2047,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public void writeModifySubscriptionCount(ServiceCounterDataType value) throws UaException {
     try {
       writeModifySubscriptionCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1842,8 +2076,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getModifySubscriptionCountNode() throws UaException {
     try {
       return getModifySubscriptionCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1854,7 +2091,7 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ModifySubscriptionCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -1876,8 +2113,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public ServiceCounterDataType readSetPublishingModeCount() throws UaException {
     try {
       return readSetPublishingModeCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1885,8 +2125,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public void writeSetPublishingModeCount(ServiceCounterDataType value) throws UaException {
     try {
       writeSetPublishingModeCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1911,8 +2154,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getSetPublishingModeCountNode() throws UaException {
     try {
       return getSetPublishingModeCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1923,7 +2169,7 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SetPublishingModeCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -1945,8 +2191,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public ServiceCounterDataType readPublishCount() throws UaException {
     try {
       return readPublishCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1954,8 +2203,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public void writePublishCount(ServiceCounterDataType value) throws UaException {
     try {
       writePublishCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1979,8 +2231,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getPublishCountNode() throws UaException {
     try {
       return getPublishCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1988,10 +2243,7 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getPublishCountNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "PublishCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "PublishCount", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -2012,8 +2264,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public ServiceCounterDataType readRepublishCount() throws UaException {
     try {
       return readRepublishCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -2021,8 +2276,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public void writeRepublishCount(ServiceCounterDataType value) throws UaException {
     try {
       writeRepublishCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -2047,8 +2305,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getRepublishCountNode() throws UaException {
     try {
       return getRepublishCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -2056,10 +2317,7 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getRepublishCountNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "RepublishCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "RepublishCount", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -2080,8 +2338,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public ServiceCounterDataType readTransferSubscriptionsCount() throws UaException {
     try {
       return readTransferSubscriptionsCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -2089,8 +2350,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public void writeTransferSubscriptionsCount(ServiceCounterDataType value) throws UaException {
     try {
       writeTransferSubscriptionsCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -2115,8 +2379,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getTransferSubscriptionsCountNode() throws UaException {
     try {
       return getTransferSubscriptionsCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -2127,7 +2394,7 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "TransferSubscriptionsCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -2149,8 +2416,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public ServiceCounterDataType readDeleteSubscriptionsCount() throws UaException {
     try {
       return readDeleteSubscriptionsCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -2158,8 +2428,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public void writeDeleteSubscriptionsCount(ServiceCounterDataType value) throws UaException {
     try {
       writeDeleteSubscriptionsCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -2184,8 +2457,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getDeleteSubscriptionsCountNode() throws UaException {
     try {
       return getDeleteSubscriptionsCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -2196,7 +2472,7 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "DeleteSubscriptionsCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -2218,8 +2494,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public ServiceCounterDataType readAddNodesCount() throws UaException {
     try {
       return readAddNodesCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -2227,8 +2506,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public void writeAddNodesCount(ServiceCounterDataType value) throws UaException {
     try {
       writeAddNodesCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -2253,8 +2535,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getAddNodesCountNode() throws UaException {
     try {
       return getAddNodesCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -2262,10 +2547,7 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getAddNodesCountNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "AddNodesCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "AddNodesCount", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -2286,8 +2568,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public ServiceCounterDataType readAddReferencesCount() throws UaException {
     try {
       return readAddReferencesCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -2295,8 +2580,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public void writeAddReferencesCount(ServiceCounterDataType value) throws UaException {
     try {
       writeAddReferencesCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -2321,8 +2609,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getAddReferencesCountNode() throws UaException {
     try {
       return getAddReferencesCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -2332,7 +2623,7 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "AddReferencesCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -2354,8 +2645,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public ServiceCounterDataType readDeleteNodesCount() throws UaException {
     try {
       return readDeleteNodesCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -2363,8 +2657,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public void writeDeleteNodesCount(ServiceCounterDataType value) throws UaException {
     try {
       writeDeleteNodesCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -2389,8 +2686,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getDeleteNodesCountNode() throws UaException {
     try {
       return getDeleteNodesCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -2400,7 +2700,7 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "DeleteNodesCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -2422,8 +2722,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public ServiceCounterDataType readDeleteReferencesCount() throws UaException {
     try {
       return readDeleteReferencesCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -2431,8 +2734,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public void writeDeleteReferencesCount(ServiceCounterDataType value) throws UaException {
     try {
       writeDeleteReferencesCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -2457,8 +2763,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getDeleteReferencesCountNode() throws UaException {
     try {
       return getDeleteReferencesCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -2468,7 +2777,7 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "DeleteReferencesCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -2490,8 +2799,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public ServiceCounterDataType readBrowseCount() throws UaException {
     try {
       return readBrowseCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -2499,8 +2811,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public void writeBrowseCount(ServiceCounterDataType value) throws UaException {
     try {
       writeBrowseCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -2524,8 +2839,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getBrowseCountNode() throws UaException {
     try {
       return getBrowseCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -2533,10 +2851,7 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getBrowseCountNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "BrowseCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "BrowseCount", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -2557,8 +2872,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public ServiceCounterDataType readBrowseNextCount() throws UaException {
     try {
       return readBrowseNextCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -2566,8 +2884,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public void writeBrowseNextCount(ServiceCounterDataType value) throws UaException {
     try {
       writeBrowseNextCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -2592,8 +2913,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getBrowseNextCountNode() throws UaException {
     try {
       return getBrowseNextCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -2601,10 +2925,7 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getBrowseNextCountNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "BrowseNextCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "BrowseNextCount", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -2626,8 +2947,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public ServiceCounterDataType readTranslateBrowsePathsToNodeIdsCount() throws UaException {
     try {
       return readTranslateBrowsePathsToNodeIdsCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -2636,8 +2960,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
       throws UaException {
     try {
       writeTranslateBrowsePathsToNodeIdsCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -2664,8 +2991,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getTranslateBrowsePathsToNodeIdsCountNode() throws UaException {
     try {
       return getTranslateBrowsePathsToNodeIdsCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -2676,7 +3006,7 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "TranslateBrowsePathsToNodeIdsCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -2698,8 +3028,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public ServiceCounterDataType readQueryFirstCount() throws UaException {
     try {
       return readQueryFirstCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -2707,8 +3040,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public void writeQueryFirstCount(ServiceCounterDataType value) throws UaException {
     try {
       writeQueryFirstCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -2733,8 +3069,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getQueryFirstCountNode() throws UaException {
     try {
       return getQueryFirstCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -2742,10 +3081,7 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getQueryFirstCountNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "QueryFirstCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "QueryFirstCount", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -2766,8 +3102,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public ServiceCounterDataType readQueryNextCount() throws UaException {
     try {
       return readQueryNextCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -2775,8 +3114,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public void writeQueryNextCount(ServiceCounterDataType value) throws UaException {
     try {
       writeQueryNextCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -2801,8 +3143,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getQueryNextCountNode() throws UaException {
     try {
       return getQueryNextCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -2810,10 +3155,7 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getQueryNextCountNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "QueryNextCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "QueryNextCount", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -2834,8 +3176,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public ServiceCounterDataType readRegisterNodesCount() throws UaException {
     try {
       return readRegisterNodesCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -2843,8 +3188,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public void writeRegisterNodesCount(ServiceCounterDataType value) throws UaException {
     try {
       writeRegisterNodesCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -2869,8 +3217,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getRegisterNodesCountNode() throws UaException {
     try {
       return getRegisterNodesCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -2880,7 +3231,7 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "RegisterNodesCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -2902,8 +3253,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public ServiceCounterDataType readUnregisterNodesCount() throws UaException {
     try {
       return readUnregisterNodesCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -2911,8 +3265,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public void writeUnregisterNodesCount(ServiceCounterDataType value) throws UaException {
     try {
       writeUnregisterNodesCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -2937,8 +3294,11 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getUnregisterNodesCountNode() throws UaException {
     try {
       return getUnregisterNodesCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -2948,7 +3308,7 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "UnregisterNodesCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/SessionSecurityDiagnosticsArrayTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/SessionSecurityDiagnosticsArrayTypeNode.java
@@ -97,8 +97,11 @@ public class SessionSecurityDiagnosticsArrayTypeNode extends BaseDataVariableTyp
   public SessionSecurityDiagnosticsDataType readSessionSecurityDiagnostics() throws UaException {
     try {
       return readSessionSecurityDiagnosticsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -107,8 +110,11 @@ public class SessionSecurityDiagnosticsArrayTypeNode extends BaseDataVariableTyp
       throws UaException {
     try {
       writeSessionSecurityDiagnosticsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -134,8 +140,11 @@ public class SessionSecurityDiagnosticsArrayTypeNode extends BaseDataVariableTyp
   public SessionSecurityDiagnosticsTypeNode getSessionSecurityDiagnosticsNode() throws UaException {
     try {
       return getSessionSecurityDiagnosticsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -146,7 +155,7 @@ public class SessionSecurityDiagnosticsArrayTypeNode extends BaseDataVariableTyp
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SessionSecurityDiagnostics",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (SessionSecurityDiagnosticsTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/SessionSecurityDiagnosticsTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/SessionSecurityDiagnosticsTypeNode.java
@@ -95,8 +95,11 @@ public class SessionSecurityDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public NodeId readSessionId() throws UaException {
     try {
       return readSessionIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -104,8 +107,11 @@ public class SessionSecurityDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public void writeSessionId(NodeId value) throws UaException {
     try {
       writeSessionIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -127,8 +133,11 @@ public class SessionSecurityDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getSessionIdNode() throws UaException {
     try {
       return getSessionIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -136,7 +145,7 @@ public class SessionSecurityDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getSessionIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "SessionId", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "SessionId", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -156,8 +165,11 @@ public class SessionSecurityDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public String readClientUserIdOfSession() throws UaException {
     try {
       return readClientUserIdOfSessionAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -165,8 +177,11 @@ public class SessionSecurityDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public void writeClientUserIdOfSession(String value) throws UaException {
     try {
       writeClientUserIdOfSessionAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -189,8 +204,11 @@ public class SessionSecurityDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getClientUserIdOfSessionNode() throws UaException {
     try {
       return getClientUserIdOfSessionNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -200,7 +218,7 @@ public class SessionSecurityDiagnosticsTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ClientUserIdOfSession",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -221,8 +239,11 @@ public class SessionSecurityDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public String[] readClientUserIdHistory() throws UaException {
     try {
       return readClientUserIdHistoryAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -230,8 +251,11 @@ public class SessionSecurityDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public void writeClientUserIdHistory(String[] value) throws UaException {
     try {
       writeClientUserIdHistoryAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -253,8 +277,11 @@ public class SessionSecurityDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getClientUserIdHistoryNode() throws UaException {
     try {
       return getClientUserIdHistoryNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -264,7 +291,7 @@ public class SessionSecurityDiagnosticsTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ClientUserIdHistory",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -285,8 +312,11 @@ public class SessionSecurityDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public String readAuthenticationMechanism() throws UaException {
     try {
       return readAuthenticationMechanismAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -294,8 +324,11 @@ public class SessionSecurityDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public void writeAuthenticationMechanism(String value) throws UaException {
     try {
       writeAuthenticationMechanismAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -318,8 +351,11 @@ public class SessionSecurityDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getAuthenticationMechanismNode() throws UaException {
     try {
       return getAuthenticationMechanismNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -330,7 +366,7 @@ public class SessionSecurityDiagnosticsTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "AuthenticationMechanism",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -351,8 +387,11 @@ public class SessionSecurityDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public String readEncoding() throws UaException {
     try {
       return readEncodingAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -360,8 +399,11 @@ public class SessionSecurityDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public void writeEncoding(String value) throws UaException {
     try {
       writeEncodingAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -383,8 +425,11 @@ public class SessionSecurityDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getEncodingNode() throws UaException {
     try {
       return getEncodingNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -392,7 +437,7 @@ public class SessionSecurityDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getEncodingNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Encoding", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "Encoding", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -412,8 +457,11 @@ public class SessionSecurityDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public String readTransportProtocol() throws UaException {
     try {
       return readTransportProtocolAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -421,8 +469,11 @@ public class SessionSecurityDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public void writeTransportProtocol(String value) throws UaException {
     try {
       writeTransportProtocolAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -444,8 +495,11 @@ public class SessionSecurityDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getTransportProtocolNode() throws UaException {
     try {
       return getTransportProtocolNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -455,7 +509,7 @@ public class SessionSecurityDiagnosticsTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "TransportProtocol",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -484,8 +538,11 @@ public class SessionSecurityDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public MessageSecurityMode readSecurityMode() throws UaException {
     try {
       return readSecurityModeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -493,8 +550,11 @@ public class SessionSecurityDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public void writeSecurityMode(MessageSecurityMode value) throws UaException {
     try {
       writeSecurityModeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -524,8 +584,11 @@ public class SessionSecurityDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getSecurityModeNode() throws UaException {
     try {
       return getSecurityModeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -533,10 +596,7 @@ public class SessionSecurityDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getSecurityModeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "SecurityMode",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "SecurityMode", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -556,8 +616,11 @@ public class SessionSecurityDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public String readSecurityPolicyUri() throws UaException {
     try {
       return readSecurityPolicyUriAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -565,8 +628,11 @@ public class SessionSecurityDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public void writeSecurityPolicyUri(String value) throws UaException {
     try {
       writeSecurityPolicyUriAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -588,8 +654,11 @@ public class SessionSecurityDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getSecurityPolicyUriNode() throws UaException {
     try {
       return getSecurityPolicyUriNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -599,7 +668,7 @@ public class SessionSecurityDiagnosticsTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SecurityPolicyUri",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -620,8 +689,11 @@ public class SessionSecurityDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public ByteString readClientCertificate() throws UaException {
     try {
       return readClientCertificateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -629,8 +701,11 @@ public class SessionSecurityDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public void writeClientCertificate(ByteString value) throws UaException {
     try {
       writeClientCertificateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -652,8 +727,11 @@ public class SessionSecurityDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getClientCertificateNode() throws UaException {
     try {
       return getClientCertificateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -663,7 +741,7 @@ public class SessionSecurityDiagnosticsTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "ClientCertificate",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/StateVariableTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/StateVariableTypeNode.java
@@ -92,8 +92,11 @@ public class StateVariableTypeNode extends BaseDataVariableTypeNode implements S
   public Object readId() throws UaException {
     try {
       return readIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -101,8 +104,11 @@ public class StateVariableTypeNode extends BaseDataVariableTypeNode implements S
   public void writeId(Object value) throws UaException {
     try {
       writeIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -123,8 +129,11 @@ public class StateVariableTypeNode extends BaseDataVariableTypeNode implements S
   public PropertyTypeNode getIdNode() throws UaException {
     try {
       return getIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -132,7 +141,7 @@ public class StateVariableTypeNode extends BaseDataVariableTypeNode implements S
   public CompletableFuture<? extends PropertyTypeNode> getIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Id", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Id", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -152,8 +161,11 @@ public class StateVariableTypeNode extends BaseDataVariableTypeNode implements S
   public QualifiedName readName() throws UaException {
     try {
       return readNameAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -161,8 +173,11 @@ public class StateVariableTypeNode extends BaseDataVariableTypeNode implements S
   public void writeName(QualifiedName value) throws UaException {
     try {
       writeNameAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -184,8 +199,11 @@ public class StateVariableTypeNode extends BaseDataVariableTypeNode implements S
   public PropertyTypeNode getNameNode() throws UaException {
     try {
       return getNameNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -193,7 +211,7 @@ public class StateVariableTypeNode extends BaseDataVariableTypeNode implements S
   public CompletableFuture<? extends PropertyTypeNode> getNameNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Name", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Name", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -213,8 +231,11 @@ public class StateVariableTypeNode extends BaseDataVariableTypeNode implements S
   public UInteger readNumber() throws UaException {
     try {
       return readNumberAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -222,8 +243,11 @@ public class StateVariableTypeNode extends BaseDataVariableTypeNode implements S
   public void writeNumber(UInteger value) throws UaException {
     try {
       writeNumberAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -245,8 +269,11 @@ public class StateVariableTypeNode extends BaseDataVariableTypeNode implements S
   public PropertyTypeNode getNumberNode() throws UaException {
     try {
       return getNumberNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -254,7 +281,7 @@ public class StateVariableTypeNode extends BaseDataVariableTypeNode implements S
   public CompletableFuture<? extends PropertyTypeNode> getNumberNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Number", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Number", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -274,8 +301,11 @@ public class StateVariableTypeNode extends BaseDataVariableTypeNode implements S
   public LocalizedText readEffectiveDisplayName() throws UaException {
     try {
       return readEffectiveDisplayNameAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -283,8 +313,11 @@ public class StateVariableTypeNode extends BaseDataVariableTypeNode implements S
   public void writeEffectiveDisplayName(LocalizedText value) throws UaException {
     try {
       writeEffectiveDisplayNameAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -307,8 +340,11 @@ public class StateVariableTypeNode extends BaseDataVariableTypeNode implements S
   public PropertyTypeNode getEffectiveDisplayNameNode() throws UaException {
     try {
       return getEffectiveDisplayNameNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -318,7 +354,7 @@ public class StateVariableTypeNode extends BaseDataVariableTypeNode implements S
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "EffectiveDisplayName",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/SubscriptionDiagnosticsArrayTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/SubscriptionDiagnosticsArrayTypeNode.java
@@ -96,8 +96,11 @@ public class SubscriptionDiagnosticsArrayTypeNode extends BaseDataVariableTypeNo
   public SubscriptionDiagnosticsDataType readSubscriptionDiagnostics() throws UaException {
     try {
       return readSubscriptionDiagnosticsAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -106,8 +109,11 @@ public class SubscriptionDiagnosticsArrayTypeNode extends BaseDataVariableTypeNo
       throws UaException {
     try {
       writeSubscriptionDiagnosticsAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -133,8 +139,11 @@ public class SubscriptionDiagnosticsArrayTypeNode extends BaseDataVariableTypeNo
   public SubscriptionDiagnosticsTypeNode getSubscriptionDiagnosticsNode() throws UaException {
     try {
       return getSubscriptionDiagnosticsNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -145,7 +154,7 @@ public class SubscriptionDiagnosticsArrayTypeNode extends BaseDataVariableTypeNo
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "SubscriptionDiagnostics",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (SubscriptionDiagnosticsTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/SubscriptionDiagnosticsTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/SubscriptionDiagnosticsTypeNode.java
@@ -93,8 +93,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public NodeId readSessionId() throws UaException {
     try {
       return readSessionIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -102,8 +105,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public void writeSessionId(NodeId value) throws UaException {
     try {
       writeSessionIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -125,8 +131,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getSessionIdNode() throws UaException {
     try {
       return getSessionIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -134,7 +143,7 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getSessionIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "SessionId", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "SessionId", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -154,8 +163,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public UInteger readSubscriptionId() throws UaException {
     try {
       return readSubscriptionIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -163,8 +175,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public void writeSubscriptionId(UInteger value) throws UaException {
     try {
       writeSubscriptionIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -186,8 +201,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getSubscriptionIdNode() throws UaException {
     try {
       return getSubscriptionIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -195,10 +213,7 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getSubscriptionIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "SubscriptionId",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "SubscriptionId", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -218,8 +233,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public UByte readPriority() throws UaException {
     try {
       return readPriorityAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -227,8 +245,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public void writePriority(UByte value) throws UaException {
     try {
       writePriorityAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -250,8 +271,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getPriorityNode() throws UaException {
     try {
       return getPriorityNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -259,7 +283,7 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getPriorityNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Priority", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "Priority", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -279,8 +303,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public Double readPublishingInterval() throws UaException {
     try {
       return readPublishingIntervalAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -288,8 +315,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public void writePublishingInterval(Double value) throws UaException {
     try {
       writePublishingIntervalAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -311,8 +341,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getPublishingIntervalNode() throws UaException {
     try {
       return getPublishingIntervalNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -322,7 +355,7 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "PublishingInterval",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -343,8 +376,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public UInteger readMaxKeepAliveCount() throws UaException {
     try {
       return readMaxKeepAliveCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -352,8 +388,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public void writeMaxKeepAliveCount(UInteger value) throws UaException {
     try {
       writeMaxKeepAliveCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -375,8 +414,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getMaxKeepAliveCountNode() throws UaException {
     try {
       return getMaxKeepAliveCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -386,7 +428,7 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaxKeepAliveCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -407,8 +449,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public UInteger readMaxLifetimeCount() throws UaException {
     try {
       return readMaxLifetimeCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -416,8 +461,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public void writeMaxLifetimeCount(UInteger value) throws UaException {
     try {
       writeMaxLifetimeCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -439,8 +487,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getMaxLifetimeCountNode() throws UaException {
     try {
       return getMaxLifetimeCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -450,7 +501,7 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaxLifetimeCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -471,8 +522,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public UInteger readMaxNotificationsPerPublish() throws UaException {
     try {
       return readMaxNotificationsPerPublishAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -480,8 +534,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public void writeMaxNotificationsPerPublish(UInteger value) throws UaException {
     try {
       writeMaxNotificationsPerPublishAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -504,8 +561,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getMaxNotificationsPerPublishNode() throws UaException {
     try {
       return getMaxNotificationsPerPublishNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -516,7 +576,7 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MaxNotificationsPerPublish",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -537,8 +597,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public Boolean readPublishingEnabled() throws UaException {
     try {
       return readPublishingEnabledAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -546,8 +609,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public void writePublishingEnabled(Boolean value) throws UaException {
     try {
       writePublishingEnabledAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -569,8 +635,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getPublishingEnabledNode() throws UaException {
     try {
       return getPublishingEnabledNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -580,7 +649,7 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "PublishingEnabled",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -601,8 +670,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public UInteger readModifyCount() throws UaException {
     try {
       return readModifyCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -610,8 +682,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public void writeModifyCount(UInteger value) throws UaException {
     try {
       writeModifyCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -633,8 +708,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getModifyCountNode() throws UaException {
     try {
       return getModifyCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -642,10 +720,7 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getModifyCountNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "ModifyCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "ModifyCount", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -665,8 +740,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public UInteger readEnableCount() throws UaException {
     try {
       return readEnableCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -674,8 +752,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public void writeEnableCount(UInteger value) throws UaException {
     try {
       writeEnableCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -697,8 +778,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getEnableCountNode() throws UaException {
     try {
       return getEnableCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -706,10 +790,7 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getEnableCountNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "EnableCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "EnableCount", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -729,8 +810,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public UInteger readDisableCount() throws UaException {
     try {
       return readDisableCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -738,8 +822,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public void writeDisableCount(UInteger value) throws UaException {
     try {
       writeDisableCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -761,8 +848,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getDisableCountNode() throws UaException {
     try {
       return getDisableCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -770,10 +860,7 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getDisableCountNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "DisableCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "DisableCount", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -793,8 +880,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public UInteger readRepublishRequestCount() throws UaException {
     try {
       return readRepublishRequestCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -802,8 +892,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public void writeRepublishRequestCount(UInteger value) throws UaException {
     try {
       writeRepublishRequestCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -826,8 +919,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getRepublishRequestCountNode() throws UaException {
     try {
       return getRepublishRequestCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -837,7 +933,7 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "RepublishRequestCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -858,8 +954,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public UInteger readRepublishMessageRequestCount() throws UaException {
     try {
       return readRepublishMessageRequestCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -867,8 +966,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public void writeRepublishMessageRequestCount(UInteger value) throws UaException {
     try {
       writeRepublishMessageRequestCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -891,8 +993,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getRepublishMessageRequestCountNode() throws UaException {
     try {
       return getRepublishMessageRequestCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -903,7 +1008,7 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "RepublishMessageRequestCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -924,8 +1029,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public UInteger readRepublishMessageCount() throws UaException {
     try {
       return readRepublishMessageCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -933,8 +1041,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public void writeRepublishMessageCount(UInteger value) throws UaException {
     try {
       writeRepublishMessageCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -957,8 +1068,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getRepublishMessageCountNode() throws UaException {
     try {
       return getRepublishMessageCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -968,7 +1082,7 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "RepublishMessageCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -989,8 +1103,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public UInteger readTransferRequestCount() throws UaException {
     try {
       return readTransferRequestCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -998,8 +1115,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public void writeTransferRequestCount(UInteger value) throws UaException {
     try {
       writeTransferRequestCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1022,8 +1142,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getTransferRequestCountNode() throws UaException {
     try {
       return getTransferRequestCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1033,7 +1156,7 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "TransferRequestCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -1054,8 +1177,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public UInteger readTransferredToAltClientCount() throws UaException {
     try {
       return readTransferredToAltClientCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1063,8 +1189,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public void writeTransferredToAltClientCount(UInteger value) throws UaException {
     try {
       writeTransferredToAltClientCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1087,8 +1216,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getTransferredToAltClientCountNode() throws UaException {
     try {
       return getTransferredToAltClientCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1099,7 +1231,7 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "TransferredToAltClientCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -1120,8 +1252,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public UInteger readTransferredToSameClientCount() throws UaException {
     try {
       return readTransferredToSameClientCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1129,8 +1264,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public void writeTransferredToSameClientCount(UInteger value) throws UaException {
     try {
       writeTransferredToSameClientCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1153,8 +1291,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getTransferredToSameClientCountNode() throws UaException {
     try {
       return getTransferredToSameClientCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1165,7 +1306,7 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "TransferredToSameClientCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -1186,8 +1327,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public UInteger readPublishRequestCount() throws UaException {
     try {
       return readPublishRequestCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1195,8 +1339,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public void writePublishRequestCount(UInteger value) throws UaException {
     try {
       writePublishRequestCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1218,8 +1365,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getPublishRequestCountNode() throws UaException {
     try {
       return getPublishRequestCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1229,7 +1379,7 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "PublishRequestCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -1250,8 +1400,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public UInteger readDataChangeNotificationsCount() throws UaException {
     try {
       return readDataChangeNotificationsCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1259,8 +1412,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public void writeDataChangeNotificationsCount(UInteger value) throws UaException {
     try {
       writeDataChangeNotificationsCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1283,8 +1439,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getDataChangeNotificationsCountNode() throws UaException {
     try {
       return getDataChangeNotificationsCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1295,7 +1454,7 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "DataChangeNotificationsCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -1316,8 +1475,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public UInteger readEventNotificationsCount() throws UaException {
     try {
       return readEventNotificationsCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1325,8 +1487,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public void writeEventNotificationsCount(UInteger value) throws UaException {
     try {
       writeEventNotificationsCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1349,8 +1514,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getEventNotificationsCountNode() throws UaException {
     try {
       return getEventNotificationsCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1361,7 +1529,7 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "EventNotificationsCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -1382,8 +1550,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public UInteger readNotificationsCount() throws UaException {
     try {
       return readNotificationsCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1391,8 +1562,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public void writeNotificationsCount(UInteger value) throws UaException {
     try {
       writeNotificationsCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1414,8 +1588,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getNotificationsCountNode() throws UaException {
     try {
       return getNotificationsCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1425,7 +1602,7 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "NotificationsCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -1446,8 +1623,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public UInteger readLatePublishRequestCount() throws UaException {
     try {
       return readLatePublishRequestCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1455,8 +1635,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public void writeLatePublishRequestCount(UInteger value) throws UaException {
     try {
       writeLatePublishRequestCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1479,8 +1662,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getLatePublishRequestCountNode() throws UaException {
     try {
       return getLatePublishRequestCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1491,7 +1677,7 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "LatePublishRequestCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -1512,8 +1698,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public UInteger readCurrentKeepAliveCount() throws UaException {
     try {
       return readCurrentKeepAliveCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1521,8 +1710,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public void writeCurrentKeepAliveCount(UInteger value) throws UaException {
     try {
       writeCurrentKeepAliveCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1545,8 +1737,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getCurrentKeepAliveCountNode() throws UaException {
     try {
       return getCurrentKeepAliveCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1556,7 +1751,7 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "CurrentKeepAliveCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -1577,8 +1772,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public UInteger readCurrentLifetimeCount() throws UaException {
     try {
       return readCurrentLifetimeCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1586,8 +1784,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public void writeCurrentLifetimeCount(UInteger value) throws UaException {
     try {
       writeCurrentLifetimeCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1610,8 +1811,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getCurrentLifetimeCountNode() throws UaException {
     try {
       return getCurrentLifetimeCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1621,7 +1825,7 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "CurrentLifetimeCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -1642,8 +1846,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public UInteger readUnacknowledgedMessageCount() throws UaException {
     try {
       return readUnacknowledgedMessageCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1651,8 +1858,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public void writeUnacknowledgedMessageCount(UInteger value) throws UaException {
     try {
       writeUnacknowledgedMessageCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1675,8 +1885,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getUnacknowledgedMessageCountNode() throws UaException {
     try {
       return getUnacknowledgedMessageCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1687,7 +1900,7 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "UnacknowledgedMessageCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -1708,8 +1921,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public UInteger readDiscardedMessageCount() throws UaException {
     try {
       return readDiscardedMessageCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1717,8 +1933,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public void writeDiscardedMessageCount(UInteger value) throws UaException {
     try {
       writeDiscardedMessageCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1741,8 +1960,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getDiscardedMessageCountNode() throws UaException {
     try {
       return getDiscardedMessageCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1752,7 +1974,7 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "DiscardedMessageCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -1773,8 +1995,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public UInteger readMonitoredItemCount() throws UaException {
     try {
       return readMonitoredItemCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1782,8 +2007,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public void writeMonitoredItemCount(UInteger value) throws UaException {
     try {
       writeMonitoredItemCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1805,8 +2033,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getMonitoredItemCountNode() throws UaException {
     try {
       return getMonitoredItemCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1816,7 +2047,7 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MonitoredItemCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -1837,8 +2068,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public UInteger readDisabledMonitoredItemCount() throws UaException {
     try {
       return readDisabledMonitoredItemCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1846,8 +2080,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public void writeDisabledMonitoredItemCount(UInteger value) throws UaException {
     try {
       writeDisabledMonitoredItemCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1870,8 +2107,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getDisabledMonitoredItemCountNode() throws UaException {
     try {
       return getDisabledMonitoredItemCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1882,7 +2122,7 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "DisabledMonitoredItemCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -1903,8 +2143,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public UInteger readMonitoringQueueOverflowCount() throws UaException {
     try {
       return readMonitoringQueueOverflowCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1912,8 +2155,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public void writeMonitoringQueueOverflowCount(UInteger value) throws UaException {
     try {
       writeMonitoringQueueOverflowCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1936,8 +2182,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getMonitoringQueueOverflowCountNode() throws UaException {
     try {
       return getMonitoringQueueOverflowCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1948,7 +2197,7 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "MonitoringQueueOverflowCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -1969,8 +2218,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public UInteger readNextSequenceNumber() throws UaException {
     try {
       return readNextSequenceNumberAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -1978,8 +2230,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public void writeNextSequenceNumber(UInteger value) throws UaException {
     try {
       writeNextSequenceNumberAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -2001,8 +2256,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getNextSequenceNumberNode() throws UaException {
     try {
       return getNextSequenceNumberNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -2012,7 +2270,7 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "NextSequenceNumber",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
@@ -2033,8 +2291,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public UInteger readEventQueueOverflowCount() throws UaException {
     try {
       return readEventQueueOverflowCountAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -2042,8 +2303,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public void writeEventQueueOverflowCount(UInteger value) throws UaException {
     try {
       writeEventQueueOverflowCountAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -2066,8 +2330,11 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   public BaseDataVariableTypeNode getEventQueueOverflowCountNode() throws UaException {
     try {
       return getEventQueueOverflowCountNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -2078,7 +2345,7 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "EventQueueOverflowCount",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ThreeDCartesianCoordinatesTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ThreeDCartesianCoordinatesTypeNode.java
@@ -93,8 +93,11 @@ public class ThreeDCartesianCoordinatesTypeNode extends CartesianCoordinatesType
   public Double readX() throws UaException {
     try {
       return readXAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -102,8 +105,11 @@ public class ThreeDCartesianCoordinatesTypeNode extends CartesianCoordinatesType
   public void writeX(Double value) throws UaException {
     try {
       writeXAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -124,8 +130,11 @@ public class ThreeDCartesianCoordinatesTypeNode extends CartesianCoordinatesType
   public BaseDataVariableTypeNode getXNode() throws UaException {
     try {
       return getXNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -133,7 +142,7 @@ public class ThreeDCartesianCoordinatesTypeNode extends CartesianCoordinatesType
   public CompletableFuture<? extends BaseDataVariableTypeNode> getXNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "X", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "X", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -153,8 +162,11 @@ public class ThreeDCartesianCoordinatesTypeNode extends CartesianCoordinatesType
   public Double readY() throws UaException {
     try {
       return readYAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -162,8 +174,11 @@ public class ThreeDCartesianCoordinatesTypeNode extends CartesianCoordinatesType
   public void writeY(Double value) throws UaException {
     try {
       writeYAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -184,8 +199,11 @@ public class ThreeDCartesianCoordinatesTypeNode extends CartesianCoordinatesType
   public BaseDataVariableTypeNode getYNode() throws UaException {
     try {
       return getYNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -193,7 +211,7 @@ public class ThreeDCartesianCoordinatesTypeNode extends CartesianCoordinatesType
   public CompletableFuture<? extends BaseDataVariableTypeNode> getYNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Y", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "Y", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -213,8 +231,11 @@ public class ThreeDCartesianCoordinatesTypeNode extends CartesianCoordinatesType
   public Double readZ() throws UaException {
     try {
       return readZAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -222,8 +243,11 @@ public class ThreeDCartesianCoordinatesTypeNode extends CartesianCoordinatesType
   public void writeZ(Double value) throws UaException {
     try {
       writeZAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -244,8 +268,11 @@ public class ThreeDCartesianCoordinatesTypeNode extends CartesianCoordinatesType
   public BaseDataVariableTypeNode getZNode() throws UaException {
     try {
       return getZNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -253,7 +280,7 @@ public class ThreeDCartesianCoordinatesTypeNode extends CartesianCoordinatesType
   public CompletableFuture<? extends BaseDataVariableTypeNode> getZNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Z", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "Z", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ThreeDFrameTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ThreeDFrameTypeNode.java
@@ -96,8 +96,11 @@ public class ThreeDFrameTypeNode extends FrameTypeNode implements ThreeDFrameTyp
   public ThreeDCartesianCoordinates readCartesianCoordinates() throws UaException {
     try {
       return readCartesianCoordinatesAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -105,8 +108,11 @@ public class ThreeDFrameTypeNode extends FrameTypeNode implements ThreeDFrameTyp
   public void writeCartesianCoordinates(ThreeDCartesianCoordinates value) throws UaException {
     try {
       writeCartesianCoordinatesAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -131,8 +137,11 @@ public class ThreeDFrameTypeNode extends FrameTypeNode implements ThreeDFrameTyp
   public ThreeDCartesianCoordinatesTypeNode getCartesianCoordinatesNode() throws UaException {
     try {
       return getCartesianCoordinatesNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -143,7 +152,7 @@ public class ThreeDFrameTypeNode extends FrameTypeNode implements ThreeDFrameTyp
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "CartesianCoordinates",
-            ExpandedNodeId.parse("ns=0;i=47"),
+            ExpandedNodeId.parse("i=47"),
             false);
     return future.thenApply(node -> (ThreeDCartesianCoordinatesTypeNode) node);
   }
@@ -165,8 +174,11 @@ public class ThreeDFrameTypeNode extends FrameTypeNode implements ThreeDFrameTyp
   public ThreeDOrientation readOrientation() throws UaException {
     try {
       return readOrientationAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -174,8 +186,11 @@ public class ThreeDFrameTypeNode extends FrameTypeNode implements ThreeDFrameTyp
   public void writeOrientation(ThreeDOrientation value) throws UaException {
     try {
       writeOrientationAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -199,8 +214,11 @@ public class ThreeDFrameTypeNode extends FrameTypeNode implements ThreeDFrameTyp
   public ThreeDOrientationTypeNode getOrientationNode() throws UaException {
     try {
       return getOrientationNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -208,10 +226,7 @@ public class ThreeDFrameTypeNode extends FrameTypeNode implements ThreeDFrameTyp
   public CompletableFuture<? extends ThreeDOrientationTypeNode> getOrientationNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "Orientation",
-            ExpandedNodeId.parse("ns=0;i=47"),
-            false);
+            "http://opcfoundation.org/UA/", "Orientation", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (ThreeDOrientationTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ThreeDOrientationTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ThreeDOrientationTypeNode.java
@@ -93,8 +93,11 @@ public class ThreeDOrientationTypeNode extends OrientationTypeNode
   public Double readA() throws UaException {
     try {
       return readAAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -102,8 +105,11 @@ public class ThreeDOrientationTypeNode extends OrientationTypeNode
   public void writeA(Double value) throws UaException {
     try {
       writeAAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -124,8 +130,11 @@ public class ThreeDOrientationTypeNode extends OrientationTypeNode
   public BaseDataVariableTypeNode getANode() throws UaException {
     try {
       return getANodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -133,7 +142,7 @@ public class ThreeDOrientationTypeNode extends OrientationTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getANodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "A", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "A", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -153,8 +162,11 @@ public class ThreeDOrientationTypeNode extends OrientationTypeNode
   public Double readB() throws UaException {
     try {
       return readBAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -162,8 +174,11 @@ public class ThreeDOrientationTypeNode extends OrientationTypeNode
   public void writeB(Double value) throws UaException {
     try {
       writeBAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -184,8 +199,11 @@ public class ThreeDOrientationTypeNode extends OrientationTypeNode
   public BaseDataVariableTypeNode getBNode() throws UaException {
     try {
       return getBNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -193,7 +211,7 @@ public class ThreeDOrientationTypeNode extends OrientationTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getBNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "B", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "B", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -213,8 +231,11 @@ public class ThreeDOrientationTypeNode extends OrientationTypeNode
   public Double readC() throws UaException {
     try {
       return readCAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -222,8 +243,11 @@ public class ThreeDOrientationTypeNode extends OrientationTypeNode
   public void writeC(Double value) throws UaException {
     try {
       writeCAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -244,8 +268,11 @@ public class ThreeDOrientationTypeNode extends OrientationTypeNode
   public BaseDataVariableTypeNode getCNode() throws UaException {
     try {
       return getCNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -253,7 +280,7 @@ public class ThreeDOrientationTypeNode extends OrientationTypeNode
   public CompletableFuture<? extends BaseDataVariableTypeNode> getCNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "C", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "C", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ThreeDVectorTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ThreeDVectorTypeNode.java
@@ -92,8 +92,11 @@ public class ThreeDVectorTypeNode extends VectorTypeNode implements ThreeDVector
   public Double readX() throws UaException {
     try {
       return readXAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -101,8 +104,11 @@ public class ThreeDVectorTypeNode extends VectorTypeNode implements ThreeDVector
   public void writeX(Double value) throws UaException {
     try {
       writeXAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -123,8 +129,11 @@ public class ThreeDVectorTypeNode extends VectorTypeNode implements ThreeDVector
   public BaseDataVariableTypeNode getXNode() throws UaException {
     try {
       return getXNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -132,7 +141,7 @@ public class ThreeDVectorTypeNode extends VectorTypeNode implements ThreeDVector
   public CompletableFuture<? extends BaseDataVariableTypeNode> getXNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "X", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "X", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -152,8 +161,11 @@ public class ThreeDVectorTypeNode extends VectorTypeNode implements ThreeDVector
   public Double readY() throws UaException {
     try {
       return readYAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -161,8 +173,11 @@ public class ThreeDVectorTypeNode extends VectorTypeNode implements ThreeDVector
   public void writeY(Double value) throws UaException {
     try {
       writeYAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -183,8 +198,11 @@ public class ThreeDVectorTypeNode extends VectorTypeNode implements ThreeDVector
   public BaseDataVariableTypeNode getYNode() throws UaException {
     try {
       return getYNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -192,7 +210,7 @@ public class ThreeDVectorTypeNode extends VectorTypeNode implements ThreeDVector
   public CompletableFuture<? extends BaseDataVariableTypeNode> getYNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Y", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "Y", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 
@@ -212,8 +230,11 @@ public class ThreeDVectorTypeNode extends VectorTypeNode implements ThreeDVector
   public Double readZ() throws UaException {
     try {
       return readZAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -221,8 +242,11 @@ public class ThreeDVectorTypeNode extends VectorTypeNode implements ThreeDVector
   public void writeZ(Double value) throws UaException {
     try {
       writeZAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -243,8 +267,11 @@ public class ThreeDVectorTypeNode extends VectorTypeNode implements ThreeDVector
   public BaseDataVariableTypeNode getZNode() throws UaException {
     try {
       return getZNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -252,7 +279,7 @@ public class ThreeDVectorTypeNode extends VectorTypeNode implements ThreeDVector
   public CompletableFuture<? extends BaseDataVariableTypeNode> getZNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Z", ExpandedNodeId.parse("ns=0;i=47"), false);
+            "http://opcfoundation.org/UA/", "Z", ExpandedNodeId.parse("i=47"), false);
     return future.thenApply(node -> (BaseDataVariableTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/TransitionVariableTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/TransitionVariableTypeNode.java
@@ -94,8 +94,11 @@ public class TransitionVariableTypeNode extends BaseDataVariableTypeNode
   public Object readId() throws UaException {
     try {
       return readIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -103,8 +106,11 @@ public class TransitionVariableTypeNode extends BaseDataVariableTypeNode
   public void writeId(Object value) throws UaException {
     try {
       writeIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -125,8 +131,11 @@ public class TransitionVariableTypeNode extends BaseDataVariableTypeNode
   public PropertyTypeNode getIdNode() throws UaException {
     try {
       return getIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -134,7 +143,7 @@ public class TransitionVariableTypeNode extends BaseDataVariableTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Id", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Id", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -154,8 +163,11 @@ public class TransitionVariableTypeNode extends BaseDataVariableTypeNode
   public QualifiedName readName() throws UaException {
     try {
       return readNameAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -163,8 +175,11 @@ public class TransitionVariableTypeNode extends BaseDataVariableTypeNode
   public void writeName(QualifiedName value) throws UaException {
     try {
       writeNameAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -186,8 +201,11 @@ public class TransitionVariableTypeNode extends BaseDataVariableTypeNode
   public PropertyTypeNode getNameNode() throws UaException {
     try {
       return getNameNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -195,7 +213,7 @@ public class TransitionVariableTypeNode extends BaseDataVariableTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getNameNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Name", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Name", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -215,8 +233,11 @@ public class TransitionVariableTypeNode extends BaseDataVariableTypeNode
   public UInteger readNumber() throws UaException {
     try {
       return readNumberAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -224,8 +245,11 @@ public class TransitionVariableTypeNode extends BaseDataVariableTypeNode
   public void writeNumber(UInteger value) throws UaException {
     try {
       writeNumberAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -247,8 +271,11 @@ public class TransitionVariableTypeNode extends BaseDataVariableTypeNode
   public PropertyTypeNode getNumberNode() throws UaException {
     try {
       return getNumberNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -256,7 +283,7 @@ public class TransitionVariableTypeNode extends BaseDataVariableTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getNumberNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Number", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Number", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -276,8 +303,11 @@ public class TransitionVariableTypeNode extends BaseDataVariableTypeNode
   public DateTime readTransitionTime() throws UaException {
     try {
       return readTransitionTimeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -285,8 +315,11 @@ public class TransitionVariableTypeNode extends BaseDataVariableTypeNode
   public void writeTransitionTime(DateTime value) throws UaException {
     try {
       writeTransitionTimeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -308,8 +341,11 @@ public class TransitionVariableTypeNode extends BaseDataVariableTypeNode
   public PropertyTypeNode getTransitionTimeNode() throws UaException {
     try {
       return getTransitionTimeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -317,10 +353,7 @@ public class TransitionVariableTypeNode extends BaseDataVariableTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getTransitionTimeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "TransitionTime",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "TransitionTime", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -340,8 +373,11 @@ public class TransitionVariableTypeNode extends BaseDataVariableTypeNode
   public DateTime readEffectiveTransitionTime() throws UaException {
     try {
       return readEffectiveTransitionTimeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -349,8 +385,11 @@ public class TransitionVariableTypeNode extends BaseDataVariableTypeNode
   public void writeEffectiveTransitionTime(DateTime value) throws UaException {
     try {
       writeEffectiveTransitionTimeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -373,8 +412,11 @@ public class TransitionVariableTypeNode extends BaseDataVariableTypeNode
   public PropertyTypeNode getEffectiveTransitionTimeNode() throws UaException {
     try {
       return getEffectiveTransitionTimeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -384,7 +426,7 @@ public class TransitionVariableTypeNode extends BaseDataVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "EffectiveTransitionTime",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/TwoStateDiscreteTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/TwoStateDiscreteTypeNode.java
@@ -92,8 +92,11 @@ public class TwoStateDiscreteTypeNode extends DiscreteItemTypeNode implements Tw
   public LocalizedText readFalseState() throws UaException {
     try {
       return readFalseStateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -101,8 +104,11 @@ public class TwoStateDiscreteTypeNode extends DiscreteItemTypeNode implements Tw
   public void writeFalseState(LocalizedText value) throws UaException {
     try {
       writeFalseStateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -124,8 +130,11 @@ public class TwoStateDiscreteTypeNode extends DiscreteItemTypeNode implements Tw
   public PropertyTypeNode getFalseStateNode() throws UaException {
     try {
       return getFalseStateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -133,7 +142,7 @@ public class TwoStateDiscreteTypeNode extends DiscreteItemTypeNode implements Tw
   public CompletableFuture<? extends PropertyTypeNode> getFalseStateNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "FalseState", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "FalseState", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -153,8 +162,11 @@ public class TwoStateDiscreteTypeNode extends DiscreteItemTypeNode implements Tw
   public LocalizedText readTrueState() throws UaException {
     try {
       return readTrueStateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -162,8 +174,11 @@ public class TwoStateDiscreteTypeNode extends DiscreteItemTypeNode implements Tw
   public void writeTrueState(LocalizedText value) throws UaException {
     try {
       writeTrueStateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -185,8 +200,11 @@ public class TwoStateDiscreteTypeNode extends DiscreteItemTypeNode implements Tw
   public PropertyTypeNode getTrueStateNode() throws UaException {
     try {
       return getTrueStateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -194,7 +212,7 @@ public class TwoStateDiscreteTypeNode extends DiscreteItemTypeNode implements Tw
   public CompletableFuture<? extends PropertyTypeNode> getTrueStateNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "TrueState", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "TrueState", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/TwoStateVariableTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/TwoStateVariableTypeNode.java
@@ -94,8 +94,11 @@ public class TwoStateVariableTypeNode extends StateVariableTypeNode
   public Boolean readId() throws UaException {
     try {
       return readIdAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -103,8 +106,11 @@ public class TwoStateVariableTypeNode extends StateVariableTypeNode
   public void writeId(Boolean value) throws UaException {
     try {
       writeIdAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -125,8 +131,11 @@ public class TwoStateVariableTypeNode extends StateVariableTypeNode
   public PropertyTypeNode getIdNode() throws UaException {
     try {
       return getIdNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -134,7 +143,7 @@ public class TwoStateVariableTypeNode extends StateVariableTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getIdNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "Id", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "Id", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -154,8 +163,11 @@ public class TwoStateVariableTypeNode extends StateVariableTypeNode
   public DateTime readTransitionTime() throws UaException {
     try {
       return readTransitionTimeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -163,8 +175,11 @@ public class TwoStateVariableTypeNode extends StateVariableTypeNode
   public void writeTransitionTime(DateTime value) throws UaException {
     try {
       writeTransitionTimeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -186,8 +201,11 @@ public class TwoStateVariableTypeNode extends StateVariableTypeNode
   public PropertyTypeNode getTransitionTimeNode() throws UaException {
     try {
       return getTransitionTimeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -195,10 +213,7 @@ public class TwoStateVariableTypeNode extends StateVariableTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getTransitionTimeNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "TransitionTime",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "TransitionTime", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -218,8 +233,11 @@ public class TwoStateVariableTypeNode extends StateVariableTypeNode
   public DateTime readEffectiveTransitionTime() throws UaException {
     try {
       return readEffectiveTransitionTimeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -227,8 +245,11 @@ public class TwoStateVariableTypeNode extends StateVariableTypeNode
   public void writeEffectiveTransitionTime(DateTime value) throws UaException {
     try {
       writeEffectiveTransitionTimeAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -251,8 +272,11 @@ public class TwoStateVariableTypeNode extends StateVariableTypeNode
   public PropertyTypeNode getEffectiveTransitionTimeNode() throws UaException {
     try {
       return getEffectiveTransitionTimeNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -262,7 +286,7 @@ public class TwoStateVariableTypeNode extends StateVariableTypeNode
         getMemberNodeAsync(
             "http://opcfoundation.org/UA/",
             "EffectiveTransitionTime",
-            ExpandedNodeId.parse("ns=0;i=46"),
+            ExpandedNodeId.parse("i=46"),
             false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
@@ -283,8 +307,11 @@ public class TwoStateVariableTypeNode extends StateVariableTypeNode
   public LocalizedText readTrueState() throws UaException {
     try {
       return readTrueStateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -292,8 +319,11 @@ public class TwoStateVariableTypeNode extends StateVariableTypeNode
   public void writeTrueState(LocalizedText value) throws UaException {
     try {
       writeTrueStateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -315,8 +345,11 @@ public class TwoStateVariableTypeNode extends StateVariableTypeNode
   public PropertyTypeNode getTrueStateNode() throws UaException {
     try {
       return getTrueStateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -324,7 +357,7 @@ public class TwoStateVariableTypeNode extends StateVariableTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getTrueStateNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "TrueState", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "TrueState", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 
@@ -344,8 +377,11 @@ public class TwoStateVariableTypeNode extends StateVariableTypeNode
   public LocalizedText readFalseState() throws UaException {
     try {
       return readFalseStateAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -353,8 +389,11 @@ public class TwoStateVariableTypeNode extends StateVariableTypeNode
   public void writeFalseState(LocalizedText value) throws UaException {
     try {
       writeFalseStateAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -376,8 +415,11 @@ public class TwoStateVariableTypeNode extends StateVariableTypeNode
   public PropertyTypeNode getFalseStateNode() throws UaException {
     try {
       return getFalseStateNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -385,7 +427,7 @@ public class TwoStateVariableTypeNode extends StateVariableTypeNode
   public CompletableFuture<? extends PropertyTypeNode> getFalseStateNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "FalseState", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "FalseState", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/VectorTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/VectorTypeNode.java
@@ -95,8 +95,11 @@ public class VectorTypeNode extends BaseDataVariableTypeNode implements VectorTy
   public EUInformation readVectorUnit() throws UaException {
     try {
       return readVectorUnitAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -104,8 +107,11 @@ public class VectorTypeNode extends BaseDataVariableTypeNode implements VectorTy
   public void writeVectorUnit(EUInformation value) throws UaException {
     try {
       writeVectorUnitAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -128,8 +134,11 @@ public class VectorTypeNode extends BaseDataVariableTypeNode implements VectorTy
   public PropertyTypeNode getVectorUnitNode() throws UaException {
     try {
       return getVectorUnitNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -137,7 +146,7 @@ public class VectorTypeNode extends BaseDataVariableTypeNode implements VectorTy
   public CompletableFuture<? extends PropertyTypeNode> getVectorUnitNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/", "VectorUnit", ExpandedNodeId.parse("ns=0;i=46"), false);
+            "http://opcfoundation.org/UA/", "VectorUnit", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/XYArrayItemTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/XYArrayItemTypeNode.java
@@ -95,8 +95,11 @@ public class XYArrayItemTypeNode extends ArrayItemTypeNode implements XYArrayIte
   public AxisInformation readXAxisDefinition() throws UaException {
     try {
       return readXAxisDefinitionAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -104,8 +107,11 @@ public class XYArrayItemTypeNode extends ArrayItemTypeNode implements XYArrayIte
   public void writeXAxisDefinition(AxisInformation value) throws UaException {
     try {
       writeXAxisDefinitionAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -129,8 +135,11 @@ public class XYArrayItemTypeNode extends ArrayItemTypeNode implements XYArrayIte
   public PropertyTypeNode getXAxisDefinitionNode() throws UaException {
     try {
       return getXAxisDefinitionNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -138,10 +147,7 @@ public class XYArrayItemTypeNode extends ArrayItemTypeNode implements XYArrayIte
   public CompletableFuture<? extends PropertyTypeNode> getXAxisDefinitionNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "XAxisDefinition",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "XAxisDefinition", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/YArrayItemTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/YArrayItemTypeNode.java
@@ -95,8 +95,11 @@ public class YArrayItemTypeNode extends ArrayItemTypeNode implements YArrayItemT
   public AxisInformation readXAxisDefinition() throws UaException {
     try {
       return readXAxisDefinitionAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -104,8 +107,11 @@ public class YArrayItemTypeNode extends ArrayItemTypeNode implements YArrayItemT
   public void writeXAxisDefinition(AxisInformation value) throws UaException {
     try {
       writeXAxisDefinitionAsync(value).get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError, e));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -129,8 +135,11 @@ public class YArrayItemTypeNode extends ArrayItemTypeNode implements YArrayItemT
   public PropertyTypeNode getXAxisDefinitionNode() throws UaException {
     try {
       return getXAxisDefinitionNodeAsync().get();
-    } catch (ExecutionException | InterruptedException e) {
-      throw UaException.extract(e).orElse(new UaException(StatusCodes.Bad_UnexpectedError));
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
     }
   }
 
@@ -138,10 +147,7 @@ public class YArrayItemTypeNode extends ArrayItemTypeNode implements YArrayItemT
   public CompletableFuture<? extends PropertyTypeNode> getXAxisDefinitionNodeAsync() {
     CompletableFuture<UaNode> future =
         getMemberNodeAsync(
-            "http://opcfoundation.org/UA/",
-            "XAxisDefinition",
-            ExpandedNodeId.parse("ns=0;i=46"),
-            false);
+            "http://opcfoundation.org/UA/", "XAxisDefinition", ExpandedNodeId.parse("i=46"), false);
     return future.thenApply(node -> (PropertyTypeNode) node);
   }
 }


### PR DESCRIPTION
Handle ExecutionException and InterruptedException separately, extracting the underlying cause when it's an ExecutionException, and restoring the interrupt state when it's an InterruptedException.
