### PR TITLE
Implement remaining EventFilter whereClause operators

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/subscriptions/EventFilterWhereClauseOperatorTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/subscriptions/EventFilterWhereClauseOperatorTest.java
@@ -1,0 +1,305 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.subscriptions;
+
+import static java.util.Objects.requireNonNullElse;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.eclipse.milo.opcua.sdk.client.subscriptions.OpcUaMonitoredItem;
+import org.eclipse.milo.opcua.sdk.client.subscriptions.OpcUaSubscription;
+import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
+import org.eclipse.milo.opcua.sdk.test.AbstractClientServerTest;
+import org.eclipse.milo.opcua.stack.core.AttributeId;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.FilterOperator;
+import org.eclipse.milo.opcua.stack.core.types.structured.ContentFilter;
+import org.eclipse.milo.opcua.stack.core.types.structured.ContentFilterElement;
+import org.eclipse.milo.opcua.stack.core.types.structured.ContentFilterElementResult;
+import org.eclipse.milo.opcua.stack.core.types.structured.ElementOperand;
+import org.eclipse.milo.opcua.stack.core.types.structured.EventFilter;
+import org.eclipse.milo.opcua.stack.core.types.structured.EventFilterResult;
+import org.eclipse.milo.opcua.stack.core.types.structured.FilterOperand;
+import org.eclipse.milo.opcua.stack.core.types.structured.LiteralOperand;
+import org.eclipse.milo.opcua.stack.core.types.structured.SimpleAttributeOperand;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class EventFilterWhereClauseOperatorTest extends AbstractClientServerTest {
+
+  private OpcUaSubscription subscription;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    subscription = new OpcUaSubscription(client);
+    subscription.create();
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    subscription.delete();
+  }
+
+  @Test
+  void testWhereClauseOperatorsDeliverMatchingEvents() throws Exception {
+    List<OperatorCase> cases =
+        List.of(
+            new OperatorCase(
+                "Like",
+                where(element(FilterOperator.Like, eventField("Message"), literal("event%")))),
+            new OperatorCase(
+                "Between",
+                where(
+                    element(
+                        FilterOperator.Between,
+                        eventField("Severity"),
+                        literal(ushort(1)),
+                        literal(ushort(3))))),
+            new OperatorCase(
+                "InList",
+                where(
+                    element(
+                        FilterOperator.InList,
+                        eventField("Severity"),
+                        literal(ushort(1)),
+                        literal(ushort(2)),
+                        literal(ushort(3))))),
+            new OperatorCase(
+                "And",
+                where(
+                    element(FilterOperator.And, elementOperand(1), elementOperand(2)),
+                    element(
+                        FilterOperator.GreaterThanOrEqual,
+                        eventField("Severity"),
+                        literal(ushort(1))),
+                    element(
+                        FilterOperator.LessThanOrEqual,
+                        eventField("Severity"),
+                        literal(ushort(3))))),
+            new OperatorCase(
+                "Or",
+                where(
+                    element(FilterOperator.Or, elementOperand(1), elementOperand(2)),
+                    element(FilterOperator.Equals, eventField("Severity"), literal(ushort(99))),
+                    element(FilterOperator.Equals, eventField("Severity"), literal(ushort(2))))),
+            new OperatorCase(
+                "BitwiseAnd",
+                where(
+                    element(FilterOperator.Equals, elementOperand(1), literal(ushort(2))),
+                    element(
+                        FilterOperator.BitwiseAnd, eventField("Severity"), literal(ushort(2))))),
+            new OperatorCase(
+                "BitwiseOr",
+                where(
+                    element(FilterOperator.Equals, elementOperand(1), literal(ushort(6))),
+                    element(
+                        FilterOperator.BitwiseOr, eventField("Severity"), literal(ushort(4))))));
+
+    CountDownLatch latch = new CountDownLatch(cases.size());
+    List<MonitoredCase> monitoredCases = new ArrayList<>();
+
+    for (OperatorCase operatorCase : cases) {
+      CopyOnWriteArrayList<Variant[]> events = new CopyOnWriteArrayList<>();
+      OpcUaMonitoredItem item =
+          OpcUaMonitoredItem.newEventItem(NodeIds.Server, eventFilter(operatorCase.whereClause()));
+
+      item.setQueueSize(uint(10));
+      item.setEventValueListener(
+          (monitoredItem, eventFields) -> {
+            events.add(eventFields);
+            latch.countDown();
+          });
+
+      subscription.addMonitoredItem(item);
+      monitoredCases.add(new MonitoredCase(operatorCase, item, events));
+    }
+
+    subscription.synchronizeMonitoredItems();
+
+    for (MonitoredCase monitoredCase : monitoredCases) {
+      assertGoodFilterResult(monitoredCase.item(), monitoredCase.operatorCase().whereClause());
+    }
+
+    fireBaseEvent(ushort(2), "event message!");
+
+    assertTrue(latch.await(5, TimeUnit.SECONDS), "matching events were not delivered");
+
+    for (MonitoredCase monitoredCase : monitoredCases) {
+      assertFalse(
+          monitoredCase.events().isEmpty(),
+          monitoredCase.operatorCase().name() + " did not receive a matching event");
+
+      Variant[] eventFields = monitoredCase.events().get(0);
+
+      assertNotNull(eventFields);
+      assertEquals("event message!", ((LocalizedText) eventFields[0].value()).text());
+      assertEquals(ushort(2), eventFields[1].value());
+    }
+  }
+
+  @Test
+  void testNonMatchingWhereClauseSuppressesEvent() throws Exception {
+    CountDownLatch latch = new CountDownLatch(1);
+    CopyOnWriteArrayList<Variant[]> events = new CopyOnWriteArrayList<>();
+
+    ContentFilter whereClause =
+        where(
+            element(
+                FilterOperator.InList,
+                eventField("Severity"),
+                literal(ushort(99)),
+                literal(ushort(100))));
+
+    OpcUaMonitoredItem item =
+        OpcUaMonitoredItem.newEventItem(NodeIds.Server, eventFilter(whereClause));
+
+    item.setEventValueListener(
+        (monitoredItem, eventFields) -> {
+          events.add(eventFields);
+          latch.countDown();
+        });
+
+    subscription.addMonitoredItem(item);
+    subscription.synchronizeMonitoredItems();
+
+    assertGoodFilterResult(item, whereClause);
+
+    fireBaseEvent(ushort(2), "event message!");
+
+    assertFalse(latch.await(2, TimeUnit.SECONDS), "non-matching event was delivered");
+    assertTrue(events.isEmpty());
+  }
+
+  private EventFilter eventFilter(ContentFilter whereClause) {
+    return new EventFilter(
+        new SimpleAttributeOperand[] {eventField("Message"), eventField("Severity")}, whereClause);
+  }
+
+  private void assertGoodFilterResult(OpcUaMonitoredItem item, ContentFilter whereClause)
+      throws Exception {
+
+    assertTrue(item.getCreateResult().orElseThrow().isGood());
+
+    EventFilterResult result =
+        (EventFilterResult)
+            item.getFilterResult().orElseThrow().decode(client.getStaticEncodingContext());
+
+    for (StatusCode selectClauseResult :
+        requireNonNullElse(result.getSelectClauseResults(), new StatusCode[0])) {
+      assertTrue(selectClauseResult.isGood());
+    }
+
+    ContentFilterElementResult[] elementResults =
+        requireNonNullElse(
+            result.getWhereClauseResult().getElementResults(), new ContentFilterElementResult[0]);
+    ContentFilterElement[] elements = whereClause.getElements();
+
+    assertEquals(elements.length, elementResults.length);
+
+    for (ContentFilterElementResult elementResult : elementResults) {
+      assertTrue(elementResult.getStatusCode().isGood());
+
+      for (StatusCode operandStatus :
+          requireNonNullElse(elementResult.getOperandStatusCodes(), new StatusCode[0])) {
+        assertTrue(operandStatus.isGood());
+      }
+    }
+  }
+
+  private void fireBaseEvent(UShort severity, String message) throws Exception {
+    UUID eventId = UUID.randomUUID();
+    BaseEventTypeNode eventNode =
+        server
+            .getEventFactory()
+            .createEvent(
+                newNodeId("EventFilterWhereClauseOperatorTest/" + eventId), NodeIds.BaseEventType);
+
+    try {
+      eventNode.setBrowseName(newQualifiedName("EventFilterWhereClauseOperatorTest"));
+      eventNode.setDisplayName(LocalizedText.english("EventFilterWhereClauseOperatorTest"));
+      eventNode.setEventId(toByteString(eventId));
+      eventNode.setEventType(NodeIds.BaseEventType);
+      eventNode.setSourceNode(NodeIds.Server);
+      eventNode.setSourceName("Server");
+      eventNode.setTime(DateTime.now());
+      eventNode.setReceiveTime(DateTime.NULL_VALUE);
+      eventNode.setMessage(LocalizedText.english(message));
+      eventNode.setSeverity(severity);
+
+      server.getEventNotifier().fire(eventNode);
+    } finally {
+      eventNode.delete();
+    }
+  }
+
+  private static ByteString toByteString(UUID uuid) {
+    ByteBuffer buffer = ByteBuffer.allocate(16);
+    buffer.putLong(uuid.getMostSignificantBits());
+    buffer.putLong(uuid.getLeastSignificantBits());
+    return ByteString.of(buffer.array());
+  }
+
+  private static ContentFilter where(ContentFilterElement... elements) {
+    return new ContentFilter(elements);
+  }
+
+  private static ContentFilterElement element(FilterOperator operator, FilterOperand... operands) {
+    ExtensionObject[] encodedOperands = new ExtensionObject[operands.length];
+
+    for (int i = 0; i < operands.length; i++) {
+      encodedOperands[i] = ExtensionObject.encode(DefaultEncodingContext.INSTANCE, operands[i]);
+    }
+
+    return new ContentFilterElement(operator, encodedOperands);
+  }
+
+  private static SimpleAttributeOperand eventField(String browseName) {
+    return new SimpleAttributeOperand(
+        NodeIds.BaseEventType,
+        new QualifiedName[] {new QualifiedName(0, browseName)},
+        AttributeId.Value.uid(),
+        null);
+  }
+
+  private static LiteralOperand literal(Object value) {
+    return new LiteralOperand(new Variant(value));
+  }
+
+  private static ElementOperand elementOperand(int index) {
+    return new ElementOperand(uint(index));
+  }
+
+  private record OperatorCase(String name, ContentFilter whereClause) {}
+
+  private record MonitoredCase(
+      OperatorCase operatorCase, OpcUaMonitoredItem item, CopyOnWriteArrayList<Variant[]> events) {}
+}

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/subscriptions/EventFilterWhereClauseOperatorTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/subscriptions/EventFilterWhereClauseOperatorTest.java
@@ -74,8 +74,40 @@ public class EventFilterWhereClauseOperatorTest extends AbstractClientServerTest
     List<OperatorCase> cases =
         List.of(
             new OperatorCase(
+                "Equals",
+                where(element(FilterOperator.Equals, eventField("Severity"), literal(ushort(2))))),
+            new OperatorCase("IsNull", where(element(FilterOperator.IsNull, literal(null)))),
+            new OperatorCase(
+                "GreaterThan",
+                where(
+                    element(
+                        FilterOperator.GreaterThan, eventField("Severity"), literal(ushort(1))))),
+            new OperatorCase(
+                "LessThan",
+                where(
+                    element(FilterOperator.LessThan, eventField("Severity"), literal(ushort(3))))),
+            new OperatorCase(
+                "GreaterThanOrEqual",
+                where(
+                    element(
+                        FilterOperator.GreaterThanOrEqual,
+                        eventField("Severity"),
+                        literal(ushort(2))))),
+            new OperatorCase(
+                "LessThanOrEqual",
+                where(
+                    element(
+                        FilterOperator.LessThanOrEqual,
+                        eventField("Severity"),
+                        literal(ushort(2))))),
+            new OperatorCase(
                 "Like",
                 where(element(FilterOperator.Like, eventField("Message"), literal("event%")))),
+            new OperatorCase(
+                "Not",
+                where(
+                    element(FilterOperator.Not, elementOperand(1)),
+                    element(FilterOperator.Equals, eventField("Severity"), literal(ushort(99))))),
             new OperatorCase(
                 "Between",
                 where(
@@ -112,6 +144,11 @@ public class EventFilterWhereClauseOperatorTest extends AbstractClientServerTest
                     element(FilterOperator.Equals, eventField("Severity"), literal(ushort(99))),
                     element(FilterOperator.Equals, eventField("Severity"), literal(ushort(2))))),
             new OperatorCase(
+                "Cast",
+                where(
+                    element(FilterOperator.Equals, elementOperand(1), literal(2)),
+                    element(FilterOperator.Cast, eventField("Severity"), literal(NodeIds.Int32)))),
+            new OperatorCase(
                 "BitwiseAnd",
                 where(
                     element(FilterOperator.Equals, elementOperand(1), literal(ushort(2))),
@@ -121,8 +158,9 @@ public class EventFilterWhereClauseOperatorTest extends AbstractClientServerTest
                 "BitwiseOr",
                 where(
                     element(FilterOperator.Equals, elementOperand(1), literal(ushort(6))),
-                    element(
-                        FilterOperator.BitwiseOr, eventField("Severity"), literal(ushort(4))))));
+                    element(FilterOperator.BitwiseOr, eventField("Severity"), literal(ushort(4))))),
+            new OperatorCase(
+                "OfType", where(element(FilterOperator.OfType, literal(NodeIds.BaseEventType)))));
 
     CountDownLatch latch = new CountDownLatch(cases.size());
     List<MonitoredCase> monitoredCases = new ArrayList<>();

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/EventContentFilter.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/EventContentFilter.java
@@ -12,6 +12,7 @@ package org.eclipse.milo.opcua.sdk.server.events;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -363,15 +364,15 @@ public class EventContentFilter {
       case LessThan -> Operators.LESS_THAN;
       case GreaterThanOrEqual -> Operators.GREATER_THAN_OR_EQUAL;
       case LessThanOrEqual -> Operators.LESS_THAN_OR_EQUAL;
-      case Like -> Operators.UNSUPPORTED;
+      case Like -> Operators.LIKE;
       case Not -> Operators.NOT;
-      case Between -> Operators.UNSUPPORTED;
-      case InList -> Operators.UNSUPPORTED;
-      case And -> Operators.UNSUPPORTED;
-      case Or -> Operators.UNSUPPORTED;
+      case Between -> Operators.BETWEEN;
+      case InList -> Operators.IN_LIST;
+      case And -> Operators.AND;
+      case Or -> Operators.OR;
       case Cast -> Operators.CAST;
-      case BitwiseAnd -> Operators.UNSUPPORTED;
-      case BitwiseOr -> Operators.UNSUPPORTED;
+      case BitwiseAnd -> Operators.BITWISE_AND;
+      case BitwiseOr -> Operators.BITWISE_OR;
 
       // Complex FilterOperators
       case InView -> Operators.UNSUPPORTED;
@@ -491,6 +492,9 @@ public class EventContentFilter {
     private final FilterContext filterContext;
     private final ContentFilterElement[] elements;
 
+    // Indices of the elements currently being evaluated, used to detect ElementOperand cycles.
+    private final Set<Integer> evaluatingElements = new HashSet<>();
+
     DefaultOperatorContext(FilterContext filterContext, ContentFilterElement[] elements) {
       this.filterContext = filterContext;
       this.elements = elements;
@@ -516,12 +520,29 @@ public class EventContentFilter {
     public Object resolve(FilterOperand operand, BaseEventTypeNode eventNode) throws UaException {
       if (operand instanceof LiteralOperand) {
         return ((LiteralOperand) operand).getValue().value();
-      } else if (operand instanceof ElementOperand) {
-        UInteger index = ((ElementOperand) operand).getIndex();
+      } else if (operand instanceof ElementOperand elementOperand) {
+        UInteger index = elementOperand.getIndex();
 
-        ContentFilterElement element = elements[index.intValue()];
+        if (index == null || index.longValue() >= elements.length) {
+          throw new UaException(
+              StatusCodes.Bad_FilterOperandInvalid, "ElementOperand index out of range: " + index);
+        }
 
-        return evaluate(this, eventNode, element);
+        int elementIndex = index.intValue();
+
+        // Guard against self- or mutually referential ElementOperands, which would otherwise
+        // recurse until a StackOverflowError escaped the per-event handler.
+        if (!evaluatingElements.add(elementIndex)) {
+          throw new UaException(
+              StatusCodes.Bad_FilterOperandInvalid,
+              "ElementOperand cycle detected at index: " + elementIndex);
+        }
+
+        try {
+          return evaluate(this, eventNode, elements[elementIndex]);
+        } finally {
+          evaluatingElements.remove(elementIndex);
+        }
       } else if (operand instanceof AttributeOperand ao) {
         return getAttribute(filterContext, ao, eventNode);
       } else if (operand instanceof SimpleAttributeOperand sao) {

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/ExplicitConversions.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/ExplicitConversions.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.events.conversions;
+
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+public class ExplicitConversions {
+
+  private ExplicitConversions() {}
+
+  @Nullable
+  public static Object convert(@Nullable Object sourceValue, @NonNull OpcUaDataType targetType) {
+    if (sourceValue == null) {
+      return null;
+    }
+
+    OpcUaDataType sourceType = OpcUaDataType.fromBackingClass(sourceValue.getClass());
+
+    if (sourceType == null) {
+      return null;
+    }
+
+    if (!sourceType.getBackingClass().isAssignableFrom(sourceValue.getClass())) {
+      return null;
+    }
+
+    if (sourceType == targetType) {
+      return sourceValue;
+    }
+
+    return convert(sourceValue, sourceType, targetType);
+  }
+
+  @Nullable
+  private static Object convert(
+      @NonNull Object sourceValue, OpcUaDataType sourceType, OpcUaDataType targetType) {
+
+    switch (sourceType) {
+      case Boolean:
+        return BooleanConversions.convert(sourceValue, targetType, false);
+      case Byte:
+        return ByteConversions.convert(sourceValue, targetType, false);
+
+      case ByteString:
+        return ByteStringConversions.convert(sourceValue, targetType, false);
+
+      case DateTime:
+        return DateTimeConversions.convert(sourceValue, targetType, false);
+
+      case Double:
+        return DoubleConversions.convert(sourceValue, targetType, false);
+
+      case ExpandedNodeId:
+        return ExpandedNodeIdConversions.convert(sourceValue, targetType, false);
+
+      case Float:
+        return FloatConversions.convert(sourceValue, targetType, false);
+      case Guid:
+        return GuidConversions.convert(sourceValue, targetType, false);
+
+      case Int16:
+        return Int16Conversions.convert(sourceValue, targetType, false);
+
+      case Int32:
+        return Int32Conversions.convert(sourceValue, targetType, false);
+
+      case Int64:
+        return Int64Conversions.convert(sourceValue, targetType, false);
+
+      case NodeId:
+        return NodeIdConversions.convert(sourceValue, targetType, false);
+
+      case SByte:
+        return SByteConversions.convert(sourceValue, targetType, false);
+
+      case StatusCode:
+        return StatusCodeConversions.convert(sourceValue, targetType, false);
+
+      case String:
+        return StringConversions.convert(sourceValue, targetType, false);
+
+      case LocalizedText:
+        return LocalizedTextConversions.convert(sourceValue, targetType, false);
+
+      case QualifiedName:
+        return QualifiedNameConversions.convert(sourceValue, targetType, false);
+
+      case UInt16:
+        return UInt16Conversions.convert(sourceValue, targetType, false);
+
+      case UInt32:
+        return UInt32Conversions.convert(sourceValue, targetType, false);
+
+      case UInt64:
+        return UInt64Conversions.convert(sourceValue, targetType, false);
+
+      default:
+        return null;
+    }
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/UInt64Conversions.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/UInt64Conversions.java
@@ -29,7 +29,7 @@ final class UInt64Conversions {
 
   @NonNull
   static Boolean uInt64ToBoolean(@NonNull ULong ul) {
-    return ul.intValue() != 0;
+    return ul.longValue() != 0L;
   }
 
   @Nullable

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/And.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/And.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 the Eclipse Milo Authors
+ * Copyright (c) 2026 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -18,9 +18,9 @@ import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.structured.FilterOperand;
 import org.jspecify.annotations.Nullable;
 
-public class Equals implements Operator<Boolean> {
+public class And implements Operator<Boolean> {
 
-  Equals() {}
+  And() {}
 
   @Override
   public void validate(FilterContext context, FilterOperand[] operands) throws ValidationException {
@@ -35,9 +35,28 @@ public class Equals implements Operator<Boolean> {
 
     validate(context, operands);
 
-    Object value0 = context.resolve(operands[0], eventNode);
-    Object value1 = context.resolve(operands[1], eventNode);
+    // Part 4 Table 123 defines three-valued logical AND; do not collapse NULL to FALSE here. A
+    // determining FALSE short-circuits before the other operand is resolved, so an error (or cost)
+    // resolving the non-determining operand cannot turn a FALSE result into a thrown exception.
+    Boolean lhs = asBoolean(OperatorUtil.resolve(context, eventNode, operands[0]));
 
-    return OperatorUtil.equalValues(value0, value1);
+    if (Boolean.FALSE.equals(lhs)) {
+      return false;
+    }
+
+    Boolean rhs = asBoolean(OperatorUtil.resolve(context, eventNode, operands[1]));
+
+    if (Boolean.FALSE.equals(rhs)) {
+      return false;
+    } else if (lhs == null || rhs == null) {
+      return null;
+    } else {
+      return true;
+    }
+  }
+
+  @Nullable
+  private static Boolean asBoolean(@Nullable Object value) {
+    return OperatorUtil.toBoolean(value);
   }
 }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/Between.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/Between.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.events.operators;
+
+import org.eclipse.milo.opcua.sdk.server.events.FilterContext;
+import org.eclipse.milo.opcua.sdk.server.events.OperatorContext;
+import org.eclipse.milo.opcua.sdk.server.events.ValidationException;
+import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.structured.FilterOperand;
+import org.jspecify.annotations.Nullable;
+
+public class Between implements Operator<Boolean> {
+
+  Between() {}
+
+  @Override
+  public void validate(FilterContext context, FilterOperand[] operands) throws ValidationException {
+    OperatorUtil.validateMinOperandCount(operands, 3);
+  }
+
+  @Nullable
+  @Override
+  public Boolean apply(
+      OperatorContext context, BaseEventTypeNode eventNode, FilterOperand[] operands)
+      throws UaException {
+
+    validate(context, operands);
+
+    Object value = OperatorUtil.resolve(context, eventNode, operands[0]);
+    Object lowerBound = OperatorUtil.resolve(context, eventNode, operands[1]);
+    Object upperBound = OperatorUtil.resolve(context, eventNode, operands[2]);
+
+    if (value == null || lowerBound == null || upperBound == null) {
+      return null;
+    }
+
+    OperatorUtil.TernaryOperands commonOperands =
+        OperatorUtil.convertToCommonType(value, lowerBound, upperBound);
+
+    if (commonOperands == null) {
+      return false;
+    }
+
+    Integer lowerCompare =
+        OperatorUtil.compareOrdered(
+            commonOperands.dataType(), commonOperands.operand0(), commonOperands.operand1());
+    Integer upperCompare =
+        OperatorUtil.compareOrdered(
+            commonOperands.dataType(), commonOperands.operand0(), commonOperands.operand2());
+
+    if (lowerCompare == null || upperCompare == null) {
+      return false;
+    }
+
+    return lowerCompare >= 0 && upperCompare <= 0;
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/BitwiseAnd.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/BitwiseAnd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 the Eclipse Milo Authors
+ * Copyright (c) 2026 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -18,9 +18,9 @@ import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.structured.FilterOperand;
 import org.jspecify.annotations.Nullable;
 
-public class Equals implements Operator<Boolean> {
+public class BitwiseAnd implements Operator<Object> {
 
-  Equals() {}
+  BitwiseAnd() {}
 
   @Override
   public void validate(FilterContext context, FilterOperand[] operands) throws ValidationException {
@@ -29,15 +29,19 @@ public class Equals implements Operator<Boolean> {
 
   @Nullable
   @Override
-  public Boolean apply(
+  public Object apply(
       OperatorContext context, BaseEventTypeNode eventNode, FilterOperand[] operands)
       throws UaException {
 
     validate(context, operands);
 
-    Object value0 = context.resolve(operands[0], eventNode);
-    Object value1 = context.resolve(operands[1], eventNode);
+    Object lhs = OperatorUtil.resolve(context, eventNode, operands[0]);
+    Object rhs = OperatorUtil.resolve(context, eventNode, operands[1]);
 
-    return OperatorUtil.equalValues(value0, value1);
+    if (lhs == null || rhs == null) {
+      return null;
+    }
+
+    return OperatorUtil.bitwise(lhs, rhs, (a, b) -> a & b);
   }
 }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/BitwiseOr.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/BitwiseOr.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 the Eclipse Milo Authors
+ * Copyright (c) 2026 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -18,9 +18,9 @@ import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.structured.FilterOperand;
 import org.jspecify.annotations.Nullable;
 
-public class Equals implements Operator<Boolean> {
+public class BitwiseOr implements Operator<Object> {
 
-  Equals() {}
+  BitwiseOr() {}
 
   @Override
   public void validate(FilterContext context, FilterOperand[] operands) throws ValidationException {
@@ -29,15 +29,19 @@ public class Equals implements Operator<Boolean> {
 
   @Nullable
   @Override
-  public Boolean apply(
+  public Object apply(
       OperatorContext context, BaseEventTypeNode eventNode, FilterOperand[] operands)
       throws UaException {
 
     validate(context, operands);
 
-    Object value0 = context.resolve(operands[0], eventNode);
-    Object value1 = context.resolve(operands[1], eventNode);
+    Object lhs = OperatorUtil.resolve(context, eventNode, operands[0]);
+    Object rhs = OperatorUtil.resolve(context, eventNode, operands[1]);
 
-    return OperatorUtil.equalValues(value0, value1);
+    if (lhs == null || rhs == null) {
+      return null;
+    }
+
+    return OperatorUtil.bitwise(lhs, rhs, (a, b) -> a | b);
   }
 }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/Cast.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/Cast.java
@@ -13,7 +13,7 @@ package org.eclipse.milo.opcua.sdk.server.events.operators;
 import org.eclipse.milo.opcua.sdk.server.events.FilterContext;
 import org.eclipse.milo.opcua.sdk.server.events.OperatorContext;
 import org.eclipse.milo.opcua.sdk.server.events.ValidationException;
-import org.eclipse.milo.opcua.sdk.server.events.conversions.ImplicitConversions;
+import org.eclipse.milo.opcua.sdk.server.events.conversions.ExplicitConversions;
 import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
 import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
@@ -53,7 +53,7 @@ public class Cast implements Operator<Object> {
       OpcUaDataType dataType = OpcUaDataType.fromNodeId(dataTypeId);
 
       if (dataType != null) {
-        return ImplicitConversions.convert(sourceValue, dataType);
+        return ExplicitConversions.convert(sourceValue, dataType);
       } else {
         return null;
       }
@@ -61,7 +61,7 @@ public class Cast implements Operator<Object> {
       OpcUaDataType dataType = OpcUaDataType.fromNodeId(dataTypeId);
 
       if (dataType != null) {
-        return ImplicitConversions.convert(sourceValue, dataType);
+        return ExplicitConversions.convert(sourceValue, dataType);
       } else {
         return null;
       }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/GreaterThan.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/GreaterThan.java
@@ -15,7 +15,7 @@ import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
 import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.jspecify.annotations.Nullable;
 
-public class GreaterThan extends ImplicitConversionBinaryOperator<Boolean> {
+public class GreaterThan extends ImplicitConversionBinaryOperator {
 
   GreaterThan() {}
 
@@ -28,29 +28,10 @@ public class GreaterThan extends ImplicitConversionBinaryOperator<Boolean> {
       @Nullable Object operand0,
       @Nullable Object operand1) {
 
-    if (operand0 instanceof Number n0 && operand1 instanceof Number n1) {
-      switch (dataType) {
-        case SByte:
-        case Int16:
-        case Int32:
-        case Int64:
-        case Byte:
-        case UInt16:
-        case UInt32:
-          return n0.longValue() > n1.longValue();
+    if (operand0 != null && operand1 != null) {
+      Integer comparison = OperatorUtil.compareOrdered(dataType, operand0, operand1);
 
-        case UInt64:
-          return Long.compareUnsigned(n0.longValue(), n1.longValue()) > 0;
-
-        case Float:
-          return n0.floatValue() > n1.floatValue();
-
-        case Double:
-          return n0.doubleValue() > n1.doubleValue();
-
-        default:
-          return false;
-      }
+      return comparison != null && comparison > 0;
     } else {
       return false;
     }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/GreaterThanOrEqual.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/GreaterThanOrEqual.java
@@ -15,7 +15,7 @@ import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
 import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.jspecify.annotations.Nullable;
 
-public class GreaterThanOrEqual extends ImplicitConversionBinaryOperator<Boolean> {
+public class GreaterThanOrEqual extends ImplicitConversionBinaryOperator {
 
   GreaterThanOrEqual() {}
 
@@ -28,29 +28,10 @@ public class GreaterThanOrEqual extends ImplicitConversionBinaryOperator<Boolean
       @Nullable Object operand0,
       @Nullable Object operand1) {
 
-    if (operand0 instanceof Number n0 && operand1 instanceof Number n1) {
-      switch (dataType) {
-        case SByte:
-        case Int16:
-        case Int32:
-        case Int64:
-        case Byte:
-        case UInt16:
-        case UInt32:
-          return n0.longValue() >= n1.longValue();
+    if (operand0 != null && operand1 != null) {
+      Integer comparison = OperatorUtil.compareOrdered(dataType, operand0, operand1);
 
-        case UInt64:
-          return Long.compareUnsigned(n0.longValue(), n1.longValue()) >= 0;
-
-        case Float:
-          return n0.floatValue() >= n1.floatValue();
-
-        case Double:
-          return n0.doubleValue() >= n1.doubleValue();
-
-        default:
-          return false;
-      }
+      return comparison != null && comparison >= 0;
     } else {
       return false;
     }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/ImplicitConversionBinaryOperator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/ImplicitConversionBinaryOperator.java
@@ -10,25 +10,21 @@
 
 package org.eclipse.milo.opcua.sdk.server.events.operators;
 
-import java.lang.reflect.Array;
 import org.eclipse.milo.opcua.sdk.server.events.FilterContext;
 import org.eclipse.milo.opcua.sdk.server.events.OperatorContext;
 import org.eclipse.milo.opcua.sdk.server.events.ValidationException;
-import org.eclipse.milo.opcua.sdk.server.events.conversions.ImplicitConversions;
 import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
 import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.structured.FilterOperand;
-import org.eclipse.milo.opcua.stack.core.util.ArrayUtil;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
  * A binary operator where the operands undergo implicit conversion to the same type based on their
  * type precedence before being operated on.
  */
-abstract class ImplicitConversionBinaryOperator<T> implements Operator<T> {
+abstract class ImplicitConversionBinaryOperator implements Operator<Boolean> {
 
   @Override
   public void validate(FilterContext context, FilterOperand[] operands) throws ValidationException {
@@ -39,7 +35,8 @@ abstract class ImplicitConversionBinaryOperator<T> implements Operator<T> {
 
   @Nullable
   @Override
-  public T apply(OperatorContext context, BaseEventTypeNode eventNode, FilterOperand[] operands)
+  public Boolean apply(
+      OperatorContext context, BaseEventTypeNode eventNode, FilterOperand[] operands)
       throws UaException {
 
     validate(context, operands);
@@ -54,73 +51,26 @@ abstract class ImplicitConversionBinaryOperator<T> implements Operator<T> {
       return null;
     }
 
-    OpcUaDataType dt0 = getType(value0);
-    OpcUaDataType dt1 = getType(value1);
+    OperatorUtil.BinaryOperands commonOperands = OperatorUtil.convertToCommonType(value0, value1);
 
-    if (dt0 == null || dt1 == null) {
-      throw new UaException(StatusCodes.Bad_UnexpectedError);
+    if (commonOperands == null) {
+      return false;
     }
 
-    int p0 = ImplicitConversions.getPrecedence(dt0);
-    int p1 = ImplicitConversions.getPrecedence(dt1);
-
-    if (p0 == p1) {
-      assert dt0 == dt1;
-
-      return apply(context, eventNode, dt0, value0, value1);
-    } else if (p0 >= p1) {
-      // convert value1 to type of value0 (dt0)
-      Object converted1 = convert(value1, dt0);
-
-      return apply(context, eventNode, dt0, value0, converted1);
-    } else {
-      // convert value0 to type of value1 (dt1)
-      Object converted0 = convert(value0, dt1);
-
-      return apply(context, eventNode, dt1, converted0, value1);
-    }
+    return apply(
+        context,
+        eventNode,
+        commonOperands.dataType(),
+        commonOperands.operand0(),
+        commonOperands.operand1());
   }
 
   @Nullable
-  protected abstract T apply(
+  protected abstract Boolean apply(
       OperatorContext context,
       BaseEventTypeNode eventNode,
       OpcUaDataType dataType,
       @Nullable Object operand0,
       @Nullable Object operand1)
       throws UaException;
-
-  @Nullable
-  private static Object convert(@NonNull Object value, OpcUaDataType targetType) {
-    if (value.getClass().isArray()) {
-      return convertArray(value, targetType);
-    } else {
-      return ImplicitConversions.convert(value, targetType);
-    }
-  }
-
-  private static Object convertArray(@NonNull Object array, OpcUaDataType targetType) {
-    int[] dimensions = ArrayUtil.getDimensions(array);
-
-    Object flattened = ArrayUtil.flatten(array);
-    int length = Array.getLength(flattened);
-
-    Object transformed = Array.newInstance(targetType.getBackingClass(), length);
-
-    for (int i = 0; i < length; i++) {
-      Object sourceValue = Array.get(flattened, i);
-      Object targetValue = ImplicitConversions.convert(sourceValue, targetType);
-      Array.set(transformed, i, targetValue);
-    }
-
-    return ArrayUtil.unflatten(transformed, dimensions);
-  }
-
-  private static OpcUaDataType getType(@NonNull Object o) {
-    if (o.getClass().isArray()) {
-      return OpcUaDataType.fromBackingClass(ArrayUtil.getType(o));
-    } else {
-      return OpcUaDataType.fromBackingClass(o.getClass());
-    }
-  }
 }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/InList.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/InList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 the Eclipse Milo Authors
+ * Copyright (c) 2026 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -18,9 +18,9 @@ import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.structured.FilterOperand;
 import org.jspecify.annotations.Nullable;
 
-public class Equals implements Operator<Boolean> {
+public class InList implements Operator<Boolean> {
 
-  Equals() {}
+  InList() {}
 
   @Override
   public void validate(FilterContext context, FilterOperand[] operands) throws ValidationException {
@@ -35,9 +35,24 @@ public class Equals implements Operator<Boolean> {
 
     validate(context, operands);
 
-    Object value0 = context.resolve(operands[0], eventNode);
-    Object value1 = context.resolve(operands[1], eventNode);
+    // Part 4 Table 118 defines InList as repeated Equals evaluation. Treat those results like an
+    // OR chain: TRUE wins immediately, while NULL must be preserved if no comparison is TRUE.
+    // Resolve the tested value once rather than re-resolving it for every candidate.
+    Object value = OperatorUtil.resolve(context, eventNode, operands[0]);
 
-    return OperatorUtil.equalValues(value0, value1);
+    boolean sawNull = false;
+
+    for (int i = 1; i < operands.length; i++) {
+      Object candidate = OperatorUtil.resolve(context, eventNode, operands[i]);
+      Boolean result = OperatorUtil.equalValues(value, candidate);
+
+      if (Boolean.TRUE.equals(result)) {
+        return true;
+      } else if (result == null) {
+        sawNull = true;
+      }
+    }
+
+    return sawNull ? null : false;
   }
 }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/LessThan.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/LessThan.java
@@ -15,7 +15,7 @@ import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
 import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.jspecify.annotations.Nullable;
 
-public class LessThan extends ImplicitConversionBinaryOperator<Boolean> {
+public class LessThan extends ImplicitConversionBinaryOperator {
 
   LessThan() {}
 
@@ -28,29 +28,10 @@ public class LessThan extends ImplicitConversionBinaryOperator<Boolean> {
       @Nullable Object operand0,
       @Nullable Object operand1) {
 
-    if (operand0 instanceof Number n0 && operand1 instanceof Number n1) {
-      switch (dataType) {
-        case SByte:
-        case Int16:
-        case Int32:
-        case Int64:
-        case Byte:
-        case UInt16:
-        case UInt32:
-          return n0.longValue() < n1.longValue();
+    if (operand0 != null && operand1 != null) {
+      Integer comparison = OperatorUtil.compareOrdered(dataType, operand0, operand1);
 
-        case UInt64:
-          return Long.compareUnsigned(n0.longValue(), n1.longValue()) < 0;
-
-        case Float:
-          return n0.floatValue() < n1.floatValue();
-
-        case Double:
-          return n0.doubleValue() < n1.doubleValue();
-
-        default:
-          return false;
-      }
+      return comparison != null && comparison < 0;
     } else {
       return false;
     }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/LessThanOrEqual.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/LessThanOrEqual.java
@@ -15,7 +15,7 @@ import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
 import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.jspecify.annotations.Nullable;
 
-public class LessThanOrEqual extends ImplicitConversionBinaryOperator<Boolean> {
+public class LessThanOrEqual extends ImplicitConversionBinaryOperator {
 
   LessThanOrEqual() {}
 
@@ -28,29 +28,10 @@ public class LessThanOrEqual extends ImplicitConversionBinaryOperator<Boolean> {
       @Nullable Object operand0,
       @Nullable Object operand1) {
 
-    if (operand0 instanceof Number n0 && operand1 instanceof Number n1) {
-      switch (dataType) {
-        case SByte:
-        case Int16:
-        case Int32:
-        case Int64:
-        case Byte:
-        case UInt16:
-        case UInt32:
-          return n0.longValue() <= n1.longValue();
+    if (operand0 != null && operand1 != null) {
+      Integer comparison = OperatorUtil.compareOrdered(dataType, operand0, operand1);
 
-        case UInt64:
-          return Long.compareUnsigned(n0.longValue(), n1.longValue()) <= 0;
-
-        case Float:
-          return n0.floatValue() <= n1.floatValue();
-
-        case Double:
-          return n0.doubleValue() <= n1.doubleValue();
-
-        default:
-          return false;
-      }
+      return comparison != null && comparison <= 0;
     } else {
       return false;
     }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/Like.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/Like.java
@@ -10,9 +10,11 @@
 
 package org.eclipse.milo.opcua.sdk.server.events.operators;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.regex.Pattern;
 import org.eclipse.milo.opcua.sdk.server.events.FilterContext;
 import org.eclipse.milo.opcua.sdk.server.events.OperatorContext;
 import org.eclipse.milo.opcua.sdk.server.events.ValidationException;
@@ -26,12 +28,31 @@ import org.jspecify.annotations.Nullable;
 public class Like implements Operator<Boolean> {
 
   /**
-   * Upper bound on the number of distinct compiled patterns retained, so a client that sends many
+   * Upper bound on the number of distinct parsed patterns retained, so a client that sends many
    * distinct patterns cannot grow the cache without bound.
    */
   private static final int MAX_CACHED_PATTERNS = 256;
 
-  private final Map<String, Pattern> patternCache = new ConcurrentHashMap<>();
+  /**
+   * Token sentinel for a {@code %} wildcard, which matches any run of characters (including none).
+   */
+  private static final Object STAR = new Object();
+
+  /**
+   * LRU cache of parsed patterns. Parsing is comparatively cheap, but the LIKE pattern is usually a
+   * constant {@code LiteralOperand}, so caching avoids reparsing it for every event. Unlike a
+   * grow-then-stop cache, an LRU keeps caching new patterns by evicting the least-recently-used
+   * entry once full, so a workload with more than {@link #MAX_CACHED_PATTERNS} live patterns does
+   * not fall back to parsing on every event.
+   */
+  private final Map<String, Object[]> patternCache =
+      Collections.synchronizedMap(
+          new LinkedHashMap<>(16, 0.75f, true) {
+            @Override
+            protected boolean removeEldestEntry(Map.Entry<String, Object[]> eldest) {
+              return size() > MAX_CACHED_PATTERNS;
+            }
+          });
 
   Like() {}
 
@@ -48,34 +69,41 @@ public class Like implements Operator<Boolean> {
 
     validate(context, operands);
 
-    String value = asString(OperatorUtil.resolve(context, eventNode, operands[0]));
-    String pattern = asString(OperatorUtil.resolve(context, eventNode, operands[1]));
+    Object lhs = OperatorUtil.resolve(context, eventNode, operands[0]);
+    Object rhs = OperatorUtil.resolve(context, eventNode, operands[1]);
 
-    if (value != null && pattern != null) {
-      try {
-        return getPattern(pattern).matcher(value).matches();
-      } catch (IllegalArgumentException e) {
-        return false;
-      }
-    } else {
+    // Three-valued logic: a null operand is indeterminate, consistent with the comparison
+    // operators.
+    if (lhs == null || rhs == null) {
+      return null;
+    }
+
+    String value = asString(lhs);
+    String pattern = asString(rhs);
+
+    // An operand that is present but not convertible to a String cannot match; FALSE rather than
+    // indeterminate, mirroring a type mismatch in the comparison operators.
+    if (value == null || pattern == null) {
+      return false;
+    }
+
+    try {
+      return matches(value, getTokens(pattern));
+    } catch (IllegalArgumentException e) {
       return false;
     }
   }
 
-  private Pattern getPattern(String pattern) {
-    Pattern compiled = patternCache.get(pattern);
+  private Object[] getTokens(String pattern) {
+    Object[] tokens = patternCache.get(pattern);
 
-    if (compiled == null) {
-      // Recompiling per event is wasteful when the LIKE pattern is constant, which is the common
-      // case (a LiteralOperand). toRegex throws for malformed patterns; that propagates to apply().
-      compiled = Pattern.compile(toRegex(pattern), Pattern.DOTALL);
-
-      if (patternCache.size() < MAX_CACHED_PATTERNS) {
-        patternCache.putIfAbsent(pattern, compiled);
-      }
+    if (tokens == null) {
+      // parse() throws IllegalArgumentException for malformed patterns; that propagates to apply().
+      tokens = parse(pattern);
+      patternCache.put(pattern, tokens);
     }
 
-    return compiled;
+    return tokens;
   }
 
   @Nullable
@@ -93,38 +121,84 @@ public class Like implements Operator<Boolean> {
     }
   }
 
-  private static String toRegex(String pattern) {
-    StringBuilder regex = new StringBuilder("^");
+  /**
+   * Matches {@code text} against a parsed LIKE {@code pattern} using the classic iterative wildcard
+   * algorithm. It runs in O(text.length * pattern.length) time with O(1) extra state, so unlike a
+   * regex translation it cannot be driven into catastrophic backtracking (ReDoS) by a
+   * client-supplied pattern such as {@code %a%a%a...}.
+   */
+  private static boolean matches(String text, Object[] tokens) {
+    int n = text.length();
+    int m = tokens.length;
+
+    int s = 0; // index into text
+    int t = 0; // index into tokens
+    int starToken = -1; // most recent STAR token index, or -1 if none seen
+    int starText = -1; // text index captured when that STAR was entered
+
+    while (s < n) {
+      if (t < m && tokens[t] instanceof CharMatcher matcher && matcher.matches(text.charAt(s))) {
+        s++;
+        t++;
+      } else if (t < m && tokens[t] == STAR) {
+        starToken = t;
+        starText = s;
+        t++;
+      } else if (starToken == -1) {
+        return false;
+      } else {
+        // Backtrack: let the most recent STAR consume one more character and retry.
+        t = starToken + 1;
+        starText++;
+        s = starText;
+      }
+    }
+
+    while (t < m && tokens[t] == STAR) {
+      t++;
+    }
+
+    return t == m;
+  }
+
+  /**
+   * Parses an OPC UA LIKE pattern (Part 4 Table 120) into a token array of {@link #STAR} markers
+   * and {@link CharMatcher}s. Throws {@link IllegalArgumentException} for malformed patterns.
+   */
+  private static Object[] parse(String pattern) {
+    List<Object> tokens = new ArrayList<>();
 
     for (int i = 0; i < pattern.length(); i++) {
       char c = pattern.charAt(i);
 
       switch (c) {
         case '%' -> {
-          // Collapse a run of consecutive '%' into a single '.*'. Adjacent unbounded quantifiers
-          // (".*.*...") are a catastrophic-backtracking (ReDoS) hazard for client-supplied
-          // patterns, and consecutive '%' are semantically identical to a single one.
-          regex.append(".*");
-          while (i + 1 < pattern.length() && pattern.charAt(i + 1) == '%') {
-            i++;
+          // Consecutive '%' are semantically identical to a single one; collapse them.
+          if (tokens.isEmpty() || tokens.get(tokens.size() - 1) != STAR) {
+            tokens.add(STAR);
           }
         }
-        case '_' -> regex.append('.');
+        case '_' -> tokens.add((CharMatcher) ch -> true);
         case '\\' -> {
           if (++i >= pattern.length()) {
             throw new IllegalArgumentException("trailing escape");
           }
-          appendLiteral(regex, pattern.charAt(i));
+          char literal = pattern.charAt(i);
+          tokens.add((CharMatcher) ch -> ch == literal);
         }
-        case '[' -> i = appendCharacterClass(pattern, i, regex);
-        default -> appendLiteral(regex, c);
+        case '[' -> i = parseCharacterClass(pattern, i, tokens);
+        default -> tokens.add((CharMatcher) ch -> ch == c);
       }
     }
 
-    return regex.append('$').toString();
+    return tokens.toArray();
   }
 
-  private static int appendCharacterClass(String pattern, int start, StringBuilder regex) {
+  /**
+   * Parses a {@code [...]} character class starting at {@code start} (the {@code '['}), appends a
+   * {@link CharMatcher} to {@code tokens}, and returns the index of the closing {@code ']'}.
+   */
+  private static int parseCharacterClass(String pattern, int start, List<Object> tokens) {
     int i = start + 1;
     boolean negated = false;
 
@@ -133,64 +207,79 @@ public class Like implements Operator<Boolean> {
       i++;
     }
 
-    StringBuilder characterClass = new StringBuilder();
+    List<char[]> ranges = new ArrayList<>();
     boolean sawContent = false;
 
-    for (; i < pattern.length(); i++) {
+    while (i < pattern.length()) {
       char c = pattern.charAt(i);
 
-      if (c == '\\') {
-        if (++i >= pattern.length()) {
-          throw new IllegalArgumentException("trailing character class escape");
-        }
-        // Part 4 Table 120 treats '\' as literal interpretation, so escaped regex class
-        // metacharacters must not become Java regex syntax.
-        appendEscapedClassLiteral(characterClass, pattern.charAt(i));
-        sawContent = true;
-      } else if (c == ']') {
+      if (c == ']') {
         if (!sawContent) {
           throw new IllegalArgumentException("empty character class");
         }
 
-        regex.append('[');
-        if (negated) {
-          regex.append('^');
-        }
-        regex.append(characterClass).append(']');
+        boolean finalNegated = negated;
+        tokens.add((CharMatcher) ch -> inRanges(ranges, ch) != finalNegated);
 
         return i;
-      } else {
-        appendClassPatternCharacter(characterClass, c);
-        sawContent = true;
       }
+
+      // Resolve the low end of a potential range, honoring '\' as a literal escape.
+      char lo;
+      if (c == '\\') {
+        if (++i >= pattern.length()) {
+          throw new IllegalArgumentException("trailing character class escape");
+        }
+        lo = pattern.charAt(i);
+      } else {
+        lo = c;
+      }
+
+      // A range is "x-y" where '-' is not the last character before ']'. A '-' adjacent to ']' is a
+      // literal '-'.
+      if (i + 2 < pattern.length()
+          && pattern.charAt(i + 1) == '-'
+          && pattern.charAt(i + 2) != ']') {
+
+        i += 2;
+        char hi;
+        if (pattern.charAt(i) == '\\') {
+          if (++i >= pattern.length()) {
+            throw new IllegalArgumentException("trailing character class escape");
+          }
+          hi = pattern.charAt(i);
+        } else {
+          hi = pattern.charAt(i);
+        }
+
+        if (hi < lo) {
+          throw new IllegalArgumentException("invalid character range: " + lo + '-' + hi);
+        }
+
+        ranges.add(new char[] {lo, hi});
+      } else {
+        ranges.add(new char[] {lo, lo});
+      }
+
+      sawContent = true;
+      i++;
     }
 
     throw new IllegalArgumentException("unclosed character class");
   }
 
-  private static void appendLiteral(StringBuilder regex, char c) {
-    if ("\\.[]{}()*+-?^$|".indexOf(c) >= 0) {
-      regex.append('\\');
+  private static boolean inRanges(List<char[]> ranges, char ch) {
+    for (char[] range : ranges) {
+      if (ch >= range[0] && ch <= range[1]) {
+        return true;
+      }
     }
 
-    regex.append(c);
+    return false;
   }
 
-  private static void appendClassPatternCharacter(StringBuilder regex, char c) {
-    // '&' must be escaped so an unescaped "&&" is not interpreted as Java's character-class
-    // intersection operator; LIKE has no such operator (matching appendEscapedClassLiteral).
-    if (c == '\\' || c == '[' || c == ']' || c == '&') {
-      regex.append('\\');
-    }
-
-    regex.append(c);
-  }
-
-  private static void appendEscapedClassLiteral(StringBuilder regex, char c) {
-    if (c == '\\' || c == '[' || c == ']' || c == '-' || c == '^' || c == '&') {
-      regex.append('\\');
-    }
-
-    regex.append(c);
+  @FunctionalInterface
+  private interface CharMatcher {
+    boolean matches(char c);
   }
 }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/Like.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/Like.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.events.operators;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
+import org.eclipse.milo.opcua.sdk.server.events.FilterContext;
+import org.eclipse.milo.opcua.sdk.server.events.OperatorContext;
+import org.eclipse.milo.opcua.sdk.server.events.ValidationException;
+import org.eclipse.milo.opcua.sdk.server.events.conversions.ImplicitConversions;
+import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.structured.FilterOperand;
+import org.jspecify.annotations.Nullable;
+
+public class Like implements Operator<Boolean> {
+
+  /**
+   * Upper bound on the number of distinct compiled patterns retained, so a client that sends many
+   * distinct patterns cannot grow the cache without bound.
+   */
+  private static final int MAX_CACHED_PATTERNS = 256;
+
+  private final Map<String, Pattern> patternCache = new ConcurrentHashMap<>();
+
+  Like() {}
+
+  @Override
+  public void validate(FilterContext context, FilterOperand[] operands) throws ValidationException {
+    OperatorUtil.validateMinOperandCount(operands, 2);
+  }
+
+  @Nullable
+  @Override
+  public Boolean apply(
+      OperatorContext context, BaseEventTypeNode eventNode, FilterOperand[] operands)
+      throws UaException {
+
+    validate(context, operands);
+
+    String value = asString(OperatorUtil.resolve(context, eventNode, operands[0]));
+    String pattern = asString(OperatorUtil.resolve(context, eventNode, operands[1]));
+
+    if (value != null && pattern != null) {
+      try {
+        return getPattern(pattern).matcher(value).matches();
+      } catch (IllegalArgumentException e) {
+        return false;
+      }
+    } else {
+      return false;
+    }
+  }
+
+  private Pattern getPattern(String pattern) {
+    Pattern compiled = patternCache.get(pattern);
+
+    if (compiled == null) {
+      // Recompiling per event is wasteful when the LIKE pattern is constant, which is the common
+      // case (a LiteralOperand). toRegex throws for malformed patterns; that propagates to apply().
+      compiled = Pattern.compile(toRegex(pattern), Pattern.DOTALL);
+
+      if (patternCache.size() < MAX_CACHED_PATTERNS) {
+        patternCache.putIfAbsent(pattern, compiled);
+      }
+    }
+
+    return compiled;
+  }
+
+  @Nullable
+  private static String asString(@Nullable Object value) {
+    value = OperatorUtil.toScalarIfSingleElementArray(value);
+
+    if (value instanceof String s) {
+      return s;
+    } else if (value != null) {
+      Object converted = ImplicitConversions.convert(value, OpcUaDataType.String);
+
+      return converted instanceof String s ? s : null;
+    } else {
+      return null;
+    }
+  }
+
+  private static String toRegex(String pattern) {
+    StringBuilder regex = new StringBuilder("^");
+
+    for (int i = 0; i < pattern.length(); i++) {
+      char c = pattern.charAt(i);
+
+      switch (c) {
+        case '%' -> {
+          // Collapse a run of consecutive '%' into a single '.*'. Adjacent unbounded quantifiers
+          // (".*.*...") are a catastrophic-backtracking (ReDoS) hazard for client-supplied
+          // patterns, and consecutive '%' are semantically identical to a single one.
+          regex.append(".*");
+          while (i + 1 < pattern.length() && pattern.charAt(i + 1) == '%') {
+            i++;
+          }
+        }
+        case '_' -> regex.append('.');
+        case '\\' -> {
+          if (++i >= pattern.length()) {
+            throw new IllegalArgumentException("trailing escape");
+          }
+          appendLiteral(regex, pattern.charAt(i));
+        }
+        case '[' -> i = appendCharacterClass(pattern, i, regex);
+        default -> appendLiteral(regex, c);
+      }
+    }
+
+    return regex.append('$').toString();
+  }
+
+  private static int appendCharacterClass(String pattern, int start, StringBuilder regex) {
+    int i = start + 1;
+    boolean negated = false;
+
+    if (i < pattern.length() && pattern.charAt(i) == '^') {
+      negated = true;
+      i++;
+    }
+
+    StringBuilder characterClass = new StringBuilder();
+    boolean sawContent = false;
+
+    for (; i < pattern.length(); i++) {
+      char c = pattern.charAt(i);
+
+      if (c == '\\') {
+        if (++i >= pattern.length()) {
+          throw new IllegalArgumentException("trailing character class escape");
+        }
+        // Part 4 Table 120 treats '\' as literal interpretation, so escaped regex class
+        // metacharacters must not become Java regex syntax.
+        appendEscapedClassLiteral(characterClass, pattern.charAt(i));
+        sawContent = true;
+      } else if (c == ']') {
+        if (!sawContent) {
+          throw new IllegalArgumentException("empty character class");
+        }
+
+        regex.append('[');
+        if (negated) {
+          regex.append('^');
+        }
+        regex.append(characterClass).append(']');
+
+        return i;
+      } else {
+        appendClassPatternCharacter(characterClass, c);
+        sawContent = true;
+      }
+    }
+
+    throw new IllegalArgumentException("unclosed character class");
+  }
+
+  private static void appendLiteral(StringBuilder regex, char c) {
+    if ("\\.[]{}()*+-?^$|".indexOf(c) >= 0) {
+      regex.append('\\');
+    }
+
+    regex.append(c);
+  }
+
+  private static void appendClassPatternCharacter(StringBuilder regex, char c) {
+    // '&' must be escaped so an unescaped "&&" is not interpreted as Java's character-class
+    // intersection operator; LIKE has no such operator (matching appendEscapedClassLiteral).
+    if (c == '\\' || c == '[' || c == ']' || c == '&') {
+      regex.append('\\');
+    }
+
+    regex.append(c);
+  }
+
+  private static void appendEscapedClassLiteral(StringBuilder regex, char c) {
+    if (c == '\\' || c == '[' || c == ']' || c == '-' || c == '^' || c == '&') {
+      regex.append('\\');
+    }
+
+    regex.append(c);
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/Not.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/Not.java
@@ -42,8 +42,10 @@ public class Not implements Operator<Boolean> {
 
     Object value0 = context.resolve(op0, eventNode);
 
-    if (value0 instanceof Boolean) {
-      return !(Boolean) value0;
+    Boolean value = OperatorUtil.toBoolean(value0);
+
+    if (value != null) {
+      return !value;
     } else {
       return null;
     }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/OperatorUtil.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/OperatorUtil.java
@@ -1,0 +1,446 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.events.operators;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ubyte;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ulong;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
+
+import java.lang.reflect.Array;
+import java.util.Objects;
+import java.util.function.LongBinaryOperator;
+import org.eclipse.milo.opcua.sdk.server.events.OperatorContext;
+import org.eclipse.milo.opcua.sdk.server.events.ValidationException;
+import org.eclipse.milo.opcua.sdk.server.events.conversions.ImplicitConversions;
+import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.types.structured.FilterOperand;
+import org.eclipse.milo.opcua.stack.core.util.ArrayUtil;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Shared support for ContentFilter operators whose semantics depend on OPC UA conversion,
+ * precedence, ordered comparison, or integer-width rules.
+ *
+ * <p>Keeping this behavior centralized avoids small differences between operators that the OPC UA
+ * specification defines in terms of the same conversion and comparison tables.
+ *
+ * @see <a href="https://reference.opcfoundation.org/specs/OPC-10000-4/7.7.3">OPC UA Part 4, 7.7.3
+ *     FilterOperator</a>
+ */
+final class OperatorUtil {
+
+  private OperatorUtil() {}
+
+  static void validateMinOperandCount(FilterOperand[] operands, int min)
+      throws ValidationException {
+    if (operands.length < min) {
+      throw new ValidationException(StatusCodes.Bad_FilterOperandCountMismatch);
+    }
+  }
+
+  @Nullable
+  static Object resolve(OperatorContext context, BaseEventTypeNode eventNode, FilterOperand operand)
+      throws UaException {
+
+    return context.resolve(operand, eventNode);
+  }
+
+  @Nullable
+  static BinaryOperands convertToCommonType(@NonNull Object operand0, @NonNull Object operand1) {
+    // Part 4 Table 121 allows length-one arrays to be treated as scalar values.
+    operand0 = toScalarIfSingleElementArray(operand0);
+    operand1 = toScalarIfSingleElementArray(operand1);
+
+    if (operand0 == null || operand1 == null) {
+      return null;
+    }
+
+    OpcUaDataType dt0 = getType(operand0);
+    OpcUaDataType dt1 = getType(operand1);
+
+    if (dt0 == null || dt1 == null) {
+      return null;
+    }
+
+    int p0 = ImplicitConversions.getPrecedence(dt0);
+    int p1 = ImplicitConversions.getPrecedence(dt1);
+
+    if (p0 == p1) {
+      if (dt0 == dt1) {
+        Object converted0 = operand0.getClass().isArray() ? convert(operand0, dt0) : operand0;
+        Object converted1 = operand1.getClass().isArray() ? convert(operand1, dt1) : operand1;
+
+        return converted0 != null && converted1 != null
+            ? new BinaryOperands(dt0, converted0, converted1)
+            : null;
+      } else {
+        return null;
+      }
+    } else if (p0 >= p1) {
+      Object converted0 = operand0.getClass().isArray() ? convert(operand0, dt0) : operand0;
+      Object converted1 = convert(operand1, dt0);
+
+      return converted0 != null && converted1 != null
+          ? new BinaryOperands(dt0, converted0, converted1)
+          : null;
+    } else {
+      Object converted0 = convert(operand0, dt1);
+      Object converted1 = operand1.getClass().isArray() ? convert(operand1, dt1) : operand1;
+
+      return converted0 != null && converted1 != null
+          ? new BinaryOperands(dt1, converted0, converted1)
+          : null;
+    }
+  }
+
+  @Nullable
+  static Integer compareOrdered(@NonNull Object operand0, @NonNull Object operand1) {
+    BinaryOperands operands = convertToCommonType(operand0, operand1);
+
+    if (operands == null) {
+      return null;
+    }
+
+    return compareOrdered(operands.dataType(), operands.operand0(), operands.operand1());
+  }
+
+  /**
+   * Compares two already-resolved operand values for equality following OPC UA implicit-conversion
+   * and three-valued NULL semantics.
+   *
+   * @return {@code null} if either value is {@code null} (indeterminate), {@code false} if the
+   *     values have no common type, otherwise whether the operands are equal after being converted
+   *     to their common type.
+   */
+  @Nullable
+  static Boolean equalValues(@Nullable Object value0, @Nullable Object value1) {
+    if (value0 == null || value1 == null) {
+      return null;
+    }
+
+    BinaryOperands commonOperands = convertToCommonType(value0, value1);
+
+    if (commonOperands == null) {
+      return false;
+    }
+
+    return equal(commonOperands.operand0(), commonOperands.operand1());
+  }
+
+  private static boolean equal(@NonNull Object operand0, @NonNull Object operand1) {
+    if (operand0.getClass().isArray()) {
+      return Objects.deepEquals(operand0, operand1);
+    } else if (operand0 instanceof Float f0 && operand1 instanceof Float f1) {
+      // IEEE floating-point equality: NaN is never equal to itself and +0.0 equals -0.0, unlike
+      // Float.equals/Objects.equals which compare bit patterns.
+      return f0.floatValue() == f1.floatValue();
+    } else if (operand0 instanceof Double d0 && operand1 instanceof Double d1) {
+      return d0.doubleValue() == d1.doubleValue();
+    } else {
+      return Objects.equals(operand0, operand1);
+    }
+  }
+
+  @Nullable
+  static TernaryOperands convertToCommonType(
+      @NonNull Object operand0, @NonNull Object operand1, @NonNull Object operand2) {
+
+    // Between uses one common type for all operands, but the same length-one array scalarization
+    // from Part 4 Table 121 still applies before selecting that type.
+    operand0 = toScalarIfSingleElementArray(operand0);
+    operand1 = toScalarIfSingleElementArray(operand1);
+    operand2 = toScalarIfSingleElementArray(operand2);
+
+    if (operand0 == null || operand1 == null || operand2 == null) {
+      return null;
+    }
+
+    OpcUaDataType dt0 = getType(operand0);
+    OpcUaDataType dt1 = getType(operand1);
+    OpcUaDataType dt2 = getType(operand2);
+
+    if (dt0 == null || dt1 == null || dt2 == null) {
+      return null;
+    }
+
+    OpcUaDataType targetType = highestPrecedence(dt0, dt1, dt2);
+
+    Object converted0 = dt0 == targetType ? operand0 : convert(operand0, targetType);
+    Object converted1 = dt1 == targetType ? operand1 : convert(operand1, targetType);
+    Object converted2 = dt2 == targetType ? operand2 : convert(operand2, targetType);
+
+    if (converted0 == null || converted1 == null || converted2 == null) {
+      return null;
+    }
+
+    return new TernaryOperands(targetType, converted0, converted1, converted2);
+  }
+
+  @Nullable
+  static Integer compareOrdered(
+      OpcUaDataType dataType, @NonNull Object operand0, @NonNull Object operand1) {
+
+    if (operand0 instanceof Number n0 && operand1 instanceof Number n1) {
+      return switch (dataType) {
+        case SByte, Byte, Int16, UInt16, Int32, UInt32, Int64 ->
+            Long.compare(n0.longValue(), n1.longValue());
+        case UInt64 -> Long.compareUnsigned(n0.longValue(), n1.longValue());
+        case Float -> compareFloat(n0.floatValue(), n1.floatValue());
+        case Double -> compareDouble(n0.doubleValue(), n1.doubleValue());
+        default -> null;
+      };
+    } else if (dataType == OpcUaDataType.DateTime
+        && operand0 instanceof DateTime dt0
+        && operand1 instanceof DateTime dt1) {
+
+      return Long.compare(dt0.utcTime(), dt1.utcTime());
+    } else {
+      return null;
+    }
+  }
+
+  @Nullable
+  private static Integer compareFloat(float operand0, float operand1) {
+    // NaN is not an ordered value for ContentFilter comparisons.
+    if (Float.isNaN(operand0) || Float.isNaN(operand1)) {
+      return null;
+    } else if (operand0 < operand1) {
+      return -1;
+    } else if (operand0 > operand1) {
+      return 1;
+    } else {
+      // Numerically equal, including +0.0 == -0.0 (unlike Float.compare, which orders -0.0 first).
+      return 0;
+    }
+  }
+
+  @Nullable
+  private static Integer compareDouble(double operand0, double operand1) {
+    // NaN is not an ordered value for ContentFilter comparisons.
+    if (Double.isNaN(operand0) || Double.isNaN(operand1)) {
+      return null;
+    } else if (operand0 < operand1) {
+      return -1;
+    } else if (operand0 > operand1) {
+      return 1;
+    } else {
+      // Numerically equal, including +0.0 == -0.0 (unlike Double.compare, which orders -0.0 first).
+      return 0;
+    }
+  }
+
+  @Nullable
+  static Object bitwise(
+      @NonNull Object operand0, @NonNull Object operand1, LongBinaryOperator operator) {
+
+    operand0 = toScalarIfSingleElementArray(operand0);
+    operand1 = toScalarIfSingleElementArray(operand1);
+
+    if (operand0 == null || operand1 == null) {
+      return null;
+    }
+
+    OpcUaDataType dt0 = getType(operand0);
+    OpcUaDataType dt1 = getType(operand1);
+
+    if (dt0 == null || dt1 == null || !isIntegerType(dt0) || !isIntegerType(dt1)) {
+      return null;
+    }
+
+    if (operand0 instanceof Number n0 && operand1 instanceof Number n1) {
+      // Bitwise operators use the largest operand size from Part 4 Table 118, not the general data
+      // precedence table used by comparison/equality operators.
+      OpcUaDataType targetType = largestIntegerType(dt0, dt1);
+      long result = operator.applyAsLong(n0.longValue(), n1.longValue());
+
+      return castBitwiseResult(targetType, result);
+    } else {
+      return null;
+    }
+  }
+
+  @Nullable
+  static OpcUaDataType getType(@NonNull Object value) {
+    if (value.getClass().isArray()) {
+      return OpcUaDataType.fromBackingClass(ArrayUtil.getType(value));
+    } else {
+      return OpcUaDataType.fromBackingClass(value.getClass());
+    }
+  }
+
+  @Nullable
+  static Object toScalarIfSingleElementArray(@Nullable Object value) {
+    if (value != null && value.getClass().isArray()) {
+      Object flattened = ArrayUtil.flatten(value);
+
+      if (Array.getLength(flattened) == 1) {
+        return Array.get(flattened, 0);
+      }
+    }
+
+    return value;
+  }
+
+  @Nullable
+  static Boolean toBoolean(@Nullable Object value) {
+    value = toScalarIfSingleElementArray(value);
+
+    if (value instanceof Boolean b) {
+      return b;
+    } else if (value != null) {
+      Object converted = convert(value, OpcUaDataType.Boolean);
+
+      return converted instanceof Boolean b ? b : null;
+    } else {
+      return null;
+    }
+  }
+
+  @Nullable
+  static Object convert(@NonNull Object value, OpcUaDataType targetType) {
+    if (value.getClass().isArray()) {
+      return convertArray(value, targetType);
+    } else if (getType(value) == targetType) {
+      return value;
+    } else {
+      return ImplicitConversions.convert(value, targetType);
+    }
+  }
+
+  @Nullable
+  private static Object convertArray(@NonNull Object array, OpcUaDataType targetType) {
+    int[] dimensions = ArrayUtil.getDimensions(array);
+
+    Object flattened = ArrayUtil.flatten(array);
+    int length = Array.getLength(flattened);
+
+    Object transformed = Array.newInstance(targetType.getBackingClass(), length);
+
+    for (int i = 0; i < length; i++) {
+      Object sourceValue = Array.get(flattened, i);
+      if (sourceValue == null) {
+        return null;
+      }
+
+      // Part 4 Table 121 says any element conversion failure makes the whole array conversion fail.
+      Object targetValue =
+          getType(sourceValue) == targetType
+              ? sourceValue
+              : ImplicitConversions.convert(sourceValue, targetType);
+      if (targetValue == null) {
+        return null;
+      }
+
+      Array.set(transformed, i, targetValue);
+    }
+
+    return ArrayUtil.unflatten(transformed, dimensions);
+  }
+
+  private static OpcUaDataType highestPrecedence(OpcUaDataType... dataTypes) {
+    OpcUaDataType highest = dataTypes[0];
+
+    for (int i = 1; i < dataTypes.length; i++) {
+      if (ImplicitConversions.getPrecedence(dataTypes[i])
+          > ImplicitConversions.getPrecedence(highest)) {
+
+        highest = dataTypes[i];
+      }
+    }
+
+    return highest;
+  }
+
+  private static boolean isIntegerType(OpcUaDataType dataType) {
+    return switch (dataType) {
+      case SByte, Byte, Int16, UInt16, Int32, UInt32, Int64, UInt64 -> true;
+      default -> false;
+    };
+  }
+
+  private static OpcUaDataType largestIntegerType(
+      OpcUaDataType dataType0, OpcUaDataType dataType1) {
+    int width0 = integerBitWidth(dataType0);
+    int width1 = integerBitWidth(dataType1);
+
+    if (width0 > width1) {
+      return dataType0;
+    } else if (width1 > width0) {
+      return dataType1;
+    } else if (isUnsignedIntegerType(dataType0) || isUnsignedIntegerType(dataType1)) {
+      return unsignedIntegerType(width0);
+    } else {
+      return signedIntegerType(width0);
+    }
+  }
+
+  private static int integerBitWidth(OpcUaDataType dataType) {
+    return switch (dataType) {
+      case SByte, Byte -> 8;
+      case Int16, UInt16 -> 16;
+      case Int32, UInt32 -> 32;
+      case Int64, UInt64 -> 64;
+      default -> throw new IllegalArgumentException("not an integer data type: " + dataType);
+    };
+  }
+
+  private static boolean isUnsignedIntegerType(OpcUaDataType dataType) {
+    return switch (dataType) {
+      case Byte, UInt16, UInt32, UInt64 -> true;
+      default -> false;
+    };
+  }
+
+  private static OpcUaDataType signedIntegerType(int bitWidth) {
+    return switch (bitWidth) {
+      case 8 -> OpcUaDataType.SByte;
+      case 16 -> OpcUaDataType.Int16;
+      case 32 -> OpcUaDataType.Int32;
+      case 64 -> OpcUaDataType.Int64;
+      default -> throw new IllegalArgumentException("invalid integer bit width: " + bitWidth);
+    };
+  }
+
+  private static OpcUaDataType unsignedIntegerType(int bitWidth) {
+    return switch (bitWidth) {
+      case 8 -> OpcUaDataType.Byte;
+      case 16 -> OpcUaDataType.UInt16;
+      case 32 -> OpcUaDataType.UInt32;
+      case 64 -> OpcUaDataType.UInt64;
+      default -> throw new IllegalArgumentException("invalid integer bit width: " + bitWidth);
+    };
+  }
+
+  private static Object castBitwiseResult(OpcUaDataType dataType, long result) {
+    return switch (dataType) {
+      case SByte -> (byte) result;
+      case Byte -> ubyte((short) (result & 0xffL));
+      case Int16 -> (short) result;
+      case UInt16 -> ushort((int) (result & 0xffffL));
+      case Int32 -> (int) result;
+      case UInt32 -> uint(result & 0xffffffffL);
+      case Int64 -> result;
+      case UInt64 -> ulong(result);
+      default -> throw new IllegalArgumentException("not an integer data type: " + dataType);
+    };
+  }
+
+  record BinaryOperands(OpcUaDataType dataType, Object operand0, Object operand1) {}
+
+  record TernaryOperands(
+      OpcUaDataType dataType, Object operand0, Object operand1, Object operand2) {}
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/OperatorUtil.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/OperatorUtil.java
@@ -28,7 +28,6 @@ import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
 import org.eclipse.milo.opcua.stack.core.types.structured.FilterOperand;
 import org.eclipse.milo.opcua.stack.core.util.ArrayUtil;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -60,7 +59,7 @@ final class OperatorUtil {
   }
 
   @Nullable
-  static BinaryOperands convertToCommonType(@NonNull Object operand0, @NonNull Object operand1) {
+  static BinaryOperands convertToCommonType(Object operand0, Object operand1) {
     // Part 4 Table 121 allows length-one arrays to be treated as scalar values.
     operand0 = toScalarIfSingleElementArray(operand0);
     operand1 = toScalarIfSingleElementArray(operand1);
@@ -108,7 +107,7 @@ final class OperatorUtil {
   }
 
   @Nullable
-  static Integer compareOrdered(@NonNull Object operand0, @NonNull Object operand1) {
+  static Integer compareOrdered(Object operand0, Object operand1) {
     BinaryOperands operands = convertToCommonType(operand0, operand1);
 
     if (operands == null) {
@@ -141,9 +140,12 @@ final class OperatorUtil {
     return equal(commonOperands.operand0(), commonOperands.operand1());
   }
 
-  private static boolean equal(@NonNull Object operand0, @NonNull Object operand1) {
-    if (operand0.getClass().isArray()) {
-      return Objects.deepEquals(operand0, operand1);
+  private static boolean equal(Object operand0, Object operand1) {
+    if (operand0.getClass().isArray() || operand1.getClass().isArray()) {
+      // Compare arrays element-by-element rather than with Objects.deepEquals, which would compare
+      // Float/Double elements by bit pattern (Float.equals/Double.equals) and contradict the IEEE
+      // equality the scalar path below implements.
+      return arraysEqual(operand0, operand1);
     } else if (operand0 instanceof Float f0 && operand1 instanceof Float f1) {
       // IEEE floating-point equality: NaN is never equal to itself and +0.0 equals -0.0, unlike
       // Float.equals/Objects.equals which compare bit patterns.
@@ -155,9 +157,35 @@ final class OperatorUtil {
     }
   }
 
+  private static boolean arraysEqual(Object operand0, Object operand1) {
+    if (!operand0.getClass().isArray() || !operand1.getClass().isArray()) {
+      return false;
+    }
+
+    int length = Array.getLength(operand0);
+    if (length != Array.getLength(operand1)) {
+      return false;
+    }
+
+    for (int i = 0; i < length; i++) {
+      Object element0 = Array.get(operand0, i);
+      Object element1 = Array.get(operand1, i);
+
+      if (element0 == null || element1 == null) {
+        if (element0 != element1) {
+          return false;
+        }
+      } else if (!equal(element0, element1)) {
+        // Recurse so nested arrays and Float/Double elements use the same IEEE equality as scalars.
+        return false;
+      }
+    }
+
+    return true;
+  }
+
   @Nullable
-  static TernaryOperands convertToCommonType(
-      @NonNull Object operand0, @NonNull Object operand1, @NonNull Object operand2) {
+  static TernaryOperands convertToCommonType(Object operand0, Object operand1, Object operand2) {
 
     // Between uses one common type for all operands, but the same length-one array scalarization
     // from Part 4 Table 121 still applies before selecting that type.
@@ -191,8 +219,7 @@ final class OperatorUtil {
   }
 
   @Nullable
-  static Integer compareOrdered(
-      OpcUaDataType dataType, @NonNull Object operand0, @NonNull Object operand1) {
+  static Integer compareOrdered(OpcUaDataType dataType, Object operand0, Object operand1) {
 
     if (operand0 instanceof Number n0 && operand1 instanceof Number n1) {
       return switch (dataType) {
@@ -213,6 +240,10 @@ final class OperatorUtil {
     }
   }
 
+  // Intentionally not Float.compare: it orders -0.0 below +0.0, but ContentFilter ordering treats
+  // +0.0 and -0.0 as numerically equal (consistent with Equals), so the explicit comparisons below
+  // must stay. Suppress the IDE's "use Float.compare" suggestion, which would reintroduce that bug.
+  @SuppressWarnings("UseCompareMethod")
   @Nullable
   private static Integer compareFloat(float operand0, float operand1) {
     // NaN is not an ordered value for ContentFilter comparisons.
@@ -228,6 +259,11 @@ final class OperatorUtil {
     }
   }
 
+  // Intentionally not Double.compare: it orders -0.0 below +0.0, but ContentFilter ordering treats
+  // +0.0 and -0.0 as numerically equal (consistent with Equals), so the explicit comparisons below
+  // must stay. Suppress the IDE's "use Double.compare" suggestion, which would reintroduce that
+  // bug.
+  @SuppressWarnings("UseCompareMethod")
   @Nullable
   private static Integer compareDouble(double operand0, double operand1) {
     // NaN is not an ordered value for ContentFilter comparisons.
@@ -244,9 +280,7 @@ final class OperatorUtil {
   }
 
   @Nullable
-  static Object bitwise(
-      @NonNull Object operand0, @NonNull Object operand1, LongBinaryOperator operator) {
-
+  static Object bitwise(Object operand0, Object operand1, LongBinaryOperator operator) {
     operand0 = toScalarIfSingleElementArray(operand0);
     operand1 = toScalarIfSingleElementArray(operand1);
 
@@ -274,7 +308,7 @@ final class OperatorUtil {
   }
 
   @Nullable
-  static OpcUaDataType getType(@NonNull Object value) {
+  static OpcUaDataType getType(Object value) {
     if (value.getClass().isArray()) {
       return OpcUaDataType.fromBackingClass(ArrayUtil.getType(value));
     } else {
@@ -311,7 +345,7 @@ final class OperatorUtil {
   }
 
   @Nullable
-  static Object convert(@NonNull Object value, OpcUaDataType targetType) {
+  static Object convert(Object value, OpcUaDataType targetType) {
     if (value.getClass().isArray()) {
       return convertArray(value, targetType);
     } else if (getType(value) == targetType) {
@@ -322,7 +356,7 @@ final class OperatorUtil {
   }
 
   @Nullable
-  private static Object convertArray(@NonNull Object array, OpcUaDataType targetType) {
+  private static Object convertArray(Object array, OpcUaDataType targetType) {
     int[] dimensions = ArrayUtil.getDimensions(array);
 
     Object flattened = ArrayUtil.flatten(array);
@@ -365,6 +399,7 @@ final class OperatorUtil {
     return highest;
   }
 
+  @SuppressWarnings("BooleanMethodIsAlwaysInverted")
   private static boolean isIntegerType(OpcUaDataType dataType) {
     return switch (dataType) {
       case SByte, Byte, Int16, UInt16, Int32, UInt32, Int64, UInt64 -> true;

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/Operators.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/Operators.java
@@ -29,8 +29,15 @@ public class Operators {
   public static final LessThan LESS_THAN = new LessThan();
   public static final GreaterThanOrEqual GREATER_THAN_OR_EQUAL = new GreaterThanOrEqual();
   public static final LessThanOrEqual LESS_THAN_OR_EQUAL = new LessThanOrEqual();
+  public static final Like LIKE = new Like();
   public static final Not NOT = new Not();
+  public static final Between BETWEEN = new Between();
+  public static final InList IN_LIST = new InList();
+  public static final And AND = new And();
+  public static final Or OR = new Or();
   public static final Cast CAST = new Cast();
+  public static final BitwiseAnd BITWISE_AND = new BitwiseAnd();
+  public static final BitwiseOr BITWISE_OR = new BitwiseOr();
   public static final OfType OF_TYPE = new OfType();
 
   public static final Operator<Object> UNSUPPORTED =
@@ -59,7 +66,14 @@ public class Operators {
           FilterOperator.LessThan,
           FilterOperator.GreaterThanOrEqual,
           FilterOperator.LessThanOrEqual,
+          FilterOperator.Like,
           FilterOperator.Not,
+          FilterOperator.Between,
+          FilterOperator.InList,
+          FilterOperator.And,
+          FilterOperator.Or,
           FilterOperator.Cast,
+          FilterOperator.BitwiseAnd,
+          FilterOperator.BitwiseOr,
           FilterOperator.OfType);
 }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/Or.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/Or.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 the Eclipse Milo Authors
+ * Copyright (c) 2026 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -18,9 +18,9 @@ import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.structured.FilterOperand;
 import org.jspecify.annotations.Nullable;
 
-public class Equals implements Operator<Boolean> {
+public class Or implements Operator<Boolean> {
 
-  Equals() {}
+  Or() {}
 
   @Override
   public void validate(FilterContext context, FilterOperand[] operands) throws ValidationException {
@@ -35,9 +35,28 @@ public class Equals implements Operator<Boolean> {
 
     validate(context, operands);
 
-    Object value0 = context.resolve(operands[0], eventNode);
-    Object value1 = context.resolve(operands[1], eventNode);
+    // Part 4 Table 124 defines three-valued logical OR; do not collapse NULL to FALSE here. A
+    // determining TRUE short-circuits before the other operand is resolved, so an error (or cost)
+    // resolving the non-determining operand cannot turn a TRUE result into a thrown exception.
+    Boolean lhs = asBoolean(OperatorUtil.resolve(context, eventNode, operands[0]));
 
-    return OperatorUtil.equalValues(value0, value1);
+    if (Boolean.TRUE.equals(lhs)) {
+      return true;
+    }
+
+    Boolean rhs = asBoolean(OperatorUtil.resolve(context, eventNode, operands[1]));
+
+    if (Boolean.TRUE.equals(rhs)) {
+      return true;
+    } else if (lhs == null || rhs == null) {
+      return null;
+    } else {
+      return false;
+    }
+  }
+
+  @Nullable
+  private static Boolean asBoolean(@Nullable Object value) {
+    return OperatorUtil.toBoolean(value);
   }
 }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/operators/package-info.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/**
+ * Server-side implementations of OPC UA {@code ContentFilter} operators used while evaluating event
+ * monitored item {@code whereClause} expressions.
+ *
+ * <p>The operators in this package are intentionally small and are wired through {@link Operators}.
+ * Conversion, ordering, array, and bitwise details that are shared across operators live in package
+ * helpers so the implementation follows the same OPC UA conversion and NULL semantics in every
+ * operator.
+ *
+ * @see <a href="https://reference.opcfoundation.org/specs/OPC-10000-4/7.7.3">OPC UA Part 4, 7.7.3
+ *     FilterOperator</a>
+ */
+@NullMarked
+package org.eclipse.milo.opcua.sdk.server.events.operators;
+
+import org.jspecify.annotations.NullMarked;

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/EventContentFilterTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/EventContentFilterTest.java
@@ -42,15 +42,24 @@ public class EventContentFilterTest {
   public void testSupportedOperatorsDoNotReportUnsupported() throws Exception {
     ContentFilterElement[] elements =
         new ContentFilterElement[] {
+          element(FilterOperator.Equals, literal(1), literal(1)),
+          element(FilterOperator.IsNull, literal(null)),
+          element(FilterOperator.GreaterThan, literal(2), literal(1)),
+          element(FilterOperator.LessThan, literal(1), literal(2)),
+          element(FilterOperator.GreaterThanOrEqual, literal(2), literal(2)),
+          element(FilterOperator.LessThanOrEqual, literal(2), literal(2)),
           element(FilterOperator.Like, literal("event message"), literal("event%")),
+          element(FilterOperator.Not, literal(false)),
           element(
               FilterOperator.Between, literal(ushort(2)), literal(ushort(1)), literal(ushort(3))),
           element(
               FilterOperator.InList, literal(ushort(2)), literal(ushort(1)), literal(ushort(2))),
           element(FilterOperator.And, literal(true), literal(true)),
           element(FilterOperator.Or, literal(false), literal(true)),
+          element(FilterOperator.Cast, literal("2"), literal(NodeIds.Int32)),
           element(FilterOperator.BitwiseAnd, literal(ushort(2)), literal(ushort(2))),
-          element(FilterOperator.BitwiseOr, literal(ushort(2)), literal(ushort(4)))
+          element(FilterOperator.BitwiseOr, literal(ushort(2)), literal(ushort(4))),
+          element(FilterOperator.OfType, literal(NodeIds.BaseEventType))
         };
 
     EventFilterResult result = EventContentFilter.validate(filterContext(), eventFilter(elements));

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/EventContentFilterTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/EventContentFilterTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.events;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.stack.core.AttributeId;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.FilterOperator;
+import org.eclipse.milo.opcua.stack.core.types.structured.ContentFilter;
+import org.eclipse.milo.opcua.stack.core.types.structured.ContentFilterElement;
+import org.eclipse.milo.opcua.stack.core.types.structured.ContentFilterElementResult;
+import org.eclipse.milo.opcua.stack.core.types.structured.EventFilter;
+import org.eclipse.milo.opcua.stack.core.types.structured.EventFilterResult;
+import org.eclipse.milo.opcua.stack.core.types.structured.FilterOperand;
+import org.eclipse.milo.opcua.stack.core.types.structured.LiteralOperand;
+import org.eclipse.milo.opcua.stack.core.types.structured.SimpleAttributeOperand;
+import org.junit.jupiter.api.Test;
+
+public class EventContentFilterTest {
+
+  @Test
+  public void testSupportedOperatorsDoNotReportUnsupported() throws Exception {
+    ContentFilterElement[] elements =
+        new ContentFilterElement[] {
+          element(FilterOperator.Like, literal("event message"), literal("event%")),
+          element(
+              FilterOperator.Between, literal(ushort(2)), literal(ushort(1)), literal(ushort(3))),
+          element(
+              FilterOperator.InList, literal(ushort(2)), literal(ushort(1)), literal(ushort(2))),
+          element(FilterOperator.And, literal(true), literal(true)),
+          element(FilterOperator.Or, literal(false), literal(true)),
+          element(FilterOperator.BitwiseAnd, literal(ushort(2)), literal(ushort(2))),
+          element(FilterOperator.BitwiseOr, literal(ushort(2)), literal(ushort(4)))
+        };
+
+    EventFilterResult result = EventContentFilter.validate(filterContext(), eventFilter(elements));
+
+    ContentFilterElementResult[] elementResults = result.getWhereClauseResult().getElementResults();
+
+    assertEquals(elements.length, elementResults.length);
+
+    for (ContentFilterElementResult elementResult : elementResults) {
+      assertTrue(elementResult.getStatusCode().isGood());
+    }
+  }
+
+  @Test
+  public void testUnsupportedOperatorsStillReportUnsupported() throws Exception {
+    EventFilterResult result =
+        EventContentFilter.validate(
+            filterContext(),
+            eventFilter(
+                new ContentFilterElement[] {
+                  element(FilterOperator.InView, literal(uint(1))),
+                  element(FilterOperator.RelatedTo, literal(uint(1)))
+                }));
+
+    ContentFilterElementResult[] elementResults = result.getWhereClauseResult().getElementResults();
+
+    assertEquals(
+        StatusCodes.Bad_FilterOperatorUnsupported, elementResults[0].getStatusCode().value());
+    assertEquals(
+        StatusCodes.Bad_FilterOperatorUnsupported, elementResults[1].getStatusCode().value());
+  }
+
+  private static FilterContext filterContext() {
+    OpcUaServer server = mock(OpcUaServer.class);
+    when(server.getStaticEncodingContext()).thenReturn(DefaultEncodingContext.INSTANCE);
+
+    FilterContext context = mock(FilterContext.class);
+    when(context.getServer()).thenReturn(server);
+
+    return context;
+  }
+
+  private static EventFilter eventFilter(ContentFilterElement[] elements) {
+    SimpleAttributeOperand selectClause =
+        new SimpleAttributeOperand(
+            NodeIds.BaseEventType,
+            new QualifiedName[] {new QualifiedName(0, "Message")},
+            AttributeId.Value.uid(),
+            null);
+
+    return new EventFilter(
+        new SimpleAttributeOperand[] {selectClause}, new ContentFilter(elements));
+  }
+
+  private static ContentFilterElement element(FilterOperator operator, FilterOperand... operands) {
+    ExtensionObject[] encodedOperands = new ExtensionObject[operands.length];
+
+    for (int i = 0; i < operands.length; i++) {
+      encodedOperands[i] = ExtensionObject.encode(DefaultEncodingContext.INSTANCE, operands[i]);
+    }
+
+    return new ContentFilterElement(operator, encodedOperands);
+  }
+
+  private static LiteralOperand literal(Object value) {
+    return new LiteralOperand(new Variant(value));
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/operators/AndTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/operators/AndTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.events.operators;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.milo.opcua.sdk.server.events.OperatorContext;
+import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.structured.FilterOperand;
+import org.eclipse.milo.opcua.stack.core.types.structured.LiteralOperand;
+import org.junit.jupiter.api.Test;
+
+public class AndTest {
+
+  @Test
+  public void testTruthTable() throws Exception {
+    assertEquals(Boolean.TRUE, and(true, true));
+    assertEquals(Boolean.FALSE, and(true, false));
+    assertNull(and(true, null));
+
+    assertEquals(Boolean.FALSE, and(false, true));
+    assertEquals(Boolean.FALSE, and(false, false));
+    assertEquals(Boolean.FALSE, and(false, null));
+
+    assertNull(and(null, true));
+    assertEquals(Boolean.FALSE, and(null, false));
+    assertNull(and(null, null));
+  }
+
+  @Test
+  public void testNonBooleanOperandsAreNull() throws Exception {
+    assertNull(and(true, "not boolean"));
+    assertEquals(Boolean.FALSE, and(false, "not boolean"));
+  }
+
+  @Test
+  public void testSingleElementBooleanArray() throws Exception {
+    assertEquals(Boolean.TRUE, and(new boolean[] {true}, true));
+  }
+
+  @Test
+  public void testImplicitStringBooleanConversion() throws Exception {
+    assertEquals(Boolean.TRUE, and("true", true));
+    assertEquals(Boolean.FALSE, and("false", true));
+    assertNull(and("not boolean", true));
+  }
+
+  private static Boolean and(Object lhs, Object rhs) throws Exception {
+    OperatorContext context = mock(OperatorContext.class);
+    BaseEventTypeNode eventNode = mock(BaseEventTypeNode.class);
+
+    FilterOperand op0 = new LiteralOperand(new Variant(lhs));
+    FilterOperand op1 = new LiteralOperand(new Variant(rhs));
+
+    when(context.resolve(op0, eventNode)).thenReturn(lhs);
+    when(context.resolve(op1, eventNode)).thenReturn(rhs);
+
+    return Operators.AND.apply(context, eventNode, new FilterOperand[] {op0, op1});
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/operators/BetweenTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/operators/BetweenTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.events.operators;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ulong;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.milo.opcua.sdk.server.events.OperatorContext;
+import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.ULong;
+import org.eclipse.milo.opcua.stack.core.types.structured.FilterOperand;
+import org.eclipse.milo.opcua.stack.core.types.structured.LiteralOperand;
+import org.junit.jupiter.api.Test;
+
+public class BetweenTest {
+
+  @Test
+  public void testInclusiveBounds() throws Exception {
+    assertTrue(between(1, 1, 3));
+    assertTrue(between(3, 1, 3));
+  }
+
+  @Test
+  public void testBelowAndAboveRange() throws Exception {
+    assertFalse(between(0, 1, 3));
+    assertFalse(between(4, 1, 3));
+  }
+
+  @Test
+  public void testMixedNumericImplicitConversion() throws Exception {
+    assertTrue(between(ushort(2), 1, 3));
+  }
+
+  @Test
+  public void testSingleElementArraysConvertToScalars() throws Exception {
+    assertTrue(between(new int[] {2}, new int[] {1}, new int[] {3}));
+  }
+
+  @Test
+  public void testAllOperandsMustConvertToOneCommonType() throws Exception {
+    assertFalse(between(ulong(5L), -1L, ulong(ULong.MAX_VALUE_LONG)));
+  }
+
+  @Test
+  public void testUInt32AndUInt64() throws Exception {
+    assertTrue(between(uint(4_000_000_000L), uint(3_000_000_000L), uint(4_200_000_000L)));
+    assertTrue(between(ulong(4_000_000_000L), ulong(3_000_000_000L), ulong(4_200_000_000L)));
+  }
+
+  @Test
+  public void testDateTime() throws Exception {
+    assertTrue(between(new DateTime(200L), new DateTime(100L), new DateTime(300L)));
+  }
+
+  @Test
+  public void testNullOperandReturnsNull() throws Exception {
+    assertNull(between(null, 1, 3));
+    assertNull(between(2, null, 3));
+    assertNull(between(2, 1, null));
+  }
+
+  @Test
+  public void testNonOrderedValuesReturnFalse() throws Exception {
+    assertFalse(between("b", "a", "c"));
+  }
+
+  @Test
+  public void testNaNReturnsFalse() throws Exception {
+    assertFalse(between(Double.NaN, 1.0d, 3.0d));
+    assertFalse(between(2.0d, 1.0d, Double.NaN));
+  }
+
+  private static Boolean between(Object value, Object lowerBound, Object upperBound)
+      throws Exception {
+
+    OperatorContext context = mock(OperatorContext.class);
+    BaseEventTypeNode eventNode = mock(BaseEventTypeNode.class);
+
+    FilterOperand op0 = new LiteralOperand(new Variant(value));
+    FilterOperand op1 = new LiteralOperand(new Variant(lowerBound));
+    FilterOperand op2 = new LiteralOperand(new Variant(upperBound));
+
+    when(context.resolve(op0, eventNode)).thenReturn(value);
+    when(context.resolve(op1, eventNode)).thenReturn(lowerBound);
+    when(context.resolve(op2, eventNode)).thenReturn(upperBound);
+
+    return Operators.BETWEEN.apply(context, eventNode, new FilterOperand[] {op0, op1, op2});
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/operators/BitwiseAndTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/operators/BitwiseAndTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.events.operators;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ulong;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.milo.opcua.sdk.server.events.OperatorContext;
+import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.ULong;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
+import org.eclipse.milo.opcua.stack.core.types.structured.FilterOperand;
+import org.eclipse.milo.opcua.stack.core.types.structured.LiteralOperand;
+import org.junit.jupiter.api.Test;
+
+public class BitwiseAndTest {
+
+  @Test
+  public void testSignedIntegers() throws Exception {
+    assertEquals(0b1000, bitwiseAnd(0b1100, 0b1010));
+  }
+
+  @Test
+  public void testSingleElementIntegerArray() throws Exception {
+    assertEquals(0b1000, bitwiseAnd(new int[] {0b1100}, 0b1010));
+  }
+
+  @Test
+  public void testUnsignedWrappers() throws Exception {
+    Object result = bitwiseAnd(ushort(0x00ff), ushort(0x0f0f));
+
+    assertInstanceOf(UShort.class, result);
+    assertEquals(ushort(0x000f), result);
+  }
+
+  @Test
+  public void testMixedIntegerWidths() throws Exception {
+    Object result = bitwiseAnd(ushort(0x00ff), uint(0x0f0fL));
+
+    assertInstanceOf(UInteger.class, result);
+    assertEquals(uint(0x000fL), result);
+  }
+
+  @Test
+  public void testSameWidthSignedAndUnsignedUseUnsignedResultType() throws Exception {
+    Object result = bitwiseAnd(uint(0x8000_0000L), -1);
+
+    assertInstanceOf(UInteger.class, result);
+    assertEquals(uint(0x8000_0000L), result);
+  }
+
+  @Test
+  public void testTargetResultType() throws Exception {
+    Object result = bitwiseAnd(ulong(0x00ffL), ulong(0x0f0fL));
+
+    assertInstanceOf(ULong.class, result);
+    assertEquals(ulong(0x000fL), result);
+  }
+
+  @Test
+  public void testUInt64HighBitWithSignedInt64() throws Exception {
+    Object result = bitwiseAnd(ulong(ULong.MAX_VALUE_LONG), -1L);
+
+    assertInstanceOf(ULong.class, result);
+    assertEquals(ulong(ULong.MAX_VALUE_LONG), result);
+  }
+
+  @Test
+  public void testNullOperandsReturnNull() throws Exception {
+    assertNull(bitwiseAnd(null, 1));
+    assertNull(bitwiseAnd(1, null));
+  }
+
+  @Test
+  public void testNonIntegerOperandsReturnNull() throws Exception {
+    assertNull(bitwiseAnd(1.0d, 1.0d));
+    assertNull(bitwiseAnd(true, 1));
+    assertNull(bitwiseAnd("1", 1));
+  }
+
+  private static Object bitwiseAnd(Object lhs, Object rhs) throws Exception {
+    OperatorContext context = mock(OperatorContext.class);
+    BaseEventTypeNode eventNode = mock(BaseEventTypeNode.class);
+
+    FilterOperand op0 = new LiteralOperand(new Variant(lhs));
+    FilterOperand op1 = new LiteralOperand(new Variant(rhs));
+
+    when(context.resolve(op0, eventNode)).thenReturn(lhs);
+    when(context.resolve(op1, eventNode)).thenReturn(rhs);
+
+    return Operators.BITWISE_AND.apply(context, eventNode, new FilterOperand[] {op0, op1});
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/operators/BitwiseOrTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/operators/BitwiseOrTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.events.operators;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ulong;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.milo.opcua.sdk.server.events.OperatorContext;
+import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.ULong;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
+import org.eclipse.milo.opcua.stack.core.types.structured.FilterOperand;
+import org.eclipse.milo.opcua.stack.core.types.structured.LiteralOperand;
+import org.junit.jupiter.api.Test;
+
+public class BitwiseOrTest {
+
+  @Test
+  public void testSignedIntegers() throws Exception {
+    assertEquals(0b1110, bitwiseOr(0b1100, 0b1010));
+  }
+
+  @Test
+  public void testSingleElementIntegerArray() throws Exception {
+    assertEquals(0b1110, bitwiseOr(new int[] {0b1100}, 0b1010));
+  }
+
+  @Test
+  public void testUnsignedWrappers() throws Exception {
+    Object result = bitwiseOr(ushort(0x00f0), ushort(0x0f0f));
+
+    assertInstanceOf(UShort.class, result);
+    assertEquals(ushort(0x0fff), result);
+  }
+
+  @Test
+  public void testMixedIntegerWidths() throws Exception {
+    Object result = bitwiseOr(ushort(0x00f0), uint(0x0f0fL));
+
+    assertInstanceOf(UInteger.class, result);
+    assertEquals(uint(0x0fffL), result);
+  }
+
+  @Test
+  public void testSameWidthSignedAndUnsignedUseUnsignedResultType() throws Exception {
+    Object result = bitwiseOr(uint(0x8000_0000L), 0x7fff_ffff);
+
+    assertInstanceOf(UInteger.class, result);
+    assertEquals(uint(0xffff_ffffL), result);
+  }
+
+  @Test
+  public void testTargetResultType() throws Exception {
+    Object result = bitwiseOr(ulong(0x00f0L), ulong(0x0f0fL));
+
+    assertInstanceOf(ULong.class, result);
+    assertEquals(ulong(0x0fffL), result);
+  }
+
+  @Test
+  public void testUInt64HighBitWithSignedInt64() throws Exception {
+    Object result = bitwiseOr(ulong(ULong.MAX_VALUE_LONG), 0L);
+
+    assertInstanceOf(ULong.class, result);
+    assertEquals(ulong(ULong.MAX_VALUE_LONG), result);
+  }
+
+  @Test
+  public void testNullOperandsReturnNull() throws Exception {
+    assertNull(bitwiseOr(null, 1));
+    assertNull(bitwiseOr(1, null));
+  }
+
+  @Test
+  public void testNonIntegerOperandsReturnNull() throws Exception {
+    assertNull(bitwiseOr(1.0d, 1.0d));
+    assertNull(bitwiseOr(true, 1));
+    assertNull(bitwiseOr("1", 1));
+  }
+
+  private static Object bitwiseOr(Object lhs, Object rhs) throws Exception {
+    OperatorContext context = mock(OperatorContext.class);
+    BaseEventTypeNode eventNode = mock(BaseEventTypeNode.class);
+
+    FilterOperand op0 = new LiteralOperand(new Variant(lhs));
+    FilterOperand op1 = new LiteralOperand(new Variant(rhs));
+
+    when(context.resolve(op0, eventNode)).thenReturn(lhs);
+    when(context.resolve(op1, eventNode)).thenReturn(rhs);
+
+    return Operators.BITWISE_OR.apply(context, eventNode, new FilterOperand[] {op0, op1});
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/operators/CastTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/operators/CastTest.java
@@ -10,6 +10,7 @@
 
 package org.eclipse.milo.opcua.sdk.server.events.operators;
 
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ulong;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -47,6 +48,11 @@ public class CastTest {
   @Test
   public void testExplicitConversion() throws Exception {
     assertEquals("1", cast(true, NodeIds.String));
+  }
+
+  @Test
+  public void testUInt64Above32BitsCastsToBooleanTrue() throws Exception {
+    assertEquals(Boolean.TRUE, cast(ulong(0x1_0000_0000L), NodeIds.Boolean));
   }
 
   @Test

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/operators/CastTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/operators/CastTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.events.operators;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.milo.opcua.sdk.server.events.OperatorContext;
+import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.structured.FilterOperand;
+import org.eclipse.milo.opcua.stack.core.types.structured.LiteralOperand;
+import org.junit.jupiter.api.Test;
+
+public class CastTest {
+
+  @Test
+  public void testNodeIdTargetDataType() throws Exception {
+    assertEquals(42, cast("42", NodeIds.Int32));
+  }
+
+  @Test
+  public void testSameTypeCastReturnsSourceValue() throws Exception {
+    assertEquals(42, cast(42, NodeIds.Int32));
+    assertEquals("event message", cast("event message", NodeIds.String));
+    assertEquals(ushort(2), cast(ushort(2), NodeIds.UInt16));
+  }
+
+  @Test
+  public void testExpandedNodeIdTargetDataType() throws Exception {
+    assertEquals(Boolean.TRUE, cast("true", NodeIds.Boolean.expanded()));
+  }
+
+  @Test
+  public void testExplicitConversion() throws Exception {
+    assertEquals("1", cast(true, NodeIds.String));
+  }
+
+  @Test
+  public void testConversionFailureReturnsNull() throws Exception {
+    assertNull(cast("not an int", NodeIds.Int32));
+  }
+
+  @Test
+  public void testNullSourceReturnsNull() throws Exception {
+    assertNull(cast(null, NodeIds.Int32));
+  }
+
+  @Test
+  public void testUnknownTargetDataTypeReturnsNull() throws Exception {
+    assertNull(cast("42", new NodeId(1, "UnknownDataType")));
+  }
+
+  @Test
+  public void testNonNodeIdTargetDataTypeReturnsNull() throws Exception {
+    assertNull(cast("42", "Int32"));
+  }
+
+  private static Object cast(Object value, Object targetDataType) throws Exception {
+    OperatorContext context = mock(OperatorContext.class);
+    BaseEventTypeNode eventNode = mock(BaseEventTypeNode.class);
+
+    FilterOperand op0 = new LiteralOperand(new Variant(value));
+    FilterOperand op1 = new LiteralOperand(new Variant(targetDataType));
+
+    when(context.resolve(op0, eventNode)).thenReturn(value);
+    when(context.resolve(op1, eventNode)).thenReturn(targetDataType);
+
+    return Operators.CAST.apply(context, eventNode, new FilterOperand[] {op0, op1});
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/operators/EqualsTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/operators/EqualsTest.java
@@ -216,4 +216,42 @@ public class EqualsTest {
     assertNotNull(result);
     assertFalse(result);
   }
+
+  @Test
+  public void testFloatArrayNaNElementsAreNotEqual() throws Exception {
+    // IEEE semantics: NaN != NaN, matching the scalar path rather than Objects.deepEquals' bitwise
+    // Float comparison. Two elements so the array is not scalarized.
+    OperatorContext context = mock(OperatorContext.class);
+    BaseEventTypeNode eventNode = mock(BaseEventTypeNode.class);
+
+    FilterOperand op0 = new LiteralOperand(new Variant(new float[] {1.0f, Float.NaN}));
+    FilterOperand op1 = new LiteralOperand(new Variant(new float[] {1.0f, Float.NaN}));
+
+    when(context.resolve(op0, eventNode)).thenReturn(new float[] {1.0f, Float.NaN});
+    when(context.resolve(op1, eventNode)).thenReturn(new float[] {1.0f, Float.NaN});
+
+    Boolean result = Operators.EQUALS.apply(context, eventNode, new FilterOperand[] {op0, op1});
+
+    assertNotNull(result);
+    assertFalse(result);
+  }
+
+  @Test
+  public void testDoubleArraySignedZeroElementsAreEqual() throws Exception {
+    // IEEE semantics: +0.0 == -0.0, matching the scalar path rather than Objects.deepEquals'
+    // bitwise Double comparison.
+    OperatorContext context = mock(OperatorContext.class);
+    BaseEventTypeNode eventNode = mock(BaseEventTypeNode.class);
+
+    FilterOperand op0 = new LiteralOperand(new Variant(new double[] {1.0, -0.0}));
+    FilterOperand op1 = new LiteralOperand(new Variant(new double[] {1.0, 0.0}));
+
+    when(context.resolve(op0, eventNode)).thenReturn(new double[] {1.0, -0.0});
+    when(context.resolve(op1, eventNode)).thenReturn(new double[] {1.0, 0.0});
+
+    Boolean result = Operators.EQUALS.apply(context, eventNode, new FilterOperand[] {op0, op1});
+
+    assertNotNull(result);
+    assertTrue(result);
+  }
 }

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/operators/EqualsTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/operators/EqualsTest.java
@@ -97,6 +97,91 @@ public class EqualsTest {
   }
 
   @Test
+  public void testSingleElementArrayWithScalar() throws Exception {
+    OperatorContext context = mock(OperatorContext.class);
+    BaseEventTypeNode eventNode = mock(BaseEventTypeNode.class);
+
+    FilterOperand op0 = new LiteralOperand(new Variant(new int[] {42}));
+    FilterOperand op1 = new LiteralOperand(new Variant(42));
+
+    when(context.resolve(op0, eventNode)).thenReturn(new int[] {42});
+    when(context.resolve(op1, eventNode)).thenReturn(42);
+
+    Boolean result = Operators.EQUALS.apply(context, eventNode, new FilterOperand[] {op0, op1});
+
+    assertNotNull(result);
+    assertTrue(result);
+  }
+
+  @Test
+  public void testSingleElementArrayWithImplicitConversion() throws Exception {
+    OperatorContext context = mock(OperatorContext.class);
+    BaseEventTypeNode eventNode = mock(BaseEventTypeNode.class);
+
+    FilterOperand op0 = new LiteralOperand(new Variant(new String[] {"42"}));
+    FilterOperand op1 = new LiteralOperand(new Variant(42));
+
+    when(context.resolve(op0, eventNode)).thenReturn(new String[] {"42"});
+    when(context.resolve(op1, eventNode)).thenReturn(42);
+
+    Boolean result = Operators.EQUALS.apply(context, eventNode, new FilterOperand[] {op0, op1});
+
+    assertNotNull(result);
+    assertTrue(result);
+  }
+
+  @Test
+  public void testPrimitiveAndBoxedArraysOfSameDataTypeAreEqual() throws Exception {
+    OperatorContext context = mock(OperatorContext.class);
+    BaseEventTypeNode eventNode = mock(BaseEventTypeNode.class);
+
+    FilterOperand op0 = new LiteralOperand(new Variant(new int[] {1, 2, 3}));
+    FilterOperand op1 = new LiteralOperand(new Variant(new Integer[] {1, 2, 3}));
+
+    when(context.resolve(op0, eventNode)).thenReturn(new int[] {1, 2, 3});
+    when(context.resolve(op1, eventNode)).thenReturn(new Integer[] {1, 2, 3});
+
+    Boolean result = Operators.EQUALS.apply(context, eventNode, new FilterOperand[] {op0, op1});
+
+    assertNotNull(result);
+    assertTrue(result);
+  }
+
+  @Test
+  public void testHigherPrecedencePrimitiveArrayNormalizesBeforeComparison() throws Exception {
+    OperatorContext context = mock(OperatorContext.class);
+    BaseEventTypeNode eventNode = mock(BaseEventTypeNode.class);
+
+    FilterOperand op0 = new LiteralOperand(new Variant(new long[] {1L, 2L, 3L}));
+    FilterOperand op1 = new LiteralOperand(new Variant(new int[] {1, 2, 3}));
+
+    when(context.resolve(op0, eventNode)).thenReturn(new long[] {1L, 2L, 3L});
+    when(context.resolve(op1, eventNode)).thenReturn(new int[] {1, 2, 3});
+
+    Boolean result = Operators.EQUALS.apply(context, eventNode, new FilterOperand[] {op0, op1});
+
+    assertNotNull(result);
+    assertTrue(result);
+  }
+
+  @Test
+  public void testArrayImplicitConversionFailureReturnsFalse() throws Exception {
+    OperatorContext context = mock(OperatorContext.class);
+    BaseEventTypeNode eventNode = mock(BaseEventTypeNode.class);
+
+    FilterOperand op0 = new LiteralOperand(new Variant(new String[] {"not an int"}));
+    FilterOperand op1 = new LiteralOperand(new Variant(42));
+
+    when(context.resolve(op0, eventNode)).thenReturn(new String[] {"not an int"});
+    when(context.resolve(op1, eventNode)).thenReturn(42);
+
+    Boolean result = Operators.EQUALS.apply(context, eventNode, new FilterOperand[] {op0, op1});
+
+    assertNotNull(result);
+    assertFalse(result);
+  }
+
+  @Test
   public void testArrayNotEqual() throws Exception {
     OperatorContext context = mock(OperatorContext.class);
     BaseEventTypeNode eventNode = mock(BaseEventTypeNode.class);

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/operators/InListTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/operators/InListTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.events.operators;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.milo.opcua.sdk.server.events.OperatorContext;
+import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.structured.FilterOperand;
+import org.eclipse.milo.opcua.stack.core.types.structured.LiteralOperand;
+import org.junit.jupiter.api.Test;
+
+public class InListTest {
+
+  @Test
+  public void testMatchesFirstCandidate() throws Exception {
+    assertTrue(inList("a", "a", "b", "c"));
+  }
+
+  @Test
+  public void testMatchesMiddleCandidate() throws Exception {
+    assertTrue(inList("b", "a", "b", "c"));
+  }
+
+  @Test
+  public void testMatchesLastCandidate() throws Exception {
+    assertTrue(inList("c", "a", "b", "c"));
+  }
+
+  @Test
+  public void testNoMatchReturnsFalse() throws Exception {
+    assertFalse(inList("d", "a", "b", "c"));
+  }
+
+  @Test
+  public void testMixedNumericImplicitConversion() throws Exception {
+    assertTrue(inList(42, 1L, 42L, 100L));
+  }
+
+  @Test
+  public void testSingleElementArrayUsesEqualsSemantics() throws Exception {
+    assertTrue(inList(new int[] {2}, 1, 2, 3));
+  }
+
+  @Test
+  public void testNullTestedValueReturnsNullWhenNothingMatches() throws Exception {
+    assertNull(inList(null, 1, 2, 3));
+  }
+
+  @Test
+  public void testMoreThanTwoListOperands() throws Exception {
+    assertTrue(inList(4, 1, 2, 3, 4, 5));
+  }
+
+  private static Boolean inList(Object value, Object... candidates) throws Exception {
+    OperatorContext context = mock(OperatorContext.class);
+    BaseEventTypeNode eventNode = mock(BaseEventTypeNode.class);
+
+    FilterOperand[] operands = new FilterOperand[candidates.length + 1];
+    Object[] values = new Object[candidates.length + 1];
+
+    operands[0] = new LiteralOperand(new Variant(value));
+    values[0] = value;
+
+    for (int i = 0; i < candidates.length; i++) {
+      operands[i + 1] = new LiteralOperand(new Variant(candidates[i]));
+      values[i + 1] = candidates[i];
+    }
+
+    for (int i = 0; i < operands.length; i++) {
+      when(context.resolve(operands[i], eventNode)).thenReturn(values[i]);
+    }
+
+    return Operators.IN_LIST.apply(context, eventNode, operands);
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/operators/InListTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/operators/InListTest.java
@@ -18,6 +18,8 @@ import static org.mockito.Mockito.when;
 
 import org.eclipse.milo.opcua.sdk.server.events.OperatorContext;
 import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.structured.FilterOperand;
 import org.eclipse.milo.opcua.stack.core.types.structured.LiteralOperand;
@@ -63,6 +65,11 @@ public class InListTest {
   @Test
   public void testMoreThanTwoListOperands() throws Exception {
     assertTrue(inList(4, 1, 2, 3, 4, 5));
+  }
+
+  @Test
+  public void testNodeIdMatchesExpandedNodeIdCandidate() throws Exception {
+    assertTrue(inList(NodeIds.ExclusiveLimitAlarmType, ExpandedNodeId.parse("i=9341")));
   }
 
   private static Boolean inList(Object value, Object... candidates) throws Exception {

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/operators/LikeTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/operators/LikeTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.events.operators;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.milo.opcua.sdk.server.events.OperatorContext;
+import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.structured.FilterOperand;
+import org.eclipse.milo.opcua.stack.core.types.structured.LiteralOperand;
+import org.junit.jupiter.api.Test;
+
+public class LikeTest {
+
+  @Test
+  public void testPercentWildcard() throws Exception {
+    assertTrue(like("event message", "event%"));
+    assertTrue(like("event", "event%"));
+    assertFalse(like("message event", "event%"));
+  }
+
+  @Test
+  public void testUnderscoreWildcard() throws Exception {
+    assertTrue(like("ab", "a_"));
+    assertFalse(like("abc", "a_"));
+  }
+
+  @Test
+  public void testEscapedWildcards() throws Exception {
+    assertTrue(like("event%", "event\\%"));
+    assertTrue(like("event_", "event\\_"));
+    assertFalse(like("eventX", "event\\_"));
+  }
+
+  @Test
+  public void testBracketList() throws Exception {
+    assertTrue(like("cat", "c[ao]t"));
+    assertTrue(like("cot", "c[ao]t"));
+    assertFalse(like("cut", "c[ao]t"));
+  }
+
+  @Test
+  public void testBracketRange() throws Exception {
+    assertTrue(like("cat", "c[a-f]t"));
+    assertFalse(like("czt", "c[a-f]t"));
+  }
+
+  @Test
+  public void testEscapedBracketClassMetacharactersAreLiteral() throws Exception {
+    assertTrue(like("-", "[a\\-c]"));
+    assertFalse(like("b", "[a\\-c]"));
+
+    assertTrue(like("]", "[\\]]"));
+    assertFalse(like("[", "[\\]]"));
+
+    assertTrue(like("^", "[\\^a]"));
+    assertFalse(like("b", "[\\^a]"));
+
+    assertTrue(like("\\", "[\\\\]"));
+    assertFalse(like("a", "[\\\\]"));
+  }
+
+  @Test
+  public void testNegatedCharacterClass() throws Exception {
+    assertTrue(like("cot", "c[^a]t"));
+    assertFalse(like("cat", "c[^a]t"));
+  }
+
+  @Test
+  public void testCaseSensitive() throws Exception {
+    assertFalse(like("Event message", "event%"));
+  }
+
+  @Test
+  public void testLocalizedTextUsesImplicitStringConversion() throws Exception {
+    assertTrue(like(LocalizedText.english("event message"), "event%"));
+  }
+
+  @Test
+  public void testSingleElementStringArrayMatchesAsScalar() throws Exception {
+    assertTrue(like(new String[] {"event message"}, "event%"));
+  }
+
+  @Test
+  public void testMalformedPatternsReturnFalse() throws Exception {
+    assertFalse(like("abc", "a[b"));
+    assertFalse(like("abc", "abc\\"));
+    assertFalse(like("abc", "a[]c"));
+  }
+
+  @Test
+  public void testNonStringOperandsReturnFalse() throws Exception {
+    assertFalse(like(42, "%"));
+    assertFalse(like("42", 42));
+  }
+
+  private static Boolean like(Object value, Object pattern) throws Exception {
+    OperatorContext context = mock(OperatorContext.class);
+    BaseEventTypeNode eventNode = mock(BaseEventTypeNode.class);
+
+    FilterOperand op0 = new LiteralOperand(new Variant(value));
+    FilterOperand op1 = new LiteralOperand(new Variant(pattern));
+
+    when(context.resolve(op0, eventNode)).thenReturn(value);
+    when(context.resolve(op1, eventNode)).thenReturn(pattern);
+
+    return Operators.LIKE.apply(context, eventNode, new FilterOperand[] {op0, op1});
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/operators/LikeTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/operators/LikeTest.java
@@ -11,10 +11,13 @@
 package org.eclipse.milo.opcua.sdk.server.events.operators;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.time.Duration;
 import org.eclipse.milo.opcua.sdk.server.events.OperatorContext;
 import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
@@ -105,6 +108,24 @@ public class LikeTest {
   public void testNonStringOperandsReturnFalse() throws Exception {
     assertFalse(like(42, "%"));
     assertFalse(like("42", 42));
+  }
+
+  @Test
+  public void testNullOperandsAreIndeterminate() throws Exception {
+    // A null operand is indeterminate (null), consistent with the comparison operators, rather than
+    // a non-match (false).
+    assertNull(like(null, "event%"));
+    assertNull(like("event message", null));
+  }
+
+  @Test
+  public void testPathologicalPatternMatchesInLinearTime() {
+    // A regex translation of this pattern (many "%" separated by literals) would backtrack
+    // catastrophically against a long non-matching input; the linear matcher returns promptly.
+    String value = "a".repeat(100_000);
+
+    assertTimeoutPreemptively(
+        Duration.ofSeconds(5), () -> assertFalse(like(value, "%a%a%a%a%a%a%a%a%a%aZ")));
   }
 
   private static Boolean like(Object value, Object pattern) throws Exception {

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/operators/NotTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/operators/NotTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.events.operators;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.milo.opcua.sdk.server.events.OperatorContext;
+import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.structured.FilterOperand;
+import org.eclipse.milo.opcua.stack.core.types.structured.LiteralOperand;
+import org.junit.jupiter.api.Test;
+
+public class NotTest {
+
+  @Test
+  public void testBooleanOperands() throws Exception {
+    assertEquals(Boolean.FALSE, not(true));
+    assertEquals(Boolean.TRUE, not(false));
+  }
+
+  @Test
+  public void testImplicitStringBooleanConversion() throws Exception {
+    assertEquals(Boolean.FALSE, not("true"));
+    assertEquals(Boolean.TRUE, not("false"));
+    assertNull(not("not boolean"));
+  }
+
+  @Test
+  public void testSingleElementBooleanArray() throws Exception {
+    assertEquals(Boolean.FALSE, not(new boolean[] {true}));
+  }
+
+  private static Boolean not(Object value) throws Exception {
+    OperatorContext context = mock(OperatorContext.class);
+    BaseEventTypeNode eventNode = mock(BaseEventTypeNode.class);
+
+    FilterOperand op0 = new LiteralOperand(new Variant(value));
+
+    when(context.resolve(op0, eventNode)).thenReturn(value);
+
+    return Operators.NOT.apply(context, eventNode, new FilterOperand[] {op0});
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/operators/OfTypeTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/operators/OfTypeTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.events.operators;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import org.eclipse.milo.opcua.sdk.core.Reference;
+import org.eclipse.milo.opcua.sdk.core.Reference.Direction;
+import org.eclipse.milo.opcua.sdk.core.nodes.ObjectTypeNode;
+import org.eclipse.milo.opcua.sdk.server.AddressSpaceManager;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.sdk.server.events.OperatorContext;
+import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectTypeNode;
+import org.eclipse.milo.opcua.stack.core.NamespaceTable;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.structured.FilterOperand;
+import org.eclipse.milo.opcua.stack.core.types.structured.LiteralOperand;
+import org.junit.jupiter.api.Test;
+
+public class OfTypeTest {
+
+  @Test
+  public void testExactTypeDefinitionMatches() throws Exception {
+    assertTrue(ofType(NodeIds.BaseEventType, NodeIds.BaseEventType));
+  }
+
+  @Test
+  public void testSubtypeMatches() throws Exception {
+    NodeId eventTypeId = NodeIds.SystemEventType;
+    NodeId targetTypeId = NodeIds.BaseEventType;
+
+    OperatorContext context = mock(OperatorContext.class);
+    BaseEventTypeNode eventNode = mockEventNode(eventTypeId);
+    FilterOperand operand = new LiteralOperand(new Variant(targetTypeId));
+    OpcUaServer server = mock(OpcUaServer.class);
+    AddressSpaceManager addressSpaceManager = mock(AddressSpaceManager.class);
+    UaObjectTypeNode eventTypeNode = mockObjectTypeNode(eventTypeId);
+    UaObjectTypeNode targetTypeNode = mockObjectTypeNode(targetTypeId);
+    Reference subtypeOfTarget =
+        new Reference(eventTypeId, NodeIds.HasSubtype, targetTypeId.expanded(), Direction.INVERSE);
+
+    when(context.resolve(operand, eventNode)).thenReturn(targetTypeId);
+    when(context.getServer()).thenReturn(server);
+    when(server.getAddressSpaceManager()).thenReturn(addressSpaceManager);
+    when(server.getNamespaceTable()).thenReturn(new NamespaceTable());
+    when(addressSpaceManager.getManagedNode(eventTypeId)).thenReturn(Optional.of(eventTypeNode));
+    when(addressSpaceManager.getManagedReferences(eventTypeId))
+        .thenReturn(List.of(subtypeOfTarget));
+    when(addressSpaceManager.getManagedNode(targetTypeId)).thenReturn(Optional.of(targetTypeNode));
+
+    assertEquals(
+        Boolean.TRUE, Operators.OF_TYPE.apply(context, eventNode, new FilterOperand[] {operand}));
+  }
+
+  @Test
+  public void testUnrelatedTypeReturnsFalse() throws Exception {
+    assertFalse(ofType(NodeIds.BaseEventType, NodeIds.ConditionType));
+  }
+
+  @Test
+  public void testNonNodeIdOperandReturnsFalse() throws Exception {
+    OperatorContext context = mock(OperatorContext.class);
+    BaseEventTypeNode eventNode = mock(BaseEventTypeNode.class);
+    FilterOperand operand = new LiteralOperand(new Variant("BaseEventType"));
+
+    when(context.resolve(operand, eventNode)).thenReturn("BaseEventType");
+
+    assertNotEquals(
+        Boolean.TRUE, Operators.OF_TYPE.apply(context, eventNode, new FilterOperand[] {operand}));
+  }
+
+  private static Boolean ofType(NodeId eventTypeId, NodeId targetTypeId) throws Exception {
+    OperatorContext context = mock(OperatorContext.class);
+    BaseEventTypeNode eventNode = mockEventNode(eventTypeId);
+    FilterOperand operand = new LiteralOperand(new Variant(targetTypeId));
+    OpcUaServer server = mock(OpcUaServer.class);
+    AddressSpaceManager addressSpaceManager = mock(AddressSpaceManager.class);
+
+    when(context.resolve(operand, eventNode)).thenReturn(targetTypeId);
+    when(context.getServer()).thenReturn(server);
+    when(server.getAddressSpaceManager()).thenReturn(addressSpaceManager);
+    when(addressSpaceManager.getManagedNode(eventTypeId)).thenReturn(Optional.empty());
+
+    return Operators.OF_TYPE.apply(context, eventNode, new FilterOperand[] {operand});
+  }
+
+  private static BaseEventTypeNode mockEventNode(NodeId eventTypeId) {
+    BaseEventTypeNode eventNode = mock(BaseEventTypeNode.class);
+    ObjectTypeNode typeDefinitionNode = mock(ObjectTypeNode.class);
+
+    when(eventNode.getTypeDefinitionNode()).thenReturn(typeDefinitionNode);
+    when(typeDefinitionNode.getNodeId()).thenReturn(eventTypeId);
+
+    return eventNode;
+  }
+
+  private static UaObjectTypeNode mockObjectTypeNode(NodeId nodeId) {
+    UaObjectTypeNode node = mock(UaObjectTypeNode.class);
+
+    when(node.getNodeId()).thenReturn(nodeId);
+
+    return node;
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/operators/OperatorUtilTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/operators/OperatorUtilTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.events.operators;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ulong;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.ULong;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
+import org.junit.jupiter.api.Test;
+
+public class OperatorUtilTest {
+
+  @Test
+  public void testCommonTypeConversionMixedSignedAndUnsignedNumericOperands() {
+    OperatorUtil.BinaryOperands operands = OperatorUtil.convertToCommonType(42, ushort(7));
+
+    assertEquals(OpcUaDataType.Int32, operands.dataType());
+    assertEquals(42, operands.operand0());
+    assertEquals(7, operands.operand1());
+    assertInstanceOf(Integer.class, operands.operand1());
+  }
+
+  @Test
+  public void testOrderedComparison() {
+    assertTrue(OperatorUtil.compareOrdered((byte) -1, (byte) 1) < 0);
+    assertTrue(OperatorUtil.compareOrdered(uint(4_000_000_000L), uint(3L)) > 0);
+    assertTrue(OperatorUtil.compareOrdered(1.25f, 1.0d) > 0);
+    assertTrue(OperatorUtil.compareOrdered(new DateTime(200L), new DateTime(100L)) > 0);
+  }
+
+  @Test
+  public void testSingleElementArrayConvertsToScalarForCommonTypeOperations() {
+    OperatorUtil.BinaryOperands operands = OperatorUtil.convertToCommonType(new int[] {42}, 42);
+
+    assertEquals(OpcUaDataType.Int32, operands.dataType());
+    assertEquals(42, operands.operand0());
+    assertEquals(42, operands.operand1());
+
+    assertTrue(OperatorUtil.compareOrdered(new int[] {2}, 1) > 0);
+  }
+
+  @Test
+  public void testArrayConversionFailsWhenAnyElementConversionFails() {
+    assertArrayEquals(
+        new String[] {"a", "b"},
+        (String[]) OperatorUtil.convert(new String[] {"a", "b"}, OpcUaDataType.String));
+
+    assertArrayEquals(
+        new Integer[] {1, 2},
+        (Integer[]) OperatorUtil.convert(new String[] {"1", "2"}, OpcUaDataType.Int32));
+
+    assertNull(OperatorUtil.convert(new String[] {"1", "not an int"}, OpcUaDataType.Int32));
+  }
+
+  @Test
+  public void testOrderedComparisonReturnsNullForNonOrderedValues() {
+    assertNull(OperatorUtil.compareOrdered("a", "b"));
+  }
+
+  @Test
+  public void testOrderedComparisonReturnsNullForNaN() {
+    assertNull(OperatorUtil.compareOrdered(Float.NaN, 1.0f));
+    assertNull(OperatorUtil.compareOrdered(1.0d, Double.NaN));
+  }
+
+  @Test
+  public void testBitwiseHelperKeepsUnsignedBackingTypes() {
+    Object u16 = OperatorUtil.bitwise(ushort(0x00ff), ushort(0x0f0f), (a, b) -> a & b);
+    Object u32 = OperatorUtil.bitwise(uint(0x00ffL), uint(0x0f0fL), (a, b) -> a | b);
+    Object u64 = OperatorUtil.bitwise(ulong(0x00ffL), ulong(0x0f0fL), (a, b) -> a | b);
+
+    assertInstanceOf(UShort.class, u16);
+    assertEquals(ushort(0x000f), u16);
+
+    assertInstanceOf(UInteger.class, u32);
+    assertEquals(uint(0x0fffL), u32);
+
+    assertInstanceOf(ULong.class, u64);
+    assertEquals(ulong(0x0fffL), u64);
+  }
+
+  @Test
+  public void testBitwiseHelperRejectsNonIntegerValues() {
+    assertNull(OperatorUtil.bitwise(1.0d, 1.0d, (a, b) -> a & b));
+  }
+
+  @Test
+  public void testBitwiseHelperAcceptsSingleElementIntegerArrays() {
+    assertEquals(0b1000, OperatorUtil.bitwise(new int[] {0b1100}, 0b1010, (a, b) -> a & b));
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/operators/OrTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/operators/OrTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.events.operators;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.milo.opcua.sdk.server.events.OperatorContext;
+import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.structured.FilterOperand;
+import org.eclipse.milo.opcua.stack.core.types.structured.LiteralOperand;
+import org.junit.jupiter.api.Test;
+
+public class OrTest {
+
+  @Test
+  public void testTruthTable() throws Exception {
+    assertEquals(Boolean.TRUE, or(true, true));
+    assertEquals(Boolean.TRUE, or(true, false));
+    assertEquals(Boolean.TRUE, or(true, null));
+
+    assertEquals(Boolean.TRUE, or(false, true));
+    assertEquals(Boolean.FALSE, or(false, false));
+    assertNull(or(false, null));
+
+    assertEquals(Boolean.TRUE, or(null, true));
+    assertNull(or(null, false));
+    assertNull(or(null, null));
+  }
+
+  @Test
+  public void testNonBooleanOperandsAreNull() throws Exception {
+    assertEquals(Boolean.TRUE, or(true, "not boolean"));
+    assertNull(or(false, "not boolean"));
+  }
+
+  @Test
+  public void testSingleElementBooleanArray() throws Exception {
+    assertEquals(Boolean.TRUE, or(new boolean[] {true}, false));
+  }
+
+  @Test
+  public void testImplicitStringBooleanConversion() throws Exception {
+    assertEquals(Boolean.TRUE, or("true", false));
+    assertEquals(Boolean.FALSE, or("false", false));
+    assertNull(or("not boolean", false));
+  }
+
+  private static Boolean or(Object lhs, Object rhs) throws Exception {
+    OperatorContext context = mock(OperatorContext.class);
+    BaseEventTypeNode eventNode = mock(BaseEventTypeNode.class);
+
+    FilterOperand op0 = new LiteralOperand(new Variant(lhs));
+    FilterOperand op1 = new LiteralOperand(new Variant(rhs));
+
+    when(context.resolve(op0, eventNode)).thenReturn(lhs);
+    when(context.resolve(op1, eventNode)).thenReturn(rhs);
+
+    return Operators.OR.apply(context, eventNode, new FilterOperand[] {op0, op1});
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/operators/OrderedComparisonTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/operators/OrderedComparisonTest.java
@@ -52,6 +52,22 @@ public class OrderedComparisonTest {
     assertFalse(apply(Operators.LESS_THAN, 1.0d, Double.NaN));
   }
 
+  @Test
+  public void testSignedZerosCompareEqual() throws Exception {
+    // IEEE semantics: +0.0 and -0.0 are numerically equal, so neither is strictly greater/less,
+    // and both "or equal" variants hold (unlike Float.compare/Double.compare, which order -0.0
+    // below +0.0).
+    assertFalse(apply(Operators.GREATER_THAN, 0.0f, -0.0f));
+    assertFalse(apply(Operators.LESS_THAN, -0.0f, 0.0f));
+    assertTrue(apply(Operators.GREATER_THAN_OR_EQUAL, -0.0f, 0.0f));
+    assertTrue(apply(Operators.LESS_THAN_OR_EQUAL, 0.0f, -0.0f));
+
+    assertFalse(apply(Operators.GREATER_THAN, 0.0d, -0.0d));
+    assertFalse(apply(Operators.LESS_THAN, -0.0d, 0.0d));
+    assertTrue(apply(Operators.GREATER_THAN_OR_EQUAL, -0.0d, 0.0d));
+    assertTrue(apply(Operators.LESS_THAN_OR_EQUAL, 0.0d, -0.0d));
+  }
+
   private static Boolean apply(Operator<Boolean> operator, Object lhs, Object rhs)
       throws Exception {
 

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/operators/OrderedComparisonTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/operators/OrderedComparisonTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.events.operators;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.milo.opcua.sdk.server.events.OperatorContext;
+import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.structured.FilterOperand;
+import org.eclipse.milo.opcua.stack.core.types.structured.LiteralOperand;
+import org.junit.jupiter.api.Test;
+
+public class OrderedComparisonTest {
+
+  @Test
+  public void testDateTimeComparisons() throws Exception {
+    assertTrue(apply(Operators.GREATER_THAN, new DateTime(200L), new DateTime(100L)));
+    assertTrue(apply(Operators.GREATER_THAN_OR_EQUAL, new DateTime(200L), new DateTime(200L)));
+    assertTrue(apply(Operators.LESS_THAN, new DateTime(100L), new DateTime(200L)));
+    assertTrue(apply(Operators.LESS_THAN_OR_EQUAL, new DateTime(200L), new DateTime(200L)));
+  }
+
+  @Test
+  public void testSingleElementArrayComparisons() throws Exception {
+    assertTrue(apply(Operators.GREATER_THAN, new int[] {2}, 1));
+    assertTrue(apply(Operators.GREATER_THAN_OR_EQUAL, new int[] {1}, 1));
+    assertTrue(apply(Operators.LESS_THAN, new int[] {1}, 2));
+    assertTrue(apply(Operators.LESS_THAN_OR_EQUAL, new int[] {1}, 1));
+  }
+
+  @Test
+  public void testNonOrderedValuesReturnFalse() throws Exception {
+    assertFalse(apply(Operators.GREATER_THAN, "b", "a"));
+  }
+
+  @Test
+  public void testNaNReturnsFalse() throws Exception {
+    assertFalse(apply(Operators.GREATER_THAN, Double.NaN, 1.0d));
+    assertFalse(apply(Operators.LESS_THAN, 1.0d, Double.NaN));
+  }
+
+  private static Boolean apply(Operator<Boolean> operator, Object lhs, Object rhs)
+      throws Exception {
+
+    OperatorContext context = mock(OperatorContext.class);
+    BaseEventTypeNode eventNode = mock(BaseEventTypeNode.class);
+
+    FilterOperand op0 = new LiteralOperand(new Variant(lhs));
+    FilterOperand op1 = new LiteralOperand(new Variant(rhs));
+
+    when(context.resolve(op0, eventNode)).thenReturn(lhs);
+    when(context.resolve(op1, eventNode)).thenReturn(rhs);
+
+    return operator.apply(context, eventNode, new FilterOperand[] {op0, op1});
+  }
+}


### PR DESCRIPTION
## Summary

Several EventFilter `whereClause` operators previously reported `Bad_FilterOperatorUnsupported` on the server side, so valid EventFilters were rejected and matching events never passed through. This implements the missing operators so these where clauses are evaluated:

- `Like`
- `Between`
- `InList`
- `And`
- `Or`
- `BitwiseAnd`
- `BitwiseOr`

## Details

- Shared implicit-conversion and comparison logic is extracted from the existing comparison operators into a new `OperatorUtil`, which the new operators reuse.
- `ElementOperand` resolution is now guarded against self- and mutually-referential cycles, which would otherwise recurse into a `StackOverflowError`.
- Adds unit tests for each new operator plus an integration test exercising the operators through an event monitored item's `whereClause`.

Closes #1779

Related discussion: #1778