### PR TITLE
Adopt mise toolchain

### DIFF
--- a/.claude/agents/maven-command-runner.md
+++ b/.claude/agents/maven-command-runner.md
@@ -30,6 +30,7 @@ When a build fails, your job is DONE after reporting the failure details. The ca
 
 1. **Execute Maven Commands**
    - Run Maven goals with captured output
+   - Use `mise exec -- mvn` so `.mise.toml` provides the pinned Java and Maven versions
    - Use quiet mode (`-q`) for cleaner output
    - Redirect all output to a temp file
    - Report success or failure clearly
@@ -50,7 +51,7 @@ When a build fails, your job is DONE after reporting the failure details. The ca
 Always use this bash pattern to run Maven commands:
 
 ```bash
-mvn -q <goals> >/tmp/<output_name>.log 2>&1 && echo "SUCCESS" || echo "FAILED"
+mise exec -- mvn -q <goals> >/tmp/<output_name>.log 2>&1 && echo "SUCCESS" || echo "FAILED"
 ```
 
 Replace:
@@ -61,37 +62,37 @@ Replace:
 
 **Compile:**
 ```bash
-mvn -q compile >/tmp/maven_compile.log 2>&1 && echo "SUCCESS" || echo "FAILED"
+mise exec -- mvn -q compile >/tmp/maven_compile.log 2>&1 && echo "SUCCESS" || echo "FAILED"
 ```
 
 **Run all tests:**
 ```bash
-mvn -q test >/tmp/maven_test.log 2>&1 && echo "SUCCESS" || echo "FAILED"
+mise exec -- mvn -q test >/tmp/maven_test.log 2>&1 && echo "SUCCESS" || echo "FAILED"
 ```
 
 **Run a specific test class:**
 ```bash
-mvn -q test -Dtest="com.example.MyTest" >/tmp/maven_test.log 2>&1 && echo "SUCCESS" || echo "FAILED"
+mise exec -- mvn -q test -Dtest="com.example.MyTest" >/tmp/maven_test.log 2>&1 && echo "SUCCESS" || echo "FAILED"
 ```
 
 **Clean and package:**
 ```bash
-mvn -q clean package >/tmp/maven_package.log 2>&1 && echo "SUCCESS" || echo "FAILED"
+mise exec -- mvn -q clean package >/tmp/maven_package.log 2>&1 && echo "SUCCESS" || echo "FAILED"
 ```
 
 **Build specific module:**
 ```bash
-mvn -q -pl :module-name -am package >/tmp/maven_module.log 2>&1 && echo "SUCCESS" || echo "FAILED"
+mise exec -- mvn -q -pl :module-name -am package >/tmp/maven_module.log 2>&1 && echo "SUCCESS" || echo "FAILED"
 ```
 
 **Skip tests:**
 ```bash
-mvn -q package -DskipTests >/tmp/maven_package.log 2>&1 && echo "SUCCESS" || echo "FAILED"
+mise exec -- mvn -q package -DskipTests >/tmp/maven_package.log 2>&1 && echo "SUCCESS" || echo "FAILED"
 ```
 
 **With stacktrace for debugging:**
 ```bash
-mvn -q clean package -e >/tmp/maven_package.log 2>&1 && echo "SUCCESS" || echo "FAILED"
+mise exec -- mvn -q clean package -e >/tmp/maven_package.log 2>&1 && echo "SUCCESS" || echo "FAILED"
 ```
 
 ## Execution Strategy

--- a/.claude/docs/dependencies.md
+++ b/.claude/docs/dependencies.md
@@ -10,7 +10,7 @@ If the directory doesn't exist or content is missing, run this command from the 
 download and unpack all dependency sources:
 
 ```bash
-mvn -q generate-resources -Pdownload-external-src
+mise exec -- mvn -q generate-resources -Pdownload-external-src
 ```
 
 This creates the `external/src` directory with sources from all dependencies in a single top-level

--- a/.claude/docs/testing.md
+++ b/.claude/docs/testing.md
@@ -8,19 +8,19 @@ to avoid applying the filter to all modules.
 **Run a specific test class:**
 
 ```bash
-mvn -q -pl opc-ua-sdk/sdk-server test -Dtest=ClassName
+mise exec -- mvn -q -pl opc-ua-sdk/sdk-server test -Dtest=ClassName
 ```
 
 **Run a specific test method:**
 
 ```bash
-mvn -q -pl opc-ua-sdk/sdk-server test -Dtest=ClassName#methodName
+mise exec -- mvn -q -pl opc-ua-sdk/sdk-server test -Dtest=ClassName#methodName
 ```
 
 **Run tests matching a pattern:**
 
 ```bash
-mvn -q -pl opc-ua-stack/stack-core test -Dtest=*ServiceTest
+mise exec -- mvn -q -pl opc-ua-stack/stack-core test -Dtest=*ServiceTest
 ```
 
 Most tests live in `opc-ua-sdk/integration-tests`, `opc-ua-stack/stack-core`, and
