### PR TITLE
Enforce UserWriteMask for special attribute writes

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/servicesets/impl/DefaultAccessController.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/servicesets/impl/DefaultAccessController.java
@@ -193,7 +193,8 @@ public class DefaultAccessController implements AccessController {
 
           if (roleIds != null && userRolePermissions != null) {
             boolean hasAccess =
-                hasPermission(roleIds, userRolePermissions, PermissionType::getWriteRolePermissions);
+                hasPermission(
+                    roleIds, userRolePermissions, PermissionType::getWriteRolePermissions);
 
             if (!hasAccess) {
               p.result = AccessResult.DENIED_USER_ACCESS;

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/servicesets/impl/DefaultAccessController.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/servicesets/impl/DefaultAccessController.java
@@ -160,34 +160,6 @@ public class DefaultAccessController implements AccessController {
             p.result = AccessResult.DENIED_USER_ACCESS;
           }
         }
-      } else if (AttributeId.RolePermissions.uid().equals(attributeId)) {
-        List<NodeId> roleIds = context.getRoleIds().orElse(null);
-
-        RolePermissionType[] userRolePermissions = attributes.get(nodeId).userRolePermissions();
-
-        if (roleIds != null && userRolePermissions != null) {
-          boolean hasAccess =
-              Stream.of(userRolePermissions)
-                  .anyMatch(rp -> rp.getPermissions().getWriteRolePermissions());
-
-          if (!hasAccess) {
-            p.result = AccessResult.DENIED_USER_ACCESS;
-          }
-        }
-      } else if (AttributeId.Historizing.uid().equals(attributeId)) {
-        List<NodeId> roleIds = context.getRoleIds().orElse(null);
-
-        RolePermissionType[] userRolePermissions = attributes.get(nodeId).userRolePermissions();
-
-        if (roleIds != null && userRolePermissions != null) {
-          boolean hasAccess =
-              Stream.of(userRolePermissions)
-                  .anyMatch(rp -> rp.getPermissions().getWriteHistorizing());
-
-          if (!hasAccess) {
-            p.result = AccessResult.DENIED_USER_ACCESS;
-          }
-        }
       } else {
         UInteger userWriteMask = attributes.get(nodeId).userWriteMask();
         if (userWriteMask != null) {
@@ -198,11 +170,48 @@ public class DefaultAccessController implements AccessController {
           // the WriteAttribute PermissionType bit.
           boolean hasAccess =
               AttributeId.from(attributeId)
-                  .map(id -> userWriteMasks.contains(WriteMask.forAttribute(id)))
+                  .map(
+                      id ->
+                          id != AttributeId.UserRolePermissions
+                              && userWriteMasks.contains(WriteMask.forAttribute(id)))
                   .orElse(false);
 
           if (!hasAccess) {
             p.result = AccessResult.DENIED_USER_ACCESS;
+          }
+        }
+
+        if (p.result.isDenied()) {
+          continue;
+        }
+
+        if (AttributeId.RolePermissions.uid().equals(attributeId)) {
+          List<NodeId> roleIds = context.getRoleIds().orElse(null);
+
+          RolePermissionType[] userRolePermissions = attributes.get(nodeId).userRolePermissions();
+
+          if (roleIds != null && userRolePermissions != null) {
+            boolean hasAccess =
+                Stream.of(userRolePermissions)
+                    .anyMatch(rp -> rp.getPermissions().getWriteRolePermissions());
+
+            if (!hasAccess) {
+              p.result = AccessResult.DENIED_USER_ACCESS;
+            }
+          }
+        } else if (AttributeId.Historizing.uid().equals(attributeId)) {
+          List<NodeId> roleIds = context.getRoleIds().orElse(null);
+
+          RolePermissionType[] userRolePermissions = attributes.get(nodeId).userRolePermissions();
+
+          if (roleIds != null && userRolePermissions != null) {
+            boolean hasAccess =
+                Stream.of(userRolePermissions)
+                    .anyMatch(rp -> rp.getPermissions().getWriteHistorizing());
+
+            if (!hasAccess) {
+              p.result = AccessResult.DENIED_USER_ACCESS;
+            }
           }
         }
       }

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/servicesets/impl/DefaultAccessControllerTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/servicesets/impl/DefaultAccessControllerTest.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.eclipse.milo.opcua.sdk.core.AccessLevel;
+import org.eclipse.milo.opcua.sdk.core.WriteMask;
 import org.eclipse.milo.opcua.sdk.server.servicesets.impl.AccessController.AccessResult;
 import org.eclipse.milo.opcua.sdk.server.servicesets.impl.DefaultAccessController.AccessControlAttributes;
 import org.eclipse.milo.opcua.sdk.server.servicesets.impl.DefaultAccessController.AccessControlContext;
@@ -257,6 +258,115 @@ class DefaultAccessControllerTest {
     assertEquals(AccessResult.DENIED_USER_ACCESS, results.get(wvDisplayName));
     assertEquals(AccessResult.DENIED_USER_ACCESS, results.get(wvDescription));
     assertEquals(AccessResult.DENIED_USER_ACCESS, results.get(wvBrowseName));
+  }
+
+  @Test
+  void checkWriteAccess_RolePermissions_DeniedByUserWriteMask() {
+    var nodeId = new NodeId(1, "foo");
+    var writeValue =
+        new WriteValue(
+            nodeId,
+            AttributeId.RolePermissions.uid(),
+            null,
+            DataValue.valueOnly(Variant.NULL_VALUE));
+
+    attributesMap.put(
+        nodeId,
+        new AccessControlAttributes(
+            null,
+            null,
+            UInteger.MIN,
+            null,
+            null,
+            new RolePermissionType[] {
+              new RolePermissionType(
+                  ROLE_A, PermissionType.of(PermissionType.Field.WriteRolePermissions))
+            }));
+    Mockito.when(context.getRoleIds()).thenReturn(Optional.of(List.of(ROLE_A)));
+
+    AccessResult result =
+        DefaultAccessController.checkWriteAccess(context, List.of(writeValue)).get(writeValue);
+
+    assertEquals(AccessResult.DENIED_USER_ACCESS, result);
+  }
+
+  @Test
+  void checkWriteAccess_Historizing_DeniedByUserWriteMask() {
+    var nodeId = new NodeId(1, "foo");
+    var writeValue =
+        new WriteValue(
+            nodeId, AttributeId.Historizing.uid(), null, DataValue.valueOnly(Variant.NULL_VALUE));
+
+    attributesMap.put(
+        nodeId,
+        new AccessControlAttributes(
+            null,
+            null,
+            UInteger.MIN,
+            null,
+            null,
+            new RolePermissionType[] {
+              new RolePermissionType(
+                  ROLE_A, PermissionType.of(PermissionType.Field.WriteHistorizing))
+            }));
+    Mockito.when(context.getRoleIds()).thenReturn(Optional.of(List.of(ROLE_A)));
+
+    AccessResult result =
+        DefaultAccessController.checkWriteAccess(context, List.of(writeValue)).get(writeValue);
+
+    assertEquals(AccessResult.DENIED_USER_ACCESS, result);
+  }
+
+  @Test
+  void checkWriteAccess_UserRolePermissions_DeniedByUserWriteMask() {
+    var nodeId = new NodeId(1, "foo");
+    var writeValue =
+        new WriteValue(
+            nodeId,
+            AttributeId.UserRolePermissions.uid(),
+            null,
+            DataValue.valueOnly(Variant.NULL_VALUE));
+
+    attributesMap.put(
+        nodeId,
+        new AccessControlAttributes(
+            null, null, UInteger.MAX, null, null, new RolePermissionType[] {}));
+    Mockito.when(context.getRoleIds()).thenReturn(Optional.of(List.of()));
+
+    AccessResult result =
+        DefaultAccessController.checkWriteAccess(context, List.of(writeValue)).get(writeValue);
+
+    assertEquals(AccessResult.DENIED_USER_ACCESS, result);
+  }
+
+  @Test
+  void checkWriteAccess_RolePermissions_AllowedByUserWriteMask() {
+    var nodeId = new NodeId(1, "foo");
+    var writeValue =
+        new WriteValue(
+            nodeId,
+            AttributeId.RolePermissions.uid(),
+            null,
+            DataValue.valueOnly(Variant.NULL_VALUE));
+
+    attributesMap.put(
+        nodeId,
+        new AccessControlAttributes(
+            null,
+            null,
+            UInteger.valueOf(WriteMask.RolePermissions.getValue()),
+            null,
+            null,
+            new RolePermissionType[] {
+              new RolePermissionType(
+                  ROLE_A, PermissionType.of(PermissionType.Field.WriteRolePermissions))
+            }));
+    Mockito.when(context.getRoleIds()).thenReturn(Optional.of(List.of(ROLE_A)));
+
+    AccessResult result =
+        DefaultAccessController.checkWriteAccess(context, List.of(writeValue)).get(writeValue);
+
+    assertEquals(AccessResult.ALLOWED, result);
   }
 
   @Test


### PR DESCRIPTION
### Motivation
- Fix a privilege escalation where writes to authorization-relevant attributes could bypass per-user `UserWriteMask` checks for `RolePermissions` and `Historizing` attributes. 
- Prevent an unchecked `IllegalArgumentException` path when `UserRolePermissions` is evaluated by `WriteMask.forAttribute`. 

### Description
- Apply the `UserWriteMask` check to all non-`Value` attribute writes before running the special-case `RolePermissions` and `Historizing` role-permission checks in `DefaultAccessController`. 
- Treat `UserRolePermissions` as explicitly denied during the `UserWriteMask` evaluation (exclude it from the `WriteMask.forAttribute` lookup) so it cannot trigger `WriteMask.forAttribute`'s `default` exception while preserving non-writability semantics. 
- Retain the existing role-permission checks for `RolePermissions` and `Historizing` after the `UserWriteMask` check and short-circuit further checks when `UserWriteMask` denies access. 
- Add regression tests in `DefaultAccessControllerTest` that cover denial and allowance scenarios for `RolePermissions`, `Historizing`, and `UserRolePermissions` w.r.t. `UserWriteMask`. 

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a089bc457d88325ae9d1039d85fcb84)