### PR TITLE
Ignore data encoding on server reads

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/UaNodeTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/UaNodeTest.java
@@ -10,6 +10,7 @@
 
 package org.eclipse.milo.opcua.sdk.client;
 
+import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
@@ -31,6 +32,7 @@ import org.eclipse.milo.opcua.stack.core.NodeIds;
 import org.eclipse.milo.opcua.stack.core.ReferenceTypes;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
@@ -113,6 +115,43 @@ public class UaNodeTest extends AbstractClientServerTest {
   }
 
   @Test
+  public void readIgnoresDataEncoding() throws UaException {
+    NodeId nodeId = new NodeId(2, "TestInt32");
+
+    List<ReadValueId> readValueIds =
+        List.of(
+            new ReadValueId(
+                nodeId, AttributeId.Value.uid(), null, new QualifiedName(0, "Default Binary")),
+            new ReadValueId(nodeId, AttributeId.Value.uid(), null, new QualifiedName(0, "Modbus")),
+            new ReadValueId(
+                nodeId, AttributeId.Value.uid(), null, new QualifiedName(9999, "Default Binary")),
+            new ReadValueId(
+                nodeId,
+                AttributeId.BrowseName.uid(),
+                null,
+                new QualifiedName(0, "Default Binary")));
+
+    ReadResponse response = client.read(0.0, TimestampsToReturn.Both, readValueIds);
+    DataValue[] results = requireNonNull(response.getResults());
+
+    assertEquals(4, results.length);
+
+    Object expectedValue = results[0].value().value();
+
+    for (int i = 0; i < 3; i++) {
+      assertTrue(results[i].statusCode().isGood());
+      assertEquals(expectedValue, results[i].value().value());
+      assertNotNull(results[i].sourceTime());
+      assertNotNull(results[i].serverTime());
+    }
+
+    assertTrue(results[3].statusCode().isGood());
+    assertEquals(new QualifiedName(2, "TestInt32"), results[3].value().value());
+    assertEquals(DateTime.NULL_VALUE, results[3].sourceTime());
+    assertNotNull(results[3].serverTime());
+  }
+
+  @Test
   public void readBaseNodeAttributes() throws ExecutionException, InterruptedException {
     NodeId nodeId = new NodeId(2, "TestInt32");
 
@@ -123,7 +162,8 @@ public class UaNodeTest extends AbstractClientServerTest {
 
     ReadResponse response = client.readAsync(0.0, TimestampsToReturn.Both, readValueIds).get();
 
-    Arrays.stream(response.getResults()).forEach(v -> LOGGER.debug("{}", v.value().value()));
+    DataValue[] results = requireNonNull(response.getResults());
+    Arrays.stream(results).forEach(v -> LOGGER.debug("{}", v.value().value()));
   }
 
   @Test

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaMonitoredItemTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaMonitoredItemTest.java
@@ -19,10 +19,13 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.LinkedList;
 import java.util.List;
 import org.eclipse.milo.opcua.sdk.test.AbstractClientServerTest;
+import org.eclipse.milo.opcua.stack.core.AttributeId;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.MonitoringMode;
+import org.eclipse.milo.opcua.stack.core.types.structured.ReadValueId;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -54,6 +57,35 @@ public class OpcUaMonitoredItemTest extends AbstractClientServerTest {
     assertTrue(created.get(0).serviceResult().isGood());
     assertTrue(created.get(0).operationResult().orElseThrow().isGood());
     assertEquals(OpcUaMonitoredItem.SyncState.SYNCHRONIZED, monitoredItem.getSyncState());
+  }
+
+  @Test
+  void createMonitoredItemsIgnoresDataEncoding() {
+    NodeId nodeId = new NodeId(2, "TestInt32");
+
+    var valueItem =
+        new OpcUaMonitoredItem(
+            new ReadValueId(
+                nodeId, AttributeId.Value.uid(), null, new QualifiedName(9999, "Default Binary")));
+    var browseNameItem =
+        new OpcUaMonitoredItem(
+            new ReadValueId(
+                nodeId,
+                AttributeId.BrowseName.uid(),
+                null,
+                new QualifiedName(0, "Default Binary")));
+
+    subscription.addMonitoredItem(valueItem);
+    subscription.addMonitoredItem(browseNameItem);
+    List<MonitoredItemServiceOperationResult> created = subscription.createMonitoredItems();
+
+    assertEquals(2, created.size());
+    assertTrue(created.get(0).serviceResult().isGood());
+    assertTrue(created.get(0).operationResult().orElseThrow().isGood());
+    assertEquals(OpcUaMonitoredItem.SyncState.SYNCHRONIZED, valueItem.getSyncState());
+    assertTrue(created.get(1).serviceResult().isGood());
+    assertTrue(created.get(1).operationResult().orElseThrow().isGood());
+    assertEquals(OpcUaMonitoredItem.SyncState.SYNCHRONIZED, browseNameItem.getSyncState());
   }
 
   @Test

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/AttributeReader.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/AttributeReader.java
@@ -12,7 +12,6 @@ package org.eclipse.milo.opcua.sdk.server;
 
 import static org.eclipse.milo.opcua.stack.core.util.ArrayUtil.transformArray;
 
-import java.util.Optional;
 import org.eclipse.milo.opcua.sdk.core.NumericRange;
 import org.eclipse.milo.opcua.sdk.core.nodes.Node;
 import org.eclipse.milo.opcua.sdk.core.nodes.VariableNode;
@@ -58,25 +57,6 @@ public class AttributeReader {
 
     if (!AttributeId.getAttributes(node.getNodeClass()).contains(attributeId)) {
       return new DataValue(StatusCodes.Bad_AttributeIdInvalid);
-    }
-
-    if (encodingName != null && encodingName.isNotNull()) {
-      if (attributeId != AttributeId.Value) {
-        return new DataValue(StatusCodes.Bad_DataEncodingInvalid);
-      }
-
-      NodeId dataTypeId;
-      if (node instanceof VariableNode) {
-        dataTypeId = ((VariableNode) node).getDataType();
-      } else if (node instanceof VariableTypeNode) {
-        dataTypeId = ((VariableTypeNode) node).getDataType();
-      } else {
-        return new DataValue(StatusCodes.Bad_DataEncodingInvalid);
-      }
-
-      if (!isStructureSubtype(node.getNodeContext().getServer(), dataTypeId)) {
-        return new DataValue(StatusCodes.Bad_DataEncodingInvalid);
-      }
     }
 
     Object value;
@@ -194,24 +174,6 @@ public class AttributeReader {
           .setStatus(StatusCode.GOOD)
           .applyTimestamps(attributeId, timestamps)
           .build();
-    }
-  }
-
-  private static boolean isStructureSubtype(OpcUaServer server, NodeId dataTypeId) {
-    UaNode dataTypeNode = server.getAddressSpaceManager().getManagedNode(dataTypeId).orElse(null);
-
-    if (dataTypeNode != null) {
-      Optional<NodeId> superTypeId =
-          dataTypeNode.getReferences().stream()
-              .filter(r -> r.isInverse() && r.getReferenceTypeId().equals(NodeIds.HasSubtype))
-              .flatMap(r -> r.getTargetNodeId().toNodeId(server.getNamespaceTable()).stream())
-              .findFirst();
-
-      return superTypeId
-          .map(id -> id.equals(NodeIds.Structure) || isStructureSubtype(server, id))
-          .orElse(false);
-    } else {
-      return false;
     }
   }
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/subscriptions/SubscriptionManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/subscriptions/SubscriptionManager.java
@@ -636,20 +636,9 @@ public class SubscriptionManager {
       AttributesResponse attributeResponse)
       throws UaException {
 
-    QualifiedName dataEncoding = request.getItemToMonitor().getDataEncoding();
     AttributeId attributeId =
         AttributeId.from(request.getItemToMonitor().getAttributeId())
             .orElseThrow(() -> new UaException(StatusCodes.Bad_AttributeIdInvalid));
-
-    if (dataEncoding.isNotNull()) {
-      if (attributeId != AttributeId.Value) {
-        throw new UaException(StatusCodes.Bad_DataEncodingInvalid);
-      }
-
-      if (!server.getEncodingManager().hasEncoding(dataEncoding)) {
-        throw new UaException(StatusCodes.Bad_DataEncodingUnsupported);
-      }
-    }
 
     if (attributeResponse instanceof NegativeResponse negativeResponse) {
       throw new UaException(negativeResponse.statusCode());


### PR DESCRIPTION
## Summary

Server read and monitored item creation now tolerate unnecessary `dataEncoding` names instead of rejecting requests before reading attributes or creating monitored items.

- Remove server-side pre-validation of requested data encodings for reads and monitored item creation.
- Preserve normal attribute read behavior while allowing clients that send arbitrary encoding names to receive successful responses.
- Add integration coverage for both direct reads and monitored item creation with non-null data encodings.

## Key Changes

- **Read handling:** `AttributeReader` no longer rejects non-null data encodings before attribute access, so primitive Value reads and non-Value attribute reads follow the same path as ordinary reads.
- **Subscription setup:** `SubscriptionManager` no longer rejects monitored item requests solely because `ReadValueId.dataEncoding` is non-null or unknown.
- **Integration coverage:** Client/server tests assert that arbitrary data encodings do not prevent read responses or monitored item synchronization.

## Testing

- `UaNodeTest.readIgnoresDataEncoding` covers Value and BrowseName reads with arbitrary data encoding names.
- `OpcUaMonitoredItemTest.createMonitoredItemsIgnoresDataEncoding` covers monitored item creation with arbitrary data encoding names.
- `mvn -q spotless:apply`
- `mvn -q clean compile`
- Preflight review: APPROVED