@@ -38,7 +38,7 @@ Most tests live in `opc-ua-sdk/integration-tests`, `opc-ua-stack/stack-core`, an
 
 ```bash
 # Changed and testing sdk-server only
-mvn -q -pl opc-ua-sdk/sdk-server test -Dtest=ClassName
+mise exec -- mvn -q -pl opc-ua-sdk/sdk-server test -Dtest=ClassName
 ```
 
 **`-pl ... -am`** — the change is in a dependency of the module being tested. This
@@ -46,7 +46,7 @@ rebuilds the dependency chain so tests run against the latest code:
 
 ```bash
 # Changed stack-core, running integration-tests
-mvn -q -pl opc-ua-sdk/integration-tests -am test -Dtest=ClassName
+mise exec -- mvn -q -pl opc-ua-sdk/integration-tests -am test -Dtest=ClassName
 ```
 
 **`-pl ... -amd`** — the change is in a low-level module and you want to test all modules
@@ -54,7 +54,7 @@ that depend on it:
 
 ```bash
 # Changed stack-core, run tests in stack-core and everything that depends on it
-mvn -q -pl opc-ua-stack/stack-core -amd test
+mise exec -- mvn -q -pl opc-ua-stack/stack-core -amd test
 ```
 
 ### Rule of thumb
@@ -66,5 +66,5 @@ against stale (previously compiled) code.
 ## Run All Tests
 
 ```bash
-mvn -q clean verify
+mise exec -- mvn -q clean verify
 ```

--- a/.codex/agents/maven-command-runner.md
+++ b/.codex/agents/maven-command-runner.md
@@ -20,6 +20,7 @@ contained and failures are analyzed once.
   the parent agent explicitly asks you to continue.
 - Always capture Maven output to `/tmp/maven_*.log`.
 - Use Maven quiet mode (`-q`) unless the parent agent explicitly asks for verbose output.
+- Run Maven through `mise exec -- mvn` so `.mise.toml` provides the pinned Java and Maven versions.
 - Before running any test command, read `.claude/docs/testing.md` and follow its module targeting
   and test selection guidance.
 
@@ -29,7 +30,7 @@ Use this pattern for each Maven command:
 
 ```bash
 log="/tmp/maven_<purpose>_$(date +%Y%m%d%H%M%S).log"
-mvn -q <goals> >"$log" 2>&1 && echo "SUCCESS $log" || echo "FAILED $log"
+mise exec -- mvn -q <goals> >"$log" 2>&1 && echo "SUCCESS $log" || echo "FAILED $log"
 ```
 
 Replace `<purpose>` with a short descriptive name such as `compile`, `test`, `verify`, or
@@ -39,12 +40,12 @@ Examples:
 
 ```bash
 log="/tmp/maven_compile_$(date +%Y%m%d%H%M%S).log"
-mvn -q clean compile >"$log" 2>&1 && echo "SUCCESS $log" || echo "FAILED $log"
+mise exec -- mvn -q clean compile >"$log" 2>&1 && echo "SUCCESS $log" || echo "FAILED $log"
 ```
 
 ```bash
 log="/tmp/maven_spotless_apply_$(date +%Y%m%d%H%M%S).log"
-mvn -q spotless:apply >"$log" 2>&1 && echo "SUCCESS $log" || echo "FAILED $log"
+mise exec -- mvn -q spotless:apply >"$log" 2>&1 && echo "SUCCESS $log" || echo "FAILED $log"
 ```
 
 ## Failure Analysis
@@ -64,7 +65,7 @@ For success:
 
 ```markdown
 Maven command succeeded.
-- Command: `mvn -q ...`
+- Command: `mise exec -- mvn -q ...`
 - Output: `/tmp/maven_....log`
 ```
 

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,3 @@
+[tools]
+java = "temurin-17.0.19+10"
+maven = "3.9.16"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Project Context
 
-**Tech Stack:** Java 17, Maven multi-module
+**Tech Stack:** Java 17 managed through `mise`, Maven multi-module
 
 Milo is an open-source OPC UA (IEC 62541) implementation for Java, enabling
 industrial communication and IoT integration. It provides a complete client/server
@@ -19,11 +19,13 @@ SDK for building OPC UA applications.
 
 ## Building and Testing
 
