### PR TITLE
Release pending UASC chunks on teardown

### DIFF
--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/channel/ChunkDecoder.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/channel/ChunkDecoder.java
@@ -23,6 +23,8 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.Signature;
 import java.security.SignatureException;
+import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import javax.crypto.Cipher;
 import javax.crypto.spec.IvParameterSpec;
@@ -65,11 +67,17 @@ public final class ChunkDecoder {
   public DecodedMessage decodeSymmetric(SecureChannel channel, List<ByteBuf> chunkBuffers)
       throws MessageAbortException, MessageDecodeException {
 
+    boolean validated = false;
+
     try {
       validateSymmetricSecurityHeaders(channel, chunkBuffers);
+      validated = true;
     } catch (UaException e) {
-      chunkBuffers.forEach(ReferenceCountUtil::safeRelease);
       throw new MessageDecodeException(e);
+    } finally {
+      if (!validated) {
+        releaseAll(chunkBuffers);
+      }
     }
 
     return decode(symmetricDecoder, channel, chunkBuffers);
@@ -80,18 +88,25 @@ public final class ChunkDecoder {
       throws MessageAbortException, MessageDecodeException {
 
     CompositeByteBuf composite = BufferUtil.compositeBuffer();
+    List<ByteBuf> buffersToDecode = new ArrayList<>(chunkBuffers);
+    boolean decoded = false;
 
     try {
-      return decoder.decode(channel, composite, chunkBuffers);
-    } catch (MessageAbortException e) {
-      ReferenceCountUtil.safeRelease(composite);
-      chunkBuffers.forEach(ReferenceCountUtil::safeRelease);
-      throw e;
+      DecodedMessage decodedMessage = decoder.decode(channel, composite, buffersToDecode);
+      decoded = true;
+      return decodedMessage;
     } catch (UaException e) {
-      ReferenceCountUtil.safeRelease(composite);
-      chunkBuffers.forEach(ReferenceCountUtil::safeRelease);
       throw new MessageDecodeException(e);
+    } finally {
+      if (!decoded) {
+        ReferenceCountUtil.safeRelease(composite);
+        releaseAll(buffersToDecode);
+      }
     }
+  }
+
+  private static void releaseAll(List<ByteBuf> chunkBuffers) {
+    chunkBuffers.forEach(ReferenceCountUtil::safeRelease);
   }
 
   private static void validateSymmetricSecurityHeaders(
@@ -154,7 +169,8 @@ public final class ChunkDecoder {
 
       long requestId = -1L;
 
-      for (ByteBuf chunkBuffer : chunkBuffers) {
+      for (Iterator<ByteBuf> iterator = chunkBuffers.iterator(); iterator.hasNext(); ) {
+        ByteBuf chunkBuffer = iterator.next();
         final char chunkType = (char) chunkBuffer.getByte(3);
 
         chunkBuffer.skipBytes(SecureMessageHeader.SECURE_MESSAGE_HEADER_SIZE);
@@ -218,6 +234,7 @@ public final class ChunkDecoder {
               errorMessage.getReason(), requestId, errorMessage.getError());
         }
 
+        iterator.remove();
         composite.addComponent(bodyBuffer);
         composite.writerIndex(composite.writerIndex() + bodyBuffer.readableBytes());
       }

--- a/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/server/uasc/ChunkBufferAccumulator.java
+++ b/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/server/uasc/ChunkBufferAccumulator.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.transport.server.uasc;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.util.ReferenceCountUtil;
+import java.util.ArrayList;
+import java.util.List;
+
+final class ChunkBufferAccumulator {
+
+  private final int initialCapacity;
+
+  private List<ByteBuf> chunkBuffers;
+
+  ChunkBufferAccumulator() {
+    this(0);
+  }
+
+  ChunkBufferAccumulator(int initialCapacity) {
+    this.initialCapacity = initialCapacity;
+
+    chunkBuffers = new ArrayList<>(initialCapacity);
+  }
+
+  void add(ByteBuf buffer) {
+    chunkBuffers.add(buffer.retain());
+  }
+
+  int size() {
+    return chunkBuffers.size();
+  }
+
+  List<ByteBuf> takeAll() {
+    List<ByteBuf> buffers = chunkBuffers;
+    chunkBuffers = new ArrayList<>(initialCapacity);
+    return buffers;
+  }
+
+  void releaseAll() {
+    List<ByteBuf> buffers = takeAll();
+    buffers.forEach(ReferenceCountUtil::safeRelease);
+    buffers.clear();
+  }
+}

--- a/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/server/uasc/UascServerAsymmetricHandler.java
+++ b/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/server/uasc/UascServerAsymmetricHandler.java
@@ -18,12 +18,10 @@ import io.netty.buffer.CompositeByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.util.AttributeKey;
-import io.netty.util.ReferenceCountUtil;
 import io.netty.util.Timeout;
 import java.io.IOException;
 import java.security.KeyPair;
 import java.security.cert.X509Certificate;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -87,7 +85,7 @@ public class UascServerAsymmetricHandler extends ByteToMessageDecoder implements
 
   private boolean symmetricHandlerAdded = false;
 
-  private List<ByteBuf> chunkBuffers = new ArrayList<>();
+  private final ChunkBufferAccumulator chunkBuffers = new ChunkBufferAccumulator();
 
   private final AtomicReference<AsymmetricSecurityHeader> headerRef = new AtomicReference<>();
 
@@ -128,6 +126,8 @@ public class UascServerAsymmetricHandler extends ByteToMessageDecoder implements
 
   @Override
   public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+    chunkBuffers.releaseAll();
+
     if (secureChannelTimeout != null) {
       secureChannelTimeout.cancel();
       secureChannelTimeout = null;
@@ -137,9 +137,15 @@ public class UascServerAsymmetricHandler extends ByteToMessageDecoder implements
   }
 
   @Override
+  protected void handlerRemoved0(ChannelHandlerContext ctx) throws Exception {
+    chunkBuffers.releaseAll();
+
+    super.handlerRemoved0(ctx);
+  }
+
+  @Override
   public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-    chunkBuffers.forEach(ReferenceCountUtil::safeRelease);
-    chunkBuffers.clear();
+    chunkBuffers.releaseAll();
 
     if (cause instanceof IOException) {
       ctx.close();
@@ -206,8 +212,7 @@ public class UascServerAsymmetricHandler extends ByteToMessageDecoder implements
     char chunkType = (char) buffer.readByte();
 
     if (chunkType == 'A') {
-      chunkBuffers.forEach(ByteBuf::release);
-      chunkBuffers.clear();
+      chunkBuffers.releaseAll();
       headerRef.set(null);
     } else {
       buffer.skipBytes(4); // Skip messageSize
@@ -343,7 +348,7 @@ public class UascServerAsymmetricHandler extends ByteToMessageDecoder implements
             String.format("max chunk size exceeded (%s)", maxChunkSize));
       }
 
-      chunkBuffers.add(buffer.retain());
+      chunkBuffers.add(buffer);
 
       if (maxChunkCount > 0 && chunkBuffers.size() > maxChunkCount) {
         throw new UaException(
@@ -352,9 +357,7 @@ public class UascServerAsymmetricHandler extends ByteToMessageDecoder implements
       }
 
       if (chunkType == 'F') {
-        final List<ByteBuf> buffersToDecode = chunkBuffers;
-
-        chunkBuffers = new ArrayList<>();
+        final List<ByteBuf> buffersToDecode = chunkBuffers.takeAll();
         headerRef.set(null);
 
         ByteBuf message;

--- a/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/server/uasc/UascServerSymmetricHandler.java
+++ b/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/server/uasc/UascServerSymmetricHandler.java
@@ -14,7 +14,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.CompositeByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.ByteToMessageCodec;
-import java.util.ArrayList;
 import java.util.List;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
@@ -52,7 +51,7 @@ public class UascServerSymmetricHandler extends ByteToMessageCodec<UascServiceRe
 
   private final int maxChunkCount;
   private final int maxChunkSize;
-  private List<ByteBuf> chunkBuffers;
+  private final ChunkBufferAccumulator chunkBuffers;
 
   private final OpcUaBinaryEncoder binaryEncoder;
   private final OpcUaBinaryDecoder binaryDecoder;
@@ -88,7 +87,7 @@ public class UascServerSymmetricHandler extends ByteToMessageCodec<UascServiceRe
     maxChunkCount = channelParameters.getLocalMaxChunkCount();
     maxChunkSize = channelParameters.getLocalReceiveBufferSize();
 
-    chunkBuffers = new ArrayList<>(maxChunkCount);
+    chunkBuffers = new ChunkBufferAccumulator(maxChunkCount);
   }
 
   @Override
@@ -96,6 +95,27 @@ public class UascServerSymmetricHandler extends ByteToMessageCodec<UascServiceRe
     ctx.pipeline().addLast(new UascServiceRequestHandler(config, applicationContext));
 
     super.handlerAdded(ctx);
+  }
+
+  @Override
+  public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
+    chunkBuffers.releaseAll();
+
+    super.handlerRemoved(ctx);
+  }
+
+  @Override
+  public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+    chunkBuffers.releaseAll();
+
+    super.channelInactive(ctx);
+  }
+
+  @Override
+  public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
+    chunkBuffers.releaseAll();
+
+    super.exceptionCaught(ctx, cause);
   }
 
   @Override
@@ -142,8 +162,7 @@ public class UascServerSymmetricHandler extends ByteToMessageCodec<UascServiceRe
     char chunkType = (char) buffer.readByte();
 
     if (chunkType == 'A') {
-      chunkBuffers.forEach(ByteBuf::release);
-      chunkBuffers.clear();
+      chunkBuffers.releaseAll();
     } else {
       buffer.skipBytes(4); // Skip messageSize
 
@@ -161,7 +180,7 @@ public class UascServerSymmetricHandler extends ByteToMessageCodec<UascServiceRe
             String.format("max chunk size exceeded (%s)", maxChunkSize));
       }
 
-      chunkBuffers.add(buffer.retain());
+      chunkBuffers.add(buffer);
 
       if (maxChunkCount > 0 && chunkBuffers.size() > maxChunkCount) {
         throw new UaException(
@@ -170,8 +189,7 @@ public class UascServerSymmetricHandler extends ByteToMessageCodec<UascServiceRe
       }
 
       if (chunkType == 'F') {
-        final List<ByteBuf> buffersToDecode = chunkBuffers;
-        chunkBuffers = new ArrayList<>();
+        final List<ByteBuf> buffersToDecode = chunkBuffers.takeAll();
 
         ByteBuf message = null;
 

--- a/opc-ua-stack/transport/src/test/java/org/eclipse/milo/opcua/stack/transport/server/uasc/UascServerChunkLifecycleTest.java
+++ b/opc-ua-stack/transport/src/test/java/org/eclipse/milo/opcua/stack/transport/server/uasc/UascServerChunkLifecycleTest.java
@@ -1,0 +1,368 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.transport.server.uasc;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ubyte;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.DecoderException;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.channel.ChannelParameters;
+import org.eclipse.milo.opcua.stack.core.channel.ChannelSecurity;
+import org.eclipse.milo.opcua.stack.core.channel.ChunkDecoder;
+import org.eclipse.milo.opcua.stack.core.channel.ChunkEncoder;
+import org.eclipse.milo.opcua.stack.core.channel.ServerSecureChannel;
+import org.eclipse.milo.opcua.stack.core.channel.headers.AsymmetricSecurityHeader;
+import org.eclipse.milo.opcua.stack.core.channel.headers.SequenceHeader;
+import org.eclipse.milo.opcua.stack.core.channel.messages.MessageType;
+import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
+import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
+import org.eclipse.milo.opcua.stack.core.security.CertificateManager;
+import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
+import org.eclipse.milo.opcua.stack.core.transport.TransportProfile;
+import org.eclipse.milo.opcua.stack.core.types.UaRequestMessageType;
+import org.eclipse.milo.opcua.stack.core.types.UaResponseMessageType;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.ApplicationType;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.MessageSecurityMode;
+import org.eclipse.milo.opcua.stack.core.types.structured.ApplicationDescription;
+import org.eclipse.milo.opcua.stack.core.types.structured.ChannelSecurityToken;
+import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
+import org.eclipse.milo.opcua.stack.transport.server.ServerApplicationContext;
+import org.eclipse.milo.opcua.stack.transport.server.ServiceRequestContext;
+import org.junit.jupiter.api.Test;
+
+class UascServerChunkLifecycleTest {
+
+  private static final String ENDPOINT_URL = "opc.tcp://localhost:4840";
+
+  private static final ChannelParameters CHANNEL_PARAMETERS =
+      new ChannelParameters(8192, 8192, 8192, 16, 8192, 8192, 8192, 16);
+
+  private static final ServerApplicationContext APPLICATION_CONTEXT =
+      new ServerApplicationContext() {
+        @Override
+        public List<EndpointDescription> getEndpointDescriptions() {
+          return List.of(
+              new EndpointDescription(
+                  ENDPOINT_URL,
+                  new ApplicationDescription(
+                      "urn:test:server",
+                      "urn:test:product",
+                      LocalizedText.NULL_VALUE,
+                      ApplicationType.Server,
+                      null,
+                      null,
+                      new String[] {ENDPOINT_URL}),
+                  ByteString.NULL_VALUE,
+                  MessageSecurityMode.None,
+                  SecurityPolicy.None.getUri(),
+                  null,
+                  TransportProfile.TCP_UASC_UABINARY.getUri(),
+                  ubyte(0)));
+        }
+
+        @Override
+        public CertificateManager getCertificateManager() {
+          throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public EncodingContext getEncodingContext() {
+          return DefaultEncodingContext.INSTANCE;
+        }
+
+        @Override
+        public Long getNextSecureChannelId() {
+          return 1L;
+        }
+
+        @Override
+        public Long getNextSecureChannelTokenId() {
+          return 1L;
+        }
+
+        @Override
+        public CompletableFuture<UaResponseMessageType> handleServiceRequest(
+            ServiceRequestContext context, UaRequestMessageType requestMessage) {
+          return CompletableFuture.failedFuture(new UnsupportedOperationException());
+        }
+      };
+
+  @Test
+  void asymmetricPartialChunkIsReleasedOnDisconnectBeforeSession() {
+    var handler =
+        new UascServerAsymmetricHandler(
+            null, APPLICATION_CONTEXT, TransportProfile.TCP_UASC_UABINARY, CHANNEL_PARAMETERS);
+    var channel = new EmbeddedChannel(handler);
+    channel.attr(UascServerHelloHandler.ENDPOINT_URL_KEY).set(ENDPOINT_URL);
+
+    ByteBuf chunk = newAsymmetricPartialChunk();
+
+    channel.writeInbound(chunk);
+    assertEquals(1, chunk.refCnt());
+
+    channel.close().syncUninterruptibly();
+    assertEquals(0, chunk.refCnt());
+
+    channel.finishAndReleaseAll();
+  }
+
+  @Test
+  void asymmetricPartialChunkIsReleasedOnHandlerRemoval() {
+    var handler =
+        new UascServerAsymmetricHandler(
+            null, APPLICATION_CONTEXT, TransportProfile.TCP_UASC_UABINARY, CHANNEL_PARAMETERS);
+    var channel = new EmbeddedChannel(handler);
+    channel.attr(UascServerHelloHandler.ENDPOINT_URL_KEY).set(ENDPOINT_URL);
+
+    ByteBuf chunk = newAsymmetricPartialChunk();
+
+    channel.writeInbound(chunk);
+    assertEquals(1, chunk.refCnt());
+
+    channel.pipeline().remove(handler);
+    assertEquals(0, chunk.refCnt());
+
+    channel.finishAndReleaseAll();
+  }
+
+  @Test
+  void symmetricPartialChunkIsReleasedOnDisconnect() {
+    UascServerSymmetricHandler handler = newSymmetricHandler();
+    var channel = new EmbeddedChannel(handler);
+
+    ByteBuf chunk = newSymmetricPartialChunk();
+
+    channel.writeInbound(chunk);
+    assertEquals(1, chunk.refCnt());
+
+    channel.close().syncUninterruptibly();
+    assertEquals(0, chunk.refCnt());
+
+    channel.finishAndReleaseAll();
+  }
+
+  @Test
+  void symmetricPartialChunkIsReleasedOnHandlerRemoval() {
+    UascServerSymmetricHandler handler = newSymmetricHandler();
+    var channel = new EmbeddedChannel(handler);
+
+    ByteBuf chunk = newSymmetricPartialChunk();
+
+    channel.writeInbound(chunk);
+    assertEquals(1, chunk.refCnt());
+
+    channel.pipeline().remove(handler);
+    assertEquals(0, chunk.refCnt());
+
+    channel.finishAndReleaseAll();
+  }
+
+  @Test
+  void symmetricPartialChunksAreReleasedOnException() {
+    var channelParameters = new ChannelParameters(8192, 8192, 8192, 1, 8192, 8192, 8192, 16);
+    UascServerSymmetricHandler handler = newSymmetricHandler(channelParameters);
+    var channel = new EmbeddedChannel(handler);
+
+    ByteBuf firstChunk = newSymmetricChunk('C');
+    ByteBuf secondChunk = newSymmetricChunk('C');
+
+    channel.writeInbound(firstChunk);
+    assertEquals(1, firstChunk.refCnt());
+
+    DecoderException exception =
+        assertThrows(DecoderException.class, () -> channel.writeInbound(secondChunk));
+    assertInstanceOf(UaException.class, exception.getCause());
+    assertEquals(0, firstChunk.refCnt());
+    assertEquals(0, secondChunk.refCnt());
+
+    channel.finishAndReleaseAll();
+  }
+
+  @Test
+  void symmetricPartialChunkIsReleasedOnAbort() {
+    UascServerSymmetricHandler handler = newSymmetricHandler();
+    var channel = new EmbeddedChannel(handler);
+
+    ByteBuf partialChunk = newSymmetricPartialChunk();
+    ByteBuf abortChunk = newSymmetricChunk('A');
+
+    channel.writeInbound(partialChunk);
+    assertEquals(1, partialChunk.refCnt());
+
+    channel.writeInbound(abortChunk);
+    assertEquals(0, partialChunk.refCnt());
+    assertEquals(0, abortChunk.refCnt());
+
+    channel.finishAndReleaseAll();
+  }
+
+  @Test
+  void asymmetricMalformedFinalChunkIsReleasedBeforeSession() {
+    var handler =
+        new UascServerAsymmetricHandler(
+            null, APPLICATION_CONTEXT, TransportProfile.TCP_UASC_UABINARY, CHANNEL_PARAMETERS);
+    var channel = new EmbeddedChannel(handler);
+    channel.attr(UascServerHelloHandler.ENDPOINT_URL_KEY).set(ENDPOINT_URL);
+
+    ByteBuf chunk = newAsymmetricChunk('F', false);
+
+    channel.writeInbound(chunk);
+    assertEquals(0, chunk.refCnt());
+
+    channel.finishAndReleaseAll();
+  }
+
+  @Test
+  void symmetricMalformedFinalChunkIsReleased() {
+    UascServerSymmetricHandler handler = newSymmetricHandler();
+    var channel = new EmbeddedChannel(handler);
+
+    ByteBuf chunk = newSymmetricFinalChunkWithoutSequenceHeader();
+
+    assertThrows(DecoderException.class, () -> channel.writeInbound(chunk));
+    assertEquals(0, chunk.refCnt());
+
+    channel.finishAndReleaseAll();
+  }
+
+  @Test
+  void coalescedAsymmetricChunksAreReleasedOnMalformedFinalChunk() {
+    var handler =
+        new UascServerAsymmetricHandler(
+            null, APPLICATION_CONTEXT, TransportProfile.TCP_UASC_UABINARY, CHANNEL_PARAMETERS);
+    var channel = new EmbeddedChannel(handler);
+    channel.attr(UascServerHelloHandler.ENDPOINT_URL_KEY).set(ENDPOINT_URL);
+
+    ByteBuf chunks = PooledByteBufAllocator.DEFAULT.directBuffer();
+    writeAsymmetricChunk(chunks, 'C', true);
+    writeAsymmetricChunk(chunks, 'F', false);
+
+    channel.writeInbound(chunks);
+    assertEquals(0, chunks.refCnt());
+
+    channel.finishAndReleaseAll();
+  }
+
+  @Test
+  void transferredChunksRemainOwnedByCaller() {
+    var accumulator = new ChunkBufferAccumulator();
+    ByteBuf chunk = PooledByteBufAllocator.DEFAULT.directBuffer(1);
+
+    accumulator.add(chunk);
+    chunk.release();
+
+    List<ByteBuf> transferred = accumulator.takeAll();
+    accumulator.releaseAll();
+
+    assertEquals(1, chunk.refCnt());
+
+    transferred.forEach(ByteBuf::release);
+    assertEquals(0, chunk.refCnt());
+  }
+
+  private static UascServerSymmetricHandler newSymmetricHandler() {
+    return newSymmetricHandler(CHANNEL_PARAMETERS);
+  }
+
+  private static UascServerSymmetricHandler newSymmetricHandler(
+      ChannelParameters channelParameters) {
+    var secureChannel = new ServerSecureChannel();
+    secureChannel.setChannelId(1L);
+    secureChannel.setSecurityPolicy(SecurityPolicy.None);
+    secureChannel.setMessageSecurityMode(MessageSecurityMode.None);
+    secureChannel.setChannelSecurity(
+        new ChannelSecurity(
+            null, new ChannelSecurityToken(uint(1), uint(1), DateTime.now(), uint(60_000))));
+
+    var chunkEncoder = new ChunkEncoder(channelParameters);
+    var chunkDecoder =
+        new ChunkDecoder(
+            channelParameters, APPLICATION_CONTEXT.getEncodingContext().getEncodingLimits());
+
+    return new UascServerSymmetricHandler(
+        null,
+        APPLICATION_CONTEXT,
+        TransportProfile.TCP_UASC_UABINARY,
+        channelParameters,
+        chunkEncoder,
+        chunkDecoder,
+        secureChannel);
+  }
+
+  private static ByteBuf newAsymmetricPartialChunk() {
+    return newAsymmetricChunk('C', false);
+  }
+
+  private static ByteBuf newAsymmetricChunk(char chunkType, boolean includeSequenceHeader) {
+    ByteBuf buffer = PooledByteBufAllocator.DEFAULT.directBuffer();
+
+    writeAsymmetricChunk(buffer, chunkType, includeSequenceHeader);
+
+    return buffer;
+  }
+
+  private static void writeAsymmetricChunk(
+      ByteBuf buffer, char chunkType, boolean includeSequenceHeader) {
+    int chunkStart = buffer.writerIndex();
+
+    buffer.writeMediumLE(MessageType.toMediumInt(MessageType.OpenSecureChannel));
+    buffer.writeByte(chunkType);
+    buffer.writeIntLE(0);
+    buffer.writeIntLE(0);
+    AsymmetricSecurityHeader.encode(
+        new AsymmetricSecurityHeader(
+            SecurityPolicy.None.getUri(), ByteString.NULL_VALUE, ByteString.NULL_VALUE),
+        buffer);
+    if (includeSequenceHeader) {
+      SequenceHeader.encode(new SequenceHeader(1L, 1L), buffer);
+    }
+    buffer.setIntLE(chunkStart + 4, buffer.writerIndex() - chunkStart);
+  }
+
+  private static ByteBuf newSymmetricPartialChunk() {
+    return newSymmetricChunk('C');
+  }
+
+  private static ByteBuf newSymmetricChunk(char chunkType) {
+    ByteBuf buffer = PooledByteBufAllocator.DEFAULT.directBuffer(12);
+
+    buffer.writeMediumLE(MessageType.toMediumInt(MessageType.SecureMessage));
+    buffer.writeByte(chunkType);
+    buffer.writeIntLE(12);
+    buffer.writeIntLE(1);
+
+    return buffer;
+  }
+
+  private static ByteBuf newSymmetricFinalChunkWithoutSequenceHeader() {
+    ByteBuf buffer = PooledByteBufAllocator.DEFAULT.directBuffer(16);
+
+    buffer.writeMediumLE(MessageType.toMediumInt(MessageType.SecureMessage));
+    buffer.writeByte('F');
+    buffer.writeIntLE(16);
+    buffer.writeIntLE(1);
+    buffer.writeIntLE(1);
+
+    return buffer;
+  }
+}


### PR DESCRIPTION
## Summary

- release retained UASC chunk buffers when server channels become inactive, handlers are removed, decoding fails, or messages are aborted
- make final-message ownership transfer exception-safe without double-releasing coalesced buffers
- add focused pooled-buffer lifecycle regressions for asymmetric, symmetric, pre-session `SecurityPolicy.None`, malformed-final, and shared-parent paths

## Root cause

The server handlers retained partial message chunks independently from Netty's inbound ownership. Some teardown paths did not release those references, and unchecked final-message decode failures could escape after ownership had moved out of the handler accumulator.

This change centralizes idempotent pending-buffer cleanup and makes `ChunkDecoder` track composite-owned and not-yet-transferred chunks as disjoint ownership sets. Every retained chunk is now either released on failure or cleanup, or transferred exactly once to the successfully decoded message.

## Verification

- `mise exec -- mvn -q spotless:apply`
- `mise exec -- mvn -q clean compile`
- focused `UascServerChunkLifecycleTest`
- `ChunkDecoderTest`
- `ChunkSerializationTest`
- complete `opc-ua-stack/transport` test suite
