### PR TITLE
Use DataTypeTree for write type checks

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/api/util/AttributeWriterTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/api/util/AttributeWriterTest.java
@@ -10,15 +10,30 @@
 
 package org.eclipse.milo.opcua.sdk.server.api.util;
 
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ubyte;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ulong;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.eclipse.milo.opcua.sdk.core.AccessLevel;
+import org.eclipse.milo.opcua.sdk.core.Reference;
+import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.sdk.core.WriteMask;
+import org.eclipse.milo.opcua.sdk.server.AccessContext;
+import org.eclipse.milo.opcua.sdk.server.AttributeWriter;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaDataTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaServerNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableTypeNode;
 import org.eclipse.milo.opcua.sdk.test.AbstractClientServerTest;
+import org.eclipse.milo.opcua.stack.core.AttributeId;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
@@ -78,6 +93,203 @@ public class AttributeWriterTest extends AbstractClientServerTest {
                 List.of(new NodeId(2, "UByteArray")),
                 List.of(DataValue.valueOnly(new Variant(ByteString.of(new byte[] {1, 2, 3})))))
             .get(0);
+
+    assertEquals(StatusCode.GOOD, statusCode);
+  }
+
+  @Test
+  void writeUnsignedIntegerSubtypesToAbstractUInteger() throws Exception {
+    for (Object unsignedValue : List.of(ubyte(1), ushort(2), uint(3), ulong(4))) {
+      StatusCode statusCode =
+          client
+              .writeValues(
+                  List.of(new NodeId(2, "AbstractUInteger")),
+                  List.of(DataValue.valueOnly(new Variant(unsignedValue))))
+              .get(0);
+
+      assertEquals(StatusCode.GOOD, statusCode);
+    }
+  }
+
+  @Test
+  void rejectSignedIntegerSubtypesForAbstractUInteger() throws Exception {
+    for (Object signedValue : List.of((byte) 1, (short) 2, 3, 4L)) {
+      StatusCode statusCode =
+          client
+              .writeValues(
+                  List.of(new NodeId(2, "AbstractUInteger")),
+                  List.of(DataValue.valueOnly(new Variant(signedValue))))
+              .get(0);
+
+      assertEquals(new StatusCode(StatusCodes.Bad_TypeMismatch), statusCode);
+    }
+  }
+
+  @Test
+  void writeSignedIntegerSubtypesToAbstractInteger() throws Exception {
+    for (Object signedValue : List.of((byte) 1, (short) 2, 3, 4L)) {
+      StatusCode statusCode =
+          client
+              .writeValues(
+                  List.of(new NodeId(2, "AbstractInteger")),
+                  List.of(DataValue.valueOnly(new Variant(signedValue))))
+              .get(0);
+
+      assertEquals(StatusCode.GOOD, statusCode);
+    }
+  }
+
+  @Test
+  void rejectUnsignedIntegerSubtypesForAbstractInteger() throws Exception {
+    for (Object unsignedValue : List.of(ubyte(1), ushort(2), uint(3), ulong(4))) {
+      StatusCode statusCode =
+          client
+              .writeValues(
+                  List.of(new NodeId(2, "AbstractInteger")),
+                  List.of(DataValue.valueOnly(new Variant(unsignedValue))))
+              .get(0);
+
+      assertEquals(new StatusCode(StatusCodes.Bad_TypeMismatch), statusCode);
+    }
+  }
+
+  @Test
+  void writeNumericSubtypesToAbstractNumber() {
+    UaServerNode node = getManagedNode("AbstractNumber");
+
+    for (Object number :
+        List.of(1.0f, 2.0d, (byte) 3, (short) 4, 5, 6L, ubyte(7), ushort(8), uint(9), ulong(10))) {
+      StatusCode statusCode =
+          AttributeWriter.writeAttribute(
+              AccessContext.INTERNAL,
+              node,
+              AttributeId.Value,
+              DataValue.valueOnly(new Variant(number)),
+              null);
+
+      assertEquals(StatusCode.GOOD, statusCode);
+    }
+  }
+
+  @Test
+  void rejectNonBuiltinNumberSubtypesForAbstractNumber() {
+    UaServerNode node = getManagedNode("AbstractNumber");
+
+    for (Number number : List.of(BigInteger.ONE, BigDecimal.ONE, new AtomicInteger(1))) {
+      StatusCode statusCode =
+          AttributeWriter.writeAttribute(
+              AccessContext.INTERNAL,
+              node,
+              AttributeId.Value,
+              DataValue.valueOnly(new Variant(number)),
+              null);
+
+      assertEquals(new StatusCode(StatusCodes.Bad_TypeMismatch), statusCode);
+    }
+  }
+
+  @Test
+  void writeBuiltinValueToBaseDataType() {
+    UaServerNode node = getManagedNode("BaseDataType");
+
+    StatusCode statusCode =
+        AttributeWriter.writeAttribute(
+            AccessContext.INTERNAL,
+            node,
+            AttributeId.Value,
+            DataValue.valueOnly(new Variant("anything")),
+            null);
+
+    assertEquals(StatusCode.GOOD, statusCode);
+  }
+
+  @Test
+  void writeAnythingToBaseDataType() {
+    UaServerNode node = getManagedNode("VariantDataType");
+
+    StatusCode statusCode =
+        AttributeWriter.writeAttribute(
+            AccessContext.INTERNAL,
+            node,
+            AttributeId.Value,
+            DataValue.valueOnly(new Variant(BigDecimal.ONE)),
+            null);
+
+    assertEquals(StatusCode.GOOD, statusCode);
+  }
+
+  @Test
+  void writeIntegerToEnumerationSubtype() throws Exception {
+    StatusCode statusCode =
+        client
+            .writeValues(
+                List.of(new NodeId(2, "ApplicationTypeEnum")),
+                List.of(DataValue.valueOnly(new Variant(1))))
+            .get(0);
+
+    assertEquals(StatusCode.GOOD, statusCode);
+  }
+
+  @Test
+  void rejectNonIntegerForEnumerationSubtype() throws Exception {
+    StatusCode statusCode =
+        client
+            .writeValues(
+                List.of(new NodeId(2, "ApplicationTypeEnum")),
+                List.of(DataValue.valueOnly(new Variant("not an enum"))))
+            .get(0);
+
+    assertEquals(new StatusCode(StatusCodes.Bad_TypeMismatch), statusCode);
+  }
+
+  @Test
+  void writeCustomDataTypeAddedAfterDataTypeTreeIsBuilt() {
+    server.getDataTypeTree();
+
+    NodeId dataTypeId = new NodeId(2, "LateUInt32Subtype");
+
+    testNamespace.configure(
+        (context, nodeManager) -> {
+          var dataTypeNode =
+              new UaDataTypeNode(
+                  context,
+                  dataTypeId,
+                  new QualifiedName(2, "LateUInt32Subtype"),
+                  LocalizedText.english("LateUInt32Subtype"),
+                  LocalizedText.NULL_VALUE,
+                  uint(0),
+                  uint(0),
+                  false);
+
+          dataTypeNode.addReference(
+              new Reference(
+                  dataTypeId,
+                  NodeIds.HasSubtype,
+                  NodeIds.UInt32.expanded(),
+                  Reference.Direction.INVERSE));
+
+          nodeManager.addNode(dataTypeNode);
+
+          UaVariableNode.build(
+              context,
+              b -> {
+                b.setNodeId(new NodeId(2, "LateUInt32SubtypeValue"));
+                b.setBrowseName(new QualifiedName(2, "LateUInt32SubtypeValue"));
+                b.setDisplayName(LocalizedText.english("LateUInt32SubtypeValue"));
+                b.setDataType(dataTypeId);
+                b.setAccessLevel(AccessLevel.READ_WRITE);
+                b.setUserAccessLevel(AccessLevel.READ_WRITE);
+                return b.buildAndAdd();
+              });
+        });
+
+    StatusCode statusCode =
+        AttributeWriter.writeAttribute(
+            AccessContext.INTERNAL,
+            getManagedNode("LateUInt32SubtypeValue"),
+            AttributeId.Value,
+            DataValue.valueOnly(new Variant(uint(42))),
+            null);
 
     assertEquals(StatusCode.GOOD, statusCode);
   }
