### PR TITLE
Fix non-Value attribute writes

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/api/util/AttributeWriterTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/api/util/AttributeWriterTest.java
@@ -14,11 +14,13 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ulong;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.eclipse.milo.opcua.sdk.core.AccessLevel;
 import org.eclipse.milo.opcua.sdk.core.Reference;
@@ -43,6 +45,8 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.structured.AccessLevelExType;
+import org.eclipse.milo.opcua.stack.core.types.structured.WriteValue;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -332,6 +336,96 @@ public class AttributeWriterTest extends AbstractClientServerTest {
     assertEquals(new StatusCode(StatusCodes.Bad_NotWritable), fail);
   }
 
+  @Test
+  void writeNonValueAttributeUnwrapsDataValue() throws Exception {
+    LocalizedText displayName = LocalizedText.english("UpdatedDisplayName");
+
+    StatusCode statusCode =
+        client
+            .writeAsync(
+                List.of(
+                    new WriteValue(
+                        new NodeId(2, "WritableDisplayName"),
+                        AttributeId.DisplayName.uid(),
+                        null,
+                        DataValue.valueOnly(new Variant(displayName)))))
+            .get(5, TimeUnit.SECONDS)
+            .getResults()[0];
+
+    assertEquals(StatusCode.GOOD, statusCode);
+    assertEquals(
+        displayName,
+        getManagedNode("WritableDisplayName")
+            .getAttribute(AccessContext.INTERNAL, AttributeId.DisplayName));
+  }
+
+  @Test
+  void rejectNonValueAttributeTypeMismatch() throws Exception {
+    StatusCode statusCode =
+        client
+            .writeAsync(
+                List.of(
+                    new WriteValue(
+                        new NodeId(2, "WritableDisplayName"),
+                        AttributeId.DisplayName.uid(),
+                        null,
+                        DataValue.valueOnly(new Variant("not a LocalizedText")))))
+            .get(5, TimeUnit.SECONDS)
+            .getResults()[0];
+
+    assertEquals(new StatusCode(StatusCodes.Bad_TypeMismatch), statusCode);
+  }
+
+  @Test
+  void writeNonValueArrayAttributeUnwrapsDataValue() throws Exception {
+    UInteger[] arrayDimensions = new UInteger[] {uint(3)};
+
+    StatusCode statusCode =
+        client
+            .writeAsync(
+                List.of(
+                    new WriteValue(
+                        new NodeId(2, "WritableArrayDimensions"),
+                        AttributeId.ArrayDimensions.uid(),
+                        null,
+                        DataValue.valueOnly(new Variant(arrayDimensions)))))
+            .get(5, TimeUnit.SECONDS)
+            .getResults()[0];
+
+    assertEquals(StatusCode.GOOD, statusCode);
+    assertArrayEquals(
+        arrayDimensions,
+        (UInteger[])
+            getManagedNode("WritableArrayDimensions")
+                .getAttribute(AccessContext.INTERNAL, AttributeId.ArrayDimensions));
+  }
+
+  @Test
+  void writeNonValueOptionSetAttributeConvertsBackingType() throws Exception {
+    UInteger accessLevelEx = uint(3);
+
+    StatusCode statusCode =
+        client
+            .writeAsync(
+                List.of(
+                    new WriteValue(
+                        new NodeId(2, "WritableAccessLevelEx"),
+                        AttributeId.AccessLevelEx.uid(),
+                        null,
+                        DataValue.valueOnly(new Variant(accessLevelEx)))))
+            .get(5, TimeUnit.SECONDS)
+            .getResults()[0];
+
+    assertEquals(StatusCode.GOOD, statusCode);
+
+    AccessLevelExType value =
+        (AccessLevelExType)
+            getManagedNode("WritableAccessLevelEx")
+                .getAttribute(AccessContext.INTERNAL, AttributeId.AccessLevelEx);
+
+    assertEquals(accessLevelEx, value.getValue());
+  }
+
   @BeforeAll
   void configure() {
     testNamespace.configure(
@@ -401,6 +495,47 @@ public class AttributeWriterTest extends AbstractClientServerTest {
                 b.setDataType(NodeIds.Int32);
                 b.setAccessLevel(AccessLevel.READ_WRITE);
                 b.setUserAccessLevel(AccessLevel.READ_WRITE);
+                return b.buildAndAdd();
+              });
+
+          UaVariableNode.build(
+              context,
+              b -> {
+                b.setNodeId(new NodeId(2, "WritableDisplayName"));
+                b.setBrowseName(new QualifiedName(2, "WritableDisplayName"));
+                b.setDisplayName(LocalizedText.english("WritableDisplayName"));
+                b.setDataType(NodeIds.Int32);
+                b.setWriteMask(UInteger.valueOf(WriteMask.DisplayName.getValue()));
+                b.setUserWriteMask(UInteger.valueOf(WriteMask.DisplayName.getValue()));
+                return b.buildAndAdd();
+              });
+
+          UaVariableNode.build(
+              context,
+              b -> {
+                b.setNodeId(new NodeId(2, "WritableArrayDimensions"));
+                b.setBrowseName(new QualifiedName(2, "WritableArrayDimensions"));
+                b.setDisplayName(LocalizedText.english("WritableArrayDimensions"));
+                b.setDataType(NodeIds.Int32);
+                b.setValueRank(ValueRanks.OneDimension);
+                b.setArrayDimensions(new UInteger[] {UInteger.valueOf(0)});
+                b.setWriteMask(UInteger.valueOf(WriteMask.ArrayDimensions.getValue()));
+                b.setUserWriteMask(UInteger.valueOf(WriteMask.ArrayDimensions.getValue()));
+                return b.buildAndAdd();
+              });
+
+          UaVariableNode.build(
+              context,
+              b -> {
+                b.setNodeId(new NodeId(2, "WritableAccessLevelEx"));
+                b.setBrowseName(new QualifiedName(2, "WritableAccessLevelEx"));
+                b.setDisplayName(LocalizedText.english("WritableAccessLevelEx"));
+                b.setDataType(NodeIds.Int32);
+                b.setAccessLevel(AccessLevel.READ_WRITE);
+                b.setUserAccessLevel(AccessLevel.READ_WRITE);
+                b.setAccessLevelEx(new AccessLevelExType(uint(0)));
+                b.setWriteMask(UInteger.valueOf(WriteMask.AccessLevelEx.getValue()));
+                b.setUserWriteMask(UInteger.valueOf(WriteMask.AccessLevelEx.getValue()));
                 return b.buildAndAdd();
               });
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/AttributeWriter.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/AttributeWriter.java
@@ -20,14 +20,21 @@ import org.eclipse.milo.opcua.sdk.core.WriteMask;
 import org.eclipse.milo.opcua.sdk.core.nodes.VariableNode;
 import org.eclipse.milo.opcua.sdk.core.nodes.VariableTypeNode;
 import org.eclipse.milo.opcua.sdk.core.typetree.DataTypeTree;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNodeContext;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaServerNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableTypeNode;
 import org.eclipse.milo.opcua.stack.core.*;
+import org.eclipse.milo.opcua.stack.core.types.UaStructuredType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.*;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
 import org.eclipse.milo.opcua.stack.core.types.structured.AccessLevelExType;
+import org.eclipse.milo.opcua.stack.core.types.structured.AccessRestrictionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.DataTypeDefinition;
+import org.eclipse.milo.opcua.stack.core.types.structured.RolePermissionType;
 import org.eclipse.milo.opcua.stack.core.util.ArrayUtil;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -189,11 +196,155 @@ public class AttributeWriter {
       }
     }
 
