### PR TITLE
Fix duplicate monitored item delete accounting

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/subscriptions/SubscriptionManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/subscriptions/SubscriptionManager.java
@@ -20,11 +20,13 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -1256,6 +1258,7 @@ public class SubscriptionManager {
 
     var deleteResults = new StatusCode[itemsToDelete.length];
     var deletedItems = new ArrayList<BaseMonitoredItem<?>>(itemsToDelete.length);
+    Set<UInteger> deletedItemIds = new HashSet<>();
 
     synchronized (subscription) {
       for (int i = 0; i < itemsToDelete.length; i++) {
@@ -1265,12 +1268,14 @@ public class SubscriptionManager {
         if (item == null) {
           deleteResults[i] = new StatusCode(StatusCodes.Bad_MonitoredItemIdInvalid);
         } else {
-          deletedItems.add(item);
+          if (deletedItemIds.add(itemId)) {
+            deletedItems.add(item);
+
+            monitoredItemCount.decrementAndGet();
+            server.getMonitoredItemCount().decrementAndGet();
+          }
 
           deleteResults[i] = StatusCode.GOOD;
-
-          monitoredItemCount.decrementAndGet();
-          server.getMonitoredItemCount().decrementAndGet();
         }
       }
 


### PR DESCRIPTION
### Motivation
- The server-wide monitored item counter could be decremented multiple times if a `DeleteMonitoredItems` request contains duplicate MonitoredItemIds, which allows a client to drive the counter below the real item count and bypass the configured `maxMonitoredItems` limit.

### Description
- Track unique monitored item IDs during `deleteMonitoredItems` by adding a `Set<UInteger> deletedItemIds` and the corresponding `HashSet`/`Set` imports.
- Decrement the session and server `monitoredItemCount` only once per unique monitored item removed, while still returning `GOOD` for duplicate valid IDs in the request.
- Add only the actual monitored items (one per unique id) to the `deletedItems` list so `subscription.removeMonitoredItems` is called once per real removal.