@@ -173,6 +385,7 @@ public class AttributeWriterTest extends AbstractClientServerTest {
                 b.setBrowseName(new QualifiedName(2, "UByteArray"));
                 b.setDisplayName(LocalizedText.english("UByteArray"));
                 b.setDataType(NodeIds.Byte);
+                b.setValueRank(ValueRanks.OneDimension);
                 b.setArrayDimensions(new UInteger[] {UInteger.valueOf(0)});
                 b.setAccessLevel(AccessLevel.READ_WRITE);
                 b.setUserAccessLevel(AccessLevel.READ_WRITE);
@@ -194,12 +407,84 @@ public class AttributeWriterTest extends AbstractClientServerTest {
           UaVariableNode.build(
               context,
               b -> {
+                b.setNodeId(new NodeId(2, "AbstractNumber"));
+                b.setBrowseName(new QualifiedName(2, "AbstractNumber"));
+                b.setDisplayName(LocalizedText.english("AbstractNumber"));
+                b.setDataType(NodeIds.Number);
+                b.setAccessLevel(AccessLevel.READ_WRITE);
+                b.setUserAccessLevel(AccessLevel.READ_WRITE);
+                return b.buildAndAdd();
+              });
+
+          UaVariableNode.build(
+              context,
+              b -> {
+                b.setNodeId(new NodeId(2, "AbstractUInteger"));
+                b.setBrowseName(new QualifiedName(2, "AbstractUInteger"));
+                b.setDisplayName(LocalizedText.english("AbstractUInteger"));
+                b.setDataType(NodeIds.UInteger);
+                b.setAccessLevel(AccessLevel.READ_WRITE);
+                b.setUserAccessLevel(AccessLevel.READ_WRITE);
+                return b.buildAndAdd();
+              });
+
+          UaVariableNode.build(
+              context,
+              b -> {
+                b.setNodeId(new NodeId(2, "AbstractInteger"));
+                b.setBrowseName(new QualifiedName(2, "AbstractInteger"));
+                b.setDisplayName(LocalizedText.english("AbstractInteger"));
+                b.setDataType(NodeIds.Integer);
+                b.setAccessLevel(AccessLevel.READ_WRITE);
+                b.setUserAccessLevel(AccessLevel.READ_WRITE);
+                return b.buildAndAdd();
+              });
+
+          UaVariableNode.build(
+              context,
+              b -> {
                 b.setNodeId(new NodeId(2, "ReadOnlyVariable"));
                 b.setBrowseName(new QualifiedName(2, "ReadOnlyVariable"));
                 b.setDisplayName(LocalizedText.english("ReadOnlyVariable"));
                 b.setDataType(NodeIds.Int32);
                 b.setAccessLevel(AccessLevel.READ_ONLY);
                 // allow the service call to reach AttributeWriter
+                b.setUserAccessLevel(AccessLevel.READ_WRITE);
+                return b.buildAndAdd();
+              });
+
+          UaVariableNode.build(
+              context,
+              b -> {
+                b.setNodeId(new NodeId(2, "ApplicationTypeEnum"));
+                b.setBrowseName(new QualifiedName(2, "ApplicationTypeEnum"));
+                b.setDisplayName(LocalizedText.english("ApplicationTypeEnum"));
+                b.setDataType(NodeIds.ApplicationType);
+                b.setAccessLevel(AccessLevel.READ_WRITE);
+                b.setUserAccessLevel(AccessLevel.READ_WRITE);
+                return b.buildAndAdd();
+              });
+
+          UaVariableNode.build(
+              context,
+              b -> {
+                b.setNodeId(new NodeId(2, "BaseDataType"));
+                b.setBrowseName(new QualifiedName(2, "BaseDataType"));
+                b.setDisplayName(LocalizedText.english("BaseDataType"));
+                b.setDataType(NodeIds.BaseDataType);
+                b.setAccessLevel(AccessLevel.READ_WRITE);
+                b.setUserAccessLevel(AccessLevel.READ_WRITE);
+                return b.buildAndAdd();
+              });
+
+          UaVariableNode.build(
+              context,
+              b -> {
+                b.setNodeId(new NodeId(2, "VariantDataType"));
+                b.setBrowseName(new QualifiedName(2, "VariantDataType"));
+                b.setDisplayName(LocalizedText.english("VariantDataType"));
+                b.setDataType(OpcUaDataType.Variant.getNodeId());
+                b.setAccessLevel(AccessLevel.READ_WRITE);
                 b.setUserAccessLevel(AccessLevel.READ_WRITE);
                 return b.buildAndAdd();
               });
@@ -228,5 +513,10 @@ public class AttributeWriterTest extends AbstractClientServerTest {
                 return b.buildAndAdd();
               });
         });
