### PR TITLE
Clamp session diagnostics browse names

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/objects/SessionsDiagnosticsSummaryObject.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/objects/SessionsDiagnosticsSummaryObject.java
@@ -36,6 +36,8 @@ import org.slf4j.LoggerFactory;
 
 public class SessionsDiagnosticsSummaryObject extends AbstractLifecycle {
 
+  static final int MAX_BROWSE_NAME_LENGTH = 512;
+
   private final Logger logger = LoggerFactory.getLogger(getClass());
 
   private final Map<NodeId, SessionDiagnosticsObject> sessionDiagnosticsObjects =
@@ -117,12 +119,15 @@ public class SessionsDiagnosticsSummaryObject extends AbstractLifecycle {
 
   private void createSessionDiagnosticsObject(Session session) {
     try {
+      String sessionName = session.getSessionName();
+      QualifiedName browseName = new QualifiedName(1, sessionNameBrowseName(sessionName));
+
       SessionDiagnosticsObjectTypeNode sdoNode =
           (SessionDiagnosticsObjectTypeNode)
               nodeFactory.createNode(
                   new NodeId(1, UUID.randomUUID()), NodeIds.SessionDiagnosticsObjectType);
-      sdoNode.setBrowseName(new QualifiedName(1, session.getSessionName()));
-      sdoNode.setDisplayName(LocalizedText.english(session.getSessionName()));
+      sdoNode.setBrowseName(browseName);
+      sdoNode.setDisplayName(LocalizedText.english(sessionName));
 
       sdoNode.addReference(
           new Reference(
@@ -140,6 +145,14 @@ public class SessionsDiagnosticsSummaryObject extends AbstractLifecycle {
     } catch (UaException e) {
       LoggerFactory.getLogger(getClass()).warn("Failed to create SessionDiagnosticsObject", e);
     }
+  }
+
+  static String sessionNameBrowseName(String sessionName) {
+    if (sessionName != null && sessionName.length() > MAX_BROWSE_NAME_LENGTH) {
+      return sessionName.substring(0, MAX_BROWSE_NAME_LENGTH);
+    }
+
+    return sessionName;
   }
 
   @Override

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/diagnostics/objects/SessionsDiagnosticsSummaryObjectTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/diagnostics/objects/SessionsDiagnosticsSummaryObjectTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.diagnostics.objects;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.junit.jupiter.api.Test;
+
+class SessionsDiagnosticsSummaryObjectTest {
+
+  @Test
+  void sessionNameBrowseNamePreservesValidName() {
+    String sessionName = "session";
+
+    assertSame(sessionName, SessionsDiagnosticsSummaryObject.sessionNameBrowseName(sessionName));
+  }
+
+  @Test
+  void sessionNameBrowseNameTruncatesOverlongName() {
+    String sessionName = "a".repeat(SessionsDiagnosticsSummaryObject.MAX_BROWSE_NAME_LENGTH + 1);
+
+    String browseName = SessionsDiagnosticsSummaryObject.sessionNameBrowseName(sessionName);
+
+    assertEquals(SessionsDiagnosticsSummaryObject.MAX_BROWSE_NAME_LENGTH, browseName.length());
+    assertDoesNotThrow(() -> new QualifiedName(1, browseName));
+  }
+}


### PR DESCRIPTION
### Motivation

- Creating diagnostics nodes used the raw client-controlled session name as a `QualifiedName` BrowseName which throws an unchecked `IllegalArgumentException` for names over 512 characters and could leak sessions/nodes leading to DoS.

### Description

- Add `MAX_BROWSE_NAME_LENGTH = 512` and a helper `sessionNameBrowseName(String)` to truncate session names to the `QualifiedName` limit before constructing the BrowseName.
- Use the truncated value for `sdoNode.setBrowseName(...)` while preserving the original session name for `setDisplayName(...)` so presentation is unchanged.
- Add focused unit tests `SessionsDiagnosticsSummaryObjectTest` that verify valid names are preserved and overlong names are truncated and accepted by `QualifiedName`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08d4540b288325bc78c0b680704c0d)