### PR TITLE
Return BadSessionIdInvalid for wrong-channel CloseSession

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/CloseSessionWrongChannelTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/CloseSessionWrongChannelTest.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server;
+
+import static org.eclipse.milo.opcua.stack.core.StatusCodes.Bad_SessionIdInvalid;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.test.TestClient;
+import org.eclipse.milo.opcua.sdk.test.TestServer;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.UaResponseMessageType;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.ApplicationType;
+import org.eclipse.milo.opcua.stack.core.types.structured.ApplicationDescription;
+import org.eclipse.milo.opcua.stack.core.types.structured.CloseSessionRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.CreateSessionRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.CreateSessionResponse;
+import org.junit.jupiter.api.Test;
+
+public class CloseSessionWrongChannelTest {
+
+  @Test
+  void closeUnactivatedSessionFromDifferentSecureChannelReturnsBadSessionIdInvalid()
+      throws Exception {
+
+    OpcUaServer server = TestServer.create().getServer();
+    server.startup().get();
+
+    OpcUaClient ownerClient = TestClient.create(server, cfg -> {});
+    OpcUaClient wrongChannelClient = TestClient.create(server, cfg -> {});
+    try {
+      ownerClient.connect();
+      wrongChannelClient.connect();
+
+      CreateSessionResponse createSessionResponse = createSession(ownerClient, "unactivated");
+      NodeId authToken = createSessionResponse.getAuthenticationToken();
+
+      assertCloseSessionServiceFault(wrongChannelClient, authToken, Bad_SessionIdInvalid);
+
+      closeSession(ownerClient, authToken);
+    } finally {
+      try {
+        ownerClient.disconnectAsync().get(2, TimeUnit.SECONDS);
+        wrongChannelClient.disconnectAsync().get(2, TimeUnit.SECONDS);
+      } finally {
+        server.shutdown().get(2, TimeUnit.SECONDS);
+      }
+    }
+  }
+
+  @Test
+  void closeActivatedSessionFromDifferentSecureChannelReturnsBadSessionIdInvalid()
+      throws Exception {
+
+    OpcUaServer server = TestServer.create().getServer();
+    server.startup().get();
+
+    OpcUaClient ownerClient = TestClient.create(server, cfg -> {});
+    OpcUaClient wrongChannelClient = TestClient.create(server, cfg -> {});
+    try {
+      ownerClient.connect();
+      wrongChannelClient.connect();
+
+      NodeId authToken = ownerClient.getSession().getAuthenticationToken();
+
+      assertCloseSessionServiceFault(wrongChannelClient, authToken, Bad_SessionIdInvalid);
+    } finally {
+      try {
+        ownerClient.disconnectAsync().get(2, TimeUnit.SECONDS);
+        wrongChannelClient.disconnectAsync().get(2, TimeUnit.SECONDS);
+      } finally {
+        server.shutdown().get(2, TimeUnit.SECONDS);
+      }
+    }
+  }
+
+  private static CreateSessionResponse createSession(OpcUaClient client, String sessionName)
+      throws Exception {
+
+    UInteger maxResponseMessageSize = client.getConfig().getMaxResponseMessageSize();
+
+    ApplicationDescription clientDescription =
+        new ApplicationDescription(
+            client.getConfig().getApplicationUri(),
+            client.getConfig().getProductUri(),
+            client.getConfig().getApplicationName(),
+            ApplicationType.Client,
+            null,
+            null,
+            null);
+
+    CreateSessionRequest request =
+        new CreateSessionRequest(
+            client.newRequestHeader(),
+            clientDescription,
+            null,
+            client.getConfig().getEndpoint().getEndpointUrl(),
+            sessionName,
+            ByteString.NULL_VALUE,
+            ByteString.NULL_VALUE,
+            60_000.0,
+            maxResponseMessageSize);
+
+    return (CreateSessionResponse) client.getTransport().sendRequestMessage(request).get();
+  }
+
+  private static void assertCloseSessionServiceFault(
+      OpcUaClient client, NodeId authToken, long expectedStatusCode) {
+
+    ExecutionException exception =
+        assertThrows(ExecutionException.class, () -> closeSession(client, authToken));
+
+    Throwable cause = exception.getCause();
+
+    if (cause instanceof UaException uaException) {
+      assertEquals(expectedStatusCode, uaException.getStatusCode().getValue());
+    } else {
+      throw new AssertionError("expected UaException, got " + cause, cause);
+    }
+  }
+
+  private static UaResponseMessageType closeSession(OpcUaClient client, NodeId authToken)
+      throws Exception {
+
+    CloseSessionRequest request = new CloseSessionRequest(client.newRequestHeader(authToken), true);
+
+    return client.getTransport().sendRequestMessage(request).get();
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/SessionManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/SessionManager.java
@@ -811,7 +811,7 @@ public class SessionManager {
 
     if (session != null) {
       if (session.getSecureChannelId() != secureChannelId) {
-        throw new UaException(StatusCodes.Bad_SecureChannelIdInvalid);
+        throw new UaException(StatusCodes.Bad_SessionIdInvalid);
       } else {
         activeSessions.remove(authToken);
         session.close(request.getDeleteSubscriptions());
@@ -823,7 +823,7 @@ public class SessionManager {
       if (session == null) {
         throw new UaException(StatusCodes.Bad_SessionIdInvalid);
       } else if (session.getSecureChannelId() != secureChannelId) {
-        throw new UaException(StatusCodes.Bad_SecureChannelIdInvalid);
+        throw new UaException(StatusCodes.Bad_SessionIdInvalid);
       } else {
         createdSessions.remove(authToken);
         session.close(request.getDeleteSubscriptions());


### PR DESCRIPTION
## Summary

Return the CTT-expected `BadSessionIdInvalid` when `CloseSession` is sent over a SecureChannel that is not associated with the request's authentication token.

- Aligns `CloseSession` handling for active and not-yet-activated sessions with the Session Multiple negative case.
- Keeps successful `CloseSession` behavior unchanged when the request arrives on the owning SecureChannel.
- Adds integration coverage that exercises both CTT branches over real client channels.

## Key Changes

- **CloseSession validation:** A token found in either the active-session map or created-session map is treated as invalid for `CloseSession` if it arrives on a different SecureChannel, returning `BadSessionIdInvalid` instead of `BadSecureChannelIdInvalid`.
- **Regression coverage:** The new integration test verifies wrong-channel close attempts for both an unactivated raw `CreateSession` response and a fully activated client session, then confirms the request fails as a service fault with the expected status.

## Testing

- `mvn -q -pl opc-ua-sdk/integration-tests -am test -Dtest=CloseSessionWrongChannelTest -Dsurefire.failIfNoSpecifiedTests=false`
- `mvn -q spotless:apply`
- `mvn -q clean compile`
- Preflight review: APPROVED
- Focused CTT selection was generated and dry-run checked; live CTT rerun was deferred to the serialized train workflow because the demo server endpoint and CTT project are shared resources.

## References

- OPC UA CTT: `Session Services / Session Multiple / Err-001.js`
