### PR TITLE
Update Maven dependencies (2026-07-06)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -387,6 +387,16 @@
                   </ignoreVersion>
                 </ignoreVersions>
               </rule>
+              <rule>
+                <groupId>com.puppycrawl.tools</groupId>
+                <artifactId>checkstyle</artifactId>
+                <ignoreVersions>
+                  <ignoreVersion>
+                    <type>range</type>
+                    <version>[13.0.0,)</version>
+                  </ignoreVersion>
+                </ignoreVersions>
+              </rule>
             </rules>
           </ruleSet>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -64,42 +64,42 @@
     <guava.version>33.6.0-jre</guava.version>
     <jakarta-activation.version>2.0.1</jakarta-activation.version>
     <jakarta-xml-bind-api.version>4.0.5</jakarta-xml-bind-api.version>
-    <jaxb.version>4.0.8</jaxb.version>
-    <netty.version>4.1.133.Final</netty.version>
+    <jaxb.version>4.0.9</jaxb.version>
+    <netty.version>4.1.135.Final</netty.version>
     <netty-channel-fsm.version>1.0.2</netty-channel-fsm.version>
     <slf4j.version>2.0.18</slf4j.version>
     <jspecify.version>1.0.0</jspecify.version>
-    <xmlunit.version>2.11.0</xmlunit.version>
+    <xmlunit.version>2.12.0</xmlunit.version>
 
     <!-- Plugin Dependency Versions -->
-    <central-publishing-maven-plugin.version>0.10.0</central-publishing-maven-plugin.version>
-    <checkstyle.version>11.0.1</checkstyle.version>
+    <central-publishing-maven-plugin.version>0.11.0</central-publishing-maven-plugin.version>
+    <checkstyle.version>12.3.1</checkstyle.version>
     <jaxb2-maven-plugin.version>4.1.0</jaxb2-maven-plugin.version>
     <license-tool-plugin.version>1.1.0</license-tool-plugin.version>
     <maven-bundle-plugin.version>6.0.2</maven-bundle-plugin.version>
     <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
     <maven-clean-plugin.version>3.5.0</maven-clean-plugin.version>
-    <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
-    <maven-dependency-plugin.version>3.9.0</maven-dependency-plugin.version>
+    <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
+    <maven-dependency-plugin.version>3.11.0</maven-dependency-plugin.version>
     <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
-    <maven-enforcer-plugin.version>3.6.1</maven-enforcer-plugin.version>
-    <maven-failsafe-plugin.version>3.5.3</maven-failsafe-plugin.version>
+    <maven-enforcer-plugin.version>3.6.3</maven-enforcer-plugin.version>
+    <maven-failsafe-plugin.version>3.5.6</maven-failsafe-plugin.version>
     <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
     <maven-install-plugin.version>3.1.4</maven-install-plugin.version>
-    <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
-    <maven-javadoc-plugin.version>3.11.3</maven-javadoc-plugin.version>
-    <maven-release-plugin.version>3.1.1</maven-release-plugin.version>
-    <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-    <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
+    <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>
+    <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
+    <maven-release-plugin.version>3.3.1</maven-release-plugin.version>
+    <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
+    <maven-shade-plugin.version>3.6.2</maven-shade-plugin.version>
     <maven-site-plugin.version>4.0.0-M9</maven-site-plugin.version>
-    <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
-    <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
-    <spotless-maven-plugin.version>3.5.1</spotless-maven-plugin.version>
+    <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
+    <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
+    <spotless-maven-plugin.version>3.8.0</spotless-maven-plugin.version>
     <versions-maven-plugin.version>2.21.0</versions-maven-plugin.version>
     <flatten-maven-plugin.version>1.7.3</flatten-maven-plugin.version>
 
     <!-- Test Dependency Versions -->
-    <junit.version>6.0.3</junit.version>
+    <junit.version>6.1.1</junit.version>
     <mockito.version>5.23.0</mockito.version>
   </properties>
 


### PR DESCRIPTION
## Summary

Update stable Maven dependency and plugin versions reported by the weekly automation run.

- Applies centralized root POM property updates only, keeping the reactor dependency declarations unchanged.
- Uses Checkstyle `12.3.1` instead of the reported `13.7.0` because the 13.x line requires Java 21 while Milo targets Java 17.

## Updated Dependencies

- `io.netty:netty-codec`: `4.1.133.Final` -> `4.1.135.Final`
- `io.netty:netty-codec-http`: `4.1.133.Final` -> `4.1.135.Final`
- `io.netty:netty-handler`: `4.1.133.Final` -> `4.1.135.Final`
- `org.glassfish.jaxb:jaxb-runtime`: `4.0.8` -> `4.0.9`
- `org.glassfish.jaxb:jaxb-xjc`: `4.0.8` -> `4.0.9`
- `org.junit.jupiter:junit-jupiter*`: `6.0.3` -> `6.1.1`
- `org.junit.platform:junit-platform*`: `6.0.3` -> `6.1.1`
- `org.junit.vintage:junit-vintage-engine`: `6.0.3` -> `6.1.1`
- `org.xmlunit:xmlunit-core`: `2.11.0` -> `2.12.0`

## Updated Plugins And Plugin Dependencies

- `com.diffplug.spotless:spotless-maven-plugin`: `3.5.1` -> `3.8.0`
- `com.puppycrawl.tools:checkstyle`: `11.0.1` -> `12.3.1`
- `maven-compiler-plugin`: `3.14.0` -> `3.15.0`
- `maven-dependency-plugin`: `3.9.0` -> `3.11.0`
- `maven-enforcer-plugin`: `3.6.1` -> `3.6.3`
- `maven-failsafe-plugin`: `3.5.3` -> `3.5.6`
- `maven-jar-plugin`: `3.4.2` -> `3.5.0`
- `maven-javadoc-plugin`: `3.11.3` -> `3.12.0`
- `maven-release-plugin`: `3.1.1` -> `3.3.1`
- `maven-resources-plugin`: `3.3.1` -> `3.5.0`
- `maven-shade-plugin`: `3.6.0` -> `3.6.2`
- `maven-source-plugin`: `3.3.1` -> `3.4.0`
- `maven-surefire-plugin`: `3.5.3` -> `3.5.6`
- `org.sonatype.central:central-publishing-maven-plugin`: `0.10.0` -> `0.11.0`

## Skipped Suggestions

- `com.puppycrawl.tools:checkstyle` `13.7.0` was reported by `versions:display-dependency-updates`, but it was skipped because Checkstyle 13.x is built for Java 21. Milo remains a Java 17 project, so this PR uses the latest stable Java 17-compatible Checkstyle release, `12.3.1`.
- No alpha, beta, milestone, RC, snapshot, or other prerelease dependency/plugin suggestions were applied.

## Verification

Report-only commands:

- `mvn versions:display-dependency-updates` - passed
- `mvn versions:display-plugin-updates` - passed

Final verification after applying updates:

- `mvn dependency:resolve` - passed
- `mvn -q spotless:apply` - passed
- `mvn -q clean compile` - passed
- `mvn -q clean verify` - passed

## Preflight

APPROVED: Preflight reviewed the final root `pom.xml` diff only, confirmed it contains stable dependency/plugin property updates and no source changes, and confirmed Checkstyle `12.3.1` remains Java 17-compatible.
