### PR TITLE
Fix session shutdown diagnostics race

### DIFF
--- a/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/ClientExampleRunner.java
+++ b/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/ClientExampleRunner.java
@@ -152,8 +152,6 @@ public class ClientExampleRunner {
             try {
               client.disconnectAsync().get();
               if (serverRequired && exampleServer != null) {
-                // let the session listener callbacks run
-                Thread.sleep(500);
                 exampleServer.shutdown().get();
               }
               Stack.releaseSharedResources();

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/ServerShutdownSessionDiagnosticsRaceTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/ServerShutdownSessionDiagnosticsRaceTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.test.TestClient;
+import org.eclipse.milo.opcua.sdk.test.TestServer;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression coverage for shutdown races between session listener callbacks and diagnostics
+ * namespace teardown.
+ *
+ * <p>The server shutdown contract is that listener callbacks already in progress are allowed to
+ * finish before diagnostics nodes are torn down. At the same time, shutdown must stay re-entrant
+ * enough for a listener callback to request shutdown without waiting on itself.
+ */
+public class ServerShutdownSessionDiagnosticsRaceTest {
+
+  @Test
+  void shutdownWaitsForInFlightSessionListenerBeforeNamespaceTeardown() throws Exception {
+    OpcUaServer server = TestServer.create().getServer();
+    ExecutorService shutdownExecutor = Executors.newFixedThreadPool(2);
+    CountDownLatch listenerStarted = new CountDownLatch(1);
+    CountDownLatch releaseListener = new CountDownLatch(1);
+    CompletableFuture<OpcUaServer> shutdownFuture = null;
+    CompletableFuture<OpcUaServer> concurrentShutdownFuture = null;
+    OpcUaClient client = null;
+
+    server
+        .getSessionManager()
+        .addSessionListener(
+            new SessionListener() {
+              @Override
+              public void onSessionCreated(Session session) {
+                listenerStarted.countDown();
+                try {
+                  assertTrue(
+                      releaseListener.await(5, TimeUnit.SECONDS), "listener release timed out");
+                } catch (InterruptedException e) {
+                  Thread.currentThread().interrupt();
+                  throw new RuntimeException(e);
+                }
+              }
+            });
+
+    try {
+      server.startup().get();
+
+      client = TestClient.create(server, cfg -> {});
+      client.connectAsync();
+
+      assertTrue(listenerStarted.await(5, TimeUnit.SECONDS), "listener did not start");
+
+      // The first shutdown must wait for the in-flight listener before namespace teardown.
+      shutdownFuture =
+          CompletableFuture.supplyAsync(
+              () -> {
+                try {
+                  return server.shutdown().get();
+                } catch (InterruptedException e) {
+                  Thread.currentThread().interrupt();
+                  throw new CompletionException(e);
+                } catch (ExecutionException e) {
+                  throw new CompletionException(e);
+                }
+              },
+              shutdownExecutor);
+
+      CompletableFuture<OpcUaServer> future = shutdownFuture;
+      assertThrows(TimeoutException.class, () -> future.get(200, TimeUnit.MILLISECONDS));
+
+      // A second caller must observe the same shutdown instead of racing ahead to teardown.
+      concurrentShutdownFuture =
+          CompletableFuture.supplyAsync(
+              () -> {
+                try {
+                  return server.shutdown().get();
+                } catch (InterruptedException e) {
+                  Thread.currentThread().interrupt();
+                  throw new CompletionException(e);
+                } catch (ExecutionException e) {
+                  throw new CompletionException(e);
+                }
+              },
+              shutdownExecutor);
+
+      CompletableFuture<OpcUaServer> concurrentFuture = concurrentShutdownFuture;
+      assertThrows(TimeoutException.class, () -> concurrentFuture.get(200, TimeUnit.MILLISECONDS));
+
+      releaseListener.countDown();
+
+      assertSame(server, future.get(5, TimeUnit.SECONDS));
+      assertSame(server, concurrentFuture.get(5, TimeUnit.SECONDS));
+    } finally {
+      releaseListener.countDown();
+
+      if (shutdownFuture != null) {
+        try {
+          shutdownFuture.get(5, TimeUnit.SECONDS);
+        } catch (Exception ignored) {
+          // The assertion path reports shutdown failures.
+        }
+      } else {
+        server.shutdown().get(5, TimeUnit.SECONDS);
+      }
+      if (concurrentShutdownFuture != null) {
+        try {
+          concurrentShutdownFuture.get(5, TimeUnit.SECONDS);
+        } catch (Exception ignored) {
+          // The assertion path reports shutdown failures.
+        }
+      }
+
+      if (client != null) {
+        try {
+          client.disconnectAsync().get(2, TimeUnit.SECONDS);
+        } catch (Exception ignored) {
+          // The server may already be shut down by the assertion path above.
+        }
+      }
+
+      shutdownExecutor.shutdownNow();
+    }
+  }
+
+  @Test
+  void shutdownFromSessionListenerDoesNotWaitOnItself() throws Exception {
+    OpcUaServer server = TestServer.create().getServer();
+    CountDownLatch listenerStarted = new CountDownLatch(1);
+    CountDownLatch laterListenerCalled = new CountDownLatch(1);
+    CompletableFuture<OpcUaServer> shutdownFuture = new CompletableFuture<>();
+    CompletableFuture<OpcUaClient> connectFuture = null;
+    OpcUaClient client = null;
+
+    server
+        .getSessionManager()
+        .addSessionListener(
+            new SessionListener() {
+              @Override
+              public void onSessionCreated(Session session) {
+                listenerStarted.countDown();
+                try {
+                  shutdownFuture.complete(server.shutdown().get(5, TimeUnit.SECONDS));
+                } catch (Exception e) {
+                  shutdownFuture.completeExceptionally(e);
+                }
+              }
+            });
+    server
+        .getSessionManager()
+        .addSessionListener(
+            new SessionListener() {
+              @Override
+              public void onSessionCreated(Session session) {
+                laterListenerCalled.countDown();
+              }
+            });
+
+    try {
+      server.startup().get();
+
+      client = TestClient.create(server, cfg -> {});
+      connectFuture = client.connectAsync();
+
+      assertTrue(listenerStarted.await(5, TimeUnit.SECONDS), "listener did not start");
+      assertSame(server, shutdownFuture.get(5, TimeUnit.SECONDS));
+      // Once the first listener starts shutdown, later listeners in the same notification pass are
+      // skipped so they cannot run against partially torn-down diagnostics state.
+      assertFalse(
+          laterListenerCalled.await(200, TimeUnit.MILLISECONDS),
+          "later listener was invoked after shutdown started");
+    } finally {
+      if (connectFuture != null) {
+        try {
+          connectFuture.get(2, TimeUnit.SECONDS);
+        } catch (Exception ignored) {
+          // The listener shuts the server down during the connection attempt.
+        }
+      }
+
+      if (client != null) {
+        try {
+          client.disconnectAsync().get(2, TimeUnit.SECONDS);
+        } catch (Exception ignored) {
+          // The server may already be shut down by the assertion path above.
+        }
+      }
+
+      try {
+        server.shutdown().get(2, TimeUnit.SECONDS);
+      } catch (Exception ignored) {
+        // The assertion path reports shutdown failures.
+      }
+    }
+  }
+}

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/test/AbstractClientServerTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/test/AbstractClientServerTest.java
@@ -53,8 +53,6 @@ public abstract class AbstractClientServerTest {
       e.printStackTrace(System.err);
     }
     try {
-      // let the session listener callbacks run
-      Thread.sleep(500);
       testNamespace.shutdown();
       server.shutdown().get(2, TimeUnit.SECONDS);
     } catch (Exception e) {

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/ManagedAddressSpaceFragmentWithLifecycle.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/ManagedAddressSpaceFragmentWithLifecycle.java
@@ -18,11 +18,16 @@ package org.eclipse.milo.opcua.sdk.server;
  *
  * <p>Subclasses can register additional startup/shutdown tasks with the {@link LifecycleManager}
  * obtained from {@link #getLifecycleManager()}.
+ *
+ * <p>Shutdown runs in reverse registration order, so subclass lifecycles are stopped before this
+ * base class unregisters the fragment and its {@link UaNodeManager}.
  */
 public abstract class ManagedAddressSpaceFragmentWithLifecycle extends ManagedAddressSpaceFragment
     implements Lifecycle {
 
-  private final LifecycleManager lifecycleManager = new LifecycleManager();
+  /** Keeps child lifecycle shutdown ahead of base fragment unregistration. */
+  private final LifecycleManager lifecycleManager =
+      new LifecycleManager(LifecycleManager.ShutdownOrder.INVERSE);
 
   private final AddressSpaceComposite composite;
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/ManagedAddressSpaceWithLifecycle.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/ManagedAddressSpaceWithLifecycle.java
@@ -10,10 +10,19 @@
 
 package org.eclipse.milo.opcua.sdk.server;
 
+/**
+ * A {@link ManagedAddressSpace} whose registration is controlled by a {@link LifecycleManager}.
+ *
+ * <p>Subclasses can add their own lifecycle work with {@link #getLifecycleManager()}. Shutdown runs
+ * in reverse registration order, so subclass lifecycles are stopped before this base class
+ * unregisters the {@link UaNodeManager} from the server's {@link AddressSpaceManager}.
+ */
 public abstract class ManagedAddressSpaceWithLifecycle extends ManagedAddressSpace
     implements Lifecycle {
 
-  private final LifecycleManager lifecycleManager = new LifecycleManager();
+  /** Keeps child lifecycle shutdown ahead of base address-space unregistration. */
+  private final LifecycleManager lifecycleManager =
+      new LifecycleManager(LifecycleManager.ShutdownOrder.INVERSE);
 
   public ManagedAddressSpaceWithLifecycle(OpcUaServer server) {
     super(server);

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/ManagedNamespaceWithLifecycle.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/ManagedNamespaceWithLifecycle.java
@@ -10,9 +10,18 @@
 
 package org.eclipse.milo.opcua.sdk.server;
 
+/**
+ * A {@link ManagedNamespace} whose address-space and node-manager registration is lifecycle-bound.
+ *
+ * <p>Subclasses can add their own lifecycle work with {@link #getLifecycleManager()}. Shutdown runs
+ * in reverse registration order, so namespace children shut down before this base class unregisters
+ * the namespace and its {@link UaNodeManager} from the server.
+ */
 public abstract class ManagedNamespaceWithLifecycle extends ManagedNamespace implements Lifecycle {
 
-  private final LifecycleManager lifecycleManager = new LifecycleManager();
+  /** Keeps child lifecycle shutdown ahead of base namespace unregistration. */
+  private final LifecycleManager lifecycleManager =
+      new LifecycleManager(LifecycleManager.ShutdownOrder.INVERSE);
 
   public ManagedNamespaceWithLifecycle(OpcUaServer server, String namespaceUri) {
     super(server, namespaceUri);

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServer.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServer.java
@@ -30,6 +30,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import org.eclipse.milo.opcua.sdk.core.typetree.DataTypeTree;
 import org.eclipse.milo.opcua.sdk.core.typetree.ObjectTypeTree;
@@ -155,6 +156,15 @@ public class OpcUaServer extends AbstractServiceHandler {
   private final AtomicLong secureChannelTokenIds = new AtomicLong();
 
   private final Map<TransportProfile, OpcServerTransport> transports = new ConcurrentHashMap<>();
+
+  /**
+   * Shared shutdown result for the terminal server shutdown.
+   *
+   * <p>Shutdown tears down diagnostics and namespace state that cannot be safely torn down twice,
+   * so concurrent callers must observe the same operation instead of each running teardown logic.
+   */
+  private final AtomicReference<CompletableFuture<OpcUaServer>> shutdownFuture =
+      new AtomicReference<>();
 
   private final EventBus eventBus = new EventBus("server");
   private final EventFactory eventFactory = new EventFactory(this);
@@ -323,7 +333,48 @@ public class OpcUaServer extends AbstractServiceHandler {
     }
   }
 
+  /**
+   * Stop accepting new sessions and tear down the server runtime.
+   *
+   * <p>This method is the synchronization point for server shutdown. The first caller performs the
+   * shutdown sequence: reject new sessions, unbind transports, drain session listener work, close
+   * sessions, then shut down namespaces, diagnostics, events, and subscriptions. Concurrent callers
+   * receive the same {@link CompletableFuture} so namespace and diagnostics lifecycle code is only
+   * run once.
+   *
+   * <p>If shutdown is requested from a session listener callback, the shutdown path avoids waiting
+   * on the callback that is currently executing. When another caller is already waiting for
+   * listener quiescence, this method returns a completed future for that callback and the outer
+   * shutdown caller continues the real teardown after the callback returns.
+   *
+   * @return a future completed when the server shutdown sequence has finished.
+   */
   public CompletableFuture<OpcUaServer> shutdown() {
+    sessionManager.beginShutdown();
+
+    CompletableFuture<OpcUaServer> newShutdownFuture = new CompletableFuture<>();
+    if (!shutdownFuture.compareAndSet(null, newShutdownFuture)) {
+      CompletableFuture<OpcUaServer> existingShutdownFuture = shutdownFuture.get();
+      if (sessionManager.isSessionListenerCallback() && !existingShutdownFuture.isDone()) {
+        // The active shutdown is waiting for this callback to return; joining it here would
+        // deadlock the listener queue.
+        return CompletableFuture.completedFuture(this);
+      } else {
+        return existingShutdownFuture;
+      }
+    }
+
+    try {
+      shutdownInternal();
+      newShutdownFuture.complete(this);
+    } catch (Exception e) {
+      newShutdownFuture.completeExceptionally(e);
+    }
+
+    return newShutdownFuture;
+  }
+
+  private void shutdownInternal() {
     transports
         .values()
         .forEach(
@@ -336,14 +387,14 @@ public class OpcUaServer extends AbstractServiceHandler {
             });
     transports.clear();
 
+    sessionManager.shutdown();
+
     serverNamespace.shutdown();
     opcUaNamespace.shutdown();
 
     eventFactory.shutdown();
 
     subscriptions.values().forEach(Subscription::deleteSubscription);
-
-    return CompletableFuture.completedFuture(this);
   }
 
   public OpcUaServerConfig getConfig() {

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/Session.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/Session.java
@@ -23,6 +23,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.eclipse.milo.opcua.sdk.server.diagnostics.SessionDiagnostics;
 import org.eclipse.milo.opcua.sdk.server.diagnostics.SessionSecurityDiagnostics;
 import org.eclipse.milo.opcua.sdk.server.identity.Identity;
@@ -44,6 +45,19 @@ import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Server-side representation of an OPC UA Session.
+ *
+ * <p>A Session owns the per-client state established by CreateSession and ActivateSession:
+ * diagnostics, security context, user identity, continuation points, subscriptions, timeout
+ * tracking, and the secure channel association used to validate service calls. The {@link
+ * SessionManager} creates and indexes sessions, while the Session itself owns cleanup of the
+ * resources that hang from that client relationship.
+ *
+ * <p>Closing a Session is terminal and idempotent. Several paths can race to close the same
+ * Session, including client CloseSession, timeout checks, explicit server-side session removal, and
+ * server shutdown. Lifecycle listeners therefore observe at most one close notification.
+ */
 public class Session {
 
   private static final int IDENTITY_HISTORY_MAX_SIZE = 10;
@@ -56,6 +70,9 @@ public class Session {
   private final List<LifecycleListener> listeners = new CopyOnWriteArrayList<>();
 
   private final SubscriptionManager subscriptionManager;
+
+  /** Ensures timeout, subscription, and lifecycle cleanup run once across all close paths. */
+  private final AtomicBoolean closed = new AtomicBoolean(false);
 
   private final LinkedList<String> clientUserIdHistory = new LinkedList<>();
 
@@ -346,7 +363,21 @@ public class Session {
     return callSemaphore;
   }
 
+  /**
+   * Close this Session and release the resources owned by it.
+   *
+   * <p>This method may be reached concurrently from protocol handling, timeout handling, explicit
+   * administrative removal, and server shutdown. Only the first caller performs cleanup and
+   * notifies lifecycle listeners; later callers return without changing state.
+   *
+   * @param deleteSubscriptions {@code true} if subscriptions owned by this Session should be
+   *     deleted as part of the close.
+   */
   void close(boolean deleteSubscriptions) {
+    if (!closed.compareAndSet(false, true)) {
+      return;
+    }
+
     if (checkTimeoutFuture != null) {
       checkTimeoutFuture.cancel(false);
     }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/SessionListener.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/SessionListener.java
@@ -10,9 +10,28 @@
 
 package org.eclipse.milo.opcua.sdk.server;
 
+/**
+ * Listener for server-side session lifecycle notifications.
+ *
+ * <p>{@link SessionManager} delivers these callbacks asynchronously on its listener queue. During
+ * server shutdown, callbacks that are already running are allowed to finish before diagnostics and
+ * namespace teardown proceed, while callbacks that have not started may be skipped once shutdown
+ * has been requested. Implementations should therefore treat these notifications as best-effort
+ * lifecycle observations rather than as ownership of the Session itself.
+ */
 public interface SessionListener {
 
+  /**
+   * Called after a Session has been created and registered with the {@link SessionManager}.
+   *
+   * @param session the created Session.
+   */
   default void onSessionCreated(Session session) {}
 
+  /**
+   * Called after a Session has been closed and removed from the {@link SessionManager}.
+   *
+   * @param session the closed Session.
+   */
   default void onSessionClosed(Session session) {}
 }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/SessionManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/SessionManager.java
@@ -32,7 +32,9 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import org.eclipse.milo.opcua.sdk.server.identity.Identity;
 import org.eclipse.milo.opcua.sdk.server.identity.IdentityValidator;
@@ -95,6 +97,29 @@ public class SessionManager {
   private final TaskQueue sessionListenerTaskQueue;
 
   /**
+   * Marks executor threads while they are inside {@link SessionListener} callbacks.
+   *
+   * <p>Shutdown normally waits for in-flight listener callbacks, but a listener is allowed to
+   * trigger shutdown itself. In that re-entrant path the callback must not wait for the queue
+   * currently waiting for the callback to return.
+   */
+  private final ThreadLocal<Boolean> sessionListenerCallback = new ThreadLocal<>();
+
+  /** Completes when the one-time session shutdown cleanup has finished. */
+  private final CountDownLatch shutdownComplete = new CountDownLatch(1);
+
+  /**
+   * Terminal shutdown state for session creation and listener delivery.
+   *
+   * <p>{@link #beginShutdown()} moves the manager out of {@link ShutdownState#RUNNING} before
+   * transports are unbound, which rejects new CreateSession requests while existing listener work
+   * can still drain. {@link #shutdown()} performs the one-time cleanup and wakes any concurrent
+   * callers waiting on {@link #shutdownComplete}.
+   */
+  private final AtomicReference<ShutdownState> shutdownState =
+      new AtomicReference<>(ShutdownState.RUNNING);
+
+  /**
    * Store the last N client nonces and to make sure they aren't re-used.
    *
    * <p>This number is arbitrary; trying to prevent clients from re-using nonces is merely to
@@ -110,6 +135,16 @@ public class SessionManager {
     sessionListenerTaskQueue = new TaskQueue(executor);
   }
 
+  /** Session-manager shutdown phases. */
+  private enum ShutdownState {
+    /** Normal operation: CreateSession requests and listener notifications may proceed. */
+    RUNNING,
+    /** New sessions are rejected, but listener quiescence and session cleanup have not started. */
+    REQUESTED,
+    /** The one-time queue drain and session close pass have started. */
+    CLEANUP_STARTED
+  }
+
   /**
    * Kill the session identified by {@code nodeId} and optionally delete all its subscriptions.
    *
@@ -120,13 +155,7 @@ public class SessionManager {
     activeSessions.values().stream()
         .filter(s -> s.getSessionId().equals(nodeId))
         .findFirst()
-        .ifPresent(
-            s -> {
-              s.close(deleteSubscriptions);
-
-              sessionListenerTaskQueue.execute(
-                  () -> sessionListeners.forEach(l -> l.onSessionClosed(s)));
-            });
+        .ifPresent(s -> s.close(deleteSubscriptions));
   }
 
   /**
@@ -203,6 +232,10 @@ public class SessionManager {
 
   public CreateSessionResponse createSession(
       ServiceRequestContext context, CreateSessionRequest request) throws UaException {
+
+    if (isShutdownRequested()) {
+      throw new UaException(StatusCodes.Bad_Shutdown);
+    }
 
     ByteString serverNonce = NonceUtil.generateNonce(32);
     NodeId authenticationToken = new NodeId(0, NonceUtil.generateNonce(32));
@@ -350,6 +383,11 @@ public class SessionManager {
     // CreateSession requests cannot exceed the maximum. Done after validation so that a request
     // which is going to fail never evicts another client's pending session.
     synchronized (sessionLock) {
+      if (isShutdownRequested()) {
+        session.close(false);
+        throw new UaException(StatusCodes.Bad_Shutdown);
+      }
+
       long maxSessionCount = server.getConfig().getLimits().getMaxSessions().longValue();
       if (createdSessions.size() + activeSessions.size() >= maxSessionCount) {
         // OPC UA Part 4, 5.7.2: at the session limit the Server shall close the oldest Session
@@ -375,15 +413,13 @@ public class SessionManager {
             createdSessions.remove(authenticationToken);
             activeSessions.remove(authenticationToken);
 
-            sessionListenerTaskQueue.execute(
-                () -> sessionListeners.forEach(l -> l.onSessionClosed(s)));
+            fireSessionClosed(s);
           });
 
       createdSessions.put(authenticationToken, session);
     }
 
-    sessionListenerTaskQueue.execute(
-        () -> sessionListeners.forEach(l -> l.onSessionCreated(session)));
+    fireSessionCreated(session);
 
     return new CreateSessionResponse(
         createResponseHeader(request),
@@ -396,6 +432,151 @@ public class SessionManager {
         new SignedSoftwareCertificate[0],
         serverSignature,
         uint(maxRequestMessageSize));
+  }
+
+  /**
+   * Drain session listener callbacks, stop accepting queued listener work, and close all sessions.
+   *
+   * <p>The first caller performs cleanup. Concurrent callers outside a listener callback wait for
+   * that cleanup to complete so their caller can safely continue to namespace teardown. If the
+   * caller is itself a session listener callback, shutdown stops the queue without waiting for the
+   * current callback and discards queued callbacks that have not started.
+   */
+  void shutdown() {
+    boolean sessionListenerCallback = isSessionListenerCallback();
+
+    beginShutdown();
+
+    if (!shutdownState.compareAndSet(ShutdownState.REQUESTED, ShutdownState.CLEANUP_STARTED)) {
+      if (!sessionListenerCallback) {
+        awaitShutdownComplete();
+      }
+      return;
+    }
+
+    try {
+      sessionListenerTaskQueue.shutdown(!sessionListenerCallback);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      logger.warn("Interrupted while waiting for session listener callbacks to complete", e);
+    } finally {
+      try {
+        List<Session> sessions;
+        synchronized (sessionLock) {
+          sessions = getAllSessions();
+          createdSessions.clear();
+          activeSessions.clear();
+        }
+
+        sessions.forEach(s -> s.close(true));
+      } finally {
+        shutdownComplete.countDown();
+      }
+    }
+  }
+
+  /**
+   * Mark shutdown as requested before transports are unbound.
+   *
+   * <p>This early transition is visible to {@link #createSession(ServiceRequestContext,
+   * CreateSessionRequest)}, causing new CreateSession requests to fail with {@link
+   * StatusCodes#Bad_Shutdown} while the server drains already-started session listener callbacks.
+   */
+  void beginShutdown() {
+    shutdownState.compareAndSet(ShutdownState.RUNNING, ShutdownState.REQUESTED);
+  }
+
+  private boolean isShutdownRequested() {
+    return shutdownState.get() != ShutdownState.RUNNING;
+  }
+
+  /**
+   * Return whether the current thread is executing a {@link SessionListener} notification.
+   *
+   * <p>{@link OpcUaServer#shutdown()} uses this to avoid returning an in-progress shutdown future
+   * to the callback that the in-progress shutdown is waiting for.
+   *
+   * @return {@code true} if the current thread is inside session listener notification dispatch.
+   */
+  boolean isSessionListenerCallback() {
+    return Boolean.TRUE.equals(sessionListenerCallback.get());
+  }
+
+  /** Wait for the first shutdown caller to finish the session cleanup pass. */
+  private void awaitShutdownComplete() {
+    try {
+      shutdownComplete.await();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      logger.warn("Interrupted while waiting for session shutdown to complete", e);
+    }
+  }
+
+  /** Queue a session-created notification unless shutdown has already started. */
+  private void fireSessionCreated(Session session) {
+    if (!isShutdownRequested()) {
+      sessionListenerTaskQueue.execute(
+          () -> {
+            if (!isShutdownRequested()) {
+              notifySessionCreated(session);
+            }
+          });
+    }
+  }
+
+  /** Queue a session-closed notification unless shutdown has already started. */
+  private void fireSessionClosed(Session session) {
+    if (!isShutdownRequested()) {
+      sessionListenerTaskQueue.execute(
+          () -> {
+            if (!isShutdownRequested()) {
+              notifySessionClosed(session);
+            }
+          });
+    }
+  }
+
+  /** Notify listeners until shutdown starts or the listener snapshot is exhausted. */
+  private void notifySessionCreated(Session session) {
+    withSessionListenerCallback(
+        () -> {
+          for (SessionListener listener : sessionListeners) {
+            if (isShutdownRequested()) {
+              break;
+            }
+
+            listener.onSessionCreated(session);
+          }
+        });
+  }
+
+  /** Notify listeners until shutdown starts or the listener snapshot is exhausted. */
+  private void notifySessionClosed(Session session) {
+    withSessionListenerCallback(
+        () -> {
+          for (SessionListener listener : sessionListeners) {
+            if (isShutdownRequested()) {
+              break;
+            }
+
+            listener.onSessionClosed(session);
+          }
+        });
+  }
+
+  /** Run listener dispatch with re-entrant shutdown detection enabled for the current thread. */
+  private void withSessionListenerCallback(Runnable notification) {
+    Boolean previous = sessionListenerCallback.get();
+    sessionListenerCallback.set(true);
+    try {
+      notification.run();
+    } finally {
+      if (previous != null) {
+        sessionListenerCallback.set(previous);
+      } else {
+        sessionListenerCallback.remove();
+      }
+    }
   }
 
   private SecurityConfiguration createSecurityConfiguration(SecureChannel secureChannel)

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/namespaces/ServerNamespace.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/namespaces/ServerNamespace.java
@@ -29,9 +29,18 @@ import org.eclipse.milo.opcua.sdk.server.util.SubscriptionModel;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
 
+/**
+ * Server-owned namespace that exposes nodes from the standard Server object hierarchy.
+ *
+ * <p>The namespace registers itself with the server address-space manager and owns fragments such
+ * as diagnostics. Those fragments can depend on their nodes and node managers still being
+ * registered while they shut down, so lifecycle shutdown runs in reverse registration order.
+ */
 public class ServerNamespace extends AddressSpaceComposite implements Lifecycle, Namespace {
 
-  private final LifecycleManager lifecycleManager = new LifecycleManager();
+  /** Keeps diagnostics and other child fragments alive until they have shut themselves down. */
+  private final LifecycleManager lifecycleManager =
+      new LifecycleManager(LifecycleManager.ShutdownOrder.INVERSE);
 
   private final String namespaceUri;
   private final UShort namespaceIndex;

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/SessionTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/SessionTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ubyte;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
+import org.eclipse.milo.opcua.stack.core.transport.TransportProfile;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.ApplicationType;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.MessageSecurityMode;
+import org.eclipse.milo.opcua.stack.core.types.structured.ApplicationDescription;
+import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
+import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
+import org.junit.jupiter.api.Test;
+
+/** Tests session lifecycle behavior that is local to {@link Session}. */
+class SessionTest {
+
+  @Test
+  void closeNotifiesLifecycleListenersOnce() {
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    ScheduledExecutorService scheduledExecutor = mock(ScheduledExecutorService.class);
+    ScheduledFuture<?> timeoutFuture = mock(ScheduledFuture.class);
+
+    OpcUaServerConfig config = mock(OpcUaServerConfig.class);
+    when(config.getExecutor()).thenReturn(executor);
+
+    OpcUaServer server = mock(OpcUaServer.class);
+    when(server.getConfig()).thenReturn(config);
+    when(server.getScheduledExecutorService()).thenReturn(scheduledExecutor);
+    doReturn(timeoutFuture)
+        .when(scheduledExecutor)
+        .schedule(any(Runnable.class), anyLong(), eq(TimeUnit.NANOSECONDS));
+
+    try {
+      Session session =
+          new Session(
+              server,
+              new NodeId(1, "session"),
+              "session",
+              Duration.ofMinutes(1),
+              clientDescription(),
+              "urn:eclipse:milo:test",
+              uint(0),
+              endpointDescription(),
+              1L,
+              new SecurityConfiguration(
+                  SecurityPolicy.None, MessageSecurityMode.None, null, null, null, null, null));
+
+      AtomicInteger closed = new AtomicInteger();
+      session.addLifecycleListener((s, subscriptionsDeleted) -> closed.incrementAndGet());
+
+      session.close(false);
+      session.close(false);
+
+      assertEquals(1, closed.get());
+      verify(timeoutFuture, times(1)).cancel(false);
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  private static ApplicationDescription clientDescription() {
+    return new ApplicationDescription(
+        "urn:eclipse:milo:test:client",
+        "urn:eclipse:milo:test",
+        LocalizedText.english("test client"),
+        ApplicationType.Client,
+        null,
+        null,
+        null);
+  }
+
+  private static EndpointDescription endpointDescription() {
+    return new EndpointDescription(
+        "opc.tcp://localhost:12685",
+        clientDescription(),
+        ByteString.NULL_VALUE,
+        MessageSecurityMode.None,
+        SecurityPolicy.None.getUri(),
+        new UserTokenPolicy[0],
+        TransportProfile.TCP_UASC_UABINARY.getUri(),
+        ubyte(0));
+  }
+}


### PR DESCRIPTION
## Summary

Make server shutdown the synchronization point for session listener quiescence so diagnostics and namespace teardown no longer race with session callbacks.

- Stop accepting new sessions as soon as shutdown begins so new CreateSession work cannot enqueue diagnostics callbacks during teardown.
- Drain in-flight session listener callbacks before namespace and diagnostics shutdown, while still avoiding self-deadlock when shutdown is requested from a listener callback.
- Make session close idempotent so concurrent shutdown, timeout, and close paths notify lifecycle listeners only once.
- Shut down managed lifecycle children before unregistering their node managers, keeping diagnostics nodes valid during child teardown.
- Remove sleep-based shutdown ordering from examples and integration test cleanup.

## Key Changes

- **Server shutdown ownership:** `OpcUaServer.shutdown()` now uses a shared shutdown future so concurrent callers observe the same teardown instead of running namespace and diagnostics shutdown multiple times.
- **Session listener quiescence:** `SessionManager` tracks shutdown state, rejects new sessions with `Bad_Shutdown`, drains listener work, and skips queued callbacks once shutdown starts.
- **Re-entrant shutdown handling:** Session listener dispatch marks callback threads so shutdown requested from inside a listener does not wait on itself, while external callers still wait for the active shutdown to finish.
- **Lifecycle ordering:** Managed namespace/address-space lifecycle managers now shut down in inverse registration order so child diagnostics and subscription lifecycles run before node managers are unregistered.
- **Test cleanup:** Sleep-based waits were removed because `server.shutdown()` now provides the ordering guarantee.

## Testing

- `SessionTest` covers idempotent `Session.close(...)` behavior and verifies lifecycle listeners are notified once.
- `ServerShutdownSessionDiagnosticsRaceTest` covers blocked session listener shutdown, concurrent shutdown callers, and shutdown requested from inside a session listener callback.
- `mvn -q spotless:apply`
- `mvn -q -pl opc-ua-sdk/sdk-server -am test -Dtest=SessionTest -Dsurefire.failIfNoSpecifiedTests=false`
- `mvn -q -pl opc-ua-sdk/integration-tests -am test -Dtest=ServerShutdownSessionDiagnosticsRaceTest -Dsurefire.failIfNoSpecifiedTests=false`
- `mvn -q clean compile`