+    Object attributeValue = value;
+    if (attributeId != AttributeId.Value) {
+      try {
+        attributeValue =
+            convertAttributeValue(node.getNodeContext(), attributeId, value.value().value());
+      } catch (UaException e) {
+        return e.getStatusCode();
+      }
+    }
+
     try {
-      node.writeAttribute(context, attributeId, value);
+      node.writeAttribute(context, attributeId, attributeValue);
       return StatusCode.GOOD;
     } catch (UaException e) {
       return e.getStatusCode();
+    } catch (UaRuntimeException e) {
+      return e.getStatusCode();
+    } catch (ClassCastException e) {
+      return new StatusCode(StatusCodes.Bad_TypeMismatch);
+    }
+  }
+
+  private static Object convertAttributeValue(
+      UaNodeContext nodeContext, AttributeId attributeId, @Nullable Object value)
+      throws UaException {
+    if (value == null) {
+      throw new UaException(StatusCodes.Bad_TypeMismatch);
+    }
+
+    return switch (attributeId) {
+      case NodeClass -> convertNodeClass(value);
+      case AccessRestrictions -> convertAccessRestrictions(value);
+      case AccessLevelEx -> convertAccessLevelEx(value);
+      case DataTypeDefinition -> convertDataTypeDefinition(nodeContext, value);
+      case RolePermissions, UserRolePermissions -> convertRolePermissions(nodeContext, value);
+      default -> validateAttributeValue(attributeId, value);
+    };
+  }
+
+  private static Object validateAttributeValue(AttributeId attributeId, Object value)
+      throws UaException {
+
+    Class<?> valueType = getAttributeValueType(attributeId);
+    if (valueType.isInstance(value)) {
+      return value;
+    } else {
+      throw new UaException(StatusCodes.Bad_TypeMismatch);
+    }
+  }
+
+  private static Class<?> getAttributeValueType(AttributeId attributeId) {
+    return switch (attributeId) {
+      case NodeId, DataType -> NodeId.class;
+      case NodeClass -> NodeClass.class;
+      case BrowseName -> QualifiedName.class;
+      case DisplayName, Description, InverseName -> LocalizedText.class;
+      case WriteMask, UserWriteMask -> UInteger.class;
+      case IsAbstract, Symmetric, ContainsNoLoops, Historizing, Executable, UserExecutable ->
+          Boolean.class;
+      case EventNotifier, AccessLevel, UserAccessLevel -> UByte.class;
+      case Value -> DataValue.class;
+      case ValueRank -> Integer.class;
+      case ArrayDimensions -> UInteger[].class;
+      case MinimumSamplingInterval -> Double.class;
+      case DataTypeDefinition -> DataTypeDefinition.class;
+      case RolePermissions, UserRolePermissions -> RolePermissionType[].class;
+      case AccessRestrictions -> AccessRestrictionType.class;
+      case AccessLevelEx -> AccessLevelExType.class;
+    };
+  }
+
+  private static NodeClass convertNodeClass(Object value) throws UaException {
+    if (value instanceof NodeClass nodeClass) {
+      return nodeClass;
+    } else if (value instanceof Integer i) {
+      NodeClass nodeClass = NodeClass.from(i);
+      if (nodeClass != null) {
+        return nodeClass;
+      }
+    }
+
+    throw new UaException(StatusCodes.Bad_TypeMismatch);
+  }
+
+  private static AccessRestrictionType convertAccessRestrictions(Object value) throws UaException {
+    if (value instanceof AccessRestrictionType accessRestrictionType) {
+      return accessRestrictionType;
+    } else if (value instanceof UShort uShort) {
+      return new AccessRestrictionType(uShort);
+    }
+
+    throw new UaException(StatusCodes.Bad_TypeMismatch);
+  }
+
+  private static AccessLevelExType convertAccessLevelEx(Object value) throws UaException {
+    if (value instanceof AccessLevelExType accessLevelExType) {
+      return accessLevelExType;
+    } else if (value instanceof UInteger uInteger) {
+      return new AccessLevelExType(uInteger);
+    }
+
+    throw new UaException(StatusCodes.Bad_TypeMismatch);
+  }
+
+  private static DataTypeDefinition convertDataTypeDefinition(
+      UaNodeContext nodeContext, Object value) throws UaException {
+
+    if (value instanceof DataTypeDefinition dataTypeDefinition) {
+      return dataTypeDefinition;
+    } else if (value instanceof ExtensionObject extensionObject) {
+      UaStructuredType decoded = decodeExtensionObject(nodeContext, extensionObject);
+      if (decoded instanceof DataTypeDefinition dataTypeDefinition) {
+        return dataTypeDefinition;
+      }
+    }
+
+    throw new UaException(StatusCodes.Bad_TypeMismatch);
+  }
+
+  private static RolePermissionType[] convertRolePermissions(
+      UaNodeContext nodeContext, Object value) throws UaException {
+
+    if (value instanceof RolePermissionType[] rolePermissions) {
+      return rolePermissions;
+    } else if (value instanceof ExtensionObject[] extensionObjects) {
+      RolePermissionType[] rolePermissions = new RolePermissionType[extensionObjects.length];
+
+      for (int i = 0; i < extensionObjects.length; i++) {
+        UaStructuredType decoded = decodeExtensionObject(nodeContext, extensionObjects[i]);
+        if (decoded instanceof RolePermissionType rolePermission) {
+          rolePermissions[i] = rolePermission;
+        } else {
+          throw new UaException(StatusCodes.Bad_TypeMismatch);
+        }
+      }
+
+      return rolePermissions;
+    }
+
+    throw new UaException(StatusCodes.Bad_TypeMismatch);
+  }
+
+  private static UaStructuredType decodeExtensionObject(
+      UaNodeContext nodeContext, ExtensionObject extensionObject) throws UaException {
+
+    try {
+      return extensionObject.decode(nodeContext.getServer().getStaticEncodingContext());
+    } catch (UaSerializationException e) {
+      throw new UaException(StatusCodes.Bad_TypeMismatch, e);
     }
   }
 


