### PR TITLE
Limit eager ExtensionObject decode recursion

### DIFF
--- a/opc-ua-sdk/sdk-core/src/main/java/org/eclipse/milo/opcua/sdk/core/types/codec/FieldUtil.java
+++ b/opc-ua-sdk/sdk-core/src/main/java/org/eclipse/milo/opcua/sdk/core/types/codec/FieldUtil.java
@@ -55,6 +55,8 @@ import org.slf4j.LoggerFactory;
 /** Field serialization logic shared by {@link DynamicStructCodec} and {@link DynamicUnionCodec}. */
 class FieldUtil {
 
+  private static final ThreadLocal<Integer> EAGER_DECODE_DEPTH = ThreadLocal.withInitial(() -> 0);
+
   private FieldUtil() {}
 
   static Object decodeFieldValue(
@@ -89,11 +91,11 @@ class FieldUtil {
 
     try {
       if (value instanceof ExtensionObject xo) {
-        return xo.decode(decoder.getEncodingContext());
+        return eagerlyDecodeExtensionObject(decoder, xo);
       } else if (value instanceof ExtensionObject[] xos) {
         Object decodedArray = null;
         for (int i = 0; i < xos.length; i++) {
-          Object decoded = xos[i].decode(decoder.getEncodingContext());
+          Object decoded = eagerlyDecodeExtensionObject(decoder, xos[i]);
           if (decodedArray == null) {
             decodedArray = Array.newInstance(decoded.getClass(), xos.length);
           }
@@ -106,7 +108,7 @@ class FieldUtil {
         Class<?> elementType = matrix.getElementType().orElse(Object.class);
 
         if (elementType == ExtensionObject.class) {
-          return matrix.transform(o -> ((ExtensionObject) o).decode(decoder.getEncodingContext()));
+          return matrix.transform(o -> eagerlyDecodeExtensionObject(decoder, (ExtensionObject) o));
         }
       }
     } catch (Exception e) {
@@ -120,6 +122,29 @@ class FieldUtil {
     }
 
     return value;
+  }
+
+  private static UaStructuredType eagerlyDecodeExtensionObject(
+      UaDecoder decoder, ExtensionObject xo) {
+    int depth = EAGER_DECODE_DEPTH.get();
+    int maxDepth = decoder.getEncodingContext().getEncodingLimits().getMaxRecursionDepth();
+
+    if (depth >= maxDepth) {
+      throw new UaSerializationException(
+          StatusCodes.Bad_EncodingLimitsExceeded,
+          "max eager ExtensionObject decode depth exceeded: " + maxDepth);
+    }
+
+    EAGER_DECODE_DEPTH.set(depth + 1);
+    try {
+      return xo.decode(decoder.getEncodingContext());
+    } finally {
+      if (depth == 0) {
+        EAGER_DECODE_DEPTH.remove();
+      } else {
+        EAGER_DECODE_DEPTH.set(depth);
+      }
+    }
   }
 
   private static Object _decodeFieldValue(

--- a/opc-ua-sdk/sdk-core/src/test/java/org/eclipse/milo/opcua/sdk/core/types/DynamicTypeSerializationTest.java
+++ b/opc-ua-sdk/sdk-core/src/test/java/org/eclipse/milo/opcua/sdk/core/types/DynamicTypeSerializationTest.java
@@ -42,6 +42,7 @@ import java.util.stream.Stream;
 import org.eclipse.milo.opcua.sdk.core.types.DynamicUnionType.UnionValue;
 import org.eclipse.milo.opcua.sdk.core.types.util.DynamicEncodingContext;
 import org.eclipse.milo.opcua.sdk.core.types.util.StaticEncodingContext;
+import org.eclipse.milo.opcua.stack.core.channel.EncodingLimits;
 import org.eclipse.milo.opcua.stack.core.types.UaStructuredType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
@@ -664,6 +665,29 @@ class DynamicTypeSerializationTest {
   }
 
   @Test
+  void eagerExtensionObjectDecodeHonorsMaxRecursionDepth() {
+    var limitedEncodingContext =
+        new DynamicEncodingContext() {
+          @Override
+          public EncodingLimits getEncodingLimits() {
+            return new EncodingLimits(8196, 1, 65535, 4);
+          }
+        };
+
+    ExtensionObject encoded1 = nestedStructWithStructureScalarFields(8);
+
+    DynamicStructType decoded = (DynamicStructType) encoded1.decode(limitedEncodingContext);
+    Object value = decoded.getMembers().get("Struct1");
+
+    for (int i = 0; i < limitedEncodingContext.getEncodingLimits().getMaxRecursionDepth(); i++) {
+      DynamicStructType nested = assertInstanceOf(DynamicStructType.class, value);
+      value = nested.getMembers().get("Struct1");
+    }
+
+    assertInstanceOf(ExtensionObject.class, value);
+  }
+
+  @Test
   void structWithStructureArrayFields() {
     var xo1 = ExtensionObject.encode(staticEncodingContext, new XVType(0.0d, 0.0f));
     var xo2 =
@@ -735,6 +759,14 @@ class DynamicTypeSerializationTest {
     var encoded2 = ExtensionObject.encode(dynamicEncodingContext, decoded);
 
     assertEquals(encoded1, encoded2);
+  }
+
+  private ExtensionObject nestedStructWithStructureScalarFields(int depth) {
+    ExtensionObject leaf = ExtensionObject.encode(staticEncodingContext, new XVType(0.0d, 0.0f));
+    ExtensionObject nested = depth > 0 ? nestedStructWithStructureScalarFields(depth - 1) : leaf;
+
+    return ExtensionObject.encode(
+        staticEncodingContext, new StructWithStructureScalarFields(nested, leaf, leaf));
   }
 
   private static Stream<Arguments> structWithOptionalScalarFieldsProvider() {


### PR DESCRIPTION
### Motivation
- Prevent a denial-of-service vector where dynamic eager decoding recursively decodes nested `ExtensionObject` bodies without honoring the configured recursion budget, causing stack or heap exhaustion.
- Keep existing behavior of eagerly decoding known/expected dynamic types where safe, but ensure a shared recursion budget prevents unbounded nested decodes.

### Description
- Add a thread-local recursion guard `EAGER_DECODE_DEPTH` and helper `eagerlyDecodeExtensionObject(...)` to `FieldUtil` so eager decoding of scalar, array, matrix, and `Variant`-contained `ExtensionObject`s checks `EncodingLimits.getMaxRecursionDepth()` and increments/decrements a local depth counter.
- Replace direct calls to `xo.decode(...)` in `maybeEagerlyDecodeValue(...)` with calls to `eagerlyDecodeExtensionObject(...)` so nested eager decodes share the same per-thread depth budget.
- Add a regression test `eagerExtensionObjectDecodeHonorsMaxRecursionDepth` and helper `nestedStructWithStructureScalarFields(...)` in `DynamicTypeSerializationTest` that constructs nested `ExtensionObject`s and verifies eager decoding halts at the configured depth and leaves deeper values opaque.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08a80d8e7083259cfea496e872d21d)