### PR TITLE
Fix user token policy IDs for endpoint variants

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServer.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServer.java
@@ -19,10 +19,14 @@ import java.net.InetSocketAddress;
 import java.security.KeyPair;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -81,6 +85,7 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.ApplicationType;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.MessageSecurityMode;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.UserTokenType;
 import org.eclipse.milo.opcua.stack.core.types.structured.ApplicationDescription;
 import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
 import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
@@ -585,8 +590,7 @@ public class OpcUaServer extends AbstractServiceHandler {
 
     @Override
     public List<EndpointDescription> getEndpointDescriptions() {
-      return endpointDescriptions.get(
-          () -> config.getEndpoints().stream().map(this::transformEndpoint).toList());
+      return endpointDescriptions.get(() -> transformEndpoints(config.getEndpoints()));
     }
 
     @Override
@@ -764,16 +768,155 @@ public class OpcUaServer extends AbstractServiceHandler {
       return false;
     }
 
-    private EndpointDescription transformEndpoint(EndpointConfig endpoint) {
+    private List<EndpointDescription> transformEndpoints(Set<EndpointConfig> endpoints) {
+      Map<UserTokenPolicyKey, String> userTokenPolicyIds = assignUserTokenPolicyIds(endpoints);
+
+      return endpoints.stream().map(e -> transformEndpoint(e, userTokenPolicyIds)).toList();
+    }
+
+    private EndpointDescription transformEndpoint(
+        EndpointConfig endpoint, Map<UserTokenPolicyKey, String> userTokenPolicyIds) {
       return new EndpointDescription(
           endpoint.getEndpointUrl(),
           getApplicationDescription(),
           certificateByteString(endpoint.getCertificate()),
           endpoint.getSecurityMode(),
           endpoint.getSecurityPolicy().getUri(),
-          endpoint.getTokenPolicies().toArray(new UserTokenPolicy[0]),
+          transformUserTokenPolicies(endpoint, userTokenPolicyIds),
           endpoint.getTransportProfile().getUri(),
           ubyte(getSecurityLevel(endpoint.getSecurityPolicy(), endpoint.getSecurityMode())));
+    }
+
+    private UserTokenPolicy[] transformUserTokenPolicies(
+        EndpointConfig endpoint, Map<UserTokenPolicyKey, String> userTokenPolicyIds) {
+
+      return endpoint.getTokenPolicies().stream()
+          .map(
+              tokenPolicy -> {
+                UserTokenPolicyKey key = UserTokenPolicyKey.from(endpoint, tokenPolicy);
+                String assignedPolicyId = userTokenPolicyIds.get(key);
+
+                String policyId =
+                    policyIdChanged(tokenPolicy.getPolicyId(), assignedPolicyId)
+                        ? assignedPolicyId
+                        : tokenPolicy.getPolicyId();
+
+                return new UserTokenPolicy(
+                    policyId,
+                    tokenPolicy.getTokenType(),
+                    tokenPolicy.getIssuedTokenType(),
+                    tokenPolicy.getIssuerEndpointUrl(),
+                    key.securityPolicyUri());
+              })
+          .toArray(UserTokenPolicy[]::new);
+    }
+
+    private Map<UserTokenPolicyKey, String> assignUserTokenPolicyIds(
+        Set<EndpointConfig> endpoints) {
+      Map<String, List<UserTokenPolicyKey>> keysByPolicyId = new LinkedHashMap<>();
+
+      for (EndpointConfig endpoint : endpoints) {
+        for (UserTokenPolicy tokenPolicy : endpoint.getTokenPolicies()) {
+          UserTokenPolicyKey key = UserTokenPolicyKey.from(endpoint, tokenPolicy);
+          List<UserTokenPolicyKey> keys =
+              keysByPolicyId.computeIfAbsent(key.policyId(), ignored -> new ArrayList<>());
+
+          if (!keys.contains(key)) {
+            keys.add(key);
+          }
+        }
+      }
+
+      Set<String> reservedPolicyIds = new LinkedHashSet<>(keysByPolicyId.keySet());
+      Map<UserTokenPolicyKey, String> assignedPolicyIds = new HashMap<>();
+
+      for (List<UserTokenPolicyKey> keys : keysByPolicyId.values()) {
+        if (keys.size() == 1) {
+          UserTokenPolicyKey key = keys.get(0);
+          assignedPolicyIds.put(key, key.policyId());
+        } else {
+          UserTokenPolicyKey firstKey = keys.get(0);
+          assignedPolicyIds.put(firstKey, firstKey.policyId());
+
+          for (int i = 1; i < keys.size(); i++) {
+            UserTokenPolicyKey key = keys.get(i);
+            assignedPolicyIds.put(key, uniquePolicyId(key, reservedPolicyIds));
+          }
+        }
+      }
+
+      return assignedPolicyIds;
+    }
+
+    private boolean policyIdChanged(@Nullable String configuredPolicyId, String assignedPolicyId) {
+      if (Objects.equals(configuredPolicyId, assignedPolicyId)) {
+        return false;
+      } else {
+        return !(isNullOrEmpty(configuredPolicyId) && assignedPolicyId.isEmpty());
+      }
+    }
+
+    private String uniquePolicyId(UserTokenPolicyKey key, Set<String> reservedPolicyIds) {
+      String base =
+          key.policyId().isEmpty()
+              ? key.tokenType().name().toLowerCase(Locale.ROOT)
+              : key.policyId();
+
+      String securityPolicyName = securityPolicyName(key.securityPolicyUri());
+
+      String candidate = base + "-" + securityPolicyName;
+      if (reservedPolicyIds.add(candidate)) {
+        return candidate;
+      }
+
+      candidate = base + "-" + key.tokenType().name() + "-" + securityPolicyName;
+      if (reservedPolicyIds.add(candidate)) {
+        return candidate;
+      }
+
+      for (int i = 2; ; i++) {
+        String indexedCandidate = candidate + "-" + i;
+        if (reservedPolicyIds.add(indexedCandidate)) {
+          return indexedCandidate;
+        }
+      }
+    }
+
+    private String securityPolicyName(String securityPolicyUri) {
+      int index = securityPolicyUri.lastIndexOf('#');
+      String name = index >= 0 ? securityPolicyUri.substring(index + 1) : securityPolicyUri;
+
+      return name.replaceAll("[^A-Za-z0-9_.-]", "-");
+    }
+
+    private boolean isNullOrEmpty(@Nullable String value) {
+      return value == null || value.isEmpty();
+    }
+
+    private record UserTokenPolicyKey(
+        String policyId,
+        UserTokenType tokenType,
+        @Nullable String issuedTokenType,
+        @Nullable String issuerEndpointUrl,
+        String securityPolicyUri) {
+
+      static UserTokenPolicyKey from(EndpointConfig endpoint, UserTokenPolicy tokenPolicy) {
+        String policyId = tokenPolicy.getPolicyId();
+        String securityPolicyUri = tokenPolicy.getSecurityPolicyUri();
+
+        return new UserTokenPolicyKey(
+            policyId == null ? "" : policyId,
+            tokenPolicy.getTokenType(),
+            tokenPolicy.getIssuedTokenType(),
+            tokenPolicy.getIssuerEndpointUrl(),
+            isNullOrEmpty(securityPolicyUri)
+                ? endpoint.getSecurityPolicy().getUri()
+                : securityPolicyUri);
+      }
+
+      private static boolean isNullOrEmpty(@Nullable String value) {
+        return value == null || value.isEmpty();
+      }
     }
 
     private ByteString certificateByteString(@Nullable X509Certificate certificate) {

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/OpcUaServerEndpointDescriptionTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/OpcUaServerEndpointDescriptionTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Method;
+import java.security.cert.X509Certificate;
+import java.time.Duration;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.eclipse.milo.opcua.stack.core.security.DefaultCertificateManager;
+import org.eclipse.milo.opcua.stack.core.security.MemoryCertificateQuarantine;
+import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.ApplicationType;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.MessageSecurityMode;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.UserTokenType;
+import org.eclipse.milo.opcua.stack.core.types.structured.AnonymousIdentityToken;
+import org.eclipse.milo.opcua.stack.core.types.structured.ApplicationDescription;
+import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
+import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
+import org.junit.jupiter.api.Test;
+
+public class OpcUaServerEndpointDescriptionTest {
+
+  @Test
+  public void userTokenPolicyIdsAreUniqueWhenEffectiveSecurityPolicyDiffers() throws Exception {
+    X509Certificate certificate = mock(X509Certificate.class);
+    when(certificate.getEncoded()).thenReturn(new byte[] {1, 2, 3});
+
+    UserTokenPolicy anonymousPolicy = OpcUaServerConfig.USER_TOKEN_POLICY_ANONYMOUS;
+
+    EndpointConfig noneEndpoint =
+        endpoint(SecurityPolicy.None, MessageSecurityMode.None, anonymousPolicy, null);
+    EndpointConfig signEndpoint =
+        endpoint(
+            SecurityPolicy.Basic256Sha256, MessageSecurityMode.Sign, anonymousPolicy, certificate);
+    EndpointConfig signAndEncryptEndpoint =
+        endpoint(
+            SecurityPolicy.Basic256Sha256,
+            MessageSecurityMode.SignAndEncrypt,
+            anonymousPolicy,
+            certificate);
+
+    Set<EndpointConfig> endpoints = new LinkedHashSet<>();
+    endpoints.add(noneEndpoint);
+    endpoints.add(signEndpoint);
+    endpoints.add(signAndEncryptEndpoint);
+
+    OpcUaServerConfig config =
+        OpcUaServerConfig.builder()
+            .setCertificateManager(new DefaultCertificateManager(new MemoryCertificateQuarantine()))
+            .setEndpoints(endpoints)
+            .build();
+
+    OpcUaServer server = new OpcUaServer(config, transportProfile -> null);
+
+    List<EndpointDescription> endpointDescriptions =
+        server.getApplicationContext().getEndpointDescriptions();
+
+    EndpointDescription noneEndpointDescription =
+        getEndpointDescription(endpointDescriptions, SecurityPolicy.None, MessageSecurityMode.None);
+    EndpointDescription signEndpointDescription =
+        getEndpointDescription(
+            endpointDescriptions, SecurityPolicy.Basic256Sha256, MessageSecurityMode.Sign);
+    EndpointDescription signAndEncryptEndpointDescription =
+        getEndpointDescription(
+            endpointDescriptions,
+            SecurityPolicy.Basic256Sha256,
+            MessageSecurityMode.SignAndEncrypt);
+
+    UserTokenPolicy nonePolicy = getAnonymousPolicy(noneEndpointDescription);
+    UserTokenPolicy signPolicy = getAnonymousPolicy(signEndpointDescription);
+    UserTokenPolicy signAndEncryptPolicy = getAnonymousPolicy(signAndEncryptEndpointDescription);
+
+    assertEquals("anonymous", nonePolicy.getPolicyId());
+    assertEquals(SecurityPolicy.None.getUri(), nonePolicy.getSecurityPolicyUri());
+    assertEquals("anonymous-Basic256Sha256", signPolicy.getPolicyId());
+    assertEquals(SecurityPolicy.Basic256Sha256.getUri(), signPolicy.getSecurityPolicyUri());
+    assertEquals("anonymous-Basic256Sha256", signAndEncryptPolicy.getPolicyId());
+    assertEquals(
+        SecurityPolicy.Basic256Sha256.getUri(), signAndEncryptPolicy.getSecurityPolicyUri());
+
+    assertEquals("anonymous", noneEndpoint.getTokenPolicies().get(0).getPolicyId());
+    assertNull(noneEndpoint.getTokenPolicies().get(0).getSecurityPolicyUri());
+    assertEquals("anonymous", OpcUaServerConfig.USER_TOKEN_POLICY_ANONYMOUS.getPolicyId());
+    assertNull(OpcUaServerConfig.USER_TOKEN_POLICY_ANONYMOUS.getSecurityPolicyUri());
+
+    Session session =
+        new Session(
+            server,
+            new NodeId(1, "session"),
+            "session",
+            Duration.ofMinutes(1),
+            clientDescription(),
+            "urn:eclipse:milo:test",
+            uint(0),
+            signEndpointDescription,
+            1L,
+            new SecurityConfiguration(
+                SecurityPolicy.Basic256Sha256,
+                MessageSecurityMode.Sign,
+                null,
+                null,
+                null,
+                null,
+                null));
+
+    try {
+      UserTokenPolicy validatedPolicy =
+          validatePolicyId(
+              server.getSessionManager(),
+              session,
+              new AnonymousIdentityToken(signPolicy.getPolicyId()));
+
+      assertEquals(signPolicy, validatedPolicy);
+    } finally {
+      session.close(false);
+    }
+  }
+
+  private EndpointConfig endpoint(
+      SecurityPolicy securityPolicy,
+      MessageSecurityMode securityMode,
+      UserTokenPolicy userTokenPolicy,
+      X509Certificate certificate) {
+
+    return EndpointConfig.newBuilder()
+        .setBindPort(4840)
+        .setHostname("localhost")
+        .setPath("/milo")
+        .setSecurityPolicy(securityPolicy)
+        .setSecurityMode(securityMode)
+        .setCertificate(certificate)
+        .addTokenPolicy(userTokenPolicy)
+        .build();
+  }
+
+  private EndpointDescription getEndpointDescription(
+      List<EndpointDescription> endpointDescriptions,
+      SecurityPolicy securityPolicy,
+      MessageSecurityMode securityMode) {
+
+    return endpointDescriptions.stream()
+        .filter(e -> securityPolicy.getUri().equals(e.getSecurityPolicyUri()))
+        .filter(e -> securityMode == e.getSecurityMode())
+        .findFirst()
+        .orElseThrow();
+  }
+
+  private UserTokenPolicy getAnonymousPolicy(EndpointDescription endpointDescription) {
+    return List.of(endpointDescription.getUserIdentityTokens()).stream()
+        .filter(t -> t.getTokenType() == UserTokenType.Anonymous)
+        .findFirst()
+        .orElseThrow();
+  }
+
+  private ApplicationDescription clientDescription() {
+    return new ApplicationDescription(
+        "urn:eclipse:milo:test:client",
+        "urn:eclipse:milo:test",
+        LocalizedText.english("test client"),
+        ApplicationType.Client,
+        null,
+        null,
+        null);
+  }
+
+  private UserTokenPolicy validatePolicyId(
+      SessionManager sessionManager, Session session, AnonymousIdentityToken token)
+      throws Exception {
+
+    Method method =
+        SessionManager.class.getDeclaredMethod("validatePolicyId", Session.class, Object.class);
+    method.setAccessible(true);
+
+    return (UserTokenPolicy) method.invoke(sessionManager, session, token);
+  }
+}


### PR DESCRIPTION
## Summary

Milo now advertises user token policies with IDs that remain unique when the same configured policy is reused across endpoint variants with different effective security policies. This addresses the Standard 2025 CTT `Security User Token / Security User Name Password 2 / 015.js` failure without mutating configured `EndpointConfig` policies or shared token constants.

- Derives advertised user token policies from each endpoint's effective security policy so null or empty token security policy URIs are treated as the endpoint security policy.
- Preserves existing configuration objects and public constants while emitting adjusted `UserTokenPolicy` copies in `EndpointDescription`.
- Adds focused regression coverage for both discovery output and activation policy lookup.

## Key Changes

- **Endpoint description generation:** User token policies are keyed across all configured endpoints before endpoint descriptions are built. Existing policy IDs are preserved when they describe one effective token policy, and conflicting variants receive deterministic suffixes such as `anonymous-Basic256Sha256`.
- **Session compatibility:** Because sessions use the generated `EndpointDescription`, the remapped policy IDs advertised by `GetEndpoints` are accepted by the activation policy lookup path.

## Testing

- `OpcUaServerEndpointDescriptionTest` covers reused anonymous token policies over `None` and `Basic256Sha256` endpoint variants, verifies configured policies/constants remain unchanged, and checks the suffixed advertised policy ID passes `SessionManager` policy validation.
- `mvn -q spotless:apply`
- `mvn -q -pl opc-ua-sdk/sdk-server -am test -Dtest=OpcUaServerEndpointDescriptionTest -Dsurefire.failIfNoSpecifiedTests=false`
- `mvn -q clean compile`

Live CTT was not run from this worker thread per the shared endpoint/project lock. The focused CTT selection was generated at `/Users/kevin/Documents/CTT/milo-demo-server-105/codex-runs/user-token-policy-id-uniqueness.selection.xml` for the orchestrator's serialized train rerun.

## References

- OPC UA Part 4, 7.41 `UserTokenPolicy`: https://reference.opcfoundation.org/specs/OPC-10000-4/7.41
