### PR TITLE
Fix OptionSet variant JSON encoding for empty arrays and scalars

### DIFF
--- a/opc-ua-stack/encoding-json/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoder.java
+++ b/opc-ua-stack/encoding-json/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoder.java
@@ -40,6 +40,10 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Matrix;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.OptionSetUI16;
+import org.eclipse.milo.opcua.stack.core.types.builtin.OptionSetUI32;
+import org.eclipse.milo.opcua.stack.core.types.builtin.OptionSetUI64;
+import org.eclipse.milo.opcua.stack.core.types.builtin.OptionSetUI8;
 import org.eclipse.milo.opcua.stack.core.types.builtin.OptionSetUInteger;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
@@ -851,12 +855,10 @@ public class OpcUaJsonEncoder implements UaEncoder, AutoCloseable {
     } else if (typeHint == TypeHint.STRUCT) {
       typeId = OpcUaDataType.ExtensionObject.getTypeId();
     } else if (typeHint == TypeHint.OPTION_SET) {
-      // TODO this would fail on empty array
-      //  would be better to have size-specific OptionSetUI subclasses, e.g. OptionSetUI8,
-      // OptionSetUI16, etc...
-      Object os = Array.get(value, 0);
-      Object osv = ((OptionSetUInteger<?>) os).getValue();
-      typeId = OpcUaDataType.getBuiltinTypeId(osv.getClass());
+      // Derive typeId from the OptionSet subclass. This works for single values,
+      // non-empty arrays, and empty arrays alike (the previous implementation peeked
+      // at element 0, which threw on empty arrays and on non-array values).
+      typeId = optionSetBuiltinTypeId(valueClass);
     } else {
       typeId = OpcUaDataType.getBuiltinTypeId(valueClass);
     }
@@ -1032,6 +1034,21 @@ public class OpcUaJsonEncoder implements UaEncoder, AutoCloseable {
       return ArrayUtil.getType(o);
     } else {
       return o.getClass();
+    }
+  }
+
+  private static int optionSetBuiltinTypeId(Class<?> optionSetClass) {
+    if (OptionSetUI8.class.isAssignableFrom(optionSetClass)) {
+      return OpcUaDataType.Byte.getTypeId();
+    } else if (OptionSetUI16.class.isAssignableFrom(optionSetClass)) {
+      return OpcUaDataType.UInt16.getTypeId();
+    } else if (OptionSetUI32.class.isAssignableFrom(optionSetClass)) {
+      return OpcUaDataType.UInt32.getTypeId();
+    } else if (OptionSetUI64.class.isAssignableFrom(optionSetClass)) {
+      return OpcUaDataType.UInt64.getTypeId();
+    } else {
+      throw new UaSerializationException(
+          StatusCodes.Bad_EncodingError, "unknown OptionSet subclass: " + optionSetClass.getName());
     }
   }
 

--- a/opc-ua-stack/encoding-json/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoderTest.java
+++ b/opc-ua-stack/encoding-json/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoderTest.java
@@ -977,6 +977,56 @@ class OpcUaJsonEncoderTest {
   }
 
   @Test
+  void encodeVariantOptionSet() throws Exception {
+    try (var encoder = new OpcUaJsonEncoder(context)) {
+      // Single OptionSet value: typeId is taken from the subclass (OptionSetUI8 -> Byte=3).
+      encoder.encodeVariant(null, new Variant(new AccessLevelType(ubyte(5))));
+      assertEquals("{\"Type\":3,\"Body\":5}", encoder.getOutputString());
+
+      // Non-empty UI8 array: regression coverage for the existing path.
+      encoder.reset();
+      var nonEmptyUi8 =
+          new AccessLevelType[] {new AccessLevelType(ubyte(1)), new AccessLevelType(ubyte(2))};
+      encoder.encodeVariant(null, new Variant(nonEmptyUi8));
+      assertEquals("{\"Type\":3,\"Body\":[1,2]}", encoder.getOutputString());
+
+      // Non-empty UI16 array: confirms element encoding for 16-bit OptionSets.
+      encoder.reset();
+      var nonEmptyUi16 =
+          new AccessRestrictionType[] {
+            new AccessRestrictionType(ushort(1)), new AccessRestrictionType(ushort(2))
+          };
+      encoder.encodeVariant(null, new Variant(nonEmptyUi16));
+      assertEquals("{\"Type\":5,\"Body\":[1,2]}", encoder.getOutputString());
+
+      // Non-empty UI32 array: confirms element encoding for 32-bit OptionSets.
+      encoder.reset();
+      var nonEmptyUi32 =
+          new AttributeWriteMask[] {
+            new AttributeWriteMask(uint(1)), new AttributeWriteMask(uint(2))
+          };
+      encoder.encodeVariant(null, new Variant(nonEmptyUi32));
+      assertEquals("{\"Type\":7,\"Body\":[1,2]}", encoder.getOutputString());
+
+      // Empty UI8 array: previously threw ArrayIndexOutOfBoundsException because
+      // the encoder peeked at element 0 to derive the typeId.
+      encoder.reset();
+      encoder.encodeVariant(null, new Variant(new AccessLevelType[0]));
+      assertEquals("{\"Type\":3,\"Body\":[]}", encoder.getOutputString());
+
+      // Empty UI16 array: confirms typeId derivation via subclass for 16-bit OptionSets.
+      encoder.reset();
+      encoder.encodeVariant(null, new Variant(new AccessRestrictionType[0]));
+      assertEquals("{\"Type\":5,\"Body\":[]}", encoder.getOutputString());
+
+      // Empty UI32 array: confirms typeId derivation via subclass for 32-bit OptionSets.
+      encoder.reset();
+      encoder.encodeVariant(null, new Variant(new AttributeWriteMask[0]));
+      assertEquals("{\"Type\":7,\"Body\":[]}", encoder.getOutputString());
+    }
+  }
+
+  @Test
   void encodeDiagnosticInfo() throws Exception {
     try (var encoder = new OpcUaJsonEncoder(context)) {
       var diagnosticInfo = new DiagnosticInfo(0, 1, 2, 3, "foo", null, null);


### PR DESCRIPTION
- [x] You have signed an Eclipse Contributor Agreement and are committing using the same email address
- [x] Your code contains any tests relevant to the problem you are solving
- [x] All new and existing tests passed
- [x] Code follows the style guidelines and Checkstyle passes

The `OPTION_SET` branch in `OpcUaJsonEncoder.encodeVariantValue` derived the JSON `typeId` by calling `Array.get(value, 0)` on the variant value. This failed in two real cases: empty arrays threw `ArrayIndexOutOfBoundsException`, and single (non-array) `OptionSet` values threw `IllegalArgumentException("Argument is not an array")`. The latter is reachable via the existing scalar pattern in production code, e.g. `new Variant(defaultAccessRestrictions)` in `NamespaceMetadataTypeNode`.

Derive the `typeId` from the value's class instead, using the existing `OptionSetUI8`/`UI16`/`UI32`/`UI64` subclasses — the approach the original TODO comment in this branch proposed. `OptionSetUI64` is supported preemptively even though no DataType in stack-core currently extends it.

Test coverage in `OpcUaJsonEncoderTest.encodeVariantOptionSet` covers the width × cardinality matrix for the OptionSet subclasses in current use: scalar UI8, non-empty UI8/UI16/UI32, and empty UI8/UI16/UI32.