### PR DESCRIPTION
## Summary

Fix server-side Write handling for non-Value attributes so requests write the raw attribute value instead of the surrounding `DataValue` wrapper. Invalid or incompatible payloads now return operation `StatusCode` results instead of bubbling unchecked setter exceptions.

- Unwrap non-Value Write payloads before dispatching to node attribute setters, while preserving existing `Value` attribute behavior.
- Convert wire-decoded enum, option-set, and structured forms into the concrete Java types expected by the built-in setters.
- Add integration coverage for writable non-Value attributes and type mismatch handling.

## Key Changes

- **Attribute conversion:** Non-Value writes now go through a conversion helper keyed by `AttributeId`, including special handling for `NodeClass`, option sets, `DataTypeDefinition`, and role permission arrays.
- **Error mapping:** Invalid converted values return `Bad_TypeMismatch`, and `UaRuntimeException` status codes are preserved instead of escaping the Write service path.
- **Regression coverage:** `AttributeWriterTest` now exercises remote Write requests for `DisplayName`, `ArrayDimensions`, `AccessLevelEx`, and mismatched non-Value payloads.

## References

- [OPC UA Part 4, 5.11.4.2 Write Parameters](https://reference.opcfoundation.org/specs/OPC-10000-4/5.11.4.2.md)
- [OPC UA Part 4, 5.11.4.4 Write StatusCodes](https://reference.opcfoundation.org/specs/OPC-10000-4/5.11.4.4.md)
