### PR TITLE
Propagate the real Call denial status in DefaultAccessController

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/servicesets/impl/DefaultAccessController.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/servicesets/impl/DefaultAccessController.java
@@ -335,9 +335,16 @@ public class DefaultAccessController implements AccessController {
       PendingResult<NodeId> p0 = pending.get(i);
       PendingResult<NodeId> p1 = pending.get(i + 1);
 
-      boolean allowed = p0.result.isAllowed() && p1.result.isAllowed();
+      AccessResult result;
+      if (p0.result.isDenied()) {
+        result = p0.result;
+      } else if (p1.result.isDenied()) {
+        result = p1.result;
+      } else {
+        result = AccessResult.ALLOWED;
+      }
 
-      results.put(request, allowed ? AccessResult.ALLOWED : AccessResult.DENIED_USER_ACCESS);
+      results.put(request, result);
     }
 
     return results;

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/servicesets/impl/DefaultAccessControllerTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/servicesets/impl/DefaultAccessControllerTest.java
@@ -28,7 +28,10 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.MessageSecurityMode;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
+import org.eclipse.milo.opcua.stack.core.types.structured.AccessRestrictionType;
 import org.eclipse.milo.opcua.stack.core.types.structured.AddReferencesItem;
 import org.eclipse.milo.opcua.stack.core.types.structured.CallMethodRequest;
 import org.eclipse.milo.opcua.stack.core.types.structured.DeleteNodesItem;
@@ -642,6 +645,117 @@ class DefaultAccessControllerTest {
 
       assertEquals(AccessResult.ALLOWED, result);
     }
+  }
+
+  @Test
+  void checkCallAccess_AccessRestrictions() {
+    var objectNodeId = new NodeId(1, "object");
+    var methodNodeId = new NodeId(1, "method");
+    var callMethodRequest = new CallMethodRequest(objectNodeId, methodNodeId, null);
+
+    // SigningRequired | EncryptionRequired
+    var accessRestrictions = new AccessRestrictionType(UShort.valueOf(3));
+
+    attributesMap.put(
+        objectNodeId, new AccessControlAttributes(null, null, null, null, null, null));
+    attributesMap.put(
+        methodNodeId,
+        new AccessControlAttributes(null, accessRestrictions, null, null, null, null));
+
+    {
+      Mockito.when(context.getSecurityMode()).thenReturn(MessageSecurityMode.None);
+
+      AccessResult result =
+          DefaultAccessController.checkCallAccess(context, List.of(callMethodRequest))
+              .get(callMethodRequest);
+
+      assertEquals(AccessResult.DENIED_SECURITY_MODE, result);
+    }
+
+    {
+      Mockito.when(context.getSecurityMode()).thenReturn(MessageSecurityMode.Sign);
+
+      AccessResult result =
+          DefaultAccessController.checkCallAccess(context, List.of(callMethodRequest))
+              .get(callMethodRequest);
+
+      assertEquals(AccessResult.DENIED_SECURITY_MODE, result);
+    }
+
+    {
+      Mockito.when(context.getSecurityMode()).thenReturn(MessageSecurityMode.SignAndEncrypt);
+
+      AccessResult result =
+          DefaultAccessController.checkCallAccess(context, List.of(callMethodRequest))
+              .get(callMethodRequest);
+
+      assertEquals(AccessResult.ALLOWED, result);
+    }
+  }
+
+  @Test
+  void checkCallAccess_AccessRestrictions_ObjectNode() {
+    var objectNodeId = new NodeId(1, "object");
+    var methodNodeId = new NodeId(1, "method");
+    var callMethodRequest = new CallMethodRequest(objectNodeId, methodNodeId, null);
+
+    // SigningRequired | EncryptionRequired
+    var accessRestrictions = new AccessRestrictionType(UShort.valueOf(3));
+
+    attributesMap.put(
+        objectNodeId,
+        new AccessControlAttributes(null, accessRestrictions, null, null, null, null));
+    attributesMap.put(
+        methodNodeId, new AccessControlAttributes(null, null, null, null, null, null));
+
+    {
+      Mockito.when(context.getSecurityMode()).thenReturn(MessageSecurityMode.None);
+
+      AccessResult result =
+          DefaultAccessController.checkCallAccess(context, List.of(callMethodRequest))
+              .get(callMethodRequest);
+
+      assertEquals(AccessResult.DENIED_SECURITY_MODE, result);
+    }
+
+    {
+      Mockito.when(context.getSecurityMode()).thenReturn(MessageSecurityMode.SignAndEncrypt);
+
+      AccessResult result =
+          DefaultAccessController.checkCallAccess(context, List.of(callMethodRequest))
+              .get(callMethodRequest);
+
+      assertEquals(AccessResult.ALLOWED, result);
+    }
+  }
+
+  @Test
+  void checkCallAccess_RolePermissions_DeniedOnSecureChannel() {
+    var objectNodeId = new NodeId(1, "object");
+    var methodNodeId = new NodeId(1, "method");
+    var callMethodRequest = new CallMethodRequest(objectNodeId, methodNodeId, null);
+
+    var attributes =
+        new AccessControlAttributes(
+            null,
+            null,
+            null,
+            null,
+            null,
+            new RolePermissionType[] {
+              new RolePermissionType(ROLE_A, PermissionType.of()),
+            });
+    attributesMap.put(objectNodeId, attributes);
+    attributesMap.put(methodNodeId, attributes);
+
+    Mockito.when(context.getSecurityMode()).thenReturn(MessageSecurityMode.SignAndEncrypt);
+    Mockito.when(context.getRoleIds()).thenReturn(Optional.of(List.of(ROLE_A)));
+
+    AccessResult result =
+        DefaultAccessController.checkCallAccess(context, List.of(callMethodRequest))
+            .get(callMethodRequest);
+
+    assertEquals(AccessResult.DENIED_USER_ACCESS, result);
   }
 
   @Test


### PR DESCRIPTION
## Summary

- preserve the specific denial returned while collating object and method Call access checks
- return `Bad_SecurityModeInsufficient` when AccessRestrictions require a stronger channel security mode
- retain `Bad_UserAccessDenied` behavior for role-permission and UserExecutable denials
- add regression coverage for method- and object-level AccessRestrictions

## Root cause

`DefaultAccessController.checkCallAccess()` collapsed every denied object/method pair to `DENIED_USER_ACCESS`. Although the method service already surfaces the denial's status code, it could never receive `DENIED_SECURITY_MODE` from this path.

## Impact

Clients calling a method whose AccessRestrictions require signing or encryption now receive the accurate security-mode status instead of a generic user-access denial.

## Verification

- `mise exec -- mvn -q spotless:apply`
- `mise exec -- mvn -q clean compile`
- `mise exec -- mvn -q -pl opc-ua-sdk/sdk-server test -Dtest=DefaultAccessControllerTest`
