### PR TITLE
Return due keep-alives from queued publishes

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/subscriptions/Subscription.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/subscriptions/Subscription.java
@@ -936,6 +936,22 @@ public class Subscription {
         setState(State.KeepAlive);
         resetKeepAliveCounter();
         keepAliveCounter--;
+
+        if (keepAliveCounter < 1) {
+          PendingPublish pending = publishRequestQueued ? publishQueue().poll() : null;
+
+          if (pending != null) {
+            subscriptionDiagnostics.getPublishRequestCount().increment();
+
+            resetLifetimeCounter();
+            resetKeepAliveCounter();
+            messageSent = true;
+            returnKeepAlive(pending);
+          } else {
+            setState(State.Late);
+            publishQueue().addSubscription(Subscription.this);
+          }
+        }
       } else {
         throw new IllegalStateException("unhandled subscription state");
       }

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/subscriptions/SubscriptionKeepAliveTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/subscriptions/SubscriptionKeepAliveTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.subscriptions;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServerConfig;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServerConfigLimits;
+import org.eclipse.milo.opcua.sdk.server.subscriptions.PublishQueue.PendingPublish;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.structured.PublishRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.RequestHeader;
+import org.eclipse.milo.opcua.stack.core.types.structured.SubscriptionAcknowledgement;
+import org.eclipse.milo.opcua.stack.transport.server.ServiceRequestContext;
+import org.junit.jupiter.api.Test;
+
+class SubscriptionKeepAliveTest {
+
+  @Test
+  void secondQueuedPublishCompletesWhenMaxKeepAliveCountIsOne() {
+    Subscription subscription = newSubscription();
+    PendingPublish firstPublish = newPendingPublish(1);
+    PendingPublish secondPublish = newPendingPublish(2);
+
+    subscription.onPublish(firstPublish);
+    subscription.onPublish(secondPublish);
+
+    subscription.onPublishingTimer();
+
+    assertTrue(firstPublish.responseFuture.isDone());
+    assertFalse(secondPublish.responseFuture.isDone());
+
+    subscription.onPublishingTimer();
+
+    assertTrue(secondPublish.responseFuture.isDone());
+    assertTrue(secondPublish.responseFuture.join().getResponseHeader().getServiceResult().isGood());
+  }
+
+  private static Subscription newSubscription() {
+    OpcUaServerConfigLimits limits = new OpcUaServerConfigLimits() {};
+
+    OpcUaServerConfig config = mock(OpcUaServerConfig.class);
+    when(config.getLimits()).thenReturn(limits);
+
+    ScheduledExecutorService scheduledExecutor = mock(ScheduledExecutorService.class);
+    ScheduledFuture<?> scheduledFuture = mock(ScheduledFuture.class);
+    doReturn(scheduledFuture)
+        .when(scheduledExecutor)
+        .schedule(any(Runnable.class), anyLong(), any(TimeUnit.class));
+
+    OpcUaServer server = mock(OpcUaServer.class);
+    when(server.getConfig()).thenReturn(config);
+    when(server.getScheduledExecutorService()).thenReturn(scheduledExecutor);
+
+    ExecutorService executor = mock(ExecutorService.class);
+    PublishQueue publishQueue = new PublishQueue(executor);
+
+    SubscriptionManager subscriptionManager = mock(SubscriptionManager.class);
+    when(subscriptionManager.getServer()).thenReturn(server);
+    when(subscriptionManager.getPublishQueue()).thenReturn(publishQueue);
+
+    return new Subscription(subscriptionManager, uint(1), 1_000.0, 1, 60, 0, true, 0);
+  }
+
+  private static PendingPublish newPendingPublish(long requestHandle) {
+    ServiceRequestContext context = mock(ServiceRequestContext.class);
+    when(context.receivedAtNanos()).thenReturn(System.nanoTime());
+
+    RequestHeader requestHeader =
+        new RequestHeader(
+            NodeId.NULL_VALUE, DateTime.now(), uint(requestHandle), uint(0), null, uint(0), null);
+
+    PublishRequest request = new PublishRequest(requestHeader, new SubscriptionAcknowledgement[0]);
+
+    return new PendingPublish(context, request, new StatusCode[0]);
+  }
+}


### PR DESCRIPTION
## Summary

Fix a keep-alive timing edge in the server-side Subscription state machine when a client queues multiple Publish requests and the revised `MaxKeepAliveCount` is `1`.

OPC UA Part 4 describes Publish requests as a shared session queue: Subscriptions dequeue a Publish request when a NotificationMessage or keep-alive message is ready. The first keep-alive after subscription creation is special, but after that the keep-alive counter controls when the next empty NotificationMessage should be returned. This PR handles the boundary case where Milo transitions from `NORMAL` into `KEEPALIVE`, resets the counter, and immediately decrements it to zero in the same publishing cycle.

- Return the queued Publish response as soon as the keep-alive becomes due during the `NORMAL` to `KEEPALIVE` transition.
- Preserve the existing `LATE` behavior when a keep-alive is due but no valid Publish request is queued.
- Add a regression test for the CTT scenario: two queued Publish requests, no notifications, publishing interval `1000ms`, and `MaxKeepAliveCount=1`.

## Key Changes

- **Subscription timing edge:** In the OPC UA subscription state table, row 9 is the path taken when the publishing timer expires after a message has already been sent and there are still no notifications available. Milo already reset and decremented the keep-alive counter on this path; with `MaxKeepAliveCount=1`, that made the counter due immediately but did not return the queued Publish response on that timer tick.
- **Due keep-alive handling:** When that row 9 decrement crosses the due threshold, Milo now consumes a queued Publish request and returns a keep-alive immediately. This matches the practical timing expectation that a keep-alive count of `1` produces one keep-alive per publishing interval while Publish requests are available.
- **Late fallback:** If the keep-alive is due but the queue no longer contains a usable Publish request, the Subscription transitions to `LATE` and waits for the next Publish request through the existing late-state path.
- **Regression coverage:** `SubscriptionKeepAliveTest` drives the state machine directly: it queues two Publish requests, advances the publishing timer twice, and verifies the second response completes on the second tick.

## Testing

- `SubscriptionKeepAliveTest` covers the `MaxKeepAliveCount=1` two queued Publish keep-alive sequence.
- `mvn -q -pl opc-ua-sdk/sdk-server -am test -Dtest=SubscriptionKeepAliveTest -Dsurefire.failIfNoSpecifiedTests=false`
- `mvn -q spotless:apply`
- `mvn -q clean compile`

Live CTT was not rerun from this branch because the demo server endpoint and CTT project are shared resources controlled by the Standard 2025 train orchestrator.

## References

- [OPC UA Part 4, §5.14.1 Subscription model](https://reference.opcfoundation.org/specs/OPC-10000-4/5.14.1)
