### PR TITLE
Validate JSON matrix dimensions

### DIFF
--- a/opc-ua-stack/encoding-json/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonDecoder.java
+++ b/opc-ua-stack/encoding-json/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonDecoder.java
@@ -899,6 +899,8 @@ public class OpcUaJsonDecoder implements UaDecoder {
             Array.set(flatArray, i, elements.get(i));
           }
 
+          validateMatrixDimensions(flatArray, dimensions);
+
           var matrix = new Matrix(flatArray, dimensions, OpcUaDataType.fromTypeId(typeId));
 
           return new Variant(matrix);
@@ -908,6 +910,58 @@ public class OpcUaJsonDecoder implements UaDecoder {
       }
     } catch (IOException e) {
       throw new UaSerializationException(StatusCodes.Bad_DecodingError, e);
+    }
+  }
+
+  private void validateMatrixDimensions(Object flatArray, int[] dimensions)
+      throws UaSerializationException {
+    if (flatArray == null) {
+      throw new UaSerializationException(StatusCodes.Bad_DecodingError, "matrix Array is missing");
+    }
+
+    if (dimensions == null) {
+      throw new UaSerializationException(
+          StatusCodes.Bad_DecodingError, "matrix Dimensions is missing");
+    }
+
+    int maxMessageSize = context.getEncodingLimits().getMaxMessageSize();
+    int flatArrayLength = Array.getLength(flatArray);
+    int expectedLength = 1;
+
+    for (int dimension : dimensions) {
+      if (dimension < 0) {
+        throw new UaSerializationException(
+            StatusCodes.Bad_DecodingError,
+            String.format("matrix dimension is negative (dimension=%s)", dimension));
+      }
+
+      if (dimension > maxMessageSize) {
+        throw new UaSerializationException(
+            StatusCodes.Bad_EncodingLimitsExceeded,
+            String.format(
+                "matrix dimension exceeds max message size (dimension=%s, max=%s)",
+                dimension, maxMessageSize));
+      }
+
+      if (expectedLength == 0 || dimension == 0) {
+        expectedLength = 0;
+      } else {
+        if (expectedLength > maxMessageSize / dimension) {
+          throw new UaSerializationException(
+              StatusCodes.Bad_EncodingLimitsExceeded,
+              String.format("matrix length exceeds max message size (max=%s)", maxMessageSize));
+        }
+
+        expectedLength *= dimension;
+      }
+    }
+
+    if (expectedLength != flatArrayLength) {
+      throw new UaSerializationException(
+          StatusCodes.Bad_DecodingError,
+          String.format(
+              "matrix dimensions do not match array length (dimensionsLength=%s, arrayLength=%s)",
+              expectedLength, flatArrayLength));
     }
   }
 
@@ -1386,6 +1440,8 @@ public class OpcUaJsonDecoder implements UaDecoder {
           }
         }
 
+        validateMatrixDimensions(flatArray, dimensions);
+
         return new Matrix(flatArray, dimensions, dataType);
       } finally {
         jsonReader.endObject();
@@ -1473,6 +1529,8 @@ public class OpcUaJsonDecoder implements UaDecoder {
                     String.format("readLocalizedText: unexpected field: " + nextName));
             }
           }
