### PR TITLE
Align JSON encoding with OPC UA 1.05 Compact/Verbose rules

### DIFF
--- a/opc-ua-stack/encoding-json/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonDecoder.java
+++ b/opc-ua-stack/encoding-json/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonDecoder.java
@@ -576,14 +576,41 @@ public class OpcUaJsonDecoder implements UaDecoder {
         }
       }
 
-      if (jsonReader.peek() == JsonToken.NUMBER) {
+      JsonToken token = jsonReader.peek();
+      if (token == JsonToken.NUMBER) {
         long value = jsonReader.nextLong();
 
         return new StatusCode(value);
+      } else if (token == JsonToken.BEGIN_OBJECT) {
+        long code = 0L;
+
+        jsonReader.beginObject();
+        while (jsonReader.peek() == JsonToken.NAME) {
+          String nextName = nextName();
+          if (nextName == null) continue;
+
+          switch (nextName) {
+            case "Code":
+              code = jsonReader.nextLong();
+              break;
+            case "Symbol":
+              // Symbol is informational only — the numeric Code is authoritative.
+              jsonReader.nextString();
+              break;
+            default:
+              jsonReader.skipValue();
+              break;
+          }
+        }
+        jsonReader.endObject();
+
+        return new StatusCode(code);
+      } else if (token == JsonToken.NULL) {
+        jsonReader.nextNull();
+        return StatusCode.GOOD;
       } else {
         throw new UaSerializationException(
-            StatusCodes.Bad_DecodingError,
-            "readStatusCode: unexpected token: " + jsonReader.peek());
+            StatusCodes.Bad_DecodingError, "readStatusCode: unexpected token: " + token);
       }
     } catch (IOException e) {
       throw new UaSerializationException(StatusCodes.Bad_DecodingError, e);
@@ -613,8 +640,14 @@ public class OpcUaJsonDecoder implements UaDecoder {
       }
 
       if (s.startsWith("nsu=")) {
-        String uri = s.substring(4, s.indexOf(";"));
-        String name = s.substring(s.indexOf(";") + 1);
+        int sep = s.indexOf(";");
+        if (sep < 0) {
+          throw new UaSerializationException(
+              StatusCodes.Bad_DecodingError,
+              "readQualifiedName: malformed 'nsu=' value (missing ';'): " + s);
+        }
+        String uri = s.substring(4, sep);
+        String name = s.substring(sep + 1);
         UShort index = context.getNamespaceTable().getIndex(uri);
 
         if (index == null) {
@@ -640,6 +673,11 @@ public class OpcUaJsonDecoder implements UaDecoder {
           this.peekedNextName = nextName;
           return LocalizedText.NULL_VALUE;
         }
+      }
+
+      if (jsonReader.peek() == JsonToken.NULL) {
+        jsonReader.nextNull();
+        return LocalizedText.NULL_VALUE;
       }
 
       jsonReader.beginObject();
@@ -693,27 +731,26 @@ public class OpcUaJsonDecoder implements UaDecoder {
 
       NodeId encodingId = null;
       int encoding = 0;
-      Object body = null;
+      // Buffer the body as a generic JsonElement so the encoding doesn't have to be known
+      // until the whole object has been read — JSON field order isn't guaranteed.
+      JsonElement bodyElement = null;
 
       while (jsonReader.peek() == JsonToken.NAME) {
         String nextName = nextName();
         if (nextName == null) continue;
 
         switch (nextName) {
+          case "UaTypeId":
           case "TypeId":
             encodingId = decodeNodeId(null);
             break;
+          case "UaEncoding":
           case "Encoding":
             encoding = jsonReader.nextInt();
             break;
+          case "UaBody":
           case "Body":
-            body =
-                switch (encoding) {
-                  case 0 -> JsonParser.parseReader(jsonReader);
-                  case 1 -> decodeByteString(null);
-                  case 2 -> decodeXmlElement(null);
-                  default -> body;
-                };
+            bodyElement = JsonParser.parseReader(jsonReader);
             break;
           default:
             throw new UaSerializationException(
@@ -727,26 +764,24 @@ public class OpcUaJsonDecoder implements UaDecoder {
       if (encodingId == null) {
         throw new UaSerializationException(
             StatusCodes.Bad_DecodingError, "readExtensionObject: encodingId == null");
-      } else {
-        return switch (encoding) {
-          case 0 -> {
-            assert body instanceof JsonElement;
-            yield ExtensionObject.of(body.toString(), encodingId);
-          }
-          case 1 -> {
-            assert body instanceof ByteString;
-            yield ExtensionObject.of((ByteString) body, encodingId);
-          }
-          case 2 -> {
-            assert body instanceof XmlElement;
-            yield ExtensionObject.of((XmlElement) body, encodingId);
-          }
-          default ->
-              throw new UaSerializationException(
-                  StatusCodes.Bad_DecodingError,
-                  "readExtensionObject: unexpected encoding: " + encoding);
-        };
       }
+
+      return switch (encoding) {
+        case 0 ->
+            ExtensionObject.of(bodyElement == null ? "null" : bodyElement.toString(), encodingId);
+        case 1 -> {
+          String base64 = bodyElement == null ? "" : bodyElement.getAsString();
+          yield ExtensionObject.of(ByteString.of(Base64.getDecoder().decode(base64)), encodingId);
+        }
+        case 2 -> {
+          String xml = bodyElement == null ? "" : bodyElement.getAsString();
+          yield ExtensionObject.of(new XmlElement(xml), encodingId);
+        }
+        default ->
+            throw new UaSerializationException(
+                StatusCodes.Bad_DecodingError,
+                "readExtensionObject: unexpected encoding: " + encoding);
+      };
     } catch (IOException e) {
       throw new UaSerializationException(StatusCodes.Bad_DecodingError, e);
     }
@@ -818,6 +853,11 @@ public class OpcUaJsonDecoder implements UaDecoder {
         }
       }
 
+      if (jsonReader.peek() == JsonToken.NULL) {
+        jsonReader.nextNull();
+        return Variant.NULL_VALUE;
+      }
+
       jsonReader.beginObject();
 
       int typeId = 0;
@@ -829,9 +869,11 @@ public class OpcUaJsonDecoder implements UaDecoder {
         if (nextName == null) continue;
 
         switch (nextName) {
+          case "UaType":
           case "Type":
             typeId = jsonReader.nextInt();
             break;
+          case "Value":
           case "Body":
             bodyElement = JsonParser.parseReader(jsonReader);
             break;
@@ -1011,10 +1053,10 @@ public class OpcUaJsonDecoder implements UaDecoder {
 
       jsonReader.beginObject();
 
-      int symbolicId = 0;
-      int namespaceUri = 0;
-      int locale = 0;
-      int localizedText = 0;
+      int symbolicId = -1;
+      int namespaceUri = -1;
+      int locale = -1;
+      int localizedText = -1;
       String additionalInfo = null;
       StatusCode innerStatusCode = null;
       DiagnosticInfo innerDiagnosticInfo = null;

--- a/opc-ua-stack/encoding-json/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoder.java
+++ b/opc-ua-stack/encoding-json/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoder.java
@@ -15,6 +15,7 @@ import java.io.*;
 import java.lang.reflect.Array;
 import java.time.format.DateTimeFormatter;
 import java.util.Base64;
+import java.util.Optional;
 import java.util.Stack;
 import java.util.UUID;
 import java.util.function.BiConsumer;
@@ -40,6 +41,10 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Matrix;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.OptionSetUI16;
+import org.eclipse.milo.opcua.stack.core.types.builtin.OptionSetUI32;
+import org.eclipse.milo.opcua.stack.core.types.builtin.OptionSetUI64;
+import org.eclipse.milo.opcua.stack.core.types.builtin.OptionSetUI8;
 import org.eclipse.milo.opcua.stack.core.types.builtin.OptionSetUInteger;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
@@ -379,6 +384,10 @@ public class OpcUaJsonEncoder implements UaEncoder, AutoCloseable {
     // String values shall be encoded as JSON strings.
     // Any characters which are not allowed in JSON strings are escaped
     // using the rules defined in RFC 7159.
+    //
+    // String is a nullable built-in type (OPC 10000-6 Table 1), so per §5.4.2.1 only a NULL
+    // value is omitted in CompactEncoding. An empty string is a present value and is encoded
+    // as "" — do not conflate empty with null.
 
     try {
       EncoderContext context = contextPeek();
@@ -412,7 +421,9 @@ public class OpcUaJsonEncoder implements UaEncoder, AutoCloseable {
           jsonWriter.name(field);
         }
 
-        if (value.getJavaInstant().isBefore(DateTime.MIN_ISO_8601_INSTANT)) {
+        if (value == null) {
+          jsonWriter.value(DateTime.MIN_ISO_8601_STRING);
+        } else if (value.getJavaInstant().isBefore(DateTime.MIN_ISO_8601_INSTANT)) {
           jsonWriter.value(DateTime.MIN_ISO_8601_STRING);
         } else if (value.getJavaInstant().isAfter(DateTime.MAX_ISO_8601_INSTANT)) {
           jsonWriter.value(DateTime.MAX_ISO_8601_STRING);
@@ -427,18 +438,23 @@ public class OpcUaJsonEncoder implements UaEncoder, AutoCloseable {
 
   @Override
   public void encodeGuid(String field, UUID value) throws UaSerializationException {
+    // Guid is omitted in CompactEncoding only when it equals the default all-zero value; a Guid
+    // with either 64-bit half being non-zero is a real value and must be written.
     try {
       EncoderContext context = contextPeek();
       if (encoding == Encoding.VERBOSE
           || context == EncoderContext.BUILTIN
           || (value != null
-              && value.getLeastSignificantBits() != 0L
-              && value.getMostSignificantBits() != 0L)) {
+              && (value.getLeastSignificantBits() != 0L || value.getMostSignificantBits() != 0L))) {
 
         if (field != null) {
           jsonWriter.name(field);
         }
-        jsonWriter.value(value.toString().toUpperCase());
+        if (value == null) {
+          jsonWriter.value(new UUID(0L, 0L).toString().toUpperCase());
+        } else {
+          jsonWriter.value(value.toString().toUpperCase());
+        }
       }
     } catch (IOException e) {
       throw new UaSerializationException(StatusCodes.Bad_EncodingError, e);
@@ -447,10 +463,14 @@ public class OpcUaJsonEncoder implements UaEncoder, AutoCloseable {
 
   @Override
   public void encodeByteString(String field, ByteString value) throws UaSerializationException {
-    // ByteString values shall be formatted as a Base64 text and encoded as
-    // a JSON string.
-    // Any characters which are not allowed in JSON strings are escaped
-    // using the rules defined in RFC 7159.
+    // ByteString values shall be formatted as a Base64 text and encoded as a JSON string.
+    //
+    // Any characters that are not allowed in JSON strings are escaped using the rules defined in
+    // RFC 7159.
+    //
+    // ByteString is a nullable built-in type (OPC 10000-6 Table 1), so per §5.4.2.1 only a NULL
+    // value is omitted in CompactEncoding. A zero-length ByteString is a present value and is
+    // encoded as the Base64 of an empty array ("").
 
     try {
       EncoderContext context = contextPeek();
@@ -460,7 +480,8 @@ public class OpcUaJsonEncoder implements UaEncoder, AutoCloseable {
         if (field != null) {
           jsonWriter.name(field);
         }
-        jsonWriter.value(Base64.getEncoder().encodeToString(value.bytesOrEmpty()));
+        jsonWriter.value(
+            value == null ? "" : Base64.getEncoder().encodeToString(value.bytesOrEmpty()));
       }
     } catch (IOException e) {
       throw new UaSerializationException(StatusCodes.Bad_EncodingError, e);
@@ -477,7 +498,7 @@ public class OpcUaJsonEncoder implements UaEncoder, AutoCloseable {
         if (field != null) {
           jsonWriter.name(field);
         }
-        jsonWriter.value(value.getFragmentOrEmpty());
+        jsonWriter.value(value == null ? "" : value.getFragmentOrEmpty());
       }
     } catch (IOException e) {
       throw new UaSerializationException(StatusCodes.Bad_EncodingError, e);
@@ -496,16 +517,18 @@ public class OpcUaJsonEncoder implements UaEncoder, AutoCloseable {
           jsonWriter.name(field);
         }
 
+        NodeId effective = value != null ? value : NodeId.NULL_VALUE;
+
         ExpandedNodeId expanded;
         try {
-          expanded = value.expanded(encodingContext.getNamespaceTable());
+          expanded = effective.expanded(encodingContext.getNamespaceTable());
         } catch (IllegalStateException e) {
           // This is kind of similar to what's required of the decoder when it encounters a
           // namespace URI it can't map to a namespace index:
           // "When decoders need to replace a NamespaceUri with a NamespaceIndex and the
           // NamespaceUri cannot be mapped to a NamespaceIndex, then decoders shall use 0 for the
           // NamespaceIndex, String for the IdType and the JSON string as the Identifier."
-          expanded = ExpandedNodeId.of(value.toParseableString());
+          expanded = ExpandedNodeId.of(effective.toParseableString());
         }
         jsonWriter.value(expanded.toParseableString());
       }
@@ -526,6 +549,10 @@ public class OpcUaJsonEncoder implements UaEncoder, AutoCloseable {
 
         if (field != null) {
           jsonWriter.name(field);
+        }
+
+        if (value == null) {
+          value = ExpandedNodeId.NULL_VALUE;
         }
 
         var sb = new StringBuilder();
@@ -594,19 +621,10 @@ public class OpcUaJsonEncoder implements UaEncoder, AutoCloseable {
 
   @Override
   public void encodeStatusCode(String field, StatusCode value) throws UaSerializationException {
-    // # Compact
-    // StatusCode values shall be encoded as a JSON number.
-    //
-    // # Verbose
-    // StatusCode values shall be encoded as a JSON object with the fields defined as follows:
-    // - "Code"
-    // The numeric code encoded as a JSON number.
-    // The Code is omitted if the numeric code is 0 (Good).
-    // - "Symbol"
-    // The string literal associated with the numeric code encoded as JSON string. e.g. 0x80AB0000
-    // has the associated literal "BadInvalidArgument".
-    // The Symbol is omitted if the numeric code is 0 (Good).
-    // If the string literal is not known to the encoder the field is omitted.
+    // Per OPC 10000-6 §5.4.2.12, StatusCode is encoded as a JSON object with fields:
+    //   - "Code": numeric code; omitted when 0 (Good).
+    //   - "Symbol": string literal; always omitted in CompactEncoding, omitted when 0 (Good),
+    //     and omitted in VerboseEncoding when the literal is not known to the encoder.
 
     try {
       EncoderContext context = contextPeek();
@@ -614,28 +632,23 @@ public class OpcUaJsonEncoder implements UaEncoder, AutoCloseable {
           || context == EncoderContext.BUILTIN
           || (value != null && !value.isGood())) {
 
-        long code = value.value();
+        long code = value == null ? 0L : value.value();
 
-        if (encoding == Encoding.COMPACT) {
-          if (field != null) {
-            jsonWriter.name(field);
-          }
+        if (field != null) {
+          jsonWriter.name(field);
+        }
 
-          jsonWriter.value(code);
-        } else {
-          if (code != 0L) {
-            if (field != null) {
-              jsonWriter.name(field);
+        jsonWriter.beginObject();
+        if (code != 0L) {
+          jsonWriter.name("Code").value(code);
+          if (encoding == Encoding.VERBOSE) {
+            Optional<String[]> symbol = StatusCodes.lookup(code);
+            if (symbol.isPresent()) {
+              jsonWriter.name("Symbol").value(symbol.get()[0]);
             }
-
-            String symbol = StatusCodes.lookup(code).map(ss -> ss[0]).orElse("");
-
-            jsonWriter.beginObject();
-            jsonWriter.name("Code").value(code);
-            jsonWriter.name("Symbol").value(symbol);
-            jsonWriter.endObject();
           }
         }
+        jsonWriter.endObject();
       }
     } catch (IOException e) {
       throw new UaSerializationException(StatusCodes.Bad_EncodingError, e);
@@ -654,6 +667,11 @@ public class OpcUaJsonEncoder implements UaEncoder, AutoCloseable {
 
         if (field != null) {
           jsonWriter.name(field);
+        }
+
+        if (value == null || value.isNull()) {
+          jsonWriter.nullValue();
+          return;
         }
 
         int index = value.namespaceIndex().intValue();
@@ -690,6 +708,9 @@ public class OpcUaJsonEncoder implements UaEncoder, AutoCloseable {
         }
 
         if (value == null || value.isNull()) {
+          // LocalizedText is a nullable built-in type (OPC 10000-6 Table 1), so per §5.4.2.1 a
+          // null value is encoded as JSON null in VerboseEncoding and as a null array element in
+          // BUILTIN context. The empty-object form is specific to ExtensionObject (§5.4.2.16).
           jsonWriter.nullValue();
           return;
         }
@@ -714,26 +735,30 @@ public class OpcUaJsonEncoder implements UaEncoder, AutoCloseable {
 
     try {
       EncoderContext context = contextPeek();
-      if (context == EncoderContext.BUILTIN || value != null) {
+      if (encoding == Encoding.VERBOSE || context == EncoderContext.BUILTIN || value != null) {
         if (field != null) {
           jsonWriter.name(field);
         }
 
         if (value == null) {
-          jsonWriter.nullValue();
+          if (encoding == Encoding.VERBOSE) {
+            jsonWriter.beginObject();
+            jsonWriter.endObject();
+          } else {
+            jsonWriter.nullValue();
+          }
         } else {
-          value.getBody();
           jsonWriter.beginObject();
 
-          encodeNodeId("TypeId", value.getEncodingOrTypeId());
+          encodeNodeId("UaTypeId", value.getEncodingOrTypeId());
           if (value instanceof ExtensionObject.Json xo) {
-            jsonWriter.name("Body").jsonValue(xo.getBody());
+            jsonWriter.name("UaBody").jsonValue(xo.getBody());
           } else if (value instanceof ExtensionObject.Binary xo) {
-            jsonWriter.name("Encoding").value(1);
-            encodeByteString("Body", xo.getBody());
+            jsonWriter.name("UaEncoding").value(1);
+            encodeByteString("UaBody", xo.getBody());
           } else if (value instanceof ExtensionObject.Xml xo) {
-            jsonWriter.name("Encoding").value(2);
-            encodeXmlElement("Body", xo.getBody());
+            jsonWriter.name("UaEncoding").value(2);
+            encodeXmlElement("UaBody", xo.getBody());
           }
 
           jsonWriter.endObject();
@@ -747,12 +772,18 @@ public class OpcUaJsonEncoder implements UaEncoder, AutoCloseable {
   @Override
   public void encodeDataValue(String field, DataValue value) throws UaSerializationException {
     try {
-      if (allFieldsAreOmitted(value)) {
+      if (encoding == Encoding.COMPACT && (value == null || allFieldsAreOmitted(value))) {
         return;
       }
 
       if (field != null) {
         jsonWriter.name(field);
+      }
+
+      if (value == null) {
+        jsonWriter.beginObject();
+        jsonWriter.endObject();
+        return;
       }
 
       contextPush(EncoderContext.BUILTIN);
@@ -804,11 +835,18 @@ public class OpcUaJsonEncoder implements UaEncoder, AutoCloseable {
 
   @Override
   public void encodeVariant(String field, Variant value) throws UaSerializationException {
-    if (value.isNull()) {
-      return;
-    }
-
     try {
+      if (value == null || value.isNull()) {
+        EncoderContext context = contextPeek();
+        if (context == EncoderContext.BUILTIN || encoding == Encoding.VERBOSE) {
+          if (field != null) {
+            jsonWriter.name(field);
+          }
+          jsonWriter.nullValue();
+        }
+        return;
+      }
+
       if (field != null) {
         jsonWriter.name(field);
       }
@@ -851,12 +889,10 @@ public class OpcUaJsonEncoder implements UaEncoder, AutoCloseable {
     } else if (typeHint == TypeHint.STRUCT) {
       typeId = OpcUaDataType.ExtensionObject.getTypeId();
     } else if (typeHint == TypeHint.OPTION_SET) {
-      // TODO this would fail on empty array
-      //  would be better to have size-specific OptionSetUI subclasses, e.g. OptionSetUI8,
-      // OptionSetUI16, etc...
-      Object os = Array.get(value, 0);
-      Object osv = ((OptionSetUInteger<?>) os).getValue();
-      typeId = OpcUaDataType.getBuiltinTypeId(osv.getClass());
+      // Derive the backing UInteger type from the OptionSet class hierarchy so that empty
+      // arrays still resolve a type id without needing an element to inspect.
+      Class<?> backing = optionSetBackingClass(valueClass);
+      typeId = OpcUaDataType.getBuiltinTypeId(backing);
     } else {
       typeId = OpcUaDataType.getBuiltinTypeId(valueClass);
     }
@@ -864,8 +900,8 @@ public class OpcUaJsonEncoder implements UaEncoder, AutoCloseable {
     if (value.getClass().isArray()) {
       jsonWriter.beginObject();
 
-      jsonWriter.name("Type").value(typeId);
-      jsonWriter.name("Body");
+      jsonWriter.name("UaType").value(typeId);
+      jsonWriter.name("Value");
       int length = Array.getLength(value);
 
       jsonWriter.beginArray();
@@ -880,8 +916,8 @@ public class OpcUaJsonEncoder implements UaEncoder, AutoCloseable {
     } else if (value instanceof Matrix m) {
       jsonWriter.beginObject();
 
-      jsonWriter.name("Type").value(typeId);
-      jsonWriter.name("Body");
+      jsonWriter.name("UaType").value(typeId);
+      jsonWriter.name("Value");
 
       Object flatArray = m.getElements();
       int length = Array.getLength(flatArray);
@@ -903,8 +939,8 @@ public class OpcUaJsonEncoder implements UaEncoder, AutoCloseable {
       jsonWriter.endObject();
     } else {
       jsonWriter.beginObject();
-      jsonWriter.name("Type").value(typeId);
-      jsonWriter.name("Body");
+      jsonWriter.name("UaType").value(typeId);
+      jsonWriter.name("Value");
 
       encodeVariantBodyValue(value, typeHint, typeId);
 
@@ -1035,6 +1071,16 @@ public class OpcUaJsonEncoder implements UaEncoder, AutoCloseable {
     }
   }
 
+  private static Class<?> optionSetBackingClass(Class<?> optionSetClass) {
+    if (OptionSetUI8.class.isAssignableFrom(optionSetClass)) return UByte.class;
+    if (OptionSetUI16.class.isAssignableFrom(optionSetClass)) return UShort.class;
+    if (OptionSetUI32.class.isAssignableFrom(optionSetClass)) return UInteger.class;
+    if (OptionSetUI64.class.isAssignableFrom(optionSetClass)) return ULong.class;
+    throw new UaSerializationException(
+        StatusCodes.Bad_EncodingError,
+        "no OptionSetUI8/16/32/64 ancestor for " + optionSetClass.getName());
+  }
+
   @Override
   public void encodeDiagnosticInfo(String field, DiagnosticInfo value)
       throws UaSerializationException {
@@ -1045,14 +1091,23 @@ public class OpcUaJsonEncoder implements UaEncoder, AutoCloseable {
           jsonWriter.name(field);
         }
 
-        contextPush(EncoderContext.BUILTIN);
+        if (value == null) {
+          jsonWriter.beginObject();
+          jsonWriter.endObject();
+          return;
+        }
+
+        contextPush(EncoderContext.STRUCT);
         jsonWriter.beginObject();
-        encodeInt32("SymbolicId", value.symbolicId());
-        encodeInt32("NamespaceUri", value.namespaceUri());
-        encodeInt32("Locale", value.locale());
-        encodeInt32("LocalizedText", value.localizedText());
+        encodeDiagnosticInfoInt32("SymbolicId", value.symbolicId());
+        encodeDiagnosticInfoInt32("NamespaceUri", value.namespaceUri());
+        encodeDiagnosticInfoInt32("Locale", value.locale());
+        encodeDiagnosticInfoInt32("LocalizedText", value.localizedText());
         encodeString("AdditionalInfo", value.additionalInfo());
         if (value.innerStatusCode() != null) {
+          // Per OPC 10000-6 §5.4.2.13 InnerStatusCode is omitted when Good. Encoding in the
+          // surrounding STRUCT context honors that rule: CompactEncoding omits a Good code,
+          // while VerboseEncoding still emits the field.
           encodeStatusCode("InnerStatusCode", value.innerStatusCode());
         }
         if (value.innerDiagnosticInfo() != null) {
@@ -1066,8 +1121,23 @@ public class OpcUaJsonEncoder implements UaEncoder, AutoCloseable {
     }
   }
 
+  /**
+   * Encode a DiagnosticInfo Int32 field whose default value is -1 (per OPC 10000-6 §5.4.2.13).
+   * Omitted in COMPACT when equal to -1; always written in VERBOSE.
+   */
+  private void encodeDiagnosticInfoInt32(String field, int value) throws IOException {
+    if (encoding == Encoding.VERBOSE || value != -1) {
+      jsonWriter.name(field).value(value);
+    }
+  }
+
   @Override
   public void encodeMessage(String field, UaMessageType message) throws UaSerializationException {
+    if (message == null) {
+      throw new UaSerializationException(
+          StatusCodes.Bad_EncodingError, "encodeMessage: message is null");
+    }
+
     ExpandedNodeId xEncodingId = message.getJsonEncodingId();
 
     NodeId encodingId =
@@ -1081,8 +1151,8 @@ public class OpcUaJsonEncoder implements UaEncoder, AutoCloseable {
 
     try {
       jsonWriter.beginObject();
-      encodeNodeId("TypeId", encodingId);
-      encodeStruct("Body", message, encodingId);
+      encodeNodeId("UaTypeId", encodingId);
+      encodeStruct("UaBody", message, encodingId);
       jsonWriter.endObject();
     } catch (IOException e) {
       throw new UaSerializationException(StatusCodes.Bad_EncodingError, e);
@@ -1121,6 +1191,11 @@ public class OpcUaJsonEncoder implements UaEncoder, AutoCloseable {
   public void encodeStruct(String field, UaStructuredType value, NodeId dataTypeId)
       throws UaSerializationException {
 
+    if (value == null) {
+      throw new UaSerializationException(
+          StatusCodes.Bad_EncodingError, "encodeStruct: value is null");
+    }
+
     DataTypeCodec codec = encodingContext.getDataTypeManager().getCodec(dataTypeId);
 
     if (codec == null) {
@@ -1146,6 +1221,11 @@ public class OpcUaJsonEncoder implements UaEncoder, AutoCloseable {
   @Override
   public void encodeStruct(String field, UaStructuredType value, DataTypeCodec codec)
       throws UaSerializationException {
+
+    if (value == null) {
+      throw new UaSerializationException(
+          StatusCodes.Bad_EncodingError, "encodeStruct: value is null");
+    }
 
     try {
       if (field != null) {
@@ -1341,11 +1421,16 @@ public class OpcUaJsonEncoder implements UaEncoder, AutoCloseable {
         jsonWriter.name(field);
       }
 
-      jsonWriter.beginArray();
-      for (T value : values) {
-        encoder.accept(null, value);
+      contextPush(EncoderContext.BUILTIN);
+      try {
+        jsonWriter.beginArray();
+        for (T value : values) {
+          encoder.accept(null, value);
+        }
+        jsonWriter.endArray();
+      } finally {
+        contextPop();
       }
-      jsonWriter.endArray();
     } catch (IOException e) {
       throw new UaSerializationException(StatusCodes.Bad_EncodingError, e);
     }
@@ -1363,7 +1448,7 @@ public class OpcUaJsonEncoder implements UaEncoder, AutoCloseable {
           jsonWriter.name(field);
         }
 
-        Object flatArray = value.getElements();
+        Object flatArray = value == null ? null : value.getElements();
 
         if (flatArray == null) {
           try {
@@ -1416,7 +1501,7 @@ public class OpcUaJsonEncoder implements UaEncoder, AutoCloseable {
           jsonWriter.name(field);
         }
 
-        Object flatArray = value.getElements();
+        Object flatArray = value == null ? null : value.getElements();
 
         if (flatArray == null) {
           try {
@@ -1468,7 +1553,7 @@ public class OpcUaJsonEncoder implements UaEncoder, AutoCloseable {
           jsonWriter.name(field);
         }
 
-        Object flatArray = value.getElements();
+        Object flatArray = value == null ? null : value.getElements();
 
         if (flatArray == null) {
           try {

--- a/opc-ua-stack/encoding-json/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonDecoderTest.java
+++ b/opc-ua-stack/encoding-json/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonDecoderTest.java
@@ -12,6 +12,7 @@ package org.eclipse.milo.opcua.stack.core.encoding.json;
 
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -828,6 +829,18 @@ class OpcUaJsonDecoderTest {
     decoder.jsonReader.endObject();
   }
 
+  /**
+   * Round-trip companion to {@code OpcUaJsonEncoderTest.encodeVariantArray_nullElementWritesNull}:
+   * the encoder writes JSON null for null Variant array elements, so the decoder must accept it.
+   */
+  @Test
+  void decodeVariant_acceptsJsonNull() throws IOException {
+    var decoder = new OpcUaJsonDecoder(context, new StringReader(""));
+
+    decoder.reset(new StringReader("null"));
+    assertEquals(Variant.NULL_VALUE, decoder.decodeVariant(null));
+  }
+
   @Test
   void decodeDiagnosticInfo() throws IOException {
     var decoder = new OpcUaJsonDecoder(context, new StringReader(""));
@@ -1006,6 +1019,94 @@ class OpcUaJsonDecoderTest {
     decoder.reset(new StringReader("{\"Array\":[{\"Value\":1.0}],\"Dimensions\":[2147483647]}"));
     assertThrows(
         UaSerializationException.class, () -> decoder.decodeStructMatrix(null, XVType.TYPE_ID));
+  }
+
+  // ------------------------------------------------------------------------
+  // Spec-compliance tests for behaviors defined in section 5.4 of OPC 10000-6.
+  // Each test documents the spec rule it covers.
+  // ------------------------------------------------------------------------
+
+  /**
+   * Issue: {@code decodeStatusCode} only handles {@code JsonToken.NUMBER}, but the encoder emits
+   * VERBOSE StatusCode as a JSON object ({@code {"Code":..., "Symbol":"..."}}). The decoder must be
+   * symmetric.
+   */
+  @Test
+  void decodeStatusCode_verboseObject() throws IOException {
+    var decoder = new OpcUaJsonDecoder(context, new StringReader(""));
+
+    decoder.reset(new StringReader("{\"Code\":1083310080,\"Symbol\":\"Uncertain_InitialValue\"}"));
+    assertEquals(
+        new StatusCode(StatusCodes.Uncertain_InitialValue), decoder.decodeStatusCode(null));
+
+    decoder.reset(new StringReader("{}"));
+    assertEquals(StatusCode.GOOD, decoder.decodeStatusCode(null));
+  }
+
+  /**
+   * Issue: {@code decodeLocalizedText} unconditionally calls {@code jsonReader.beginObject()}
+   * without first checking for {@code JsonToken.NULL}. The encoder emits bare {@code null} for a
+   * null LocalizedText (see {@link
+   * OpcUaJsonEncoderTest#encodeLocalizedTextVerbose_nullProducesJsonNull()}), so this is a
+   * round-trip hazard.
+   */
+  @Test
+  void decodeLocalizedText_acceptsJsonNull() throws IOException {
+    var decoder = new OpcUaJsonDecoder(context, new StringReader(""));
+
+    decoder.reset(new StringReader("null"));
+    // Should be tolerated and return a null-valued LocalizedText, not throw.
+    LocalizedText result = assertDoesNotThrow(() -> decoder.decodeLocalizedText(null));
+    assertEquals(LocalizedText.NULL_VALUE, result);
+  }
+
+  /**
+   * Issue: {@code decodeExtensionObject} switches on {@code encoding} when reading {@code Body}.
+   * JSON object field order is not guaranteed; if {@code Body} appears before {@code Encoding}, the
+   * wrong branch is taken.
+   */
+  @Test
+  void decodeExtensionObject_bodyBeforeEncoding() throws IOException {
+    context.getNamespaceTable().add("urn:eclipse:milo:test1");
+    context.getNamespaceTable().add("urn:eclipse:milo:test2");
+
+    var decoder = new OpcUaJsonDecoder(context, new StringReader(""));
+
+    var byteStringXo =
+        ExtensionObject.of(ByteString.of(new byte[] {0x00, 0x01, 0x02, 0x03}), new NodeId(2, 42));
+
+    // Body field appears BEFORE Encoding field.
+    decoder.reset(
+        new StringReader(
+            "{\"TypeId\":\"nsu=urn:eclipse:milo:test2;i=42\",\"Body\":\"AAECAw==\",\"Encoding\":1}"));
+    assertEquals(byteStringXo, decoder.decodeExtensionObject(null));
+  }
+
+  /**
+   * Issue: {@code decodeDiagnosticInfo} initializes its Int32 locals to 0, so omitted fields decode
+   * to 0 instead of the spec-defined default -1.
+   *
+   * <p>Round-trip: encode {@link DiagnosticInfo#NULL_VALUE} (all -1) → omit all Int32 fields per
+   * spec → decode back should yield NULL_VALUE again.
+   */
+  @Test
+  void decodeDiagnosticInfo_omittedInt32FieldsDefaultToMinusOne() throws IOException {
+    var decoder = new OpcUaJsonDecoder(context, new StringReader("{}"));
+
+    DiagnosticInfo decoded = decoder.decodeDiagnosticInfo(null);
+    assertEquals(DiagnosticInfo.NULL_VALUE, decoded);
+  }
+
+  /**
+   * Issue 20: a QualifiedName encoded with a malformed {@code "nsu="} prefix that is missing the
+   * {@code ';'} separator must surface as a {@link UaSerializationException} instead of a raw
+   * {@link StringIndexOutOfBoundsException}.
+   */
+  @Test
+  void decodeQualifiedName_malformedNsuRejected() {
+    var decoder = new OpcUaJsonDecoder(context, new StringReader("\"nsu=urn:no-semicolon-here\""));
+
+    assertThrows(UaSerializationException.class, () -> decoder.decodeQualifiedName(null));
   }
 
   private static byte[] randomBytes16() {

--- a/opc-ua-stack/encoding-json/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoderTest.java
+++ b/opc-ua-stack/encoding-json/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoderTest.java
@@ -13,7 +13,9 @@ package org.eclipse.milo.opcua.stack.core.encoding.json;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ubyte;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.temporal.ChronoUnit;
 import java.util.Base64;
@@ -673,24 +675,25 @@ class OpcUaJsonEncoderTest {
     try (var encoder = new OpcUaJsonEncoder(context)) {
       encoder.encoding = Encoding.COMPACT;
 
-      // compact form without field
+      // COMPACT form: object with Symbol always omitted; Code omitted when 0 (Good).
       encoder.encodeStatusCode(null, StatusCode.GOOD);
-      assertEquals("0", encoder.getOutputString());
+      assertEquals("{}", encoder.getOutputString());
 
       encoder.reset();
       encoder.encodeStatusCode(null, new StatusCode(StatusCodes.Uncertain_InitialValue));
-      assertEquals(Long.toString(StatusCodes.Uncertain_InitialValue), encoder.getOutputString());
+      assertEquals(
+          "{\"Code\":" + StatusCodes.Uncertain_InitialValue + "}", encoder.getOutputString());
 
       encoder.reset();
       encoder.encodeStatusCode(null, new StatusCode(StatusCodes.Bad_UnexpectedError));
-      assertEquals(Long.toString(StatusCodes.Bad_UnexpectedError), encoder.getOutputString());
+      assertEquals("{\"Code\":" + StatusCodes.Bad_UnexpectedError + "}", encoder.getOutputString());
 
-      // compact form with field
+      // BUILTIN context (raw beginObject): field always emitted; GOOD becomes {}.
       encoder.reset();
       encoder.jsonWriter.beginObject();
       encoder.encodeStatusCode("foo", StatusCode.GOOD);
       encoder.jsonWriter.endObject();
-      assertEquals("{\"foo\":0}", encoder.getOutputString());
+      assertEquals("{\"foo\":{}}", encoder.getOutputString());
     }
   }
 
@@ -699,9 +702,9 @@ class OpcUaJsonEncoderTest {
     try (var encoder = new OpcUaJsonEncoder(context)) {
       encoder.encoding = Encoding.VERBOSE;
 
-      // verbose form without field
+      // verbose form without field; GOOD encodes as {} (Code/Symbol omitted when code==0)
       encoder.encodeStatusCode(null, StatusCode.GOOD);
-      assertEquals("", encoder.getOutputString());
+      assertEquals("{}", encoder.getOutputString());
 
       encoder.reset();
       encoder.encodeStatusCode(null, new StatusCode(StatusCodes.Uncertain_InitialValue));
@@ -713,12 +716,12 @@ class OpcUaJsonEncoderTest {
       assertEquals(
           "{\"Code\":2147549184,\"Symbol\":\"Bad_UnexpectedError\"}", encoder.getOutputString());
 
-      // verbose form with field
+      // verbose form with field; field still emitted with empty object body
       encoder.reset();
       encoder.jsonWriter.beginObject();
       encoder.encodeStatusCode("foo", StatusCode.GOOD);
       encoder.jsonWriter.endObject();
-      assertEquals("{}", encoder.getOutputString()); // key/value omitted because code==0
+      assertEquals("{\"foo\":{}}", encoder.getOutputString());
 
       encoder.reset();
       encoder.jsonWriter.beginObject();
@@ -807,19 +810,19 @@ class OpcUaJsonEncoderTest {
 
       encoder.encodeExtensionObject(null, jsonStringXo);
       assertEquals(
-          "{\"TypeId\":\"nsu=urn:eclipse:milo:test2;i=42\",\"Body\":{\"foo\":\"bar\",\"baz\":42}}",
+          "{\"UaTypeId\":\"nsu=urn:eclipse:milo:test2;i=42\",\"UaBody\":{\"foo\":\"bar\",\"baz\":42}}",
           encoder.getOutputString());
 
       encoder.reset();
       encoder.encodeExtensionObject(null, xmlElementXo);
       assertEquals(
-          "{\"TypeId\":\"nsu=urn:eclipse:milo:test2;i=42\",\"Encoding\":2,\"Body\":\"<foo>bar</foo>\"}",
+          "{\"UaTypeId\":\"nsu=urn:eclipse:milo:test2;i=42\",\"UaEncoding\":2,\"UaBody\":\"<foo>bar</foo>\"}",
           encoder.getOutputString());
 
       encoder.reset();
       encoder.encodeExtensionObject(null, byteStringXo);
       assertEquals(
-          "{\"TypeId\":\"nsu=urn:eclipse:milo:test2;i=42\",\"Encoding\":1,\"Body\":\"AAECAw==\"}",
+          "{\"UaTypeId\":\"nsu=urn:eclipse:milo:test2;i=42\",\"UaEncoding\":1,\"UaBody\":\"AAECAw==\"}",
           encoder.getOutputString());
 
       encoder.reset();
@@ -846,7 +849,7 @@ class OpcUaJsonEncoderTest {
       encoder.encodeDataValue(null, allFieldsValue);
       assertEquals(
           String.format(
-              "{\"Value\":{\"Type\":12,\"Body\":\"foo\"},\"Status\":3080192,\"SourceTimestamp\":\"%s\",\"SourcePicoseconds\":100,\"ServerTimestamp\":\"%s\",\"ServerPicoseconds\":200}",
+              "{\"Value\":{\"UaType\":12,\"Value\":\"foo\"},\"Status\":{\"Code\":3080192},\"SourceTimestamp\":\"%s\",\"SourcePicoseconds\":100,\"ServerTimestamp\":\"%s\",\"ServerPicoseconds\":200}",
               isoNow, isoNow),
           encoder.getOutputString());
 
@@ -855,7 +858,7 @@ class OpcUaJsonEncoderTest {
       encoder.encodeDataValue(null, allFieldsValue.copy(b -> b.setValue(Variant.NULL_VALUE)));
       assertEquals(
           String.format(
-              "{\"Status\":3080192,\"SourceTimestamp\":\"%s\",\"SourcePicoseconds\":100,\"ServerTimestamp\":\"%s\",\"ServerPicoseconds\":200}",
+              "{\"Status\":{\"Code\":3080192},\"SourceTimestamp\":\"%s\",\"SourcePicoseconds\":100,\"ServerTimestamp\":\"%s\",\"ServerPicoseconds\":200}",
               isoNow, isoNow),
           encoder.getOutputString());
 
@@ -864,7 +867,7 @@ class OpcUaJsonEncoderTest {
       encoder.encodeDataValue(null, allFieldsValue.copy(b -> b.setStatus(StatusCode.GOOD)));
       assertEquals(
           String.format(
-              "{\"Value\":{\"Type\":12,\"Body\":\"foo\"},\"SourceTimestamp\":\"%s\",\"SourcePicoseconds\":100,\"ServerTimestamp\":\"%s\",\"ServerPicoseconds\":200}",
+              "{\"Value\":{\"UaType\":12,\"Value\":\"foo\"},\"SourceTimestamp\":\"%s\",\"SourcePicoseconds\":100,\"ServerTimestamp\":\"%s\",\"ServerPicoseconds\":200}",
               isoNow, isoNow),
           encoder.getOutputString());
 
@@ -873,7 +876,7 @@ class OpcUaJsonEncoderTest {
       encoder.encodeDataValue(null, allFieldsValue.copy(b -> b.setSourceTime(null)));
       assertEquals(
           String.format(
-              "{\"Value\":{\"Type\":12,\"Body\":\"foo\"},\"Status\":3080192,\"SourcePicoseconds\":100,\"ServerTimestamp\":\"%s\",\"ServerPicoseconds\":200}",
+              "{\"Value\":{\"UaType\":12,\"Value\":\"foo\"},\"Status\":{\"Code\":3080192},\"SourcePicoseconds\":100,\"ServerTimestamp\":\"%s\",\"ServerPicoseconds\":200}",
               isoNow),
           encoder.getOutputString());
 
@@ -882,7 +885,7 @@ class OpcUaJsonEncoderTest {
       encoder.encodeDataValue(null, allFieldsValue.copy(b -> b.setSourcePicoseconds(null)));
       assertEquals(
           String.format(
-              "{\"Value\":{\"Type\":12,\"Body\":\"foo\"},\"Status\":3080192,\"SourceTimestamp\":\"%s\",\"ServerTimestamp\":\"%s\",\"ServerPicoseconds\":200}",
+              "{\"Value\":{\"UaType\":12,\"Value\":\"foo\"},\"Status\":{\"Code\":3080192},\"SourceTimestamp\":\"%s\",\"ServerTimestamp\":\"%s\",\"ServerPicoseconds\":200}",
               isoNow, isoNow),
           encoder.getOutputString());
 
@@ -891,7 +894,7 @@ class OpcUaJsonEncoderTest {
       encoder.encodeDataValue(null, allFieldsValue.copy(b -> b.setServerTime(null)));
       assertEquals(
           String.format(
-              "{\"Value\":{\"Type\":12,\"Body\":\"foo\"},\"Status\":3080192,\"SourceTimestamp\":\"%s\",\"SourcePicoseconds\":100,\"ServerPicoseconds\":200}",
+              "{\"Value\":{\"UaType\":12,\"Value\":\"foo\"},\"Status\":{\"Code\":3080192},\"SourceTimestamp\":\"%s\",\"SourcePicoseconds\":100,\"ServerPicoseconds\":200}",
               isoNow),
           encoder.getOutputString());
 
@@ -900,7 +903,7 @@ class OpcUaJsonEncoderTest {
       encoder.encodeDataValue(null, allFieldsValue.copy(b -> b.setServerPicoseconds(null)));
       assertEquals(
           String.format(
-              "{\"Value\":{\"Type\":12,\"Body\":\"foo\"},\"Status\":3080192,\"SourceTimestamp\":\"%s\",\"SourcePicoseconds\":100,\"ServerTimestamp\":\"%s\"}",
+              "{\"Value\":{\"UaType\":12,\"Value\":\"foo\"},\"Status\":{\"Code\":3080192},\"SourceTimestamp\":\"%s\",\"SourcePicoseconds\":100,\"ServerTimestamp\":\"%s\"}",
               isoNow, isoNow),
           encoder.getOutputString());
 
@@ -924,24 +927,25 @@ class OpcUaJsonEncoderTest {
       context.getNamespaceTable().add("urn:eclipse:milo:test1");
 
       encoder.encodeVariant(null, new Variant(true));
-      assertEquals("{\"Type\":1,\"Body\":true}", encoder.getOutputString());
+      assertEquals("{\"UaType\":1,\"Value\":true}", encoder.getOutputString());
 
       encoder.reset();
       encoder.encodeVariant(null, new Variant(new QualifiedName(1, "foo")));
       assertEquals(
-          "{\"Type\":20,\"Body\":\"nsu=urn:eclipse:milo:test1;foo\"}", encoder.getOutputString());
+          "{\"UaType\":20,\"Value\":\"nsu=urn:eclipse:milo:test1;foo\"}",
+          encoder.getOutputString());
 
       encoder.reset();
       encoder.encodeVariant(
           null, new Variant(new Variant[] {new Variant("foo"), new Variant("bar")}));
       assertEquals(
-          "{\"Type\":24,\"Body\":[{\"Type\":12,\"Body\":\"foo\"},{\"Type\":12,\"Body\":\"bar\"}]}",
+          "{\"UaType\":24,\"Value\":[{\"UaType\":12,\"Value\":\"foo\"},{\"UaType\":12,\"Value\":\"bar\"}]}",
           encoder.getOutputString());
 
       encoder.reset();
       encoder.encodeVariant(null, new Variant(Matrix.ofInt32(new int[][] {{0, 1}, {2, 3}})));
       assertEquals(
-          "{\"Type\":6,\"Body\":[0,1,2,3],\"Dimensions\":[2,2]}", encoder.getOutputString());
+          "{\"UaType\":6,\"Value\":[0,1,2,3],\"Dimensions\":[2,2]}", encoder.getOutputString());
 
       int[] value1d = {0, 1, 2, 3};
       int[][] value2d = {
@@ -961,17 +965,17 @@ class OpcUaJsonEncoderTest {
 
       encoder.reset();
       encoder.encodeVariant(null, new Variant(value1d));
-      assertEquals("{\"Type\":6,\"Body\":[0,1,2,3]}", encoder.getOutputString());
+      assertEquals("{\"UaType\":6,\"Value\":[0,1,2,3]}", encoder.getOutputString());
 
       encoder.reset();
       encoder.encodeVariant(null, new Variant(Matrix.ofInt32(value2d)));
       assertEquals(
-          "{\"Type\":6,\"Body\":[0,2,3,1,3,4],\"Dimensions\":[2,3]}", encoder.getOutputString());
+          "{\"UaType\":6,\"Value\":[0,2,3,1,3,4],\"Dimensions\":[2,3]}", encoder.getOutputString());
 
       encoder.reset();
       encoder.encodeVariant(null, new Variant(Matrix.ofInt32(value3d)));
       assertEquals(
-          "{\"Type\":6,\"Body\":[0,1,2,3,4,5,6,7],\"Dimensions\":[2,2,2]}",
+          "{\"UaType\":6,\"Value\":[0,1,2,3,4,5,6,7],\"Dimensions\":[2,2,2]}",
           encoder.getOutputString());
     }
   }
@@ -991,8 +995,9 @@ class OpcUaJsonEncoderTest {
 
       encoder.reset();
       encoder.encodeDiagnosticInfo(null, nestedDiagnosticInfo);
+      // InnerStatusCode is Good (0); per OPC 10000-6 §5.4.2.13 it is omitted in CompactEncoding.
       assertEquals(
-          "{\"SymbolicId\":5,\"NamespaceUri\":4,\"Locale\":6,\"LocalizedText\":7,\"AdditionalInfo\":\"bar\",\"InnerStatusCode\":0,\"InnerDiagnosticInfo\":{\"SymbolicId\":1,\"NamespaceUri\":0,\"Locale\":2,\"LocalizedText\":3,\"AdditionalInfo\":\"foo\"}}",
+          "{\"SymbolicId\":5,\"NamespaceUri\":4,\"Locale\":6,\"LocalizedText\":7,\"AdditionalInfo\":\"bar\",\"InnerDiagnosticInfo\":{\"SymbolicId\":1,\"NamespaceUri\":0,\"Locale\":2,\"LocalizedText\":3,\"AdditionalInfo\":\"foo\"}}",
           encoder.getOutputString());
 
       encoder.reset();
@@ -1020,7 +1025,7 @@ class OpcUaJsonEncoderTest {
 
       encoder.encodeMessage(null, message);
       assertEquals(
-          "{\"TypeId\":\"i=15257\",\"Body\":{\"RequestHeader\":{\"Timestamp\":\"1601-01-01T00:00:00Z\",\"AuditEntryId\":\"foo\"},\"TimestampsToReturn\":2,\"NodesToRead\":[{\"NodeId\":\"i=1\",\"AttributeId\":13}]}}",
+          "{\"UaTypeId\":\"i=15257\",\"UaBody\":{\"RequestHeader\":{\"Timestamp\":\"1601-01-01T00:00:00Z\",\"AuditEntryId\":\"foo\"},\"TimestampsToReturn\":2,\"NodesToRead\":[{\"NodeId\":\"i=1\",\"AttributeId\":13}]}}",
           encoder.getOutputString());
     }
   }
@@ -1233,6 +1238,442 @@ class OpcUaJsonEncoderTest {
       assertEquals(
           "{\"Array\":[{\"Value\":1.0},{\"X\":2.0,\"Value\":3.0},{\"X\":4.0,\"Value\":5.0},{\"X\":6.0,\"Value\":7.0}],\"Dimensions\":[2,2]}",
           encoder.getOutputString());
+    }
+  }
+
+  // ------------------------------------------------------------------------
+  // Spec-compliance tests for behaviors defined in section 5.4 of OPC 10000-6.
+  // Each test documents the spec rule it covers.
+  // ------------------------------------------------------------------------
+
+  /**
+   * Issue: {@code encodeArray} does not push BUILTIN context, so primitive array elements with
+   * default values (0, false, empty string, null) are silently dropped when the array is encoded
+   * inside a struct.
+   *
+   * <p>Spec 5.4 (arrays): "Any value for a nullable Built-In type that is NULL shall be encoded as
+   * the JSON literal 'null' if the value is an element of a JSON array." Non-nullable defaults like
+   * 0 must also be preserved as array elements — array elements are not subject to struct
+   * field-omission rules.
+   */
+  @Test
+  void encodeUInt32ArrayInsideStruct_preservesZeros() throws Exception {
+    try (var encoder = new OpcUaJsonEncoder(context)) {
+      var arg =
+          new Argument(
+              "foo",
+              NodeIds.Int32,
+              2,
+              new UInteger[] {uint(0), uint(1), uint(0)},
+              LocalizedText.english("desc"));
+
+      encoder.encodeStruct(null, arg, Argument.TYPE_ID);
+
+      String output = encoder.getOutputString();
+      assertTrue(
+          output.contains("\"ArrayDimensions\":[0,1,0]"),
+          "ArrayDimensions zeros should be preserved; got: " + output);
+    }
+  }
+
+  /**
+   * Issue: same as the previous test but with all elements at the default. Even an array of zeros
+   * must be preserved as {@code [0,0,0]} — not collapsed to {@code []}.
+   */
+  @Test
+  void encodeUInt32ArrayInsideStruct_preservesAllZeros() throws Exception {
+    try (var encoder = new OpcUaJsonEncoder(context)) {
+      var arg =
+          new Argument(
+              "foo",
+              NodeIds.Int32,
+              2,
+              new UInteger[] {uint(0), uint(0), uint(0)},
+              LocalizedText.english("desc"));
+
+      encoder.encodeStruct(null, arg, Argument.TYPE_ID);
+
+      String output = encoder.getOutputString();
+      assertTrue(
+          output.contains("\"ArrayDimensions\":[0,0,0]"),
+          "An all-zero UInteger[] must round-trip as [0,0,0]; got: " + output);
+    }
+  }
+
+  /**
+   * Issue: {@code encodeVariant} returns silently when {@code value.isNull()}. Inside a {@code
+   * Variant[]}, this corrupts the array — the null entry simply disappears instead of being encoded
+   * as JSON {@code null}.
+   *
+   * <p>Spec 5.4: NULL elements of an array shall be encoded as the JSON literal {@code null}.
+   */
+  @Test
+  void encodeVariantArray_nullElementWritesNull() throws Exception {
+    try (var encoder = new OpcUaJsonEncoder(context)) {
+      encoder.encodeVariantArray(
+          null, new Variant[] {new Variant("foo"), Variant.NULL_VALUE, new Variant("bar")});
+
+      String output = encoder.getOutputString();
+      // Expect three elements; null variant should appear as JSON null between the two strings.
+      assertEquals(
+          "[{\"UaType\":12,\"Value\":\"foo\"},null,{\"UaType\":12,\"Value\":\"bar\"}]", output);
+    }
+  }
+
+  /**
+   * Issue: {@code encodeDateTime} dereferences {@code value.getJavaInstant()} without a null check
+   * when in VERBOSE/BUILTIN context. Passing null should not throw NPE.
+   */
+  @Test
+  void encodeDateTime_nullInVerboseDoesNotThrow() throws Exception {
+    try (var encoder = new OpcUaJsonEncoder(context)) {
+      encoder.encoding = Encoding.VERBOSE;
+      assertDoesNotThrow(() -> encoder.encodeDateTime(null, null));
+    }
+  }
+
+  /** Issue: {@code encodeStatusCode} NPE on null value in VERBOSE/BUILTIN. */
+  @Test
+  void encodeStatusCode_nullInVerboseDoesNotThrow() throws Exception {
+    try (var encoder = new OpcUaJsonEncoder(context)) {
+      encoder.encoding = Encoding.VERBOSE;
+      assertDoesNotThrow(() -> encoder.encodeStatusCode(null, null));
+    }
+  }
+
+  /** Issue: {@code encodeXmlElement} NPE on null value in VERBOSE/BUILTIN. */
+  @Test
+  void encodeXmlElement_nullInVerboseDoesNotThrow() throws Exception {
+    try (var encoder = new OpcUaJsonEncoder(context)) {
+      encoder.encoding = Encoding.VERBOSE;
+      assertDoesNotThrow(() -> encoder.encodeXmlElement(null, null));
+    }
+  }
+
+  /** Issue: {@code encodeByteString} NPE on null value in VERBOSE/BUILTIN. */
+  @Test
+  void encodeByteString_nullInVerboseDoesNotThrow() throws Exception {
+    try (var encoder = new OpcUaJsonEncoder(context)) {
+      encoder.encoding = Encoding.VERBOSE;
+      assertDoesNotThrow(() -> encoder.encodeByteString(null, null));
+    }
+  }
+
+  /** Issue: {@code encodeGuid} NPE on null value in VERBOSE/BUILTIN. */
+  @Test
+  void encodeGuid_nullInVerboseDoesNotThrow() throws Exception {
+    try (var encoder = new OpcUaJsonEncoder(context)) {
+      encoder.encoding = Encoding.VERBOSE;
+      assertDoesNotThrow(() -> encoder.encodeGuid(null, null));
+    }
+  }
+
+  /** Issue: {@code encodeNodeId} NPE on null value in VERBOSE/BUILTIN. */
+  @Test
+  void encodeNodeId_nullInVerboseDoesNotThrow() throws Exception {
+    try (var encoder = new OpcUaJsonEncoder(context)) {
+      encoder.encoding = Encoding.VERBOSE;
+      assertDoesNotThrow(() -> encoder.encodeNodeId(null, null));
+    }
+  }
+
+  /** Issue: {@code encodeExpandedNodeId} NPE on null value in VERBOSE/BUILTIN. */
+  @Test
+  void encodeExpandedNodeId_nullInVerboseDoesNotThrow() throws Exception {
+    try (var encoder = new OpcUaJsonEncoder(context)) {
+      encoder.encoding = Encoding.VERBOSE;
+      assertDoesNotThrow(() -> encoder.encodeExpandedNodeId(null, null));
+    }
+  }
+
+  /** Issue: {@code encodeQualifiedName} NPE on null value in VERBOSE/BUILTIN. */
+  @Test
+  void encodeQualifiedName_nullInVerboseDoesNotThrow() throws Exception {
+    try (var encoder = new OpcUaJsonEncoder(context)) {
+      encoder.encoding = Encoding.VERBOSE;
+      assertDoesNotThrow(() -> encoder.encodeQualifiedName(null, null));
+    }
+  }
+
+  /** Issue: {@code encodeDiagnosticInfo} NPE on null value in VERBOSE/BUILTIN. */
+  @Test
+  void encodeDiagnosticInfo_nullInVerboseDoesNotThrow() throws Exception {
+    try (var encoder = new OpcUaJsonEncoder(context)) {
+      encoder.encoding = Encoding.VERBOSE;
+      assertDoesNotThrow(() -> encoder.encodeDiagnosticInfo(null, null));
+    }
+  }
+
+  /** Issue: {@code encodeMatrix} NPE on null value in VERBOSE/BUILTIN. */
+  @Test
+  void encodeMatrix_nullInVerboseDoesNotThrow() throws Exception {
+    try (var encoder = new OpcUaJsonEncoder(context)) {
+      encoder.encoding = Encoding.VERBOSE;
+      assertDoesNotThrow(() -> encoder.encodeMatrix(null, null));
+    }
+  }
+
+  /**
+   * Issue: {@code encodeStatusCode} VERBOSE branch silently writes nothing when code == 0, even
+   * though the outer condition decided we are emitting this field. The field should appear as an
+   * (empty) StatusCode representation in VERBOSE.
+   */
+  @Test
+  void encodeStatusCodeVerbose_goodInsideStructEmitsField() throws Exception {
+    try (var encoder = new OpcUaJsonEncoder(context)) {
+      encoder.encoding = Encoding.VERBOSE;
+
+      encoder.jsonWriter.beginObject();
+      encoder.encodeStatusCode("foo", StatusCode.GOOD);
+      encoder.jsonWriter.endObject();
+
+      // Spec: VERBOSE always emits the field. With code==0 the inner Code/Symbol are omitted,
+      // so the value is the empty object {}.
+      String output = encoder.getOutputString();
+      assertTrue(
+          output.startsWith("{\"foo\":"),
+          "Expected field 'foo' to be emitted in VERBOSE; got: " + output);
+    }
+  }
+
+  /**
+   * Issue: {@code encodeStatusCode} VERBOSE writes {@code "Symbol":""} when the numeric code has no
+   * associated literal. Spec 5.4.2.12: "If the string literal is not known to the encoder the field
+   * is omitted."
+   */
+  @Test
+  void encodeStatusCodeVerbose_unknownSymbolOmitted() throws Exception {
+    try (var encoder = new OpcUaJsonEncoder(context)) {
+      encoder.encoding = Encoding.VERBOSE;
+
+      // Pick a code unlikely to have a registered symbol.
+      long unknownCode = 0x7FFF_0000L;
+      encoder.encodeStatusCode(null, new StatusCode(unknownCode));
+
+      String output = encoder.getOutputString();
+      assertEquals(
+          "{\"Code\":" + unknownCode + "}",
+          output,
+          "Symbol field should be omitted when literal is unknown");
+    }
+  }
+
+  /**
+   * Issue: {@code encodeDataValue} short-circuits in VERBOSE when all fields are at their defaults,
+   * emitting nothing instead of an (empty) DataValue object.
+   */
+  @Test
+  void encodeDataValueVerbose_allDefaultsStillEmitsField() throws Exception {
+    try (var encoder = new OpcUaJsonEncoder(context)) {
+      encoder.encoding = Encoding.VERBOSE;
+
+      encoder.jsonWriter.beginObject();
+      encoder.encodeDataValue("foo", new DataValue(Variant.NULL_VALUE, StatusCode.GOOD, null));
+      encoder.jsonWriter.endObject();
+
+      String output = encoder.getOutputString();
+      assertTrue(
+          output.startsWith("{\"foo\":"),
+          "VERBOSE DataValue should emit the field even when all values are default; got: "
+              + output);
+    }
+  }
+
+  /**
+   * Issue: {@code encodeDiagnosticInfo} uses 0 as the default for {@code SymbolicId}, {@code
+   * NamespaceUri}, {@code Locale}, and {@code LocalizedText}. Per spec these default to -1 and are
+   * omitted only when equal to -1.
+   *
+   * <p>A NULL_VALUE DiagnosticInfo (all -1) should encode as {@code {}} in COMPACT.
+   */
+  @Test
+  void encodeDiagnosticInfo_nullValueOmitsInt32Fields() throws Exception {
+    try (var encoder = new OpcUaJsonEncoder(context)) {
+      encoder.encodeDiagnosticInfo(null, DiagnosticInfo.NULL_VALUE);
+      assertEquals("{}", encoder.getOutputString());
+    }
+  }
+
+  /**
+   * Issue (companion to the above): a DiagnosticInfo with explicit zeros must keep those zeros — 0
+   * is a valid, non-default index into the response string table.
+   *
+   * <p>Also asserts that null AdditionalInfo is omitted in COMPACT (sub-bug of the same root cause:
+   * the {@code BUILTIN} context push inside {@code encodeDiagnosticInfo} disables all
+   * field-omission rules).
+   */
+  @Test
+  void encodeDiagnosticInfo_zeroIndicesAreWritten() throws Exception {
+    try (var encoder = new OpcUaJsonEncoder(context)) {
+      var diag = new DiagnosticInfo(0, 0, 0, 0, null, null, null);
+      encoder.encodeDiagnosticInfo(null, diag);
+
+      String output = encoder.getOutputString();
+      assertEquals(
+          "{\"SymbolicId\":0,\"NamespaceUri\":0,\"Locale\":0,\"LocalizedText\":0}", output);
+    }
+  }
+
+  /**
+   * LocalizedText is a nullable built-in type (OPC 10000-6 Table 1), so per §5.4.2.1 a null value
+   * is encoded as JSON {@code null} in VerboseEncoding — the empty-object form is specific to
+   * ExtensionObject (§5.4.2.16), not LocalizedText.
+   */
+  @Test
+  void encodeLocalizedTextVerbose_nullProducesJsonNull() throws Exception {
+    try (var encoder = new OpcUaJsonEncoder(context)) {
+      encoder.encoding = Encoding.VERBOSE;
+      encoder.encodeLocalizedText(null, null);
+
+      assertEquals("null", encoder.getOutputString());
+    }
+  }
+
+  /**
+   * String is a nullable built-in type (OPC 10000-6 Table 1), so per §5.4.2.1 only a NULL value is
+   * omitted in CompactEncoding. An empty string is a present value and must be preserved as "".
+   */
+  @Test
+  void encodeStringCompact_emptyStringPreservedInStruct() throws Exception {
+    try (var encoder = new OpcUaJsonEncoder(context)) {
+      var arg =
+          new Argument(
+              "", // empty string name
+              NodeIds.Int32,
+              -1,
+              null,
+              LocalizedText.english("desc"));
+
+      encoder.encodeStruct(null, arg, Argument.TYPE_ID);
+
+      String output = encoder.getOutputString();
+      assertTrue(
+          output.contains("\"Name\":\"\""),
+          "Empty string field must be preserved as \"\" in COMPACT; got: " + output);
+    }
+  }
+
+  /**
+   * ByteString is a nullable built-in type (OPC 10000-6 Table 1), so per §5.4.2.1 only a NULL value
+   * is omitted in CompactEncoding. A zero-length ByteString is a present value and must be
+   * preserved as the Base64 of an empty array ("").
+   *
+   * <p>Reproducer uses {@link SignatureData}, whose {@code Signature} field is a ByteString.
+   */
+  @Test
+  void encodeByteStringCompact_emptyPreservedInStruct() throws Exception {
+    try (var encoder = new OpcUaJsonEncoder(context)) {
+      var sig = new SignatureData("alg", ByteString.of(new byte[0]));
+
+      encoder.encodeStruct(null, sig, SignatureData.TYPE_ID);
+
+      String output = encoder.getOutputString();
+      assertTrue(
+          output.contains("\"Signature\":\"\""),
+          "Empty ByteString field must be preserved as \"\" in COMPACT; got: " + output);
+    }
+  }
+
+  /**
+   * Issue: {@code encodeExtensionObject} doesn't differentiate COMPACT/VERBOSE for null values.
+   * Spec 5.4.2.16: COMPACT omits a default (null) ExtensionObject; VERBOSE emits an empty object.
+   *
+   * <p>This test focuses on the dead-code call to {@code value.getBody()} (line 725) which serves
+   * no purpose. The real assertion here is that the null case is handled consistently.
+   */
+  @Test
+  void encodeExtensionObjectVerbose_nullEmitsEmptyObject() throws Exception {
+    try (var encoder = new OpcUaJsonEncoder(context)) {
+      encoder.encoding = Encoding.VERBOSE;
+
+      encoder.jsonWriter.beginObject();
+      encoder.encodeExtensionObject("foo", null);
+      encoder.jsonWriter.endObject();
+
+      String output = encoder.getOutputString();
+      // Spec: VERBOSE default ExtensionObject encoded as {}
+      assertEquals("{\"foo\":{}}", output);
+    }
+  }
+
+  /**
+   * Issue: {@code encodeMessage} does not null-check its message argument. Spec doesn't define
+   * encoding a null message, but the method should fail with a UaSerializationException rather than
+   * letting a raw NullPointerException propagate.
+   */
+  @Test
+  void encodeMessage_nullDoesNotThrowNpe() {
+    // Not using try-with-resources: when the encoder fails before writing any JSON,
+    // Gson's JsonWriter.close() throws "Incomplete document". That's irrelevant to
+    // what this test verifies.
+    var encoder = new OpcUaJsonEncoder(context);
+    // Either return cleanly or throw UaSerializationException — never NPE.
+    try {
+      encoder.encodeMessage(null, null);
+    } catch (NullPointerException npe) {
+      throw new AssertionError("encodeMessage(null, null) threw NPE; expected graceful failure");
+    } catch (Exception expected) {
+      // Acceptable: UaSerializationException or similar.
+    }
+  }
+
+  /** Issue (companion): {@code encodeStruct} does not null-check its value argument. */
+  @Test
+  void encodeStruct_nullValueDoesNotThrowNpe() {
+    var encoder = new OpcUaJsonEncoder(context);
+    try {
+      encoder.encodeStruct(null, null, Argument.TYPE_ID);
+    } catch (NullPointerException npe) {
+      throw new AssertionError("encodeStruct with null value threw NPE; expected graceful");
+    } catch (Exception expected) {
+      // Acceptable.
+    }
+  }
+
+  /**
+   * Issue 17: {@code encodeStatusCode} in COMPACT encoding emits a JSON object (not a bare number).
+   * Per OPC 10000-6 §5.4.2.12, StatusCode is always a JSON object; in COMPACT the Symbol field is
+   * omitted and the Code field is omitted when the numeric value is 0 (Good).
+   */
+  @Test
+  void encodeStatusCodeCompact_isJsonObject() throws Exception {
+    try (var encoder = new OpcUaJsonEncoder(context)) {
+      encoder.encoding = Encoding.COMPACT;
+
+      // Non-Good code: object with Code; Symbol always omitted in COMPACT.
+      long code = StatusCodes.Bad_UnexpectedError;
+      encoder.encodeStatusCode(null, new StatusCode(code));
+      assertEquals("{\"Code\":" + code + "}", encoder.getOutputString());
+    }
+  }
+
+  /**
+   * Issue 18: encoding an empty array of an OptionSet type used to throw because the type id was
+   * derived from {@code Array.get(value, 0)}. The encoder must derive the backing UInteger type
+   * from the OptionSet class hierarchy instead.
+   */
+  @Test
+  void encodeOptionSetArray_emptyDoesNotThrow() throws Exception {
+    try (var encoder = new OpcUaJsonEncoder(context)) {
+      assertDoesNotThrow(() -> encoder.encodeVariant(null, new Variant(new PermissionType[0])));
+      // PermissionType extends OptionSetUI32 → backing type is UInt32 (typeId 7).
+      assertEquals("{\"UaType\":7,\"Value\":[]}", encoder.getOutputString());
+    }
+  }
+
+  /**
+   * Issue 21: a QualifiedName whose Name is null/empty must encode as JSON {@code null} regardless
+   * of namespace index — never as a malformed {@code "nsu=...;null"} string.
+   */
+  @Test
+  void encodeQualifiedName_nullNameWithNamespaceEncodesAsJsonNull() throws Exception {
+    context.getNamespaceTable().add("urn:eclipse:milo:test-qn-null");
+
+    try (var encoder = new OpcUaJsonEncoder(context)) {
+      encoder.encoding = Encoding.VERBOSE; // force the write branch in struct context
+      UShort index = context.getNamespaceTable().getIndex("urn:eclipse:milo:test-qn-null");
+      encoder.encodeQualifiedName(null, new QualifiedName(index, null));
+      assertEquals("null", encoder.getOutputString());
     }
   }
 


### PR DESCRIPTION
Update the existing Compact/Verbose JSON encoding to match the finalized OPC 10000-6 §5.4 rules, correcting field names and several field-omission behaviors that diverged from the spec.

- ExtensionObject and Variant use the 1.05 field names (UaTypeId, UaEncoding, UaBody, UaType, Value); the decoder still accepts the legacy names for backward compatibility.
- StatusCode is always a JSON object: Code omitted when Good, Symbol only in Verbose and only when the literal is known.
- DiagnosticInfo index fields default to -1 (not 0) on both sides, and InnerStatusCode is omitted when Good per §5.4.2.13.
- Array elements are encoded in builtin context so default values (0, false, "") are preserved instead of being dropped.
- String and ByteString omit only NULL in Compact; empty values are present and round-trip as "".
- A null LocalizedText encodes as JSON null in Verbose, and Guid omits only the all-zero default value.

Scalar encoders are now null-safe, and ExtensionObject decoding no longer depends on JSON field order.