### PR TITLE
Validate TCP message string lengths

### DIFF
--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/channel/messages/ErrorMessage.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/channel/messages/ErrorMessage.java
@@ -10,9 +10,12 @@
 
 package org.eclipse.milo.opcua.stack.core.channel.messages;
 
-import com.google.common.base.Charsets;
 import com.google.common.base.MoreObjects;
 import io.netty.buffer.ByteBuf;
+import java.nio.charset.StandardCharsets;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.channel.EncodingLimits;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 
 public class ErrorMessage {
@@ -44,7 +47,7 @@ public class ErrorMessage {
     encodeString(message.getReason(), buffer);
   }
 
-  public static ErrorMessage decode(ByteBuf buffer) {
+  public static ErrorMessage decode(ByteBuf buffer) throws UaException {
     return new ErrorMessage(buffer.readUnsignedIntLE(), decodeString(buffer));
   }
 
@@ -52,19 +55,39 @@ public class ErrorMessage {
     if (s == null) {
       buffer.writeIntLE(-1);
     } else {
-      buffer.writeIntLE(s.length());
-      buffer.writeBytes(s.getBytes(Charsets.UTF_8));
+      byte[] bs = s.getBytes(StandardCharsets.UTF_8);
+      buffer.writeIntLE(bs.length);
+      buffer.writeBytes(bs);
     }
   }
 
-  private static String decodeString(ByteBuf buffer) {
+  private static String decodeString(ByteBuf buffer) throws UaException {
     int length = buffer.readIntLE();
-    if (length == -1) {
-      return null;
+    if (length < 0) {
+      if (length == -1) {
+        return null;
+      } else {
+        throw new UaException(
+            StatusCodes.Bad_DecodingError, "invalid error reason length: " + length);
+      }
     } else {
+      if (length > EncodingLimits.DEFAULT_MAX_MESSAGE_SIZE) {
+        throw new UaException(
+            StatusCodes.Bad_EncodingLimitsExceeded,
+            String.format(
+                "error reason length exceeds max message size (length=%s, max=%s)",
+                length, EncodingLimits.DEFAULT_MAX_MESSAGE_SIZE));
+      }
+      if (length > buffer.readableBytes()) {
+        throw new UaException(
+            StatusCodes.Bad_DecodingError,
+            String.format(
+                "error reason length exceeds remaining frame bytes (length=%s, remaining=%s)",
+                length, buffer.readableBytes()));
+      }
       byte[] bs = new byte[length];
       buffer.readBytes(bs);
-      return new String(bs, Charsets.UTF_8);
+      return new String(bs, StandardCharsets.UTF_8);
     }
   }
 }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/channel/messages/HelloMessage.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/channel/messages/HelloMessage.java
@@ -59,8 +59,9 @@ public class HelloMessage {
     checkArgument(receiveBufferSize >= 8192, "receiverBufferSize must be at least 8192 bytes");
     checkArgument(sendBufferSize >= 8192, "sendBufferSize must be at least 8192 bytes");
     checkArgument(
-        endpointUrl == null || endpointUrl.length() <= MAX_ENDPOINT_URL_LENGTH,
-        "endpointUrl length cannot be greater than 4096 bytes");
+        endpointUrl == null
+            || endpointUrl.getBytes(StandardCharsets.UTF_8).length <= MAX_ENDPOINT_URL_LENGTH,
+        "endpointUrl encoded length cannot be greater than 4096 bytes");
 
     this.protocolVersion = protocolVersion;
     this.receiveBufferSize = receiveBufferSize;
@@ -156,8 +157,9 @@ public class HelloMessage {
     if (s == null) {
       buffer.writeIntLE(-1);
     } else {
-      buffer.writeIntLE(s.length());
-      buffer.writeBytes(s.getBytes(StandardCharsets.UTF_8));
+      byte[] bs = s.getBytes(StandardCharsets.UTF_8);
+      buffer.writeIntLE(bs.length);
+      buffer.writeBytes(bs);
     }
   }
 
@@ -174,6 +176,13 @@ public class HelloMessage {
       if (length > MAX_ENDPOINT_URL_LENGTH) {
         throw new UaException(
             StatusCodes.Bad_EncodingLimitsExceeded, "endpoint URL length exceeds 4096: " + length);
+      }
+      if (length > buffer.readableBytes()) {
+        throw new UaException(
+            StatusCodes.Bad_DecodingError,
+            String.format(
+                "endpoint URL length exceeds remaining frame bytes (length=%s, remaining=%s)",
+                length, buffer.readableBytes()));
       }
       byte[] bs = new byte[length];
       buffer.readBytes(bs);

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/channel/messages/ErrorMessageTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/channel/messages/ErrorMessageTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.core.channel.messages;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.channel.EncodingLimits;
+import org.junit.jupiter.api.Test;
+
+public class ErrorMessageTest {
+
+  @Test
+  public void testDecodeFailsWhenReasonLengthIsNegative() {
+    ByteBuf buffer = Unpooled.buffer();
+    buffer.writeIntLE(0);
+    buffer.writeIntLE(-2);
+
+    assertThrows(UaException.class, () -> ErrorMessage.decode(buffer));
+
+    buffer.release();
+  }
+
+  @Test
+  public void testDecodeFailsWhenReasonLengthExceedsEncodingLimit() {
+    ByteBuf buffer = Unpooled.buffer();
+    buffer.writeIntLE(0);
+    buffer.writeIntLE(EncodingLimits.DEFAULT_MAX_MESSAGE_SIZE + 1);
+
+    assertThrows(UaException.class, () -> ErrorMessage.decode(buffer));
+
+    buffer.release();
+  }
+
+  @Test
+  public void testDecodeFailsWhenReasonLengthExceedsReadableBytes() {
+    ByteBuf buffer = Unpooled.buffer();
+    buffer.writeIntLE(0);
+    buffer.writeIntLE(EncodingLimits.DEFAULT_MAX_MESSAGE_SIZE);
+
+    assertThrows(UaException.class, () -> ErrorMessage.decode(buffer));
+
+    buffer.release();
+  }
+}

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/channel/messages/HelloMessageTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/channel/messages/HelloMessageTest.java
@@ -21,6 +21,36 @@ import org.junit.jupiter.api.Test;
 public class HelloMessageTest {
 
   @Test
+  public void testDecodeFailsWhenEndpointUrlLengthIsNegative() {
+    ByteBuf buffer = Unpooled.buffer();
+    buffer.writeIntLE(0);
+    buffer.writeIntLE(8192);
+    buffer.writeIntLE(8192);
+    buffer.writeIntLE(0);
+    buffer.writeIntLE(0);
+    buffer.writeIntLE(-2);
+
+    assertThrows(UaException.class, () -> HelloMessage.decode(buffer));
+
+    buffer.release();
+  }
+
+  @Test
+  public void testDecodeFailsWhenEndpointUrlLengthExceedsReadableBytes() {
+    ByteBuf buffer = Unpooled.buffer();
+    buffer.writeIntLE(0);
+    buffer.writeIntLE(8192);
+    buffer.writeIntLE(8192);
+    buffer.writeIntLE(0);
+    buffer.writeIntLE(0);
+    buffer.writeIntLE(HelloMessage.MAX_ENDPOINT_URL_LENGTH);
+
+    assertThrows(UaException.class, () -> HelloMessage.decode(buffer));
+
+    buffer.release();
+  }
+
+  @Test
   public void testDecodeFailsWhenEndpointUrlTooLarge() throws UaException {
     for (int i = 0; i < HelloMessage.MAX_ENDPOINT_URL_LENGTH * 2; i++) {
       ByteBuf buffer = Unpooled.buffer();


### PR DESCRIPTION
### Motivation

- Fix a remotely-triggerable denial-of-service in OPC UA TCP Hello/Error decoding where attacker-controlled string lengths could cause large/unbounded heap allocations and negative-size allocations. 
- Restore protocol and encoding limits (endpoint URL max bytes and message-size limits) and ensure frame-bounds checking happens before any allocation.

### Description

- `HelloMessage`: validate constructor using UTF-8 encoded byte length, encode endpoint URL using UTF-8 byte length, and in `decode` reject negative lengths, enforce `MAX_ENDPOINT_URL_LENGTH`, and verify the declared length fits in `buffer.readableBytes()` before allocating and reading bytes. 
- `ErrorMessage`: encode reason using UTF-8 byte length, make `decode` throw `UaException`, reject negative lengths, enforce a message-size limit (`EncodingLimits.DEFAULT_MAX_MESSAGE_SIZE`), and verify remaining frame bytes before allocation. 
- Tests: add new `ErrorMessageTest` and extend `HelloMessageTest` with cases for negative lengths, truncated frames, and oversized lengths to cover the regression. 
- Misc: adjust imports and signatures (`throws UaException`) where needed to propagate decoding errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08ea7129408325bd2024b2ac3ea797)