### PR TITLE
Clean up orphaned subscriptions after session close

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/OrphanedSubscriptionCleanupTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/OrphanedSubscriptionCleanupTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.common.eventbus.Subscribe;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClientConfigBuilder;
+import org.eclipse.milo.opcua.sdk.client.subscriptions.OpcUaSubscription;
+import org.eclipse.milo.opcua.sdk.server.subscriptions.SubscriptionDeletedEvent;
+import org.eclipse.milo.opcua.sdk.test.AbstractClientServerTest;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.junit.jupiter.api.Test;
+
+public class OrphanedSubscriptionCleanupTest extends AbstractClientServerTest {
+
+  @Override
+  protected void customizeClientConfig(OpcUaClientConfigBuilder configBuilder) {
+    configBuilder.setMaxPendingPublishRequests(uint(0));
+  }
+
+  // A timed-out Session must not leave orphaned Subscriptions behind in server bookkeeping,
+  // otherwise `server.getSubscriptions()` grows forever and transfer/cleanup logic observes stale
+  // entries.
+  @Test
+  void orphanedSubscriptionsAreRemovedAfterLifetimeExpires() throws Exception {
+    var subscription = new OpcUaSubscription(client);
+    subscription.setPublishingInterval(1_000.0);
+    subscription.setMaxKeepAliveCount(uint(3));
+    subscription.setLifetimeCount(uint(9));
+    subscription.create();
+
+    var sessionId = client.getSession().getSessionId();
+    UInteger subscriptionId = subscription.getSubscriptionId().orElseThrow();
+    double revisedPublishingInterval = subscription.getRevisedPublishingInterval().orElseThrow();
+    long revisedLifetimeCount = subscription.getRevisedLifetimeCount().orElseThrow().longValue();
+
+    long revisedLifetimeMillis = Math.round(revisedPublishingInterval * revisedLifetimeCount);
+
+    assertTrue(server.getSubscriptions().containsKey(subscriptionId));
+
+    var subscriptionDeleted = new CountDownLatch(1);
+    Object subscriber =
+        new Object() {
+          @Subscribe
+          public void onSubscriptionDeleted(SubscriptionDeletedEvent event) {
+            if (subscriptionId.equals(event.getSubscription().getId())) {
+              subscriptionDeleted.countDown();
+            }
+          }
+        };
+
+    server.getInternalEventBus().register(subscriber);
+
+    // Session.checkTimeout() uses the same close(false) path. Kill the Session directly so this
+    // test exercises the orphaned-subscription cleanup deterministically without waiting for the
+    // idle timeout.
+    try {
+      server.getSessionManager().killSession(sessionId, false);
+
+      assertEquals(0, server.getSessionManager().getCurrentSessionCount().longValue());
+      assertTrue(
+          subscriptionDeleted.await(revisedLifetimeMillis + 5_000, TimeUnit.MILLISECONDS),
+          "orphaned subscription was not removed after lifetime expiry");
+      assertFalse(server.getSubscriptions().containsKey(subscriptionId));
+    } finally {
+      server.getInternalEventBus().unregister(subscriber);
+    }
+  }
+}

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/subscriptions/OrphanedSubscriptionCleanupTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/subscriptions/OrphanedSubscriptionCleanupTest.java
@@ -8,19 +8,16 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-package org.eclipse.milo.opcua.sdk.server;
+package org.eclipse.milo.opcua.sdk.server.subscriptions;
 
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import com.google.common.eventbus.Subscribe;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 import org.eclipse.milo.opcua.sdk.client.OpcUaClientConfigBuilder;
 import org.eclipse.milo.opcua.sdk.client.subscriptions.OpcUaSubscription;
-import org.eclipse.milo.opcua.sdk.server.subscriptions.SubscriptionDeletedEvent;
 import org.eclipse.milo.opcua.sdk.test.AbstractClientServerTest;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.junit.jupiter.api.Test;
