### PR TITLE
Fix JSON BSD codec round-trip for nested struct fields

### DIFF
--- a/opc-ua-sdk/dtd-core/src/main/java/org/eclipse/milo/opcua/sdk/core/dtd/AbstractBsdCodec.java
+++ b/opc-ua-sdk/dtd-core/src/main/java/org/eclipse/milo/opcua/sdk/core/dtd/AbstractBsdCodec.java
@@ -334,14 +334,35 @@ public abstract class AbstractBsdCodec<StructureT, MemberT> implements BinaryDat
     if (dictionary instanceof BinaryDataTypeDictionary binaryDictionary) {
       TypeDescription typeDescription = binaryDictionary.getTypeDescription(description);
 
-      if (typeDescription instanceof StructuredType) {
+      if (typeDescription instanceof StructuredType structuredType) {
         DataTypeCodec codec = dictionary.getCodec(description);
 
         if (codec != null) {
-          codec.encode(context, encoder, (UaStructuredType) value);
+          UaStructuredType structValue;
+          if (value instanceof UaStructuredType uaStruct) {
+            structValue = uaStruct;
+          } else {
+            // The parent codec produced a non-UaStructuredType representation
+            // (e.g. a JsonObject from JsonObjectCodec). Wrap it in a
+            // BsdStructWrapper so the nested codec receives the same form its
+            // own decodeBinary() returns.
+            DataTypeDictionary.Type type = dictionary.getType(description);
+            if (type == null) {
+              throw new UaSerializationException(
+                  StatusCodes.Bad_EncodingError,
+                  String.format(
+                      "no Type registered for description=%s under namespaceUri=%s",
+                      description, namespaceUri));
+            }
+            BsdDataType dataType =
+                new BsdDataType(
+                    description, type.getDataTypeId(), type.getEncodingId(), structuredType);
+            structValue = new BsdStructWrapper<>(dataType, value);
+          }
+          codec.encode(context, encoder, structValue);
         } else {
           throw new UaSerializationException(
-              StatusCodes.Bad_DecodingError,
+              StatusCodes.Bad_EncodingError,
               String.format(
                   "no OpcBinaryDataTypeCodec registered for description=%s under namespaceUri=%s",
                   description, namespaceUri));

--- a/opc-ua-sdk/dtd-core/src/main/java/org/eclipse/milo/opcua/sdk/core/dtd/json/JsonObjectCodec.java
+++ b/opc-ua-sdk/dtd-core/src/main/java/org/eclipse/milo/opcua/sdk/core/dtd/json/JsonObjectCodec.java
@@ -26,6 +26,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.UUID;
 import org.eclipse.milo.opcua.sdk.core.dtd.AbstractBsdCodec;
+import org.eclipse.milo.opcua.sdk.core.dtd.BsdStructWrapper;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
@@ -112,6 +113,13 @@ public class JsonObjectCodec extends AbstractBsdCodec<JsonObject, JsonElement> {
     } else if (value instanceof StatusCode) {
       long code = ((StatusCode) value).value();
       return new JsonPrimitive(code);
+    } else if (value instanceof BsdStructWrapper<?> wrapper
+        && wrapper.object() instanceof JsonElement element) {
+      // Nested struct fields decoded by another JsonObjectCodec come back
+      // wrapped in BsdStructWrapper (AbstractBsdCodec.decodeBinary always wraps
+      // so the result satisfies the UaStructuredType return contract). Unwrap
+      // the JsonObject so it can sit directly inside the parent JsonObject.
+      return element;
     } else {
       throw new RuntimeException("could not create JsonElement for value: " + value);
     }

--- a/opc-ua-sdk/dtd-core/src/test/java/org/eclipse/milo/opcua/sdk/core/dtd/AbstractBsdCodecTest.java
+++ b/opc-ua-sdk/dtd-core/src/test/java/org/eclipse/milo/opcua/sdk/core/dtd/AbstractBsdCodecTest.java
@@ -130,16 +130,14 @@ public abstract class AbstractBsdCodecTest {
     LOGGER.debug("originalValue:\t{}", originalValue);
     ByteBuf buffer = Unpooled.buffer();
     codec.encodeBinary(
-        context,
-        new OpcUaBinaryEncoder(context).setBuffer(buffer),
-        (UaStructuredType) originalValue);
+        context, new OpcUaBinaryEncoder(context).setBuffer(buffer), wrap(type, originalValue));
 
     ByteBuf encodedValue = buffer.copy();
     LOGGER.debug("encodedValue:\t{}", ByteBufUtil.hexDump(encodedValue));
 
     Object decodedValue =
         codec.decodeBinary(context, new OpcUaBinaryDecoder(context).setBuffer(buffer));
-    assertEquals(originalValue, decodedValue);
+    assertEquals(originalValue, unwrap(decodedValue));
     LOGGER.debug("decodedValue:\t{}", decodedValue);
   }
 
@@ -159,16 +157,27 @@ public abstract class AbstractBsdCodecTest {
     LOGGER.debug("originalValue:\t{}", originalValue);
     ByteBuf buffer = Unpooled.buffer();
     codec.encodeBinary(
-        context,
-        new OpcUaBinaryEncoder(context).setBuffer(buffer),
-        (UaStructuredType) originalValue);
+        context, new OpcUaBinaryEncoder(context).setBuffer(buffer), wrap(type, originalValue));
 
     ByteBuf encodedValue = buffer.copy();
     LOGGER.debug("encodedValue:\t{}", ByteBufUtil.hexDump(encodedValue));
 
     Object decodedValue =
         codec.decodeBinary(context, new OpcUaBinaryDecoder(context).setBuffer(buffer));
-    assertEquals(originalValue.toString(), decodedValue.toString());
+    assertEquals(originalValue.toString(), unwrap(decodedValue).toString());
     LOGGER.debug("decodedValue:\t{}", decodedValue);
+  }
+
+  private UaStructuredType wrap(String type, Object value) {
+    DataTypeDictionary dictionary = dataTypeManager.getTypeDictionary(BSD_CODEC_TEST_NAMESPACE);
+    assertNotNull(dictionary);
+    DataTypeDictionary.Type t = dictionary.getType(type);
+    assertNotNull(t);
+    BsdDataType dataType = new BsdDataType(type, t.getDataTypeId(), t.getEncodingId());
+    return new BsdStructWrapper<>(dataType, value);
+  }
+
+  private static Object unwrap(Object value) {
+    return value instanceof BsdStructWrapper<?> w ? w.object() : value;
   }
 }

--- a/opc-ua-sdk/dtd-core/src/test/java/org/eclipse/milo/opcua/sdk/core/dtd/GenericBsdCodecTest.java
+++ b/opc-ua-sdk/dtd-core/src/test/java/org/eclipse/milo/opcua/sdk/core/dtd/GenericBsdCodecTest.java
@@ -15,11 +15,9 @@ import org.eclipse.milo.opcua.sdk.core.dtd.generic.Struct;
 import org.eclipse.milo.opcua.sdk.core.dtd.generic.StructCodec;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.structured.Range;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.opcfoundation.opcua.binaryschema.StructuredType;
 
-@Disabled
 public class GenericBsdCodecTest extends AbstractBsdCodecTest {
 
   public GenericBsdCodecTest() throws JAXBException {}

--- a/opc-ua-sdk/dtd-core/src/test/java/org/eclipse/milo/opcua/sdk/core/dtd/json/JsonBsdCodecTest.java
+++ b/opc-ua-sdk/dtd-core/src/test/java/org/eclipse/milo/opcua/sdk/core/dtd/json/JsonBsdCodecTest.java
@@ -18,11 +18,9 @@ import jakarta.xml.bind.JAXBException;
 import org.eclipse.milo.opcua.sdk.core.dtd.AbstractBsdCodecTest;
 import org.eclipse.milo.opcua.sdk.core.dtd.BinaryDataTypeCodec;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.opcfoundation.opcua.binaryschema.StructuredType;
 
-@Disabled
 public class JsonBsdCodecTest extends AbstractBsdCodecTest {
 
   public JsonBsdCodecTest() throws JAXBException {}


### PR DESCRIPTION
AbstractBsdCodec.encodeField cast every nested-struct value to UaStructuredType before handing it to the nested codec, which failed for JsonObjectCodec since its nested-struct values are raw JsonObjects. Wrap non-UaStructuredType values in BsdStructWrapper before invoking the nested encode, and add a matching decode-side branch in JsonObjectCodec.opcUaToMemberTypeScalar that unwraps BsdStructWrapper<JsonElement> returned from nested decodes.

Re-enable JsonBsdCodecTest and GenericBsdCodecTest, which were `@Disabled` and would otherwise have caught this regression. The round-trip helper in AbstractBsdCodecTest now wraps/unwraps BsdStructWrapper to match the current encode/decode contract.

fixes #1741
