### PR TITLE
Set event type on created event nodes

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/factories/EventFactory.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/factories/EventFactory.java
@@ -71,17 +71,22 @@ public class EventFactory extends AbstractLifecycle {
    * @throws UaException if an error occurs creating the Event instance.
    */
   public BaseEventTypeNode createEvent(NodeId nodeId, NodeId typeDefinitionId) throws UaException {
-    return (BaseEventTypeNode)
-        nodeFactory.createNode(
-            nodeId,
-            typeDefinitionId,
-            new NodeFactory.InstantiationCallback() {
-              @Override
-              public boolean includeOptionalNode(
-                  NodeId typeDefinitionId, QualifiedName browseName) {
-                return true;
-              }
-            });
+    BaseEventTypeNode eventNode =
+        (BaseEventTypeNode)
+            nodeFactory.createNode(
+                nodeId,
+                typeDefinitionId,
+                new NodeFactory.InstantiationCallback() {
+                  @Override
+                  public boolean includeOptionalNode(
+                      NodeId typeDefinitionId, QualifiedName browseName) {
+                    return true;
+                  }
+                });
+
+    eventNode.setEventType(typeDefinitionId);
+
+    return eventNode;
   }
 
   private static class EventNodeContext implements UaNodeContext {


### PR DESCRIPTION
## Summary

Factory-created event nodes now have their `EventType` property initialized from the requested type definition before they are returned to callers.

- Set the created `BaseEventTypeNode` EventType value inside `EventFactory#createEvent`.
- Preserve the existing optional-node instantiation behavior while ensuring the returned event has the requested type metadata.

## Key Changes

- **Event initialization:** `EventFactory#createEvent` now stores the created node in a local variable, calls `setEventType(typeDefinitionId)`, and then returns the initialized event node.
- **Factory behavior:** Optional event fields are still included during instantiation; the change only fills in the EventType property that callers would otherwise need to set themselves.

## Testing

- `mvn -q spotless:apply`
- `mvn -q clean compile`
- Preflight review: APPROVED