+  }
+
+  private UaServerNode getManagedNode(String identifier) {
+    return (UaServerNode)
+        server.getAddressSpaceManager().getManagedNode(new NodeId(2, identifier)).orElseThrow();
   }
 }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/AttributeWriter.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/AttributeWriter.java
@@ -15,13 +15,11 @@ import java.util.Optional;
 import java.util.Set;
 import org.eclipse.milo.opcua.sdk.core.AccessLevel;
 import org.eclipse.milo.opcua.sdk.core.NumericRange;
-import org.eclipse.milo.opcua.sdk.core.Reference;
 import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.sdk.core.WriteMask;
-import org.eclipse.milo.opcua.sdk.core.nodes.DataTypeNode;
 import org.eclipse.milo.opcua.sdk.core.nodes.VariableNode;
 import org.eclipse.milo.opcua.sdk.core.nodes.VariableTypeNode;
-import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
+import org.eclipse.milo.opcua.sdk.core.typetree.DataTypeTree;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaServerNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableTypeNode;
@@ -219,32 +217,57 @@ public class AttributeWriter {
 
     Class<?> valueClass = o.getClass().isArray() ? ArrayUtil.getType(o) : o.getClass();
 
-    Class<?> expectedClass = getExpectedClass(server, dataType, valueClass);
+    DataTypeTree dataTypeTree = server.getDataTypeTree();
 
-    if (expectedClass != null) {
-      LOGGER.debug(
-          "dataTypeId={}, valueClass={}, expectedClass={}",
-          dataType,
-          valueClass.getSimpleName(),
-          expectedClass.getSimpleName());
+    if (!dataTypeTree.containsType(dataType)) {
+      dataTypeTree = server.updateDataTypeTree();
 
-      if (!expectedClass.isAssignableFrom(valueClass)) {
-        // Writing a ByteString to a UByte[] is explicitly allowed by the spec.
-        if (o instanceof ByteString byteString && expectedClass == UByte.class) {
-          return new DataValue(
-              new Variant(byteString.uBytes()),
-              value.statusCode(),
-              value.sourceTime(),
-              value.serverTime());
-        } else if (expectedClass == Variant.class) {
-          // Allow writing anything to a Variant
-          return value;
-        } else {
-          throw new UaException(StatusCodes.Bad_TypeMismatch);
-        }
+      if (!dataTypeTree.containsType(dataType)) {
+        throw new UaException(StatusCodes.Bad_TypeMismatch);
       }
-    } else {
+    }
+
+    Class<?> expectedClass = dataTypeTree.getBackingClass(dataType);
+    Optional<OpcUaDataType> valueDataType = variant.getDataType();
+
+    // Part 4, 5.11.4.2: a written value must be the same type or a subtype of the
+    // Attribute's DataType; for Value, that DataType is defined by the DataType Attribute.
+    if (valueDataType.isEmpty() && expectedClass != Variant.class) {
       throw new UaException(StatusCodes.Bad_TypeMismatch);
+    }
+
+    if (expectedClass == Object.class && !dataType.equals(NodeIds.BaseDataType)) {
+      NodeId valueDataTypeId = valueDataType.map(OpcUaDataType::getNodeId).orElse(null);
+
+      if (!valueDataTypeId.equals(dataType)
+          && !dataTypeTree.isSubtypeOf(valueDataTypeId, dataType)) {
+
+        throw new UaException(StatusCodes.Bad_TypeMismatch);
+      }
+    }
+
+    LOGGER.debug(
+        "dataTypeId={}, valueClass={}, expectedClass={}, assignable={}",
+        dataType,
+        valueClass.getSimpleName(),
+        expectedClass.getSimpleName(),
+        dataTypeTree.isAssignable(dataType, valueClass));
+
+    if (!dataTypeTree.isAssignable(dataType, valueClass)) {
+      // Part 4, 5.11.4.2 and Part 6, 5.1.5: ByteString is structurally equivalent
+      // to a one-dimensional Byte array and must be accepted when Byte[] is expected.
+      if (o instanceof ByteString byteString && expectedClass == UByte.class) {
+        return new DataValue(
+            new Variant(byteString.uBytes()),
+            value.statusCode(),
+            value.sourceTime(),
+            value.serverTime());
+      } else if (expectedClass == Variant.class) {
+        // Allow writing anything to a Variant
+        return value;
+      } else {
+        throw new UaException(StatusCodes.Bad_TypeMismatch);
+      }
     }
 
     return value;
@@ -327,113 +350,5 @@ public class AttributeWriter {
         }
         break;
     }
-  }
-
-  private static Class<?> getExpectedClass(
-      OpcUaServer server, NodeId dataTypeId, Class<?> valueClass) throws UaException {
-
-    if (OpcUaDataType.isBuiltin(dataTypeId)) {
-      return OpcUaDataType.getBackingClass(dataTypeId);
-    } else if (subtypeOf(server, dataTypeId, NodeIds.Structure)) {
-      return ExtensionObject.class;
-    } else if (subtypeOf(server, dataTypeId, NodeIds.Enumeration)) {
-      return Integer.class;
-    } else {
-      NodeId superBuiltInType = findConcreteBuiltInSuperTypeId(server, dataTypeId);
-
-      if (superBuiltInType != null) {
-        // One of dataTypeId's supertypes is a concrete built-in
-        // type; expect the same Class<?> as that built-in type.
-        return OpcUaDataType.getBackingClass(superBuiltInType);
-      } else {
-        int valueDataTypeId = OpcUaDataType.getBuiltinTypeId(valueClass);
-
-        if (valueDataTypeId > -1) {
-          // The value they sent us maps to a built-in type.
-          // If dataTypeId is a subtype of that built-in type,
-          // the expected class is the class of the value they sent.
-          NodeId builtInTypeId = new NodeId(0, valueDataTypeId);
-
-          if (dataTypeId.equals(builtInTypeId) || subtypeOf(server, builtInTypeId, dataTypeId)) {
-
-            return valueClass;
-          } else {
-            throw new UaException(StatusCodes.Bad_TypeMismatch);
-          }
-        } else {
-          throw new UaException(StatusCodes.Bad_TypeMismatch);
-        }
-      }
-    }
-  }
-
-  /**
-   * @return {@code true} if {@code dataTypeId} is a subtype of {@code potentialSuperTypeId}.
-   */
-  private static boolean subtypeOf(
-      OpcUaServer server, NodeId dataTypeId, NodeId potentialSuperTypeId) {
-    UaNode dataTypeNode = server.getAddressSpaceManager().getManagedNode(dataTypeId).orElse(null);
-
-    if (dataTypeNode != null) {
-      NodeId superTypeId = getSuperTypeId(server, dataTypeId);
-
-      if (superTypeId != null) {
-        return superTypeId.equals(potentialSuperTypeId)
-            || subtypeOf(server, superTypeId, potentialSuperTypeId);
-      } else {
-        return false;
-      }
-    } else {
-      return false;
-    }
-  }
-
-  /**
-   * Find the first concrete built-in supertype for {@code dataTypeId}, if one exists.
-   *
-   * @return the first concrete built-in supertype for {@code dataTypeId}, if one exists.
-   */
-  @Nullable
-  private static NodeId findConcreteBuiltInSuperTypeId(OpcUaServer server, NodeId dataTypeId) {
-    if (OpcUaDataType.isBuiltin(dataTypeId) && isConcrete(server, dataTypeId)) {
-      return dataTypeId;
-    } else {
-      NodeId superTypeId = getSuperTypeId(server, dataTypeId);
-
-      if (superTypeId != null) {
-        return findConcreteBuiltInSuperTypeId(server, superTypeId);
-      } else {
-        return null;
-      }
-    }
-  }
-
-  @Nullable
-  private static NodeId getSuperTypeId(OpcUaServer server, NodeId dataTypeId) {
-    UaNode dataTypeNode = server.getAddressSpaceManager().getManagedNode(dataTypeId).orElse(null);
-
-    if (dataTypeNode != null) {
-      return dataTypeNode.getReferences().stream()
-          .filter(Reference.SUBTYPE_OF)
-          .flatMap(r -> r.getTargetNodeId().toNodeId(server.getNamespaceTable()).stream())
-          .findFirst()
-          .orElse(null);
-    } else {
-      return null;
-    }
-  }
-
-  private static boolean isAbstract(OpcUaServer server, NodeId dataTypeId) {
-    UaNode node = server.getAddressSpaceManager().getManagedNode(dataTypeId).orElse(null);
-
-    if (node instanceof DataTypeNode) {
-      return ((DataTypeNode) node).getIsAbstract();
-    } else {
-      return false;
-    }
-  }
-
-  private static boolean isConcrete(OpcUaServer server, NodeId dataTypeId) {
-    return !isAbstract(server, dataTypeId);
   }
 }


