### PR TITLE
Decode omitted/null struct members per JSON CompactEncoding

### DIFF
--- a/opc-ua-stack/encoding-json/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonDecoder.java
+++ b/opc-ua-stack/encoding-json/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonDecoder.java
@@ -1132,10 +1132,18 @@ public class OpcUaJsonDecoder implements UaDecoder {
         if (field != null) {
           String nextName = nextName();
           if (!field.equals(nextName)) {
-            throw new UaSerializationException(
-                StatusCodes.Bad_DecodingError,
-                String.format("readStruct: %s != %s", field, nextName));
+            // CompactEncoding omits default-valued and NULL struct members (Part 6, §5.4.6,
+            // Table 45). Restore the peeked name and return the default (null), mirroring the
+            // other field decoders, instead of failing the whole structure.
+            this.peekedNextName = nextName;
+            return null;
           }
+        }
+
+        // VerboseEncoding represents a NULL struct member as JSON null (Part 6, §5.4.6, Table 45).
+        if (jsonReader.peek() == JsonToken.NULL) {
+          jsonReader.nextNull();
+          return null;
         }
 
         UaStructuredType value;
@@ -1176,10 +1184,18 @@ public class OpcUaJsonDecoder implements UaDecoder {
       if (field != null) {
         String nextName = nextName();
         if (!field.equals(nextName)) {
-          throw new UaSerializationException(
-              StatusCodes.Bad_DecodingError,
-              String.format("readStruct: %s != %s", field, nextName));
+          // CompactEncoding omits default-valued and NULL struct members (Part 6, §5.4.6,
+          // Table 45). Restore the peeked name and return the default (null), mirroring the
+          // other field decoders, instead of failing the whole structure.
+          this.peekedNextName = nextName;
+          return null;
         }
+      }
+
+      // VerboseEncoding represents a NULL struct member as JSON null (Part 6, §5.4.6, Table 45).
+      if (jsonReader.peek() == JsonToken.NULL) {
+        jsonReader.nextNull();
+        return null;
       }
 
       UaStructuredType value;

--- a/opc-ua-stack/encoding-json/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonDecoderTest.java
+++ b/opc-ua-stack/encoding-json/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonDecoderTest.java
@@ -1109,6 +1109,54 @@ class OpcUaJsonDecoderTest {
     assertThrows(UaSerializationException.class, () -> decoder.decodeQualifiedName(null));
   }
 
+  /**
+   * Issue 1773: {@code decodeStruct(String field, ...)} throws {@code Bad_DecodingError} on a
+   * member-name mismatch, but the CompactEncoding omits default-valued (and NULL) struct members
+   * (OPC 10000-6 §5.4.6, Table 45). Like every sibling field decoder, it must instead stash the
+   * peeked name and return {@code null} so the surrounding object keeps decoding.
+   */
+  @Test
+  void decodeStruct_omittedMember_restoresNameAndReturnsNull() throws IOException {
+    var decoder = new OpcUaJsonDecoder(context, new StringReader("{\"Other\":42}"));
+    decoder.jsonReader.beginObject();
+
+    // "ConfigurationVersion" is absent; the next member is "Other".
+    assertNull(decoder.decodeStruct("ConfigurationVersion", XVType.TYPE_ID));
+    // The peeked name was restored, so the following member still decodes.
+    assertEquals(42, decoder.decodeInt32("Other"));
+    decoder.jsonReader.endObject();
+  }
+
+  /**
+   * Issue 1773: a struct member encoded as JSON {@code null} (the VerboseEncoding of NULL per OPC
+   * 10000-6 §5.4.6, Table 45) must decode to {@code null} rather than failing with "Expected
+   * BEGIN_OBJECT but was NULL".
+   */
+  @Test
+  void decodeStruct_jsonNullMember_returnsNull() throws IOException {
+    var decoder =
+        new OpcUaJsonDecoder(context, new StringReader("{\"ConfigurationVersion\":null}"));
+    decoder.jsonReader.beginObject();
+
+    assertNull(decoder.decodeStruct("ConfigurationVersion", XVType.TYPE_ID));
+    decoder.jsonReader.endObject();
+  }
+
+  /**
+   * Issue 1773: the real-world interop case. A spec-conformant Compact document legally omits the
+   * all-default {@code ConfigurationVersion} member of {@link DataSetMetaDataType}; the whole
+   * structure must still decode, with that member taking its default ({@code null}) value.
+   */
+  @Test
+  void decodeStruct_compactOmitsDefaultValuedStructMember() {
+    var decoder = new OpcUaJsonDecoder(context, "{\"Name\":\"Demo\",\"Fields\":[]}");
+
+    var decoded = (DataSetMetaDataType) decoder.decodeStruct(null, DataSetMetaDataType.TYPE_ID);
+
+    assertEquals("Demo", decoded.getName());
+    assertNull(decoded.getConfigurationVersion());
+  }
+
   private static byte[] randomBytes16() {
     var random = new Random();
     var bs = new byte[16];


### PR DESCRIPTION
## Summary
`OpcUaJsonDecoder.decodeStruct(String field, ...)` threw `Bad_DecodingError` when a
struct-typed member was omitted from the containing JSON object. But the JSON
CompactEncoding *omits* default-valued and NULL struct members (OPC 10000-6 §5.4.6,
Table 45), so a spec-conformant Compact document failed to decode entirely.

`decodeStruct` was the only field decoder that threw on a member-name mismatch; every
sibling (`decodeString`, `decodeStructArray`, …) already stashes the peeked name and
returns the default value. A JSON-`null` struct member (the VerboseEncoding of NULL)
also failed with `Expected BEGIN_OBJECT but was NULL`.

This was raised in #1773, filed by the maintainer, who confirmed the fix on the issue.

## Changes
- Align the `NodeId` and `DataTypeCodec` overloads of `decodeStruct(String, …)` with
  the sibling field decoders: on a member-name mismatch, restore `peekedNextName` and
  return `null` instead of throwing. The `ExpandedNodeId` overload delegates to the
  `NodeId` one, so it is covered too.
- Handle a JSON-`null` struct member by consuming it and returning `null`, mirroring
  the other decoders that peek for `JsonToken.NULL` before `beginObject()`.

## Tests
- `OpcUaJsonDecoderTest` (spec-compliance section): an omitted struct member restores
  the peeked name so the surrounding object keeps decoding; a JSON-`null` struct member
  returns `null` rather than throwing; and an end-to-end Compact `DataSetMetaDataType`
  with `ConfigurationVersion` omitted decodes, with that member taking its default value
  — the real interop case from the issue (Prosys `ua-metadata` messages).

Fixes #1773

---
Developed with AI assistance (Anthropic Claude Opus 4.8); the human contributor
reviewed, verified, and tested all changes.