### PR TITLE
Preserve Matrix type metadata for empty values

### DIFF
--- a/opc-ua-sdk/codec-json/src/main/java/org/eclipse/milo/sdk/core/types/json/JsonStructCodec.java
+++ b/opc-ua-sdk/codec-json/src/main/java/org/eclipse/milo/sdk/core/types/json/JsonStructCodec.java
@@ -730,20 +730,30 @@ public class JsonStructCodec extends GenericDataTypeCodec<JsonStruct> {
         encoder.encodeMatrix(fieldName, matrix);
       } else if (hint instanceof EnumHint) {
         Object[] flatArray = encodeEnumMatrix(dataTypeId.expanded(), jsonArray);
-        var matrix = new Matrix(flatArray, getDimensions(jsonArray), OpcUaDataType.Int32);
+        var matrix =
+            new Matrix(
+                flatArray, getDimensions(jsonArray), OpcUaDataType.Int32, dataTypeId.expanded());
         encoder.encodeEnumMatrix(fieldName, matrix);
       } else if (hint instanceof StructHint) {
         if (dataTypeId.equals(NodeIds.Structure) || fieldAllowsSubtyping(field)) {
           Object[] flatArray =
               encodeStructMatrix(encoder.getEncodingContext(), dataTypeTree, jsonArray, true);
           var matrix =
-              new Matrix(flatArray, getDimensions(jsonArray), OpcUaDataType.ExtensionObject);
+              new Matrix(
+                  flatArray,
+                  getDimensions(jsonArray),
+                  OpcUaDataType.ExtensionObject,
+                  dataTypeId.expanded());
           encoder.encodeMatrix(fieldName, matrix);
         } else {
           Object[] flatArray =
               encodeStructMatrix(encoder.getEncodingContext(), dataTypeTree, jsonArray, false);
           var matrix =
-              new Matrix(flatArray, getDimensions(jsonArray), OpcUaDataType.ExtensionObject);
+              new Matrix(
+                  flatArray,
+                  getDimensions(jsonArray),
+                  OpcUaDataType.ExtensionObject,
+                  dataTypeId.expanded());
           encoder.encodeStructMatrix(fieldName, matrix, dataTypeId);
         }
       } else {

--- a/opc-ua-sdk/sdk-core/src/main/java/org/eclipse/milo/opcua/sdk/core/types/codec/FieldUtil.java
+++ b/opc-ua-sdk/sdk-core/src/main/java/org/eclipse/milo/opcua/sdk/core/types/codec/FieldUtil.java
@@ -207,7 +207,11 @@ class FieldUtil {
       } else if (fieldHint instanceof FieldHint.Enum hint) {
         Matrix matrix = decoder.decodeEnumMatrix(fieldName);
 
-        return matrix.transform(v -> new DynamicEnumType(hint.dataType, (Integer) v));
+        return matrix.transform(
+            v -> new DynamicEnumType(hint.dataType, (Integer) v),
+            DynamicEnumType.class,
+            OpcUaDataType.Int32,
+            hint.dataType.getNodeId().expanded());
       } else if (fieldHint instanceof FieldHint.Struct) {
         if (dataTypeId.equals(NodeIds.Structure) || fieldAllowsSubtyping(definition, field)) {
           Matrix matrix = decoder.decodeMatrix(fieldName, OpcUaDataType.ExtensionObject);
@@ -216,7 +220,10 @@ class FieldUtil {
               o -> {
                 ExtensionObject xo = (ExtensionObject) o;
                 return xo.decode(decoder.getEncodingContext());
-              });
+              },
+              UaStructuredType.class,
+              OpcUaDataType.ExtensionObject,
+              dataTypeId.expanded());
         } else {
           return decoder.decodeStructMatrix(fieldName, dataTypeId);
         }
