### PR TITLE
Implement XML Matrix decoding in OpcUaXmlDecoder

### DIFF
--- a/opc-ua-stack/encoding-xml/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlDecoder.java
+++ b/opc-ua-stack/encoding-xml/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlDecoder.java
@@ -1210,18 +1210,82 @@ public class OpcUaXmlDecoder implements UaDecoder, AutoCloseable {
 
   @Override
   public Matrix decodeMatrix(String field, OpcUaDataType dataType) throws UaSerializationException {
-    // TODO implement decodeMatrix
     if (currentNode(field)) {
-      currentNode = currentNode.getNextSibling();
+      Node node = currentNode;
+
+      try {
+        Node dimensionsNode = firstElementChild(node);
+
+        if (dimensionsNode == null) {
+          // A null Matrix encodes as an empty/nil field with no Dimensions or Elements.
+          return Matrix.ofNull();
+        }
+
+        int[] dimensions = decodeMatrixDimensions(dimensionsNode);
+
+        List<Object> elements = new ArrayList<>();
+        Node elementsNode = nextElementSibling(dimensionsNode);
+
+        if (elementsNode != null) {
+          NodeList children = elementsNode.getChildNodes();
+
+          for (int i = 0; i < children.getLength(); i++) {
+            currentNode = children.item(i);
+
+            if (currentNode.getNodeType() == Node.ELEMENT_NODE) {
+              elements.add(readBuiltinType(currentNode.getLocalName(), dataType.name()));
+            }
+          }
+        }
+
+        Object array = Array.newInstance(builtinTypeClass(dataType.name()), elements.size());
+        for (int i = 0; i < elements.size(); i++) {
+          Array.set(array, i, elements.get(i));
+        }
+
+        return new Matrix(array, dimensions, dataType);
+      } finally {
+        currentNode = node.getNextSibling();
+      }
+    } else {
+      return Matrix.ofNull();
     }
-    return Matrix.ofNull();
   }
 
   @Override
   public Matrix decodeEnumMatrix(String field) {
     if (currentNode(field)) {
-      // TODO implement decodeEnumMatrix
-      return Matrix.ofNull();
+      Node node = currentNode;
+
+      try {
+        Node dimensionsNode = firstElementChild(node);
+
+        if (dimensionsNode == null) {
+          return Matrix.ofNull();
+        }
+
+        int[] dimensions = decodeMatrixDimensions(dimensionsNode);
+
+        List<Integer> elements = new ArrayList<>();
+        Node elementsNode = nextElementSibling(dimensionsNode);
+
+        if (elementsNode != null) {
+          NodeList children = elementsNode.getChildNodes();
+
+          for (int i = 0; i < children.getLength(); i++) {
+            currentNode = children.item(i);
+
+            if (currentNode.getNodeType() == Node.ELEMENT_NODE) {
+              elements.add(decodeEnum(currentNode.getLocalName()));
+            }
+          }
+        }
+
+        // Enumerations reduce to Int32, mirroring OpcUaBinaryDecoder.decodeEnumMatrix.
+        return new Matrix(elements.toArray(Integer[]::new), dimensions, OpcUaDataType.Int32);
+      } finally {
+        currentNode = node.getNextSibling();
+      }
     } else {
       return Matrix.ofNull();
     }
@@ -1229,20 +1293,74 @@ public class OpcUaXmlDecoder implements UaDecoder, AutoCloseable {
 
   @Override
   public Matrix decodeStructMatrix(String field, NodeId dataTypeId) {
-    // TODO implement decodeStructMatrix
-    if (currentNode(field)) {
-      currentNode = currentNode.getNextSibling();
-    }
-    return Matrix.ofNull();
+    return decodeStructMatrix(field);
   }
 
   @Override
   public Matrix decodeStructMatrix(String field, ExpandedNodeId dataTypeId) {
-    // TODO implement decodeStructMatrix
-    if (currentNode(field)) {
-      currentNode = currentNode.getNextSibling();
+    return decodeStructMatrix(field);
+  }
+
+  /**
+   * {@code OpcUaXmlEncoder.encodeStructMatrix} transforms each structure into a self-describing
+   * {@link ExtensionObject} before writing, so the elements are read back as ExtensionObjects and
+   * neither the NodeId nor the ExpandedNodeId form of the dataTypeId is needed to decode them. Each
+   * ExtensionObject is decoded into its structure so the result is a Matrix of {@code
+   * UaStructuredType}, mirroring {@code OpcUaBinaryDecoder.decodeStructMatrix} and {@link
+   * #decodeStructArray}; returning the raw ExtensionObjects would break the decode-encode
+   * round-trip, since {@code encodeStructMatrix} casts each element to {@code UaStructuredType}.
+   */
+  private Matrix decodeStructMatrix(String field) {
+    Matrix matrix = decodeMatrix(field, OpcUaDataType.ExtensionObject);
+
+    if (matrix.isNull()) {
+      return matrix;
     }
-    return Matrix.ofNull();
+
+    return matrix.transform(o -> ((ExtensionObject) o).decode(context));
+  }
+
+  private int[] decodeMatrixDimensions(Node dimensionsNode) {
+    List<Integer> dimensions = new ArrayList<>();
+    NodeList children = dimensionsNode.getChildNodes();
+
+    for (int i = 0; i < children.getLength(); i++) {
+      currentNode = children.item(i);
+
+      if (currentNode.getNodeType() == Node.ELEMENT_NODE) {
+        dimensions.add(decodeInt32("Int32"));
+      }
+    }
+
+    int[] dims = new int[dimensions.size()];
+    for (int i = 0; i < dims.length; i++) {
+      dims[i] = dimensions.get(i);
+    }
+    return dims;
+  }
+
+  /**
+   * @return the first child of {@code node} that is an element, skipping any intervening text nodes
+   *     (e.g. whitespace in indented XML), or {@code null} if there is none.
+   */
+  private static @Nullable Node firstElementChild(Node node) {
+    Node child = node.getFirstChild();
+    while (child != null && child.getNodeType() != Node.ELEMENT_NODE) {
+      child = child.getNextSibling();
+    }
+    return child;
+  }
+
+  /**
+   * @return the next sibling of {@code node} that is an element, skipping any intervening text
+   *     nodes (e.g. whitespace in indented XML), or {@code null} if there is none.
+   */
+  private static @Nullable Node nextElementSibling(Node node) {
+    Node sibling = node.getNextSibling();
+    while (sibling != null && sibling.getNodeType() != Node.ELEMENT_NODE) {
+      sibling = sibling.getNextSibling();
+    }
+    return sibling;
   }
 
   /**

--- a/opc-ua-stack/encoding-xml/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlDecoder.java
+++ b/opc-ua-stack/encoding-xml/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlDecoder.java
@@ -1233,10 +1233,26 @@ public class OpcUaXmlDecoder implements UaDecoder, AutoCloseable {
             currentNode = children.item(i);
 
             if (currentNode.getNodeType() == Node.ELEMENT_NODE) {
-              elements.add(readBuiltinType(currentNode.getLocalName(), dataType.name()));
+              String elementName = currentNode.getLocalName();
+
+              // OPC 10000-6 5.3.4: the element name shall be the type name. The caller asked for a
+              // dataType Matrix, so every element under <Elements> must carry that type's name.
+              if (!dataType.name().equals(elementName)) {
+                throw new UaSerializationException(
+                    StatusCodes.Bad_DecodingError,
+                    "expected Matrix element <"
+                        + dataType.name()
+                        + "> but found <"
+                        + elementName
+                        + ">");
+              }
+
+              elements.add(readBuiltinType(elementName, dataType.name()));
             }
           }
         }
+
+        checkMatrixElementCount(dimensions, elements.size());
 
         Object array = Array.newInstance(builtinTypeClass(dataType.name()), elements.size());
         for (int i = 0; i < elements.size(); i++) {
@@ -1281,6 +1297,8 @@ public class OpcUaXmlDecoder implements UaDecoder, AutoCloseable {
           }
         }
 
+        checkMatrixElementCount(dimensions, elements.size());
+
         // Enumerations reduce to Int32, mirroring OpcUaBinaryDecoder.decodeEnumMatrix.
         return new Matrix(elements.toArray(Integer[]::new), dimensions, OpcUaDataType.Int32);
       } finally {
@@ -1291,33 +1309,63 @@ public class OpcUaXmlDecoder implements UaDecoder, AutoCloseable {
     }
   }
 
+  /**
+   * {@code OpcUaXmlEncoder.encodeStructMatrix} writes each structure as a self-describing {@link
+   * ExtensionObject}, so the elements are read back as ExtensionObjects and then decoded into their
+   * structures — the result is a Matrix of {@code UaStructuredType}, mirroring {@code
+   * OpcUaBinaryDecoder.decodeStructMatrix} and {@link #decodeStructArray}. (Returning the raw
+   * ExtensionObjects would break the decode-encode round-trip, since {@code encodeStructMatrix}
+   * casts each element to {@code UaStructuredType}.)
+   *
+   * <p>{@code dataTypeId} is the expected structure type for this field; for a non-subtyped field
+   * the decoded type must match it, so an ExtensionObject of any other type is rejected rather than
+   * handing the caller a Matrix with unexpected element types.
+   */
   @Override
   public Matrix decodeStructMatrix(String field, NodeId dataTypeId) {
-    return decodeStructMatrix(field);
-  }
-
-  @Override
-  public Matrix decodeStructMatrix(String field, ExpandedNodeId dataTypeId) {
-    return decodeStructMatrix(field);
-  }
-
-  /**
-   * {@code OpcUaXmlEncoder.encodeStructMatrix} transforms each structure into a self-describing
-   * {@link ExtensionObject} before writing, so the elements are read back as ExtensionObjects and
-   * neither the NodeId nor the ExpandedNodeId form of the dataTypeId is needed to decode them. Each
-   * ExtensionObject is decoded into its structure so the result is a Matrix of {@code
-   * UaStructuredType}, mirroring {@code OpcUaBinaryDecoder.decodeStructMatrix} and {@link
-   * #decodeStructArray}; returning the raw ExtensionObjects would break the decode-encode
-   * round-trip, since {@code encodeStructMatrix} casts each element to {@code UaStructuredType}.
-   */
-  private Matrix decodeStructMatrix(String field) {
     Matrix matrix = decodeMatrix(field, OpcUaDataType.ExtensionObject);
 
     if (matrix.isNull()) {
       return matrix;
     }
 
-    return matrix.transform(o -> ((ExtensionObject) o).decode(context));
+    DataTypeCodec codec = context.getDataTypeManager().getCodec(dataTypeId);
+
+    if (codec == null) {
+      throw new UaSerializationException(
+          StatusCodes.Bad_DecodingError, "no codec registered: " + dataTypeId);
+    }
+
+    Class<?> expectedType = codec.getType();
+
+    return matrix.transform(
+        o -> {
+          Object struct = ((ExtensionObject) o).decode(context);
+
+          if (!expectedType.isInstance(struct)) {
+            throw new UaSerializationException(
+                StatusCodes.Bad_DecodingError,
+                "expected struct type "
+                    + dataTypeId
+                    + " but decoded "
+                    + (struct != null ? struct.getClass().getName() : "null"));
+          }
+
+          return struct;
+        });
+  }
+
+  @Override
+  public Matrix decodeStructMatrix(String field, ExpandedNodeId dataTypeId) {
+    NodeId localDataTypeId =
+        dataTypeId
+            .toNodeId(context.getNamespaceTable())
+            .orElseThrow(
+                () ->
+                    new UaSerializationException(
+                        StatusCodes.Bad_DecodingError, "namespace not registered: " + dataTypeId));
+
+    return decodeStructMatrix(field, localDataTypeId);
   }
 
   private int[] decodeMatrixDimensions(Node dimensionsNode) {
@@ -1328,7 +1376,16 @@ public class OpcUaXmlDecoder implements UaDecoder, AutoCloseable {
       currentNode = children.item(i);
 
       if (currentNode.getNodeType() == Node.ELEMENT_NODE) {
-        dimensions.add(decodeInt32("Int32"));
+        int dimension = decodeInt32("Int32");
+
+        // OPC 10000-6 5.3.1.17: all Matrix dimensions shall be greater than zero.
+        if (dimension <= 0) {
+          throw new UaSerializationException(
+              StatusCodes.Bad_DecodingError,
+              "Matrix dimension must be greater than zero: " + dimension);
+        }
+
+        dimensions.add(dimension);
       }
     }
 
@@ -1337,6 +1394,33 @@ public class OpcUaXmlDecoder implements UaDecoder, AutoCloseable {
       dims[i] = dimensions.get(i);
     }
     return dims;
+  }
+
+  /**
+   * Validate that the product of {@code dimensions} equals {@code elementCount}.
+   *
+   * <p>OPC 10000-6 5.3.1.17 requires the Matrix dimensions to be consistent with the number of
+   * flattened elements; a mismatch is a decoding error rather than a silently-malformed Matrix.
+   *
+   * @throws UaSerializationException if the dimensions do not describe exactly {@code elementCount}
+   *     elements.
+   */
+  private static void checkMatrixElementCount(int[] dimensions, int elementCount) {
+    long product = 1;
+    for (int dimension : dimensions) {
+      product *= dimension;
+    }
+
+    if (product != elementCount) {
+      throw new UaSerializationException(
+          StatusCodes.Bad_DecodingError,
+          "Matrix dimensions "
+              + Arrays.toString(dimensions)
+              + " describe "
+              + product
+              + " elements but found "
+              + elementCount);
+    }
   }
 
   /**

--- a/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlDecoderMatrixTest.java
+++ b/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlDecoderMatrixTest.java
@@ -13,11 +13,13 @@ package org.eclipse.milo.opcua.stack.core.encoding.xml;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.StringReader;
 import java.lang.reflect.Array;
 import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
+import org.eclipse.milo.opcua.stack.core.UaSerializationException;
 import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
 import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
 import org.eclipse.milo.opcua.stack.core.types.UaEnumeratedType;
@@ -27,6 +29,8 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Matrix;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.XmlElement;
+import org.eclipse.milo.opcua.stack.core.types.structured.ThreeDVector;
+import org.eclipse.milo.opcua.stack.core.types.structured.XVType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -254,6 +258,110 @@ public class OpcUaXmlDecoderMatrixTest {
     }
 
     assertTrue(decoded.isNull());
+  }
+
+  // ---------------------------------------------------------------------------
+  // Malformed Matrix XML must fail instead of constructing an invalid Matrix.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void decodeMatrixRejectsMismatchedDimensions() throws Exception {
+    // OPC 10000-6 5.3.1.17 requires the product of Dimensions to match the number of
+    // flattened Elements. A 2x2 matrix must therefore contain exactly 4 elements.
+    String xml =
+        """
+        <Test xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd">
+          <uax:Dimensions>
+            <uax:Int32>2</uax:Int32>
+            <uax:Int32>2</uax:Int32>
+          </uax:Dimensions>
+          <uax:Elements>
+            <uax:Int32>1</uax:Int32>
+          </uax:Elements>
+        </Test>
+        """;
+
+    try (var decoder = new OpcUaXmlDecoder(context)) {
+      decoder.setInput(new StringReader(xml));
+
+      assertThrows(
+          UaSerializationException.class,
+          () -> decoder.decodeMatrix("Test", OpcUaDataType.Int32),
+          "Matrix dimensions [2, 2] describe 4 elements, but the XML contains only 1");
+    }
+  }
+
+  @Test
+  void decodeMatrixRejectsNonPositiveDimensions() throws Exception {
+    // OPC 10000-6 5.3.1.17 says all Matrix dimensions shall be greater than zero.
+    // A zero dimension is not a valid compact representation of an empty Matrix.
+    String xml =
+        """
+        <Test xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd">
+          <uax:Dimensions>
+            <uax:Int32>0</uax:Int32>
+            <uax:Int32>1</uax:Int32>
+          </uax:Dimensions>
+          <uax:Elements>
+            <uax:Int32>1</uax:Int32>
+          </uax:Elements>
+        </Test>
+        """;
+
+    try (var decoder = new OpcUaXmlDecoder(context)) {
+      decoder.setInput(new StringReader(xml));
+
+      assertThrows(
+          UaSerializationException.class,
+          () -> decoder.decodeMatrix("Test", OpcUaDataType.Int32),
+          "Matrix dimensions must be greater than zero");
+    }
+  }
+
+  @Test
+  void decodeMatrixRejectsElementWithWrongXmlTypeName() throws Exception {
+    // OPC 10000-6 5.3.4 says array element names shall be the type name. Since the
+    // caller requested an Int32 matrix, each element in <Elements> must be <Int32>.
+    String xml =
+        """
+        <Test xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd">
+          <uax:Dimensions>
+            <uax:Int32>1</uax:Int32>
+            <uax:Int32>1</uax:Int32>
+          </uax:Dimensions>
+          <uax:Elements>
+            <uax:String>123</uax:String>
+          </uax:Elements>
+        </Test>
+        """;
+
+    try (var decoder = new OpcUaXmlDecoder(context)) {
+      decoder.setInput(new StringReader(xml));
+
+      assertThrows(
+          UaSerializationException.class,
+          () -> decoder.decodeMatrix("Test", OpcUaDataType.Int32),
+          "An Int32 Matrix must not accept elements named String");
+    }
+  }
+
+  @Test
+  void decodeStructMatrixRejectsUnexpectedStructType() throws Exception {
+    // The dataTypeId argument is the declared/expected structure type for the field.
+    // A decoder should not silently accept ExtensionObjects for a different structure type.
+    Matrix threeDVectorMatrix =
+        Matrix.ofStruct(new ThreeDVector[][] {{new ThreeDVector(1.0, 2.0, 3.0)}});
+    String encoded =
+        encode(e -> e.encodeStructMatrix("Test", threeDVectorMatrix, ThreeDVector.TYPE_ID));
+
+    try (var decoder = new OpcUaXmlDecoder(context)) {
+      decoder.setInput(new StringReader(encoded));
+
+      assertThrows(
+          UaSerializationException.class,
+          () -> decoder.decodeStructMatrix("Test", XVType.TYPE_ID),
+          "decodeStructMatrix(..., XVType.TYPE_ID) must reject ThreeDVector elements");
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlDecoderMatrixTest.java
+++ b/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlDecoderMatrixTest.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.core.encoding.xml;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.StringReader;
+import java.lang.reflect.Array;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
+import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
+import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
+import org.eclipse.milo.opcua.stack.core.types.UaEnumeratedType;
+import org.eclipse.milo.opcua.stack.core.types.UaStructuredType;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Matrix;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.XmlElement;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Round-trip tests for XML-encoded {@link Matrix} values.
+ *
+ * <p>The XML encoder ({@code OpcUaXmlEncoder.encode*Matrix}) and the four decoder methods ({@code
+ * OpcUaXmlDecoder.decodeMatrix}, {@code decodeEnumMatrix}, and the two {@code decodeStructMatrix}
+ * overloads) must round-trip: a Matrix encoded to XML must decode back to an equal value. These
+ * tests reuse the same matrix fixtures the encoder tests use ({@code
+ * org.eclipse.milo.opcua.stack.core.encoding.xml.args.MatrixArguments}).
+ *
+ * <p>Most builtin types are asserted by full equality. Enumerated types are reduced to {@code
+ * Int32} and structured types are decoded back into their {@link UaStructuredType}, mirroring the
+ * reductions {@code OpcUaBinaryDecoder} performs, so those cases assert the corresponding reduced
+ * value. The {@code XmlElement} builtin case asserts type + dimensions + element count rather than
+ * verbatim equality because the scalar XmlElement codec normalizes fragments (see {@code
+ * OpcUaXmlSerializationTest}); the {@code ExtensionObject} case decodes both sides' bodies back to
+ * their structures, which do survive exactly.
+ */
+public class OpcUaXmlDecoderMatrixTest {
+
+  private final EncodingContext context = new DefaultEncodingContext();
+
+  // ---------------------------------------------------------------------------
+  // decodeMatrix(field, OpcUaDataType) — matrices of builtin types
+  // ---------------------------------------------------------------------------
+
+  @ParameterizedTest(name = "decodeMatrix builtin: {0}")
+  @MethodSource(
+      "org.eclipse.milo.opcua.stack.core.encoding.xml.args.MatrixArguments#matrixOfBuiltinTypeArguments")
+  void builtinMatrixRoundTrips(Matrix matrix, String ignoredExpectedXml) throws Exception {
+    String encoded = encode(e -> e.encodeMatrix("Test", matrix));
+
+    Matrix decoded;
+    try (var decoder = new OpcUaXmlDecoder(context)) {
+      decoder.setInput(new StringReader(encoded));
+      decoded = decoder.decodeMatrix("Test", matrix.getDataType().orElseThrow());
+    }
+
+    Class<?> elementType = matrix.getElementType().orElseThrow();
+    if (elementType == ExtensionObject.class) {
+      // An ExtensionObject carries its body as an XmlElement whose fragment the scalar codec
+      // normalizes (so the ExtensionObjects don't compare verbatim), but the structures they wrap
+      // survive exactly. Decode both sides back to their structures and assert full equality — this
+      // verifies values, count, and order, not just that something non-null came back.
+      assertEquals(decodeExtensionObjects(matrix), decodeExtensionObjects(decoded));
+    } else if (elementType == XmlElement.class) {
+      // The scalar XmlElement codec normalizes fragments (self-closing empty tags, dropped xmlns
+      // declarations, null/empty fragments), so XmlElements do not round-trip verbatim —
+      // OpcUaXmlSerializationTest documents this and compares XML semantically. Since this fidelity
+      // limitation lives in the scalar codec, not the Matrix decode under test, assert type +
+      // dimensions + element count (the last guards against dropped/duplicated elements).
+      assertFalse(decoded.isNull(), "decodeMatrix returned a null Matrix");
+      assertArrayEquals(matrix.getDimensions(), decoded.getDimensions());
+      assertEquals(elementType, decoded.getElementType().orElseThrow());
+      assertEquals(
+          Array.getLength(matrix.getElements()),
+          Array.getLength(decoded.getElements()),
+          "decoded element count must match the original");
+    } else {
+      // Strongest assertion: the full value must survive the round-trip.
+      assertEquals(matrix, decoded);
+    }
+  }
+
+  /** Decode each ExtensionObject element back into its structure for exact comparison. */
+  private Matrix decodeExtensionObjects(Matrix matrix) {
+    return matrix.transform(o -> ((ExtensionObject) o).decode(context));
+  }
+
+  // ---------------------------------------------------------------------------
+  // decodeEnumMatrix(field) — matrices of enumerated types
+  // ---------------------------------------------------------------------------
+
+  @ParameterizedTest(name = "decodeEnumMatrix: {0}")
+  @MethodSource(
+      "org.eclipse.milo.opcua.stack.core.encoding.xml.args.MatrixArguments#matrixOfEnumeratedTypeArguments")
+  void enumMatrixRoundTrips(Matrix matrix, String ignoredExpectedXml) throws Exception {
+    String encoded = encode(e -> e.encodeEnumMatrix("Test", matrix));
+
+    Matrix decoded;
+    try (var decoder = new OpcUaXmlDecoder(context)) {
+      decoder.setInput(new StringReader(encoded));
+      decoded = decoder.decodeEnumMatrix("Test");
+    }
+
+    // A correct decoder reduces enums to Int32 (cf. OpcUaBinaryDecoder.decodeEnumMatrix), so the
+    // expected value has Int32 elements equal to each enum's value, with the dimensions preserved.
+    assertFalse(decoded.isNull(), "decodeEnumMatrix returned a null Matrix");
+    assertArrayEquals(matrix.getDimensions(), decoded.getDimensions());
+    assertEquals(OpcUaDataType.Int32, decoded.getDataType().orElseThrow());
+
+    Matrix expected = matrix.transform(v -> ((UaEnumeratedType) v).getValue());
+    assertEquals(expected, decoded);
+  }
+
+  // ---------------------------------------------------------------------------
+  // decodeStructMatrix(field, NodeId / ExpandedNodeId) — matrices of structured types
+  // ---------------------------------------------------------------------------
+
+  @ParameterizedTest(name = "decodeStructMatrix(NodeId): {0}")
+  @MethodSource(
+      "org.eclipse.milo.opcua.stack.core.encoding.xml.args.MatrixArguments#matrixOfStructuredTypeArguments")
+  void structMatrixRoundTripsWithNodeId(Matrix matrix, String ignoredExpectedXml) throws Exception {
+    NodeId dataTypeId =
+        matrix.getDataTypeId().orElseThrow().toNodeId(context.getNamespaceTable()).orElseThrow();
+
+    String encoded = encode(e -> e.encodeStructMatrix("Test", matrix, dataTypeId));
+
+    Matrix decoded;
+    try (var decoder = new OpcUaXmlDecoder(context)) {
+      decoder.setInput(new StringReader(encoded));
+      decoded = decoder.decodeStructMatrix("Test", dataTypeId);
+    }
+
+    // A correct decoder decodes the ExtensionObject elements back into their structures, so the
+    // elements must be UaStructuredType (not raw ExtensionObject) and the value must round-trip.
+    assertFalse(decoded.isNull(), "decodeStructMatrix(NodeId) returned a null Matrix");
+    assertArrayEquals(matrix.getDimensions(), decoded.getDimensions());
+    assertTrue(
+        UaStructuredType.class.isAssignableFrom(decoded.getElementType().orElseThrow()),
+        "expected struct elements, got " + decoded.getElementType().orElseThrow());
+    assertEquals(matrix, decoded);
+  }
+
+  @ParameterizedTest(name = "decodeStructMatrix(ExpandedNodeId): {0}")
+  @MethodSource(
+      "org.eclipse.milo.opcua.stack.core.encoding.xml.args.MatrixArguments#matrixOfStructuredTypeArguments")
+  void structMatrixRoundTripsWithExpandedNodeId(Matrix matrix, String ignoredExpectedXml)
+      throws Exception {
+    ExpandedNodeId dataTypeId = matrix.getDataTypeId().orElseThrow();
+
+    String encoded = encode(e -> e.encodeStructMatrix("Test", matrix, dataTypeId));
+
+    Matrix decoded;
+    try (var decoder = new OpcUaXmlDecoder(context)) {
+      decoder.setInput(new StringReader(encoded));
+      decoded = decoder.decodeStructMatrix("Test", dataTypeId);
+    }
+
+    assertFalse(decoded.isNull(), "decodeStructMatrix(ExpandedNodeId) returned a null Matrix");
+    assertArrayEquals(matrix.getDimensions(), decoded.getDimensions());
+    assertTrue(
+        UaStructuredType.class.isAssignableFrom(decoded.getElementType().orElseThrow()),
+        "expected struct elements, got " + decoded.getElementType().orElseThrow());
+    assertEquals(matrix, decoded);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Explicit, self-contained value round-trips (no fixture indirection) so the
+  // data loss is obvious at a glance.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  void int32MatrixValueRoundTrips() throws Exception {
+    Matrix original = Matrix.ofInt32(new int[][] {{1, 2, 3}, {4, 5, 6}});
+
+    String encoded = encode(e -> e.encodeMatrix("Test", original));
+
+    Matrix decoded;
+    try (var decoder = new OpcUaXmlDecoder(context)) {
+      decoder.setInput(new StringReader(encoded));
+      decoded = decoder.decodeMatrix("Test", OpcUaDataType.Int32);
+    }
+
+    assertEquals(original, decoded);
+  }
+
+  @Test
+  void stringMatrixValueRoundTrips() throws Exception {
+    Matrix original = Matrix.ofString(new String[][] {{"a", "b"}, {"c", "d"}});
+
+    String encoded = encode(e -> e.encodeMatrix("Test", original));
+
+    Matrix decoded;
+    try (var decoder = new OpcUaXmlDecoder(context)) {
+      decoder.setInput(new StringReader(encoded));
+      decoded = decoder.decodeMatrix("Test", OpcUaDataType.String);
+    }
+
+    assertEquals(original, decoded);
+  }
+
+  @Test
+  void decodesIndentedMatrixXml() throws Exception {
+    // Pretty-printed XML (e.g. copied from a UANodeSet) has whitespace text nodes between elements.
+    // The decoder must locate <Dimensions>/<Elements> by element type, not by raw child position.
+    String indented =
+        """
+        <Test xmlns:uax="http://opcfoundation.org/UA/2008/02/Types.xsd">
+          <uax:Dimensions>
+            <uax:Int32>2</uax:Int32>
+            <uax:Int32>3</uax:Int32>
+          </uax:Dimensions>
+          <uax:Elements>
+            <uax:Int32>1</uax:Int32>
+            <uax:Int32>2</uax:Int32>
+            <uax:Int32>3</uax:Int32>
+            <uax:Int32>4</uax:Int32>
+            <uax:Int32>5</uax:Int32>
+            <uax:Int32>6</uax:Int32>
+          </uax:Elements>
+        </Test>
+        """;
+
+    Matrix decoded;
+    try (var decoder = new OpcUaXmlDecoder(context)) {
+      decoder.setInput(new StringReader(indented));
+      decoded = decoder.decodeMatrix("Test", OpcUaDataType.Int32);
+    }
+
+    assertEquals(Matrix.ofInt32(new int[][] {{1, 2, 3}, {4, 5, 6}}), decoded);
+  }
+
+  @Test
+  void decodesNullMatrix() throws Exception {
+    // A field with neither <Dimensions> nor <Elements> children decodes to a null Matrix rather
+    // than throwing or returning a non-null empty Matrix.
+    Matrix decoded;
+    try (var decoder = new OpcUaXmlDecoder(context)) {
+      decoder.setInput(new StringReader("<Test/>"));
+      decoded = decoder.decodeMatrix("Test", OpcUaDataType.Int32);
+    }
+
+    assertTrue(decoded.isNull());
+  }
+
+  // ---------------------------------------------------------------------------
+
+  private interface EncodeAction {
+    void accept(OpcUaXmlEncoder encoder) throws Exception;
+  }
+
+  private String encode(EncodeAction action) throws Exception {
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      action.accept(encoder);
+      return encoder.getOutputString();
+    }
+  }
+}

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/Matrix.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/Matrix.java
@@ -250,6 +250,10 @@ public class Matrix {
             .add("dataTypeId=" + (dataTypeId != null ? dataTypeId.toParseableString() : null))
             .add("dimensions=" + Arrays.toString(dimensions));
 
+    if (flatArray == null) {
+      return joiner.add("flatArray=null").toString();
+    }
+
     Class<?> clazz = ArrayUtil.getType(flatArray);
 
     if (clazz.isPrimitive()) {

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/types/builtin/MatrixTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/types/builtin/MatrixTest.java
@@ -85,6 +85,15 @@ class MatrixTest {
   }
 
   @Test
+  void nullMatrixToString() {
+    // A null Matrix has no flatArray; toString() must not throw (previously NPE'd in
+    // ArrayUtil.getType).
+    assertEquals(
+        "Matrix{dataType=null, dataTypeId=null, dimensions=[], flatArray=null}",
+        Matrix.ofNull().toString());
+  }
+
+  @Test
   void getDataType() {
     assertEquals(OpcUaDataType.Int32, primitiveMatrix2d.getDataType().orElse(null));
     assertEquals(OpcUaDataType.ExtensionObject, vectorMatrix2d.getDataType().orElse(null));


### PR DESCRIPTION
## Summary
`OpcUaXmlDecoder`'s four Matrix decode methods (`decodeMatrix`, `decodeEnumMatrix`,
and the two `decodeStructMatrix` overloads) were stubs that returned `Matrix.ofNull()`.
The encoder side (`OpcUaXmlEncoder.encode*Matrix`) is fully implemented, so a Matrix
encoded to XML produced well-formed output but **did not round-trip** — the value was
silently lost on decode.

This was raised in #1762, where the maintainer confirmed it was missed during the
1.0 `OpcUaXmlEncoder` work and gave the go-ahead (pointing to OPC 10000-6 §5.3).

## Changes
- `decodeMatrix` reads the `<Dimensions>` and `<Elements>` the encoder writes and
  rebuilds the Matrix with the requested `OpcUaDataType`.
- `decodeEnumMatrix` reduces each element to `Int32`, and `decodeStructMatrix` decodes
  the self-describing `ExtensionObject` elements back into their structures (returning
  a Matrix of `UaStructuredType`) — both mirror `OpcUaBinaryDecoder` and keep the
  decode→encode round-trip intact.
- Locate the `<Dimensions>`/`<Elements>` wrappers by element type, so indented XML
  (e.g. copied from a UANodeSet) also decodes.
- Reject malformed Matrix XML with `Bad_DecodingError` instead of building an invalid
  Matrix, per OPC 10000-6 §5.3: dimensions whose product does not match the element
  count, non-positive dimensions, builtin elements whose XML tag name is not the
  requested type name, and (for `decodeStructMatrix`) `ExtensionObject`s that decode to
  a different structure type than the requested `dataTypeId` — the last resolves the
  codec for `dataTypeId` and validates against it, mirroring `decodeStructArray`.
- Guard `Matrix.toString()` against the null-Matrix `NullPointerException` noted in
  the issue (`ArrayUtil.getType` on a null `flatArray`).

## Tests
- `OpcUaXmlDecoderMatrixTest`: round-trips the same `MatrixArguments` fixtures the
  encoder tests use across the builtin, enumerated, and structured types; asserts that
  struct matrices decode back to `UaStructuredType`; indented-XML and null-Matrix
  decode cases; plus the validation cases for malformed XML (mismatched/non-positive
  dimensions, wrong element name, unexpected struct type).
- `MatrixTest`: `toString()` on a null Matrix no longer throws.

Fixes #1762

---
Developed with AI assistance (Anthropic Claude Opus 4.8); the human contributor
reviewed, verified, and tested all changes.