+
+          validateMatrixDimensions(flatArray, dimensions);
 
           return new Matrix(flatArray, dimensions, OpcUaDataType.ExtensionObject);
         } finally {

--- a/opc-ua-stack/encoding-json/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonDecoderTest.java
+++ b/opc-ua-stack/encoding-json/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonDecoderTest.java
@@ -15,6 +15,7 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -28,6 +29,7 @@ import java.util.stream.Stream;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
 import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaSerializationException;
 import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
 import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
 import org.eclipse.milo.opcua.stack.core.types.UaStructuredType;
@@ -817,6 +819,9 @@ class OpcUaJsonDecoderTest {
         new StringReader("{\"Type\":6,\"Body\":[0,1,2,3,4,5,6,7],\"Dimensions\":[2,2,2]}"));
     assertEquals(new Variant(Matrix.ofInt32(value3d)), decoder.decodeVariant(null));
 
+    decoder.reset(new StringReader("{\"Type\":6,\"Body\":[1],\"Dimensions\":[2147483647]}"));
+    assertThrows(UaSerializationException.class, () -> decoder.decodeVariant(null));
+
     decoder.reset(new StringReader("{\"foo\":{\"Type\":1,\"Body\":true}}"));
     decoder.jsonReader.beginObject();
     assertEquals(new Variant(true), decoder.decodeVariant("foo"));
@@ -945,6 +950,23 @@ class OpcUaJsonDecoderTest {
   }
 
   @Test
+  void decodeMatrixRejectsInvalidDimensions() {
+    var decoder = new OpcUaJsonDecoder(context, new StringReader(""));
+
+    decoder.reset(new StringReader("{\"Array\":[1],\"Dimensions\":[2147483647]}"));
+    assertThrows(
+        UaSerializationException.class, () -> decoder.decodeMatrix(null, OpcUaDataType.Int32));
+
+    decoder.reset(new StringReader("{\"Array\":[1],\"Dimensions\":[-1]}"));
+    assertThrows(
+        UaSerializationException.class, () -> decoder.decodeMatrix(null, OpcUaDataType.Int32));
+
+    decoder.reset(new StringReader("{\"Array\":[1],\"Dimensions\":[1,1]}"));
+    assertThrows(
+        UaSerializationException.class, () -> decoder.decodeMatrix(null, OpcUaDataType.Int32));
+  }
+
+  @Test
   void decodeEnumMatrix() throws Exception {
     var decoder = new OpcUaJsonDecoder(context, new StringReader(""));
 
@@ -980,6 +1002,10 @@ class OpcUaJsonDecoderTest {
     decoder.jsonReader.beginObject();
     assertEquals(matrix, decoder.decodeStructMatrix("foo", XVType.TYPE_ID));
     decoder.jsonReader.endObject();
+
+    decoder.reset(new StringReader("{\"Array\":[{\"Value\":1.0}],\"Dimensions\":[2147483647]}"));
+    assertThrows(
+        UaSerializationException.class, () -> decoder.decodeStructMatrix(null, XVType.TYPE_ID));
   }
 
   private static byte[] randomBytes16() {

--- a/opc-ua-stack/encoding-json/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonDecoderTest.java
+++ b/opc-ua-stack/encoding-json/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonDecoderTest.java
@@ -961,7 +961,7 @@ class OpcUaJsonDecoderTest {
     assertThrows(
         UaSerializationException.class, () -> decoder.decodeMatrix(null, OpcUaDataType.Int32));
 
-    decoder.reset(new StringReader("{\"Array\":[1],\"Dimensions\":[1,1]}"));
+    decoder.reset(new StringReader("{\"Array\":[1],\"Dimensions\":[2,1]}"));
     assertThrows(
         UaSerializationException.class, () -> decoder.decodeMatrix(null, OpcUaDataType.Int32));
   }


### PR DESCRIPTION
### Motivation
- The JSON decoder accepted attacker-controlled `Dimensions` arrays and constructed `Matrix` objects without validating dimensions, which could lead to uncontrolled allocations and an OutOfMemoryError (DoS). 
- The binary decoder performed per-dimension and total-length checks but the JSON decoder lacked equivalent validation for the flat `Array` + `Dimensions` representation introduced for compact JSON matrices. 

### Description
- Add a new `validateMatrixDimensions(Object flatArray, int[] dimensions)` helper in `OpcUaJsonDecoder` that rejects missing `Array`/`Dimensions`, negative dimensions, per-dimension sizes exceeding `EncodingLimits.getMaxMessageSize()`, overflow/over-limit products, and mismatched product vs flat array length. 
- Call `validateMatrixDimensions(...)` in all JSON matrix construction paths: the `Variant` multi-dimensional array path, `decodeMatrix(...)`, and `decodeStructMatrix(...)`. 
- Add unit tests to `OpcUaJsonDecoderTest` that assert oversized, negative, and mismatched `Dimensions` are rejected for `Variant`, built-in Matrix, and structured Matrix decoding. 

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08a77457608325b4c527be8ddc64b5)