### PR TITLE
Harden binary Matrix dimension decoding

### DIFF
--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryDecoder.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryDecoder.java
@@ -20,6 +20,7 @@ import io.netty.util.ByteProcessor;
 import java.lang.reflect.Array;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
@@ -421,6 +422,18 @@ public class OpcUaBinaryDecoder implements UaDecoder {
             int[] dimensions = dimensionsEncoded ? decodeDimensions() : new int[] {length};
 
             Object value;
+            if (dimensionsEncoded && dimensions.length > 0) {
+              int dimensionsLength = calculateMatrixLength(dimensions);
+              if (dimensionsLength != length) {
+                throw new UaSerializationException(
+                    StatusCodes.Bad_DecodingError,
+                    String.format(
+                        "matrix dimensions do not match array length (dimensionsLength=%s,"
+                            + " arrayLength=%s)",
+                        dimensionsLength, length));
+              }
+            }
+
             if (dimensions.length > 1) {
               value = new Matrix(flatArray, dimensions, OpcUaDataType.fromTypeId(typeId));
             } else {
@@ -483,6 +496,8 @@ public class OpcUaBinaryDecoder implements UaDecoder {
     if (length == -1) {
       return new int[0];
     } else {
+      checkArrayLength(length);
+
       int[] is = new int[length];
       for (int i = 0; i < length; i++) {
         is[i] = decodeInt32();
@@ -1185,6 +1200,12 @@ public class OpcUaBinaryDecoder implements UaDecoder {
   }
 
   private void checkArrayLength(int length) throws UaSerializationException {
+    if (length < 0) {
+      throw new UaSerializationException(
+          StatusCodes.Bad_DecodingError,
+          String.format("array length must not be negative (length=%s)", length));
+    }
+
     if (length > context.getEncodingLimits().getMaxMessageSize()) {
       throw new UaSerializationException(
           StatusCodes.Bad_EncodingLimitsExceeded,
@@ -1192,6 +1213,38 @@ public class OpcUaBinaryDecoder implements UaDecoder {
               "array length exceeds max message size (length=%s, max=%s)",
               length, context.getEncodingLimits().getMaxMessageSize()));
     }
+  }
+
+  private int calculateMatrixLength(int[] dimensions) throws UaSerializationException {
+    int length = 1;
+
+    for (int dimension : dimensions) {
+      if (dimension < 0) {
+        throw new UaSerializationException(
+            StatusCodes.Bad_DecodingError,
+            String.format("matrix dimension must not be negative (dimension=%s)", dimension));
+      }
+
+      checkArrayLength(dimension);
+
+      if (length == 0 || dimension == 0) {
+        length = 0;
+      } else {
+        try {
+          length = Math.multiplyExact(length, dimension);
+        } catch (ArithmeticException e) {
+          throw new UaSerializationException(
+              StatusCodes.Bad_EncodingLimitsExceeded,
+              String.format(
+                  "matrix length exceeds Integer.MAX_VALUE (dimensions=%s)",
+                  Arrays.toString(dimensions)));
+        }
+      }
+    }
+
+    checkArrayLength(length);
+
+    return length;
   }
 
   private <T> T[] decodeArray(String field, Function<String, T> decoder, Class<T> clazz)
@@ -1220,16 +1273,7 @@ public class OpcUaBinaryDecoder implements UaDecoder {
     int[] dimensions = decodeMatrixDimensions();
     if (dimensions == null) return null;
 
-    int length = 1;
-    for (int d : dimensions) {
-      checkArrayLength(d);
-      if (d > 0) {
-        length *= d;
-      } else {
-        length = 0;
-      }
-    }
-    checkArrayLength(length);
+    int length = calculateMatrixLength(dimensions);
 
     // TODO speed this up by switching on BuiltinDataType instead of using reflection
     Class<?> backingClass = dataType.getBackingClass();
@@ -1255,16 +1299,7 @@ public class OpcUaBinaryDecoder implements UaDecoder {
     int[] dimensions = decodeMatrixDimensions();
     if (dimensions == null) return null;
 
-    int length = 1;
-    for (int d : dimensions) {
-      checkArrayLength(d);
-      if (d > 0) {
-        length *= d;
-      } else {
-        length = 0;
-      }
-    }
-    checkArrayLength(length);
+    int length = calculateMatrixLength(dimensions);
 
     DataTypeCodec codec = context.getDataTypeManager().getCodec(dataTypeId);
 

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryDecoderTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryDecoderTest.java
@@ -10,12 +10,18 @@
 
 package org.eclipse.milo.opcua.stack.core.encoding.binary;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import java.lang.reflect.Array;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.UaSerializationException;
 import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Matrix;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.junit.jupiter.api.Test;
 
 public class OpcUaBinaryDecoderTest {
@@ -71,6 +77,163 @@ public class OpcUaBinaryDecoderTest {
       buffer.writeByte(1);
     }
     buffer.writeByte(0);
+
+    assertThrows(
+        UaSerializationException.class,
+        () ->
+            new OpcUaBinaryDecoder(DefaultEncodingContext.INSTANCE)
+                .setBuffer(buffer)
+                .decodeVariant());
+  }
+
+  @Test
+  void decodeMatrixRejectsNegativeDimensionCount() {
+    ByteBuf buffer = Unpooled.buffer();
+    buffer.writeIntLE(-2);
+
+    assertThrows(
+        UaSerializationException.class,
+        () ->
+            new OpcUaBinaryDecoder(DefaultEncodingContext.INSTANCE)
+                .setBuffer(buffer)
+                .decodeMatrix(null, OpcUaDataType.Int32));
+  }
+
+  @Test
+  void decodeMatrixRejectsNegativeDimensions() {
+    ByteBuf buffer = Unpooled.buffer();
+    buffer.writeIntLE(2);
+    buffer.writeIntLE(1);
+    buffer.writeIntLE(-1);
+
+    assertThrows(
+        UaSerializationException.class,
+        () ->
+            new OpcUaBinaryDecoder(DefaultEncodingContext.INSTANCE)
+                .setBuffer(buffer)
+                .decodeMatrix(null, OpcUaDataType.Int32));
+  }
+
+  @Test
+  void decodeMatrixAllowsZeroDimensions() {
+    ByteBuf buffer = Unpooled.buffer();
+    buffer.writeIntLE(2);
+    buffer.writeIntLE(0);
+    buffer.writeIntLE(2);
+
+    Matrix matrix =
+        new OpcUaBinaryDecoder(DefaultEncodingContext.INSTANCE)
+            .setBuffer(buffer)
+            .decodeMatrix(null, OpcUaDataType.Int32);
+
+    assertArrayEquals(new int[] {0, 2}, matrix.getDimensions());
+    assertEquals(0, Array.getLength(matrix.getElements()));
+  }
+
+  @Test
+  void decodeMatrixRejectsDimensionOverflow() {
+    ByteBuf buffer = Unpooled.buffer();
+    buffer.writeIntLE(2);
+    buffer.writeIntLE(46341);
+    buffer.writeIntLE(46341);
+
+    assertThrows(
+        UaSerializationException.class,
+        () ->
+            new OpcUaBinaryDecoder(DefaultEncodingContext.INSTANCE)
+                .setBuffer(buffer)
+                .decodeMatrix(null, OpcUaDataType.Int32));
+  }
+
+  @Test
+  void decodeVariantRejectsNegativeMatrixDimensionCount() {
+    ByteBuf buffer = Unpooled.buffer();
+    buffer.writeByte(OpcUaDataType.Int32.getTypeId() | 0xC0);
+    buffer.writeIntLE(0);
+    buffer.writeIntLE(-2);
+
+    assertThrows(
+        UaSerializationException.class,
+        () ->
+            new OpcUaBinaryDecoder(DefaultEncodingContext.INSTANCE)
+                .setBuffer(buffer)
+                .decodeVariant());
+  }
+
+  @Test
+  void decodeVariantRejectsNegativeOneDimensionalArrayDimension() {
+    ByteBuf buffer = Unpooled.buffer();
+    buffer.writeByte(OpcUaDataType.Int32.getTypeId() | 0xC0);
+    buffer.writeIntLE(0);
+    buffer.writeIntLE(1);
+    buffer.writeIntLE(-1);
+
+    assertThrows(
+        UaSerializationException.class,
+        () ->
+            new OpcUaBinaryDecoder(DefaultEncodingContext.INSTANCE)
+                .setBuffer(buffer)
+                .decodeVariant());
+  }
+
+  @Test
+  void decodeVariantRejectsMismatchedOneDimensionalArrayDimension() {
+    ByteBuf buffer = Unpooled.buffer();
+    buffer.writeByte(OpcUaDataType.Int32.getTypeId() | 0xC0);
+    buffer.writeIntLE(1);
+    buffer.writeIntLE(1);
+    buffer.writeIntLE(1);
+    buffer.writeIntLE(2);
+
+    assertThrows(
+        UaSerializationException.class,
+        () ->
+            new OpcUaBinaryDecoder(DefaultEncodingContext.INSTANCE)
+                .setBuffer(buffer)
+                .decodeVariant());
+  }
+
+  @Test
+  void decodeVariantAllowsMatchingOneDimensionalArrayDimension() {
+    ByteBuf buffer = Unpooled.buffer();
+    buffer.writeByte(OpcUaDataType.Int32.getTypeId() | 0xC0);
+    buffer.writeIntLE(1);
+    buffer.writeIntLE(1);
+    buffer.writeIntLE(1);
+    buffer.writeIntLE(1);
+
+    Variant variant =
+        new OpcUaBinaryDecoder(DefaultEncodingContext.INSTANCE).setBuffer(buffer).decodeVariant();
+
+    assertArrayEquals(new Integer[] {1}, (Integer[]) variant.value());
+  }
+
+  @Test
+  void decodeVariantRejectsMatrixDimensionOverflow() {
+    ByteBuf buffer = Unpooled.buffer();
+    buffer.writeByte(OpcUaDataType.Int32.getTypeId() | 0xC0);
+    buffer.writeIntLE(0);
+    buffer.writeIntLE(2);
+    buffer.writeIntLE(46341);
+    buffer.writeIntLE(46341);
+
+    assertThrows(
+        UaSerializationException.class,
+        () ->
+            new OpcUaBinaryDecoder(DefaultEncodingContext.INSTANCE)
+                .setBuffer(buffer)
+                .decodeVariant());
+  }
+
+  @Test
+  void decodeVariantRejectsMismatchedMatrixDimensions() {
+    ByteBuf buffer = Unpooled.buffer();
+    buffer.writeByte(OpcUaDataType.Int32.getTypeId() | 0xC0);
+    buffer.writeIntLE(1);
+    buffer.writeIntLE(1);
+    buffer.writeIntLE(2);
+    buffer.writeIntLE(2);
+    buffer.writeIntLE(2);
 
     assertThrows(
         UaSerializationException.class,


### PR DESCRIPTION
## Summary

Harden binary Matrix decoding so malformed dimension metadata is rejected with `UaSerializationException` instead of causing unchecked allocation failures or inconsistent Matrix values.

- Validate negative array and dimension counts before allocating arrays.
- Use overflow-checked Matrix length calculation for binary Matrix decode paths.
- Validate Variant `ArrayDimensions`, including product-vs-array-length consistency.
- Preserve existing zero-dimension Matrix behavior and one-dimensional Variant array shape.

## Key Changes

- **Matrix length validation:** Centralized Matrix dimension validation rejects negative dimensions, detects integer overflow with `Math.multiplyExact`, and allows zero dimensions to represent empty matrices.
- **Variant dimension validation:** Variant decoding now validates encoded dimensions whenever present, including rank-one dimensions, while still returning rank-one values as ordinary boxed arrays.
- **Regression coverage:** Added malformed binary payload tests for negative dimension counts, negative dimensions, overflowed products, mismatched Variant dimensions, and zero-dimension compatibility.