### PR TITLE
Add unsupported Query service set

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/QueryServiceUnsupportedTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/QueryServiceUnsupportedTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import org.eclipse.milo.opcua.sdk.test.AbstractClientServerTest;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.channel.SecureChannel;
+import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.TimestampsToReturn;
+import org.eclipse.milo.opcua.stack.core.types.structured.ContentFilter;
+import org.eclipse.milo.opcua.stack.core.types.structured.ReadRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.RequestHeader;
+import org.eclipse.milo.opcua.stack.core.types.structured.ViewDescription;
+import org.eclipse.milo.opcua.stack.transport.server.ServiceRequestContext;
+import org.junit.jupiter.api.Test;
+
+public class QueryServiceUnsupportedTest extends AbstractClientServerTest {
+
+  @Test
+  void queryFirstReturnsServiceUnsupported() {
+    UaException exception =
+        assertThrows(
+            UaException.class,
+            () ->
+                client.queryFirst(
+                    new ViewDescription(NodeId.NULL_VALUE, DateTime.NULL_VALUE, uint(0)),
+                    List.of(),
+                    new ContentFilter(null),
+                    uint(0),
+                    uint(0)));
+
+    assertEquals(StatusCodes.Bad_ServiceUnsupported, exception.getStatusCode().getValue());
+  }
+
+  @Test
+  void queryNextReturnsServiceUnsupported() {
+    UaException exception =
+        assertThrows(UaException.class, () -> client.queryNext(false, ByteString.NULL_VALUE));
+
+    assertEquals(StatusCodes.Bad_ServiceUnsupported, exception.getStatusCode().getValue());
+  }
+
+  @Test
+  void missingNonQueryHandlerReturnsNotImplemented() {
+    var request = new ReadRequest(newRequestHeader(), 0.0, TimestampsToReturn.Neither, null);
+
+    ExecutionException exception =
+        assertThrows(
+            ExecutionException.class,
+            () ->
+                server
+                    .getApplicationContext()
+                    .handleServiceRequest(unregisteredServiceContext(), request)
+                    .get());
+
+    UaException uaException = UaException.extract(exception).orElseThrow();
+
+    assertEquals(StatusCodes.Bad_NotImplemented, uaException.getStatusCode().getValue());
+  }
+
+  private static ServiceRequestContext unregisteredServiceContext() {
+    ServiceRequestContext context = mock(ServiceRequestContext.class);
+    SecureChannel secureChannel = mock(SecureChannel.class);
+
+    when(context.getEndpointUrl()).thenReturn("opc.tcp://localhost:4840/unregistered");
+    when(context.getSecureChannel()).thenReturn(secureChannel);
+    when(secureChannel.getSecurityPolicy()).thenReturn(SecurityPolicy.Basic256Sha256);
+
+    return context;
+  }
+
+  private static RequestHeader newRequestHeader() {
+    return new RequestHeader(
+        NodeId.NULL_VALUE, DateTime.now(), uint(1), uint(0), null, uint(0), null);
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/AbstractServiceHandler.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/AbstractServiceHandler.java
@@ -20,6 +20,7 @@ import org.eclipse.milo.opcua.sdk.server.servicesets.DiscoveryServiceSet;
 import org.eclipse.milo.opcua.sdk.server.servicesets.MethodServiceSet;
 import org.eclipse.milo.opcua.sdk.server.servicesets.MonitoredItemServiceSet;
 import org.eclipse.milo.opcua.sdk.server.servicesets.NodeManagementServiceSet;
+import org.eclipse.milo.opcua.sdk.server.servicesets.QueryServiceSet;
 import org.eclipse.milo.opcua.sdk.server.servicesets.Service;
 import org.eclipse.milo.opcua.sdk.server.servicesets.SessionServiceSet;
 import org.eclipse.milo.opcua.sdk.server.servicesets.SubscriptionServiceSet;
@@ -52,6 +53,8 @@ import org.eclipse.milo.opcua.stack.core.types.structured.ModifyMonitoredItemsRe
 import org.eclipse.milo.opcua.stack.core.types.structured.ModifySubscriptionRequest;
 import org.eclipse.milo.opcua.stack.core.types.structured.PublishRequest;
 import org.eclipse.milo.opcua.stack.core.types.structured.PublishResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.QueryFirstRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.QueryNextRequest;
 import org.eclipse.milo.opcua.stack.core.types.structured.ReadRequest;
 import org.eclipse.milo.opcua.stack.core.types.structured.RegisterNodesRequest;
 import org.eclipse.milo.opcua.stack.core.types.structured.RegisterServer2Request;
@@ -168,6 +171,17 @@ public abstract class AbstractServiceHandler {
         Service.NODE_MANAGEMENT_DELETE_REFERENCES,
         (context, request) ->
             serviceSet.onDeleteReferences(context, (DeleteReferencesRequest) request));
+  }
+
+  public void addServiceSet(String path, QueryServiceSet serviceSet) {
+    addServiceHandler(
+        path,
+        Service.QUERY_QUERY_FIRST,
+        (context, request) -> serviceSet.onQueryFirst(context, (QueryFirstRequest) request));
+    addServiceHandler(
+        path,
+        Service.QUERY_QUERY_NEXT,
+        (context, request) -> serviceSet.onQueryNext(context, (QueryNextRequest) request));
   }
 
   public void addServiceSet(String path, SessionServiceSet serviceSet) {

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServer.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServer.java
@@ -50,6 +50,7 @@ import org.eclipse.milo.opcua.sdk.server.servicesets.impl.DefaultDiscoveryServic
 import org.eclipse.milo.opcua.sdk.server.servicesets.impl.DefaultMethodServiceSet;
 import org.eclipse.milo.opcua.sdk.server.servicesets.impl.DefaultMonitoredItemServiceSet;
 import org.eclipse.milo.opcua.sdk.server.servicesets.impl.DefaultNodeManagementServiceSet;
+import org.eclipse.milo.opcua.sdk.server.servicesets.impl.DefaultQueryServiceSet;
 import org.eclipse.milo.opcua.sdk.server.servicesets.impl.DefaultSessionServiceSet;
 import org.eclipse.milo.opcua.sdk.server.servicesets.impl.DefaultSubscriptionServiceSet;
 import org.eclipse.milo.opcua.sdk.server.servicesets.impl.DefaultViewServiceSet;
@@ -248,6 +249,7 @@ public class OpcUaServer extends AbstractServiceHandler {
             addServiceSet(path, new DefaultMethodServiceSet(OpcUaServer.this));
             addServiceSet(path, new DefaultMonitoredItemServiceSet(OpcUaServer.this));
             addServiceSet(path, new DefaultNodeManagementServiceSet(OpcUaServer.this));
+            addServiceSet(path, new DefaultQueryServiceSet());
             addServiceSet(path, new DefaultSessionServiceSet(OpcUaServer.this));
             addServiceSet(path, new DefaultSubscriptionServiceSet(OpcUaServer.this));
             addServiceSet(path, new DefaultViewServiceSet(OpcUaServer.this));

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/servicesets/QueryServiceSet.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/servicesets/QueryServiceSet.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.servicesets;
+
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.structured.QueryFirstRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.QueryFirstResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.QueryNextRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.QueryNextResponse;
+import org.eclipse.milo.opcua.stack.transport.server.ServiceRequestContext;
+
+public interface QueryServiceSet {
+
+  QueryFirstResponse onQueryFirst(ServiceRequestContext context, QueryFirstRequest request)
+      throws UaException;
+
+  QueryNextResponse onQueryNext(ServiceRequestContext context, QueryNextRequest request)
+      throws UaException;
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/servicesets/impl/DefaultQueryServiceSet.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/servicesets/impl/DefaultQueryServiceSet.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.servicesets.impl;
+
+import org.eclipse.milo.opcua.sdk.server.servicesets.QueryServiceSet;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.structured.QueryFirstRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.QueryFirstResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.QueryNextRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.QueryNextResponse;
+import org.eclipse.milo.opcua.stack.transport.server.ServiceRequestContext;
+
+public class DefaultQueryServiceSet implements QueryServiceSet {
+
+  @Override
+  public QueryFirstResponse onQueryFirst(ServiceRequestContext context, QueryFirstRequest request)
+      throws UaException {
+
+    throw new UaException(StatusCodes.Bad_ServiceUnsupported);
+  }
+
+  @Override
+  public QueryNextResponse onQueryNext(ServiceRequestContext context, QueryNextRequest request)
+      throws UaException {
+
+    throw new UaException(StatusCodes.Bad_ServiceUnsupported);
+  }
+}


### PR DESCRIPTION
## Summary

Add a server-side Query service set that reports Milo's QueryFirst and QueryNext services as unsupported with `Bad_ServiceUnsupported`, matching OPC UA service-level unsupported semantics.

- Adds `QueryServiceSet` so Query services fit the same SDK service-set registration pattern as Attribute, View, Session, and the other service families.
- Registers `DefaultQueryServiceSet` on normal server endpoints and has it return `Bad_ServiceUnsupported` for QueryFirst and QueryNext until Milo implements Query semantics.
- Preserves the generic no-handler fallback of `Bad_NotImplemented` for unrelated service dispatch gaps.
- Adds integration coverage through the public client Query APIs and a dispatcher fallback regression.

## Key Changes

- **Query service architecture:** `AbstractServiceHandler` can now register QueryFirst and QueryNext handlers through `QueryServiceSet`, avoiding a dispatcher-level status special case.
- **Default unsupported behavior:** `DefaultQueryServiceSet` provides explicit service-level unsupported responses for the recognized-but-unimplemented Query services.
- **Regression coverage:** `QueryServiceUnsupportedTest` asserts client-observed service-level status for QueryFirst and QueryNext, and directly verifies a non-Query missing handler still returns `Bad_NotImplemented`.

## Testing

- `QueryServiceUnsupportedTest` covers QueryFirst/QueryNext unsupported service faults and the non-Query missing-handler fallback.
- `mvn -q spotless:apply`
- `mvn -q -pl opc-ua-sdk/integration-tests -am test -Dtest=QueryServiceUnsupportedTest -Dsurefire.failIfNoSpecifiedTests=false`
- `mvn -q clean compile`
- `mvn -q clean verify`

## References

- OPC-10000-4 Appendix B.2.3, QueryFirst
- OPC-10000-4 Appendix B.2.4, QueryNext
- OPC-10000-4 section 7.38.2, `Bad_ServiceUnsupported` and `Bad_NotImplemented`