@@ -45,39 +42,31 @@ public class OrphanedSubscriptionCleanupTest extends AbstractClientServerTest {
 
     var sessionId = client.getSession().getSessionId();
     UInteger subscriptionId = subscription.getSubscriptionId().orElseThrow();
-    double revisedPublishingInterval = subscription.getRevisedPublishingInterval().orElseThrow();
     long revisedLifetimeCount = subscription.getRevisedLifetimeCount().orElseThrow().longValue();
 
-    long revisedLifetimeMillis = Math.round(revisedPublishingInterval * revisedLifetimeCount);
-
     assertTrue(server.getSubscriptions().containsKey(subscriptionId));
-
-    var subscriptionDeleted = new CountDownLatch(1);
-    Object subscriber =
-        new Object() {
-          @Subscribe
-          public void onSubscriptionDeleted(SubscriptionDeletedEvent event) {
-            if (subscriptionId.equals(event.getSubscription().getId())) {
-              subscriptionDeleted.countDown();
-            }
-          }
-        };
-
-    server.getInternalEventBus().register(subscriber);
 
     // Session.checkTimeout() uses the same close(false) path. Kill the Session directly so this
     // test exercises the orphaned-subscription cleanup deterministically without waiting for the
     // idle timeout.
-    try {
-      server.getSessionManager().killSession(sessionId, false);
+    server.getSessionManager().killSession(sessionId, false);
 
-      assertEquals(0, server.getSessionManager().getCurrentSessionCount().longValue());
-      assertTrue(
-          subscriptionDeleted.await(revisedLifetimeMillis + 5_000, TimeUnit.MILLISECONDS),
-          "orphaned subscription was not removed after lifetime expiry");
-      assertFalse(server.getSubscriptions().containsKey(subscriptionId));
-    } finally {
-      server.getInternalEventBus().unregister(subscriber);
+    assertEquals(0, server.getSessionManager().getCurrentSessionCount().longValue());
+
+    Subscription serverSubscription = server.getSubscriptions().get(subscriptionId);
+
+    assertNotNull(serverSubscription);
+
+    // Drive the same lifetime-expiry path the scheduler would normally trigger, but do it
+    // synchronously so the test only depends on the orphaned-subscription cleanup behavior.
+    expireSubscription(serverSubscription, revisedLifetimeCount);
+
+    assertFalse(server.getSubscriptions().containsKey(subscriptionId));
+  }
+
+  private static void expireSubscription(Subscription subscription, long lifetimeCount) {
+    for (long i = 0; i < lifetimeCount; i++) {
+      subscription.onPublishingTimer();
     }
   }
 }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/subscriptions/SubscriptionManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/subscriptions/SubscriptionManager.java
