### PR TITLE
Prevent duplicate event listener registrations

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServer.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServer.java
@@ -19,9 +19,9 @@ import java.net.InetSocketAddress;
 import java.security.KeyPair;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -857,8 +857,8 @@ public class OpcUaServer extends AbstractServiceHandler {
 
   private static class ServerEventNotifier implements EventNotifier {
 
-    private final List<EventListener> eventListeners =
-        Collections.synchronizedList(new ArrayList<>());
+    private final Set<EventListener> eventListeners =
+        Collections.synchronizedSet(new LinkedHashSet<>());
 
     @Override
     public void fire(BaseEventTypeNode event) {

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/ServerEventNotifierTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/ServerEventNotifierTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.reflect.Constructor;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+public class ServerEventNotifierTest {
+
+  @Test
+  public void duplicateRegistrationsAreIgnored() throws Exception {
+    EventNotifier notifier = newServerEventNotifier();
+    AtomicInteger eventCount = new AtomicInteger();
+    EventListener listener = event -> eventCount.incrementAndGet();
+
+    notifier.register(listener);
+    notifier.register(listener);
+    notifier.register(listener);
+
+    notifier.fire(null);
+
+    assertEquals(1, eventCount.get());
+  }
+
+  @Test
+  public void unregisterRemovesDuplicateRegistration() throws Exception {
+    EventNotifier notifier = newServerEventNotifier();
+    AtomicInteger eventCount = new AtomicInteger();
+    EventListener listener = event -> eventCount.incrementAndGet();
+
+    notifier.register(listener);
+    notifier.register(listener);
+    notifier.unregister(listener);
+
+    notifier.fire(null);
+
+    assertEquals(0, eventCount.get());
+  }
+
+  private static EventNotifier newServerEventNotifier() throws Exception {
+    Class<?> notifierClass = Class.forName(OpcUaServer.class.getName() + "$ServerEventNotifier");
+    Constructor<?> constructor = notifierClass.getDeclaredConstructor();
+    constructor.setAccessible(true);
+
+    return (EventNotifier) constructor.newInstance();
+  }
+}


### PR DESCRIPTION
### Motivation
- Fix a regression where the server `EventNotifier` allowed duplicate `EventListener` registrations, enabling a remote client to amplify event delivery work and cause unbounded listener growth (DoS risk). 

### Description
- Replace the `ServerEventNotifier` backing collection from a synchronized `List` to a synchronized `LinkedHashSet` to make `register()` idempotent and prevent duplicate listener entries while preserving insertion order and snapshot-based delivery (`List.copyOf(eventListeners)`).
- Add import for `LinkedHashSet` and change the field type to `Set<EventListener>` in `opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServer.java`.
- Add regression tests in `opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/ServerEventNotifierTest.java` that assert repeated `register()` calls result in a single delivery and that a single `unregister()` removes the listener.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08c485dbb48325a3f92bac9aa8356c)