### PR TITLE
Ignore Netty 4.2 dependency update suggestions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -377,6 +377,17 @@
                 <version>(?i).*[-_\.](alpha|b|beta|rc|m|ea)[-_\.]?[0-9]*</version>
               </ignoreVersion>
             </ignoreVersions>
+            <rules>
+              <rule>
+                <groupId>io.netty</groupId>
+                <ignoreVersions>
+                  <ignoreVersion>
+                    <type>range</type>
+                    <version>[4.2.0,)</version>
+                  </ignoreVersion>
+                </ignoreVersions>
+              </rule>
+            </rules>
           </ruleSet>
         </configuration>
       </plugin>


### PR DESCRIPTION
## Summary

Keep weekly dependency update reports on the Netty 4.1.x train by filtering Netty 4.2+ candidates from the versions plugin output.

- Adds a `versions-maven-plugin` rule scoped to `io.netty` so the policy applies only to Netty dependency suggestions.
- Ignores Netty versions in `[4.2.0,)`, keeping 4.1.x patch updates visible while suppressing 4.2.x suggestions.

## Key Changes

- **Netty update policy:** The versions plugin rule set now includes a group-specific ignore range for `io.netty`, preserving the existing prerelease filtering while preventing major/minor train jumps into 4.2.x.

## Testing

- `mvn versions:display-dependency-updates` - passed; visible Netty suggestions stayed on 4.1.x (`4.1.133.Final -> 4.1.135.Final`) with no 4.2.x candidates.
- `mvn -q spotless:apply` - passed.
- `mvn -q clean compile` - passed.
- Preflight review: APPROVED.