### PR DESCRIPTION
## Summary

`AttributeWriter` now relies on the server `DataTypeTree` for Value write type validation instead of maintaining its own recursive subtype and backing-class lookup logic.

- Centralize write type compatibility checks on `DataTypeTree` so abstract, concrete, enum, and late-added DataTypes follow the same model as the rest of the server.
- Refresh the DataTypeTree when a write targets a DataType that is not yet present in the cached tree.
- Expand integration coverage for abstract numeric DataTypes, enum subtypes, BaseDataType and Variant writes, ByteString-to-Byte-array writes, and custom DataTypes added after the tree is built.

## Key Changes

- **Write validation:** `AttributeWriter` uses `DataTypeTree.getBackingClass`, `isAssignable`, and `isSubtypeOf` to decide whether the supplied Variant value is compatible with the target Value attribute DataType.
- **Dynamic DataTypes:** The writer refreshes the server DataTypeTree before rejecting an unknown DataType, which supports namespace changes after the tree has already been built.
- **Compatibility exceptions:** Existing ByteString-to-Byte-array and Variant acceptance behavior remains explicit while the surrounding type checks move to the shared type tree.
- **Regression coverage:** `AttributeWriterTest` now exercises accepted and rejected writes across abstract numeric families, enums, BaseDataType, Variant, and late-added UInt32 subtypes.

## Testing

- `AttributeWriterTest` covers the updated write compatibility behavior for abstract numeric types, enum subtypes, BaseDataType/Variant, ByteString-to-Byte-array writes, and late-added DataTypes.
- `mvn -q spotless:apply`
- `mvn -q clean compile`
- Preflight review: APPROVED