-| Command                 | Purpose                                    |
-|-------------------------|--------------------------------------------|
-| `mvn -q clean compile`  | Compile without tests                      |
-| `mvn -q clean verify`   | Full build with tests and formatting check |
-| `mvn -q spotless:apply` | Fix code formatting issues                 |
+| Command                              | Purpose                                    |
+|--------------------------------------|--------------------------------------------|
+| `mise install`                       | Install pinned Java and Maven tools        |
+| `mise trust .mise.toml`              | Trust the local mise config when prompted  |
+| `mise exec -- mvn -q clean compile`  | Compile without tests                      |
+| `mise exec -- mvn -q clean verify`   | Full build with tests and formatting check |
+| `mise exec -- mvn -q spotless:apply` | Fix code formatting issues                 |
 
 Before running any tests, read `.claude/docs/testing.md` for module targeting flags and
 test patterns.
@@ -39,8 +41,8 @@ test patterns.
 Use these steps to verify any completed work. Implementation plans should include these as success criteria.
 
 1. **Format and compile** using the `maven-command-runner` agent:
-    - `mvn -q spotless:apply` - Format code
-    - `mvn -q clean compile` - Compile (skip tests)
+    - `mise exec -- mvn -q spotless:apply` - Format code
+    - `mise exec -- mvn -q clean compile` - Compile (skip tests)
 
 No separate review-agent gate is required. Reviews are handled manually or by workflow-specific
 gates when requested.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,9 +46,9 @@ You can find all the details in the [Contributing via Git](http://wiki.eclipse.o
 * Make your changes
 * When you create new files make sure you include a proper license header at the top of the file (see License Header section below).
 * Make sure you include test cases for non-trivial features
-* Make sure the test suite passes after your changes
+* Make sure the test suite passes after your changes with `mise exec -- mvn clean verify`
 * Make sure checkstyle passes after your changes
-* Apply `google-java-format` (see https://github.com/google/google-java-format) 
+* Apply formatting with `mise exec -- mvn spotless:apply`
 * Commit your changes into that branch
 * Use descriptive and meaningful commit messages
 * If you have a lot of commits squash them into a single commit

--- a/README.md
+++ b/README.md
@@ -9,12 +9,27 @@ Stack Overflow tag: [milo](http://stackoverflow.com/questions/tagged/milo)
 
 Mailing list: https://dev.eclipse.org/mailman/listinfo/milo-dev
 
+## Requirements
+
+The repository pins its Java and Maven toolchain with `mise`:
+
+```shell
+mise install
+```
+
+If `mise` reports that the config is not trusted, review `.mise.toml` and run
+`mise trust .mise.toml` once. After installation, run Maven through `mise exec --` so
+the pinned Java 17 and Maven versions are used.
 
 ## Maven
 
 ### Building Milo
 
-**Using JDK 17**, run `mvn clean install` from the project root.
+**Using JDK 17**, run this from the project root:
+
+```shell
+mise exec -- mvn clean install
+```
 
 To maintain compatibility with Java 17 it is recommended that you build using JDK 17, however the library is runtime compatible with versions 17 and later (e.g. JDK 21, JDK 24).
 

--- a/docs/features/wireshark-key-log.md
+++ b/docs/features/wireshark-key-log.md
@@ -208,7 +208,7 @@ per channel lifetime, plus renewals).
 ## Testing
 
 ```bash
-mvn -q verify -pl opc-ua-stack/stack-core \
+mise exec -- mvn -q verify -pl opc-ua-stack/stack-core \
     -Dtest="SecurityKeysetTest,WiresharkKeyLogWriterTest"
 ```
 


### PR DESCRIPTION
## Summary

Add mise-based local toolchain pinning so developers and agents use the same Java 17 and Maven versions without changing CI setup.

- Pin Temurin Java 17 and Maven 3.9.16 in `.mise.toml`.
- Document `mise install` and one-time trust flow in the README and agent guidance.
- Route local Maven command examples through `mise exec -- mvn` so human and agent workflows use the pinned toolchain.

## Key Changes

- **Local toolchain:** Added `.mise.toml` for Java and Maven pinning while leaving GitHub Actions workflows unchanged because CI installs its own Java.
- **Command guidance:** Updated README, AGENTS.md, CONTRIBUTING.md, testing/dependency docs, and feature docs to show `mise exec -- mvn ...` for local Maven commands.
- **Agent runners:** Updated Codex and Claude Maven command runner instructions so delegated Maven commands use the pinned toolchain consistently.

## Testing

- `mise install`
- `mise exec -- mvn -q spotless:apply`
- `mise exec -- mvn -q clean compile`
- `git diff --check`