@@ -310,7 +317,9 @@ class FieldUtil {
 
           Matrix xoMatrix =
               matrix.transform(
-                  o -> ExtensionObject.encode(encoder.getEncodingContext(), (UaStructuredType) o));
+                  o -> ExtensionObject.encode(encoder.getEncodingContext(), (UaStructuredType) o),
+                  ExtensionObject.class,
+                  OpcUaDataType.ExtensionObject);
 
           encoder.encodeMatrix(fieldName, xoMatrix);
         } else {
@@ -325,7 +334,9 @@ class FieldUtil {
                   o -> {
                     DynamicStructType structValue = (DynamicStructType) o;
                     return ExtensionObject.encode(encoder.getEncodingContext(), structValue);
-                  });
+                  },
+                  ExtensionObject.class,
+                  OpcUaDataType.ExtensionObject);
 
           encoder.encodeMatrix(fieldName, xoMatrix);
         } else {

--- a/opc-ua-stack/encoding-json/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonDecoder.java
+++ b/opc-ua-stack/encoding-json/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonDecoder.java
@@ -1590,7 +1590,8 @@ public class OpcUaJsonDecoder implements UaDecoder {
 
           validateMatrixDimensions(flatArray, dimensions);
 
-          return new Matrix(flatArray, dimensions, OpcUaDataType.ExtensionObject);
+          return new Matrix(
+              flatArray, dimensions, OpcUaDataType.ExtensionObject, dataTypeId.expanded());
         } finally {
           jsonReader.endObject();
         }

--- a/opc-ua-stack/encoding-xml/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlDecoder.java
+++ b/opc-ua-stack/encoding-xml/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlDecoder.java
@@ -1352,7 +1352,10 @@ public class OpcUaXmlDecoder implements UaDecoder, AutoCloseable {
           }
 
           return struct;
-        });
+        },
+        expectedType,
+        OpcUaDataType.ExtensionObject,
+        dataTypeId.expanded());
   }
 
   @Override

--- a/opc-ua-stack/encoding-xml/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlEncoder.java
+++ b/opc-ua-stack/encoding-xml/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlEncoder.java
@@ -751,12 +751,19 @@ public class OpcUaXmlEncoder implements UaEncoder, AutoCloseable {
         switch (typeHint) {
           case BUILTIN -> encodeMatrix("Matrix", matrix);
           case ENUM -> {
-            Matrix transformed = matrix.transform(e -> ((UaEnumeratedType) e).getValue());
+            Matrix transformed =
+                matrix.transform(
+                    e -> ((UaEnumeratedType) e).getValue(), Integer.class, OpcUaDataType.Int32);
             encodeMatrix("Matrix", transformed);
           }
           case STRUCT -> encodeStructMatrix("Matrix", matrix, matrix.getDataTypeId().orElseThrow());
           case OPTION_SET -> {
-            Matrix transformed = matrix.transform(os -> ((OptionSetUInteger<?>) os).getValue());
+            OpcUaDataType optionSetDataType = matrix.getDataType().orElseThrow();
+            Matrix transformed =
+                matrix.transform(
+                    os -> ((OptionSetUInteger<?>) os).getValue(),
+                    optionSetDataType.getBackingClass(),
+                    optionSetDataType);
             encodeMatrix("Matrix", transformed);
           }
         }
@@ -1933,7 +1940,9 @@ public class OpcUaXmlEncoder implements UaEncoder, AutoCloseable {
             e -> {
               UaStructuredType struct = (UaStructuredType) e;
               return ExtensionObject.encode(context, struct, OpcUaDefaultXmlEncoding.getInstance());
-            });
+            },
+            ExtensionObject.class,
+            OpcUaDataType.ExtensionObject);
 
     encodeMatrix(field, transformed);
   }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryDecoder.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryDecoder.java
@@ -1317,7 +1317,7 @@ public class OpcUaBinaryDecoder implements UaDecoder {
       Array.set(flatArray, i, value);
     }
 
