### PR TITLE
Prevent zero-delay subscription resampling

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/util/SubscriptionModel.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/util/SubscriptionModel.java
@@ -145,6 +145,10 @@ public class SubscriptionModel extends AbstractLifecycle {
     schedule.forEach(executor::execute);
   }
 
+  static long nextDelayMillis(long samplingInterval, long elapsedMillis) {
+    return Math.max(1, samplingInterval - elapsedMillis);
+  }
+
   private class ScheduledUpdate implements Runnable {
 
     private volatile boolean cancelled = false;
@@ -207,12 +211,9 @@ public class SubscriptionModel extends AbstractLifecycle {
       if (!cancelled) {
         long elapsedNanos = System.nanoTime() - startNanos;
         long elapsedMillis = TimeUnit.NANOSECONDS.toMillis(elapsedNanos);
-        long delay = Math.max(0, samplingInterval - elapsedMillis);
-        if (delay == 0) {
-          executor.execute(this);
-        } else {
-          scheduler.schedule(() -> executor.execute(this), delay, TimeUnit.MILLISECONDS);
-        }
+        long delay = nextDelayMillis(samplingInterval, elapsedMillis);
+
+        scheduler.schedule(() -> executor.execute(this), delay, TimeUnit.MILLISECONDS);
       }
     }
   }

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/util/SubscriptionModelTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/util/SubscriptionModelTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class SubscriptionModelTest {
+
+  @Test
+  void nextDelayMillisPreservesFixedRateDelayWhenNotOverdue() {
+    assertEquals(75, SubscriptionModel.nextDelayMillis(100, 25));
+  }
+
+  @Test
+  void nextDelayMillisUsesMinimumDelayWhenOverdue() {
+    assertEquals(1, SubscriptionModel.nextDelayMillis(100, 100));
+    assertEquals(1, SubscriptionModel.nextDelayMillis(100, 125));
+  }
+}


### PR DESCRIPTION
### Motivation
- A fixed-rate scheduling change allowed overdue `ScheduledUpdate` runs to re-enqueue themselves immediately via `executor.execute(this)`, which can create a busy loop and monopolize the shared server executor leading to a practical availability (DoS) attack. 
- The goal is to prevent immediate zero-delay resubmission while preserving approximate fixed-rate behavior for non-overdue sampling intervals. 

### Description
- Add a `static long nextDelayMillis(long samplingInterval, long elapsedMillis)` helper that clamps the computed next delay to at least `1` millisecond. 
- Replace the zero-delay `executor.execute(this)` path so all subsequent executions are routed through the `scheduler.schedule(..., delay, TimeUnit.MILLISECONDS)` using the clamped delay. 
- Add `SubscriptionModelTest` with focused unit coverage for normal and overdue delay calculations. 

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0899e5a41c83259db492e713e6c846)