### PR TITLE
Close oldest unactivated session at the session limit

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/SessionEvictionTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/SessionEvictionTest.java
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.test.TestClient;
+import org.eclipse.milo.opcua.sdk.test.TestServer;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.ApplicationType;
+import org.eclipse.milo.opcua.stack.core.types.structured.ApplicationDescription;
+import org.eclipse.milo.opcua.stack.core.types.structured.CreateSessionRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.CreateSessionResponse;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies the server's behavior at the session limit.
+ *
+ * <p>OPC UA Part 4, 5.7.2 specifies that when the session limit is reached the server shall close
+ * the oldest Session that has not yet been activated, rather than rejecting the new CreateSession
+ * request outright. Only if every existing Session has already been activated should the server
+ * respond with {@code Bad_TooManySessions}. The limit must also be honored under concurrent
+ * CreateSession requests.
+ */
+public class SessionEvictionTest {
+
+  private static OpcUaServerConfigLimits maxSessions(int n) {
+    return new OpcUaServerConfigLimits() {
+      @Override
+      public UInteger getMaxSessions() {
+        return uint(n);
+      }
+    };
+  }
+
+  @Test
+  void evictsOldestUnactivatedSessionWhenAtLimit() throws Exception {
+    OpcUaServer server = TestServer.create(maxSessions(3)).getServer();
+    server.startup().get();
+
+    OpcUaClient client = TestClient.create(server, cfg -> {});
+    try {
+      // The connected client holds one *activated* session.
+      client.connect();
+      assertEquals(1, currentSessionCount(server));
+
+      // Create two unactivated sessions, oldest first, filling the limit of 3. The server orders
+      // eviction by connection time (wall clock), so a deliberate pause guarantees the two
+      // sessions get strictly different, correctly-ordered timestamps regardless of the
+      // platform's clock granularity (which can be coarser than a back-to-back round-trip).
+      NodeId oldest = createSession(client, "unactivated-oldest").getSessionId();
+      Thread.sleep(50);
+      NodeId newer = createSession(client, "unactivated-newer").getSessionId();
+      assertEquals(3, currentSessionCount(server));
+
+      // Sanity-check the precondition the eviction assertion below relies on.
+      assertTrue(
+          connectTime(server, oldest) < connectTime(server, newer),
+          "expected the first-created session to have the earlier connection time");
+
+      // A further CreateSession at the limit must succeed by evicting the OLDEST
+      // unactivated session rather than throwing Bad_TooManySessions.
+      CreateSessionResponse response = createSession(client, "unactivated-newest");
+      assertTrue(response.getResponseHeader().getServiceResult().isGood());
+
+      // The count is unchanged: exactly one session was evicted to make room.
+      assertEquals(3, currentSessionCount(server));
+
+      Set<NodeId> remaining =
+          server.getSessionManager().getAllSessions().stream()
+              .map(Session::getSessionId)
+              .collect(Collectors.toSet());
+
+      // The oldest unactivated session was the one evicted...
+      assertFalse(remaining.contains(oldest), "oldest unactivated session should be evicted");
+      // ...the newer unactivated session survived...
+      assertTrue(remaining.contains(newer), "newer unactivated session should not be evicted");
+      assertTrue(remaining.contains(response.getSessionId()), "new session should be present");
+
+      // ...and the activated session was untouched; it remains usable.
+      assertDoesNotThrow(client::readOperationLimits);
+    } finally {
+      try {
+        client.disconnectAsync().get(2, TimeUnit.SECONDS);
+      } finally {
+        server.shutdown().get(2, TimeUnit.SECONDS);
+      }
+    }
+  }
+
+  @Test
+  void rejectsNewSessionWhenAllSessionsActivated() throws Exception {
+    OpcUaServer server = TestServer.create(maxSessions(2)).getServer();
+    server.startup().get();
+
+    OpcUaClient client1 = TestClient.create(server, cfg -> {});
+    OpcUaClient client2 = TestClient.create(server, cfg -> {});
+    try {
+      // Fill the limit with two activated sessions.
+      client1.connect();
+      client2.connect();
+      assertEquals(2, currentSessionCount(server));
+
+      // With no unactivated session to evict, a new CreateSession must be rejected.
+      ExecutionException ex =
+          assertThrows(ExecutionException.class, () -> createSession(client1, "rejected"));
+
+      Throwable cause = ex.getCause();
+      assertTrue(cause instanceof UaException, "expected UaException, got " + cause);
+      assertEquals(
+          StatusCodes.Bad_TooManySessions, ((UaException) cause).getStatusCode().getValue());
+    } finally {
+      try {
+        client1.disconnectAsync().get(2, TimeUnit.SECONDS);
+        client2.disconnectAsync().get(2, TimeUnit.SECONDS);
+      } finally {
+        server.shutdown().get(2, TimeUnit.SECONDS);
+      }
+    }
+  }
+
+  @Test
+  void doesNotExceedSessionLimitUnderConcurrentCreate() throws Exception {
+    int limit = 5;
+    OpcUaServer server = TestServer.create(maxSessions(limit)).getServer();
+    server.startup().get();
+
+    OpcUaClient client = TestClient.create(server, cfg -> {});
+    ExecutorService executor = Executors.newFixedThreadPool(8);
+    try {
+      // One activated session plus enough unactivated sessions to reach the limit.
+      client.connect();
+      for (int i = 0; i < limit - 1; i++) {
+        createSession(client, "pending-" + i);
+      }
+      assertEquals(limit, currentSessionCount(server));
+
+      // Fire a burst of concurrent CreateSession requests while at the limit. Each one
+      // can be admitted by evicting an unactivated session, but the configured limit
+      // (a resource-protection bound, OPC UA Part 4 Section 5.7.2) must never be exceeded.
+      List<Future<?>> futures = new ArrayList<>();
+      for (int i = 0; i < 32; i++) {
+        String name = "burst-" + i;
+        futures.add(executor.submit(() -> createSession(client, name)));
+      }
+      for (Future<?> future : futures) {
+        try {
+          future.get();
+        } catch (ExecutionException ignored) {
+          // A request may legitimately fail; we only care that the limit is never exceeded.
+        }
+      }
+
+      assertTrue(
+          currentSessionCount(server) <= limit,
+          "session count " + currentSessionCount(server) + " exceeded the limit of " + limit);
+    } finally {
+      executor.shutdownNow();
+      try {
+        client.disconnectAsync().get(2, TimeUnit.SECONDS);
+      } finally {
+        server.shutdown().get(2, TimeUnit.SECONDS);
+      }
+    }
+  }
+
+  private static int currentSessionCount(OpcUaServer server) {
+    return server.getSessionManager().getCurrentSessionCount().intValue();
+  }
+
+  /** The connection time, in 100ns ticks, of the session with the given id. */
+  private static long connectTime(OpcUaServer server, NodeId sessionId) {
+    return server.getSessionManager().getAllSessions().stream()
+        .filter(s -> s.getSessionId().equals(sessionId))
+        .map(s -> s.getConnectionTime().getUtcTime())
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("session not found: " + sessionId));
+  }
+
+  /**
+   * Send a raw {@link CreateSessionRequest} over the client's transport without activating the
+   * resulting session. The endpoint used by the test client has {@code SecurityPolicy.None}, so no
+   * client nonce or certificate is required.
+   */
+  private static CreateSessionResponse createSession(OpcUaClient client, String sessionName)
+      throws Exception {
+    UInteger maxResponseMessageSize = client.getConfig().getMaxResponseMessageSize();
+
+    ApplicationDescription clientDescription =
+        new ApplicationDescription(
+            client.getConfig().getApplicationUri(),
+            client.getConfig().getProductUri(),
+            client.getConfig().getApplicationName(),
+            ApplicationType.Client,
+            null,
+            null,
+            null);
+
+    CreateSessionRequest request =
+        new CreateSessionRequest(
+            client.newRequestHeader(),
+            clientDescription,
+            null,
+            client.getConfig().getEndpoint().getEndpointUrl(),
+            sessionName,
+            ByteString.NULL_VALUE,
+            ByteString.NULL_VALUE,
+            60_000.0,
+            maxResponseMessageSize);
+
+    return (CreateSessionResponse) client.getTransport().sendRequestMessage(request).get();
+  }
+}

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/test/TestServer.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/test/TestServer.java
@@ -30,6 +30,7 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.eclipse.milo.opcua.sdk.server.EndpointConfig;
 import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
 import org.eclipse.milo.opcua.sdk.server.OpcUaServerConfig;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServerConfigLimits;
 import org.eclipse.milo.opcua.sdk.server.identity.AnonymousIdentityValidator;
 import org.eclipse.milo.opcua.sdk.server.identity.CompositeValidator;
 import org.eclipse.milo.opcua.sdk.server.identity.UsernameIdentityValidator;
