### PR TITLE
Decode structure method arguments before invoke

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/methods/AbstractMethodInvocationHandlerTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/methods/AbstractMethodInvocationHandlerTest.java
@@ -17,27 +17,37 @@ import static org.eclipse.milo.opcua.stack.core.StatusCodes.Bad_OutOfRange;
 import static org.eclipse.milo.opcua.stack.core.StatusCodes.Bad_TooManyArguments;
 import static org.eclipse.milo.opcua.stack.core.StatusCodes.Bad_TypeMismatch;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import org.eclipse.milo.opcua.sdk.client.AddressSpace;
 import org.eclipse.milo.opcua.sdk.client.methods.UaMethodException;
 import org.eclipse.milo.opcua.sdk.client.nodes.UaObjectNode;
+import org.eclipse.milo.opcua.sdk.core.Reference;
+import org.eclipse.milo.opcua.sdk.core.ValueRanks;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaMethodNode;
 import org.eclipse.milo.opcua.sdk.test.AbstractClientServerTest;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
+import org.eclipse.milo.opcua.stack.core.types.UaStructuredType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.structured.Argument;
 import org.eclipse.milo.opcua.stack.core.types.structured.CallMethodRequest;
 import org.eclipse.milo.opcua.stack.core.types.structured.CallMethodResult;
 import org.eclipse.milo.opcua.stack.core.types.structured.CallResponse;
 import org.eclipse.milo.opcua.stack.core.types.structured.ThreeDVector;
 import org.eclipse.milo.opcua.stack.core.types.structured.XVType;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,6 +56,69 @@ public class AbstractMethodInvocationHandlerTest extends AbstractClientServerTes
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(AbstractMethodInvocationHandlerTest.class);
+
+  /** Captures the server-side value of the "Input" argument to {@code structArrayEcho()}. */
+  private final AtomicReference<Object> structArrayEchoInput = new AtomicReference<>();
+
+  @BeforeAll
+  void configureStructArrayEcho() {
+    testNamespace.configure(
+        (context, nodeManager) ->
+            UaMethodNode.build(
+                context,
+                b -> {
+                  b.setNodeId(new NodeId(2, "structArrayEcho()"));
+                  b.setBrowseName(new QualifiedName(2, "structArrayEcho()"));
+                  b.setDisplayName(LocalizedText.english("structArrayEcho()"));
+
+                  b.addReference(
+                      new Reference(
+                          b.getNodeId(),
+                          NodeIds.HasOrderedComponent,
+                          NodeIds.ObjectsFolder.expanded(),
+                          Reference.Direction.INVERSE));
+
+                  UaMethodNode methodNode = b.buildAndAdd();
+
+                  methodNode.setInvocationHandler(
+                      new AbstractMethodInvocationHandler(methodNode) {
+                        @Override
+                        public Argument[] getInputArguments() {
+                          return new Argument[] {
+                            new Argument(
+                                "Input",
+                                NodeIds.XVType,
+                                ValueRanks.OneDimension,
+                                null,
+                                LocalizedText.NULL_VALUE)
+                          };
+                        }
+
+                        @Override
+                        public Argument[] getOutputArguments() {
+                          return new Argument[] {
+                            new Argument(
+                                "Output",
+                                NodeIds.XVType,
+                                ValueRanks.OneDimension,
+                                null,
+                                LocalizedText.NULL_VALUE)
+                          };
+                        }
+
+                        @Override
+                        protected Variant[] invoke(
+                            InvocationContext invocationContext, Variant[] inputValues) {
+
+                          structArrayEchoInput.set(inputValues[0].value());
+
+                          return new Variant[] {inputValues[0]};
+                        }
+                      });
+
+                  return methodNode;
+                }));
+  }
 
   @Test
   public void inputArgumentResultsIsEmptyOnSuccess() throws UaException {
@@ -158,7 +231,8 @@ public class AbstractMethodInvocationHandlerTest extends AbstractClientServerTes
 
   @Test
   void scalarStructureEcho() throws UaException {
-    var xo = ExtensionObject.encode(DefaultEncodingContext.INSTANCE, new XVType(1.0, 2.0f));
+    var struct = new XVType(1.0, 2.0f);
+    var xo = ExtensionObject.encode(DefaultEncodingContext.INSTANCE, struct);
     var input = Variant.ofExtensionObject(xo);
 
     CallResponse response =
@@ -173,18 +247,22 @@ public class AbstractMethodInvocationHandlerTest extends AbstractClientServerTes
 
     assertEquals(StatusCode.GOOD, result.getStatusCode());
     assertEquals(0, requireNonNull(result.getInputArgumentResults()).length);
-    assertEquals(input, requireNonNull(result.getOutputArguments())[0]);
+
+    // The handler receives and echoes the decoded struct; it is re-encoded on the wire.
+    Object outputValue = requireNonNull(result.getOutputArguments())[0].value();
+    ExtensionObject outputXo = assertInstanceOf(ExtensionObject.class, outputValue);
+    assertEquals(struct, outputXo.decode(DefaultEncodingContext.INSTANCE));
   }
 
   @Test
   void scalarAbstractStructureEcho() throws UaException {
-    var xo1 = ExtensionObject.encode(DefaultEncodingContext.INSTANCE, new XVType(1.0, 2.0f));
-    var xo2 =
-        ExtensionObject.encode(DefaultEncodingContext.INSTANCE, new ThreeDVector(1.0, 2.0, 3.0));
-    var input1 = Variant.ofExtensionObject(xo1);
-    var input2 = Variant.ofExtensionObject(xo2);
+    var struct1 = new XVType(1.0, 2.0f);
+    var struct2 = new ThreeDVector(1.0, 2.0, 3.0);
 
-    for (Variant input : List.of(input1, input2)) {
+    for (UaStructuredType struct : List.<UaStructuredType>of(struct1, struct2)) {
+      var xo = ExtensionObject.encode(DefaultEncodingContext.INSTANCE, struct);
+      var input = Variant.ofExtensionObject(xo);
+
       CallResponse response =
           client.call(
               List.of(
@@ -197,7 +275,11 @@ public class AbstractMethodInvocationHandlerTest extends AbstractClientServerTes
 
       assertEquals(StatusCode.GOOD, result.getStatusCode());
       assertEquals(0, requireNonNull(result.getInputArgumentResults()).length);
-      assertEquals(input, requireNonNull(result.getOutputArguments())[0]);
+
+      // The handler receives and echoes the decoded struct; it is re-encoded on the wire.
+      Object outputValue = requireNonNull(result.getOutputArguments())[0].value();
+      ExtensionObject outputXo = assertInstanceOf(ExtensionObject.class, outputValue);
+      assertEquals(struct, outputXo.decode(DefaultEncodingContext.INSTANCE));
     }
 
     var input3 = Variant.ofInt32(42);
@@ -209,6 +291,87 @@ public class AbstractMethodInvocationHandlerTest extends AbstractClientServerTes
                     NodeIds.ObjectsFolder,
                     NodeId.parse("ns=2;s=scalarAbstractStructureEcho()"),
                     new Variant[] {input3})));
+
+    CallMethodResult result = requireNonNull(response.getResults())[0];
+
+    assertEquals(StatusCode.of(Bad_InvalidArgument), result.getStatusCode());
+    assertEquals(
+        StatusCode.of(Bad_TypeMismatch), requireNonNull(result.getInputArgumentResults())[0]);
+  }
+
+  @Test
+  void structArrayEcho() throws UaException {
+    structArrayEchoInput.set(null);
+
+    var struct1 = new XVType(1.0, 2.0f);
+    var struct2 = new XVType(3.0, 4.0f);
+    var xo1 = ExtensionObject.encode(DefaultEncodingContext.INSTANCE, struct1);
+    var xo2 = ExtensionObject.encode(DefaultEncodingContext.INSTANCE, struct2);
+    var input = Variant.ofExtensionObjectArray(new ExtensionObject[] {xo1, xo2});
+
+    CallResponse response =
+        client.call(
+            List.of(
+                new CallMethodRequest(
+                    NodeIds.ObjectsFolder,
+                    new NodeId(2, "structArrayEcho()"),
+                    new Variant[] {input})));
+
+    CallMethodResult result = requireNonNull(response.getResults())[0];
+
+    assertEquals(StatusCode.GOOD, result.getStatusCode());
+    assertEquals(0, requireNonNull(result.getInputArgumentResults()).length);
+
+    // Server-side, the handler received the decoded, correctly-typed struct array.
+    XVType[] serverSideValue = assertInstanceOf(XVType[].class, structArrayEchoInput.get());
+    assertArrayEquals(new XVType[] {struct1, struct2}, serverSideValue);
+
+    // Client-side, the echoed array decodes element-wise to the original structs.
+    Object outputValue = requireNonNull(result.getOutputArguments())[0].value();
+    ExtensionObject[] outputXos = assertInstanceOf(ExtensionObject[].class, outputValue);
+    assertEquals(2, outputXos.length);
+    assertEquals(struct1, outputXos[0].decode(DefaultEncodingContext.INSTANCE));
+    assertEquals(struct2, outputXos[1].decode(DefaultEncodingContext.INSTANCE));
+  }
+
+  @Test
+  void emptyStructArrayEcho() throws UaException {
+    structArrayEchoInput.set(null);
+
+    var input = Variant.ofExtensionObjectArray(new ExtensionObject[0]);
+
+    CallResponse response =
+        client.call(
+            List.of(
+                new CallMethodRequest(
+                    NodeIds.ObjectsFolder,
+                    new NodeId(2, "structArrayEcho()"),
+                    new Variant[] {input})));
+
+    CallMethodResult result = requireNonNull(response.getResults())[0];
+
+    assertEquals(StatusCode.GOOD, result.getStatusCode());
+    assertEquals(0, requireNonNull(result.getInputArgumentResults()).length);
+
+    // Even an empty array is delivered as the correctly-typed array.
+    XVType[] serverSideValue = assertInstanceOf(XVType[].class, structArrayEchoInput.get());
+    assertEquals(0, serverSideValue.length);
+  }
+
+  @Test
+  void structArrayElementTypeMismatch() throws UaException {
+    var xo1 = ExtensionObject.encode(DefaultEncodingContext.INSTANCE, new XVType(1.0, 2.0f));
+    var xo2 =
+        ExtensionObject.encode(DefaultEncodingContext.INSTANCE, new ThreeDVector(1.0, 2.0, 3.0));
+    var input = Variant.ofExtensionObjectArray(new ExtensionObject[] {xo1, xo2});
+
+    CallResponse response =
+        client.call(
+            List.of(
+                new CallMethodRequest(
+                    NodeIds.ObjectsFolder,
+                    new NodeId(2, "structArrayEcho()"),
+                    new Variant[] {input})));
 
     CallMethodResult result = requireNonNull(response.getResults())[0];
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/methods/AbstractMethodInvocationHandler.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/methods/AbstractMethodInvocationHandler.java
@@ -12,6 +12,7 @@ package org.eclipse.milo.opcua.sdk.server.methods;
 
 import static java.util.Objects.requireNonNullElse;
 
+import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.Optional;
@@ -21,8 +22,11 @@ import org.eclipse.milo.opcua.sdk.server.AccessContext;
 import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
 import org.eclipse.milo.opcua.sdk.server.Session;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaMethodNode;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.UaSerializationException;
+import org.eclipse.milo.opcua.stack.core.encoding.DataTypeCodec;
 import org.eclipse.milo.opcua.stack.core.types.UaStructuredType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DiagnosticInfo;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
@@ -57,8 +61,10 @@ public abstract class AbstractMethodInvocationHandler implements MethodInvocatio
   @Override
   public final CallMethodResult invoke(AccessContext accessContext, CallMethodRequest request) {
     try {
+      // Defensive copy: values for structure-typed arguments may be substituted with their
+      // decoded values below, and the request's array should not be modified.
       Variant[] inputArgumentValues =
-          requireNonNullElse(request.getInputArguments(), new Variant[0]);
+          requireNonNullElse(request.getInputArguments(), new Variant[0]).clone();
 
       if (inputArgumentValues.length < getInputArguments().length) {
         throw new UaException(StatusCodes.Bad_ArgumentsMissing);
@@ -80,35 +86,83 @@ public abstract class AbstractMethodInvocationHandler implements MethodInvocatio
         if (value != null) {
           NodeId argDataTypeId = argument.getDataType();
 
-          NodeId valueDataTypeId =
-              variant
-                  .getDataTypeId()
-                  .flatMap(xni -> xni.toNodeId(node.getNodeContext().getNamespaceTable()))
-                  .orElse(NodeId.NULL_VALUE);
+          DataTypeTree dataTypeTree = node.getNodeContext().getServer().getDataTypeTree();
 
-          if (!argDataTypeId.equals(valueDataTypeId)) {
-            DataTypeTree dataTypeTree = node.getNodeContext().getServer().getDataTypeTree();
+          boolean argIsStructType =
+              NodeIds.Structure.equals(argDataTypeId) || dataTypeTree.isStructType(argDataTypeId);
 
-            if (dataTypeTree.isStructType(argDataTypeId)) {
-              ExtensionObject xo = (ExtensionObject) value;
-              UaStructuredType decoded =
-                  xo.decode(node.getNodeContext().getServer().getStaticEncodingContext());
+          if (argIsStructType) {
+            try {
+              if (value instanceof ExtensionObject xo) {
+                UaStructuredType decoded =
+                    xo.decode(node.getNodeContext().getServer().getStaticEncodingContext());
 
-              valueDataTypeId =
-                  decoded
-                      .getTypeId()
-                      .toNodeId(node.getNodeContext().getNamespaceTable())
-                      .orElse(NodeId.NULL_VALUE);
+                dataTypeMatch = structureTypeMatches(dataTypeTree, argDataTypeId, decoded);
 
-              DataType argType = dataTypeTree.getType(argDataTypeId);
-              boolean isAbstract = argType != null && argType.isAbstract();
+                if (dataTypeMatch) {
+                  // Substitute the decoded value so implementations receive the
+                  // UaStructuredType rather than the raw ExtensionObject.
+                  inputArgumentValues[i] = new Variant(decoded);
+                }
+              } else if (value instanceof ExtensionObject[] xos) {
+                var decodedElements = new UaStructuredType[xos.length];
 
-              if (isAbstract) {
-                dataTypeMatch = dataTypeTree.isSubtypeOf(valueDataTypeId, argDataTypeId);
+                for (int j = 0; dataTypeMatch && j < xos.length; j++) {
+                  ExtensionObject xo = xos[j];
+
+                  if (xo == null || xo.isNull()) {
+                    // A struct array with null elements has no typed representation.
+                    dataTypeMatch = false;
+                  } else {
+                    UaStructuredType decoded =
+                        xo.decode(node.getNodeContext().getServer().getStaticEncodingContext());
+
+                    dataTypeMatch = structureTypeMatches(dataTypeTree, argDataTypeId, decoded);
+
+                    decodedElements[j] = decoded;
+                  }
+                }
+
+                if (dataTypeMatch) {
+                  // Substitute a correctly-typed array of the decoded values, so that e.g. an
+                  // argument of DataType XVType is delivered as XVType[], even when empty.
+                  inputArgumentValues[i] =
+                      new Variant(typedStructArray(argDataTypeId, decodedElements));
+                }
+              } else if (value instanceof UaStructuredType structValue) {
+                dataTypeMatch = structureTypeMatches(dataTypeTree, argDataTypeId, structValue);
+              } else if (value instanceof UaStructuredType[] structValues) {
+                for (int j = 0; dataTypeMatch && j < structValues.length; j++) {
+                  UaStructuredType structValue = structValues[j];
+
+                  dataTypeMatch =
+                      structValue != null
+                          && structureTypeMatches(dataTypeTree, argDataTypeId, structValue);
+                }
+              } else if (value instanceof Matrix) {
+                // TODO decoding a Matrix of ExtensionObject into its struct elements is not
+                //  supported; accept it only if the DataType ids already match exactly.
+                NodeId valueDataTypeId =
+                    variant
+                        .getDataTypeId()
+                        .flatMap(xni -> xni.toNodeId(node.getNodeContext().getNamespaceTable()))
+                        .orElse(NodeId.NULL_VALUE);
+
+                dataTypeMatch = argDataTypeId.equals(valueDataTypeId);
               } else {
-                dataTypeMatch = Objects.equals(valueDataTypeId, argDataTypeId);
+                dataTypeMatch = false;
               }
-            } else {
+            } catch (UaSerializationException e) {
+              dataTypeMatch = false;
+            }
+          } else {
+            NodeId valueDataTypeId =
+                variant
+                    .getDataTypeId()
+                    .flatMap(xni -> xni.toNodeId(node.getNodeContext().getNamespaceTable()))
+                    .orElse(NodeId.NULL_VALUE);
+
+            if (!argDataTypeId.equals(valueDataTypeId)) {
               dataTypeMatch = dataTypeTree.isAssignable(argDataTypeId, value.getClass());
             }
           }
@@ -191,6 +245,70 @@ public abstract class AbstractMethodInvocationHandler implements MethodInvocatio
   }
 
   /**
+   * Check that a structure value's DataType matches the DataType of the {@link Argument} it was
+   * supplied for.
+   *
+   * <p>If the Argument's DataType is abstract the value's DataType may be any subtype of it;
+   * otherwise the DataTypes must match exactly.
+   *
+   * @param dataTypeTree the server's {@link DataTypeTree}.
+   * @param argDataTypeId the {@link NodeId} of the Argument's DataType.
+   * @param structValue the {@link UaStructuredType} value to check.
+   * @return {@code true} if {@code structValue}'s DataType matches the Argument's DataType.
+   */
+  private boolean structureTypeMatches(
+      DataTypeTree dataTypeTree, NodeId argDataTypeId, UaStructuredType structValue) {
+
+    NodeId valueDataTypeId =
+        structValue
+            .getTypeId()
+            .toNodeId(node.getNodeContext().getNamespaceTable())
+            .orElse(NodeId.NULL_VALUE);
+
+    DataType argType = dataTypeTree.getType(argDataTypeId);
+    boolean isAbstract = argType != null && argType.isAbstract();
+
+    if (isAbstract) {
+      return dataTypeTree.isSubtypeOf(valueDataTypeId, argDataTypeId);
+    } else {
+      return Objects.equals(valueDataTypeId, argDataTypeId);
+    }
+  }
+
+  /**
+   * Create an array of the class registered for {@code argDataTypeId} containing {@code elements}.
+   *
+   * <p>Follows the {@code OpcUaBinaryDecoder#decodeStructArray} precedent: the element class comes
+   * from the registered {@link DataTypeCodec}, so even an empty array is correctly typed. If no
+   * codec is registered, e.g. because the DataType is abstract, the {@link UaStructuredType} array
+   * is returned as-is.
+   *
+   * @param argDataTypeId the {@link NodeId} of the Argument's DataType.
+   * @param elements the decoded {@link UaStructuredType} elements.
+   * @return an array of the codec's registered class containing {@code elements}.
+   */
+  private Object typedStructArray(NodeId argDataTypeId, UaStructuredType[] elements) {
+    DataTypeCodec codec =
+        node.getNodeContext()
+            .getServer()
+            .getStaticEncodingContext()
+            .getDataTypeManager()
+            .getCodec(argDataTypeId);
+
+    if (codec == null) {
+      return elements;
+    }
+
+    Object array = Array.newInstance(codec.getType(), elements.length);
+
+    for (int i = 0; i < elements.length; i++) {
+      Array.set(array, i, elements[i]);
+    }
+
+    return array;
+  }
+
+  /**
    * Get the input {@link Argument}s expected by the Method this handler is installed on.
    *
    * @return the input {@link Argument}s expected by the Method this handler is installed on.
@@ -212,7 +330,10 @@ public abstract class AbstractMethodInvocationHandler implements MethodInvocatio
    *
    * @param invocationContext the {@link InvocationContext}.
    * @param inputValues the user-supplied values for the input arguments. Each value has been
-   *     verified to be of the type specified by its {@link Argument}.
+   *     verified to be of the type specified by its {@link Argument}. Values for arguments with a
+   *     structured DataType carry the decoded {@link UaStructuredType} value (or, for array
+   *     arguments, an array of the DataType's registered class, e.g. {@code XVType[]}) rather than
+   *     the raw {@link ExtensionObject}(s) received in the request.
    * @return this output values matching this Method's output arguments, if any.
    * @throws UaException if invocation has failed for some reason.
    */
@@ -227,6 +348,8 @@ public abstract class AbstractMethodInvocationHandler implements MethodInvocatio
    * Bad_OutOfRange for any invalid input values.
    *
    * @param inputArgumentValues the input values provided by the client for the current method call.
+   *     Values for arguments with a structured DataType carry decoded {@link UaStructuredType}
+   *     values rather than raw {@link ExtensionObject}s.
    * @throws InvalidArgumentException if one or more input argument values are invalid.
    */
   protected void validateInputArgumentValues(Variant[] inputArgumentValues)


### PR DESCRIPTION
## Summary

- decode scalar structure arguments before invoking method handlers
- decode structure arrays element-wise into correctly typed arrays, including empty arrays
- report decode failures, null array elements, and structure type mismatches as `Bad_TypeMismatch`
- avoid mutating the request by cloning its input argument array before substitution
- add integration coverage for scalar, abstract, array, empty-array, and mismatched structure inputs

## Root cause

`AbstractMethodInvocationHandler` validated structured inputs but passed their raw `ExtensionObject` or `ExtensionObject[]` representation to `invoke()`. Generated method wrappers cast inputs to their declared structure types, causing `ClassCastException`, especially for structure-array arguments.

## Impact

Method handlers now receive decoded `UaStructuredType` values and arrays of the registered Java structure class, matching the declared method argument contract. Existing handlers that intentionally consume raw `ExtensionObject` values for structure-typed arguments may need adjustment.

## Verification

- `mise exec -- mvn -q spotless:apply`
- `mise exec -- mvn -q clean compile`
- `mise exec -- mvn -q -pl opc-ua-sdk/integration-tests -am test -Dtest=AbstractMethodInvocationHandlerTest -Dsurefire.failIfNoSpecifiedTests=false`