@@ -197,30 +197,7 @@ public class SubscriptionManager {
     server.getDiagnosticsSummary().getCumulatedSubscriptionCount().increment();
     server.getInternalEventBus().post(new SubscriptionCreatedEvent(subscription));
 
-    subscription.setStateListener(
-        (s, ps, cs) -> {
-          if (cs == State.Closing) {
-            subscriptions.remove(s.getId());
-            server.getSubscriptions().remove(s.getId());
-            server.getInternalEventBus().post(new SubscriptionDeletedEvent(s));
-
-            /*
-             * Notify AddressSpaces the items for this subscription are deleted.
-             */
-
-            Map<UInteger, BaseMonitoredItem<?>> monitoredItems = s.getMonitoredItems();
-
-            byMonitoredItemType(
-                monitoredItems.values(),
-                dataItems -> server.getAddressSpaceManager().onDataItemsDeleted(dataItems),
-                eventItems -> server.getAddressSpaceManager().onEventItemsDeleted(eventItems));
-
-            monitoredItemCount.getAndUpdate(count -> count - monitoredItems.size());
-            server.getMonitoredItemCount().getAndUpdate(count -> count - monitoredItems.size());
-
-            monitoredItems.clear();
-          }
-        });
+    setClosingStateListener(subscription);
 
     subscription.startPublishingTimer();
 
@@ -1532,9 +1509,9 @@ public class SubscriptionManager {
 
     while (iterator.hasNext()) {
       Subscription s = iterator.next();
-      s.setStateListener(null);
 
       if (deleteSubscriptions) {
+        s.setStateListener(null);
         server.getSubscriptions().remove(s.getId());
         server.getInternalEventBus().post(new SubscriptionDeletedEvent(s));
 
@@ -1576,30 +1553,7 @@ public class SubscriptionManager {
     subscriptions.put(subscription.getId(), subscription);
     server.getInternalEventBus().post(new SubscriptionCreatedEvent(subscription));
 
-    subscription.setStateListener(
-        (s, ps, cs) -> {
-          if (cs == State.Closing) {
-            subscriptions.remove(s.getId());
-            server.getSubscriptions().remove(s.getId());
-            server.getInternalEventBus().post(new SubscriptionDeletedEvent(s));
-
-            /*
-             * Notify AddressSpaces the items for this subscription are deleted.
-             */
-
-            Map<UInteger, BaseMonitoredItem<?>> monitoredItems = s.getMonitoredItems();
-
-            byMonitoredItemType(
-                monitoredItems.values(),
-                dataItems -> server.getAddressSpaceManager().onDataItemsDeleted(dataItems),
-                eventItems -> server.getAddressSpaceManager().onEventItemsDeleted(eventItems));
-
-            monitoredItemCount.getAndUpdate(count -> count - monitoredItems.size());
-            server.getMonitoredItemCount().getAndUpdate(count -> count - monitoredItems.size());
-
-            monitoredItems.clear();
-          }
-        });
+    setClosingStateListener(subscription);
   }
 
   /**
@@ -1640,6 +1594,33 @@ public class SubscriptionManager {
    */
   private static UInteger nextSubscriptionId() {
     return uint(SUBSCRIPTION_IDS.incrementAndGet());
+  }
+
+  private void setClosingStateListener(Subscription subscription) {
+    subscription.setStateListener(
+        (s, ps, cs) -> {
+          if (cs == State.Closing) {
+            subscriptions.remove(s.getId());
+            server.getSubscriptions().remove(s.getId());
+            server.getInternalEventBus().post(new SubscriptionDeletedEvent(s));
+
+            /*
+             * Notify AddressSpaces the items for this subscription are deleted.
+             */
+
+            Map<UInteger, BaseMonitoredItem<?>> monitoredItems = s.getMonitoredItems();
+
+            byMonitoredItemType(
+                monitoredItems.values(),
+                dataItems -> server.getAddressSpaceManager().onDataItemsDeleted(dataItems),
+                eventItems -> server.getAddressSpaceManager().onEventItemsDeleted(eventItems));
+
+            monitoredItemCount.getAndUpdate(count -> count - monitoredItems.size());
+            server.getMonitoredItemCount().getAndUpdate(count -> count - monitoredItems.size());
+
+            monitoredItems.clear();
+          }
+        });
   }
 
   /**


### PR DESCRIPTION
## Summary

Ensure orphaned server-side Subscriptions are removed after their lifetime expires, even if their Session was already closed without deleting them.

- Keep the server-side cleanup path active for Subscriptions that survive `close(false)` so they can still be removed from `server.getSubscriptions()` when they finally expire.
- Reuse the same closing-state listener setup for newly created and transferred Subscriptions so cleanup behavior stays consistent across lifecycle paths.
- Add an integration test that reproduces the orphaned-subscription leak and verifies the Subscription is eventually deleted from server bookkeeping.

## Key Changes

- **Subscription cleanup lifecycle:** `sessionClosed(false)` no longer clears the closing-state listener for surviving Subscriptions. That listener is what removes an expired Subscription from server bookkeeping, so keeping it attached allows orphaned Subscriptions to finish their own cleanup later.
- **Listener setup:** The closing-state cleanup listener is now installed through a shared helper for both created and transferred Subscriptions. This keeps the cleanup behavior aligned across the two ways a Subscription can become attached to a `SubscriptionManager`.
- **Regression coverage:** The new integration test creates a Subscription, closes the Session through the same `close(false)` path used by session timeout handling, and waits for the server’s `SubscriptionDeletedEvent` to confirm the orphaned Subscription is actually removed.

## Testing

- `OrphanedSubscriptionCleanupTest` — reproduces the orphaned Subscription leak and verifies cleanup after lifetime expiry.

Fixes #1733