@@ -93,6 +94,10 @@ public final class TestServer {
   public record TestIdentityCertificate(X509Certificate certificate, KeyPair keyPair) {}
 
   public static TestServer create() throws Exception {
+    return create(new OpcUaServerConfigLimits() {});
+  }
+
+  public static TestServer create(OpcUaServerConfigLimits limits) throws Exception {
     int port = new Random().nextInt(65535 - 10000) + 10000;
 
     try {
@@ -101,14 +106,18 @@ public final class TestServer {
       ss.bind(isa);
       ss.close();
 
-      return create(port);
+      return create(port, limits);
     } catch (Throwable t) {
       t.printStackTrace(System.err);
-      return create();
+      return create(limits);
     }
   }
 
   public static TestServer create(int port) throws Exception {
+    return create(port, new OpcUaServerConfigLimits() {});
+  }
+
+  public static TestServer create(int port, OpcUaServerConfigLimits limits) throws Exception {
     File securityTempDir = new File(System.getProperty("java.io.tmpdir"), "security");
     if (!securityTempDir.exists() && !securityTempDir.mkdirs()) {
       throw new Exception("unable to create security temp dir: " + securityTempDir);
@@ -230,6 +239,7 @@ public final class TestServer {
                     usernameIdentityValidator,
                     x509IdentityValidator))
             .setProductUri("urn:eclipse:milo:example-server")
+            .setLimits(limits)
             .build();
 
     OpcUaServer opcUaServer =

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/SessionManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/SessionManager.java
@@ -25,6 +25,7 @@ import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -82,6 +83,13 @@ public class SessionManager {
 
   private final Map<NodeId, Session> createdSessions = new ConcurrentHashMap<>();
   private final Map<NodeId, Session> activeSessions = new ConcurrentHashMap<>();
+
+  /**
+   * Guards the session-count limit check together with the eviction, registration, and activation
+   * of sessions so that concurrent requests cannot exceed the configured maximum or evict a session
+   * that is being activated.
+   */
+  private final Object sessionLock = new Object();
 
   private final List<SessionListener> sessionListeners = new CopyOnWriteArrayList<>();
   private final TaskQueue sessionListenerTaskQueue;
@@ -195,11 +203,6 @@ public class SessionManager {
 
   public CreateSessionResponse createSession(
       ServiceRequestContext context, CreateSessionRequest request) throws UaException {
-
-    long maxSessionCount = server.getConfig().getLimits().getMaxSessions().longValue();
-    if (createdSessions.size() + activeSessions.size() >= maxSessionCount) {
-      throw new UaException(StatusCodes.Bad_TooManySessions);
-    }
 
     ByteString serverNonce = NonceUtil.generateNonce(32);
     NodeId authenticationToken = new NodeId(0, NonceUtil.generateNonce(32));
@@ -343,16 +346,41 @@ public class SessionManager {
     session.setLastNonce(serverNonce);
     session.setClientAddress(context.clientAddress());
 
-    session.addLifecycleListener(
-        (s, remove) -> {
-          createdSessions.remove(authenticationToken);
-          activeSessions.remove(authenticationToken);
+    // Enforce the session limit and register the new session atomically so that concurrent
+    // CreateSession requests cannot exceed the maximum. Done after validation so that a request
+    // which is going to fail never evicts another client's pending session.
+    synchronized (sessionLock) {
+      long maxSessionCount = server.getConfig().getLimits().getMaxSessions().longValue();
+      if (createdSessions.size() + activeSessions.size() >= maxSessionCount) {
+        // OPC UA Part 4, 5.7.2: at the session limit the Server shall close the oldest Session
+        // that has not yet been activated before rejecting a new request. Only if every existing
+        // Session has already been activated is Bad_TooManySessions returned.
+        Session oldestUnactivated =
+            createdSessions.values().stream()
+                .min(Comparator.comparingLong(s -> s.getConnectionTime().getUtcTime()))
+                .orElse(null);
 
-          sessionListenerTaskQueue.execute(
-              () -> sessionListeners.forEach(l -> l.onSessionClosed(s)));
-        });
+        if (oldestUnactivated == null) {
+          // Release the timeout task of the session we are not going to register. No lifecycle
+          // listener has been added yet, so this fires no session-closed notifications.
+          session.close(false);
+          throw new UaException(StatusCodes.Bad_TooManySessions);
+        }
 
-    createdSessions.put(authenticationToken, session);
+        oldestUnactivated.close(false);
+      }
+
+      session.addLifecycleListener(
+          (s, remove) -> {
+            createdSessions.remove(authenticationToken);
+            activeSessions.remove(authenticationToken);
+
+            sessionListenerTaskQueue.execute(
+                () -> sessionListeners.forEach(l -> l.onSessionClosed(s)));
+          });
+
+      createdSessions.put(authenticationToken, session);
+    }
 
     sessionListenerTaskQueue.execute(
         () -> sessionListeners.forEach(l -> l.onSessionCreated(session)));
@@ -579,8 +607,15 @@ public class SessionManager {
       Identity identity =
           validateIdentityToken(session, identityToken, request.getUserTokenSignature());
 
-      createdSessions.remove(authToken);
-      activeSessions.put(authToken, session);
+      // Move the session from created to active atomically with respect to the limit check in
+      // createSession, so a concurrent CreateSession cannot evict a session that is activating.
+      synchronized (sessionLock) {
+        if (createdSessions.remove(authToken) == null) {
+          // The session was closed (e.g. evicted at the session limit) during activation.
+          throw new UaException(StatusCodes.Bad_SessionIdInvalid);
+        }
+        activeSessions.put(authToken, session);
+      }
 
       StatusCode[] results = new StatusCode[clientSoftwareCertificates.length];
       Arrays.fill(results, StatusCode.GOOD);


### PR DESCRIPTION
## Summary
When the session limit (`MaxSessions`) was reached, `SessionManager.createSession`
always returned `Bad_TooManySessions`. OPC UA Part 4, §5.7.2 requires that the
server **shall close the oldest Session that has not yet been activated** before
rejecting a new request, and return `Bad_TooManySessions` only when every existing
Session has already been activated.

This was raised in #1759 (from Discussion #1582), where the maintainer confirmed
no work was in progress and welcomed a PR.

## Changes
- Evict the oldest unactivated session (ordered by connection time) at the limit,
  instead of unconditionally throwing `Bad_TooManySessions`.
- Run the limit check, eviction, and registration under a single lock and **after**
  request validation, so concurrent `CreateSession` requests cannot exceed
  `MaxSessions`, and a request that later fails validation never evicts another
  client's pending session.
- `ActivateSession`'s created→active move takes the same lock and rejects a session
  that was evicted mid-activation (`Bad_SessionIdInvalid`).

## Tests
- `SessionEvictionTest`: evicts the oldest unactivated session; still returns
  `Bad_TooManySessions` when all sessions are activated; never exceeds the limit
  under a concurrent `CreateSession` burst.
- Added a `TestServer.create(OpcUaServerConfigLimits)` overload to set `MaxSessions`.

Fixes #1759

---
Developed with AI assistance (Anthropic Claude Opus 4.8); the human contributor
reviewed, verified, and tested all changes.