-    return new Matrix(flatArray, dimensions, OpcUaDataType.ExtensionObject);
+    return new Matrix(flatArray, dimensions, OpcUaDataType.ExtensionObject, dataTypeId.expanded());
   }
 
   @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/Matrix.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/Matrix.java
@@ -72,10 +72,18 @@ public class Matrix {
   }
 
   public Matrix(Object flatArray, int[] dimensions, OpcUaDataType dataType) {
+    this(flatArray, dimensions, dataType, null);
+  }
+
+  public Matrix(
+      Object flatArray,
+      int[] dimensions,
+      OpcUaDataType dataType,
+      @Nullable ExpandedNodeId dataTypeId) {
     this.flatArray = flatArray;
     this.dimensions = dimensions;
     this.dataType = dataType;
-    this.dataTypeId = deriveDataTypeId(flatArray);
+    this.dataTypeId = dataTypeId != null ? dataTypeId : deriveDataTypeId(flatArray);
 
     assert flatArray != null && dimensions.length > 1 && dataType != null;
   }
@@ -178,9 +186,14 @@ public class Matrix {
     if (flatArray == null) {
       return new Matrix(null);
     } else {
+      int length = Array.getLength(flatArray);
+      if (length == 0) {
+        Object transformedArray = Array.newInstance(ArrayUtil.getType(flatArray), 0);
+        return new Matrix(transformedArray, dimensions, dataType, dataTypeId);
+      }
+
       Object transformedArray = null;
 
-      int length = Array.getLength(flatArray);
       for (int i = 0; i < length; i++) {
         Object e = Array.get(flatArray, i);
         Object t = f.apply(e);
@@ -191,6 +204,64 @@ public class Matrix {
       }
 
       return new Matrix(transformedArray, dimensions);
+    }
+  }
+
+  /**
+   * Create a new Matrix by applying the transform function {@code f} to each element, using
+   * explicit metadata for the transformed element type.
+   *
+   * <p>Use this overload when the Matrix may be empty and the transformed element type cannot be
+   * inferred from the first transformed element.
+   *
+   * @param f the transform function applied to each element.
+   * @param transformedType the Java class of the transformed elements.
+   * @param transformedDataType the {@link OpcUaDataType} of the transformed elements.
+   * @return a new Matrix containing transformed elements.
+   */
+  public Matrix transform(
+      Function<Object, Object> f, Class<?> transformedType, OpcUaDataType transformedDataType) {
+    return transform(f, transformedType, transformedDataType, null);
+  }
+
+  /**
+   * Create a new Matrix by applying the transform function {@code f} to each element, using
+   * explicit metadata for the transformed element type.
+   *
+   * <p>Use this overload when the Matrix may be empty and the transformed element type cannot be
+   * inferred from the first transformed element.
+   *
+   * @param f the transform function applied to each element.
+   * @param transformedType the Java class of the transformed elements.
+   * @param transformedDataType the {@link OpcUaDataType} of the transformed elements.
+   * @param transformedDataTypeId the {@link ExpandedNodeId} of the transformed element DataType.
+   * @return a new Matrix containing transformed elements.
+   */
+  public Matrix transform(
+      Function<Object, Object> f,
+      Class<?> transformedType,
+      OpcUaDataType transformedDataType,
+      @Nullable ExpandedNodeId transformedDataTypeId) {
+    if (flatArray == null) {
+      return new Matrix(null);
+    } else {
+      int length = Array.getLength(flatArray);
+      Object transformedArray = null;
+
+      for (int i = 0; i < length; i++) {
+        Object e = Array.get(flatArray, i);
+        Object t = f.apply(e);
+        if (transformedArray == null) {
+          transformedArray = Array.newInstance(t.getClass(), length);
+        }
+        Array.set(transformedArray, i, t);
+      }
+
+      if (transformedArray == null) {
+        transformedArray = Array.newInstance(transformedType, 0);
+      }
+
+      return new Matrix(transformedArray, dimensions, transformedDataType, transformedDataTypeId);
     }
   }
 
@@ -282,6 +353,10 @@ public class Matrix {
   }
 
   private static @Nullable OpcUaDataType deriveBuiltinType(Object flatArray) {
+    if (flatArray == null) {
+      return null;
+    }
+
     Class<?> type = ArrayUtil.getType(flatArray);
 
     return deriveBuiltinType(type);
@@ -312,9 +387,17 @@ public class Matrix {
   }
 
   private static @Nullable ExpandedNodeId deriveDataTypeId(Object flatArray) {
+    if (flatArray == null) {
+      return null;
+    }
+
     Class<?> type = ArrayUtil.getType(flatArray);
 
     if (UaEnumeratedType.class.isAssignableFrom(type)) {
+      if (Array.getLength(flatArray) == 0) {
+        return null;
+      }
+
       Object e = Array.get(flatArray, 0);
       if (e instanceof UaEnumeratedType) {
         return ((UaEnumeratedType) e).getTypeId();
@@ -322,6 +405,10 @@ public class Matrix {
         return null;
       }
     } else if (UaStructuredType.class.isAssignableFrom(type)) {
+      if (Array.getLength(flatArray) == 0) {
+        return null;
+      }
+
       Object e = Array.get(flatArray, 0);
       if (e instanceof UaStructuredType) {
         return ((UaStructuredType) e).getTypeId();

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryDecoderTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryDecoderTest.java
@@ -22,6 +22,7 @@ import org.eclipse.milo.opcua.stack.core.UaSerializationException;
 import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Matrix;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.structured.XVType;
 import org.junit.jupiter.api.Test;
 
 public class OpcUaBinaryDecoderTest {
@@ -128,6 +129,26 @@ public class OpcUaBinaryDecoderTest {
 
     assertArrayEquals(new int[] {0, 2}, matrix.getDimensions());
     assertEquals(0, Array.getLength(matrix.getElements()));
+  }
+
+  @Test
+  void decodeStructMatrixAllowsZeroDimensions() throws Exception {
+    ByteBuf buffer = Unpooled.buffer();
+    buffer.writeIntLE(2);
+    buffer.writeIntLE(0);
+    buffer.writeIntLE(2);
+
+    Matrix matrix =
+        new OpcUaBinaryDecoder(DefaultEncodingContext.INSTANCE)
+            .setBuffer(buffer)
+            .decodeStructMatrix(
+                null,
+                XVType.TYPE_ID.toNodeIdOrThrow(
+                    DefaultEncodingContext.INSTANCE.getNamespaceTable()));
+
+    assertArrayEquals(new int[] {0, 2}, matrix.getDimensions());
+    assertEquals(0, Array.getLength(matrix.getElements()));
+    assertEquals(XVType.TYPE_ID, matrix.getDataTypeId().orElseThrow());
   }
 
   @Test

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/types/builtin/MatrixTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/types/builtin/MatrixTest.java
@@ -10,11 +10,14 @@
 
 package org.eclipse.milo.opcua.stack.core.types.builtin;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.reflect.Array;
 import java.util.Arrays;
 import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.ApplicationType;
 import org.eclipse.milo.opcua.stack.core.types.structured.ThreeDVector;
 import org.junit.jupiter.api.Test;
 
@@ -50,6 +53,62 @@ class MatrixTest {
             });
 
     assertEquals(expected, transformed);
+  }
+
+  @Test
+  void transformEmptyMatrixWithExplicitType() {
+    Matrix m = new Matrix(new Integer[0], new int[] {0, 2}, OpcUaDataType.Int32);
+
+    Matrix transformed = m.transform(Object::toString, String.class, OpcUaDataType.String);
+
+    assertArrayEquals(new int[] {0, 2}, transformed.getDimensions());
+    assertEquals(0, Array.getLength(transformed.getElements()));
+    assertEquals(String.class, transformed.getElementType().orElseThrow());
+    assertEquals(OpcUaDataType.String, transformed.getDataType().orElseThrow());
+    assertEquals(
+        OpcUaDataType.String.getNodeId().expanded(), transformed.getDataTypeId().orElseThrow());
+  }
+
+  @Test
+  void emptyStructuredMatrixCanCarryExplicitDataTypeId() {
+    Matrix m =
+        new Matrix(
+            new ThreeDVector[0],
+            new int[] {0, 2},
+            OpcUaDataType.ExtensionObject,
+            ThreeDVector.TYPE_ID);
+
+    assertArrayEquals(new int[] {0, 2}, m.getDimensions());
+    assertEquals(0, Array.getLength(m.getElements()));
+    assertEquals(ThreeDVector.class, m.getElementType().orElseThrow());
+    assertEquals(OpcUaDataType.ExtensionObject, m.getDataType().orElseThrow());
+    assertEquals(ThreeDVector.TYPE_ID, m.getDataTypeId().orElseThrow());
+  }
+
+  @Test
+  void emptyStructuredMatrixWithoutExplicitDataTypeIdDoesNotReadElementZero() {
+    Matrix m = new Matrix(new ThreeDVector[0], new int[] {0, 2}, OpcUaDataType.ExtensionObject);
+
+    assertArrayEquals(new int[] {0, 2}, m.getDimensions());
+    assertEquals(0, Array.getLength(m.getElements()));
+    assertEquals(OpcUaDataType.ExtensionObject, m.getDataType().orElseThrow());
+    assertTrue(m.getDataTypeId().isEmpty());
+  }
+
+  @Test
+  void emptyEnumeratedMatrixCanCarryExplicitDataTypeId() {
+    Matrix m =
+        new Matrix(
+            new ApplicationType[0],
+            new int[] {0, 2},
+            OpcUaDataType.Int32,
+            ApplicationType.TypeInfo.TYPE_ID);
+
+    assertArrayEquals(new int[] {0, 2}, m.getDimensions());
+    assertEquals(0, Array.getLength(m.getElements()));
+    assertEquals(ApplicationType.class, m.getElementType().orElseThrow());
+    assertEquals(OpcUaDataType.Int32, m.getDataType().orElseThrow());
+    assertEquals(ApplicationType.TypeInfo.TYPE_ID, m.getDataTypeId().orElseThrow());
   }
 
   @Test


### PR DESCRIPTION
## Summary

Allow zero-length structured and enumerated Matrix values to retain their declared type metadata across decode, encode, and transform paths.

- Add explicit Matrix DataTypeId support so empty structured/enumerated matrices do not infer concrete type metadata from element 0.
- Preserve declared DataTypeIds when constructing structured matrices in binary, JSON, XML, and dynamic codec paths.
- Add typed Matrix transform overloads for empty matrix conversions where the transformed element type cannot be inferred from data.
- Add regression coverage for zero-dimension structured matrix decoding and empty Matrix metadata behavior.

## Key Changes

- **Matrix metadata:** Matrix can now carry an explicit `ExpandedNodeId` for the concrete element DataType. Empty structured and enumerated arrays no longer attempt to read element 0 during DataTypeId derivation.

- **Decode paths:** Structured matrix decoders pass the declared DataTypeId into Matrix construction so empty values keep the schema type known by the caller.

- **Transform paths:** Matrix transformations used by XML encoding and dynamic field codecs can now provide explicit output metadata. This keeps empty transformed matrices valid without changing non-empty inference behavior.

- **JSON struct codec:** Enum and structured matrices created from JSON field definitions preserve the declared DataTypeId before being passed to downstream encoders.

## References

- OPC 10000-6, 5.2.5: Matrix values with zero dimensions may encode no element values.
- Related hardening: #1784
