### PR TITLE
Preserve role mappings when copying server config

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServerConfig.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServerConfig.java
@@ -164,6 +164,7 @@ public interface OpcUaServerConfig {
     builder.setLimits(config.getLimits());
     builder.setIdentityValidator(config.getIdentityValidator());
     builder.setCertificateManager(config.getCertificateManager());
+    config.getRoleMapper().ifPresent(builder::setRoleMapper);
     builder.setExecutor(config.getExecutor());
     builder.setScheduledExecutor(config.getScheduledExecutorService());
     config.getSecurityKeysListener().ifPresent(builder::setSecurityKeysListener);

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/OpcUaServerConfigTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/OpcUaServerConfigTest.java
@@ -11,13 +11,19 @@
 package org.eclipse.milo.opcua.sdk.server;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
 
-import java.util.concurrent.Executors;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
-import org.eclipse.milo.opcua.sdk.server.identity.AnonymousIdentityValidator;
-import org.eclipse.milo.opcua.stack.core.security.DefaultCertificateManager;
-import org.eclipse.milo.opcua.stack.core.security.MemoryCertificateQuarantine;
+import org.eclipse.milo.opcua.sdk.server.identity.IdentityValidator;
+import org.eclipse.milo.opcua.stack.core.channel.EncodingLimits;
+import org.eclipse.milo.opcua.stack.core.channel.SecurityKeysListener;
+import org.eclipse.milo.opcua.stack.core.security.CertificateManager;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.structured.BuildInfo;
 import org.junit.jupiter.api.Test;
 
@@ -25,23 +31,51 @@ public class OpcUaServerConfigTest {
 
   @Test
   public void testCopy() {
-    ScheduledExecutorService scheduledExecutorService =
-        Executors.newSingleThreadScheduledExecutor();
+    var endpoints = Set.of(mock(EndpointConfig.class));
+    var applicationName = LocalizedText.english("application-name");
+    var buildInfo = new BuildInfo("a", "b", "c", "d", "e", DateTime.MIN_VALUE);
+    IdentityValidator identityValidator = mock(IdentityValidator.class);
+    var encodingLimits = new EncodingLimits(8196, 2, 16392, 4);
+    OpcUaServerConfigLimits limits = new OpcUaServerConfigLimits() {};
+    CertificateManager certificateManager = mock(CertificateManager.class);
+    RoleMapper roleMapper = identity -> List.of();
+    SecurityKeysListener securityKeysListener = keyset -> {};
+    ExecutorService executor = mock(ExecutorService.class);
+    ScheduledExecutorService scheduledExecutor = mock(ScheduledExecutorService.class);
 
     OpcUaServerConfig original =
         OpcUaServerConfig.builder()
-            .setCertificateManager(new DefaultCertificateManager(new MemoryCertificateQuarantine()))
-            .setIdentityValidator(AnonymousIdentityValidator.INSTANCE)
-            .setBuildInfo(new BuildInfo("a", "b", "c", "d", "e", DateTime.MIN_VALUE))
-            .setLimits(new OpcUaServerConfigLimits() {})
-            .setScheduledExecutor(scheduledExecutorService)
+            .setEndpoints(endpoints)
+            .setApplicationName(applicationName)
+            .setApplicationUri("urn:application")
+            .setProductUri("urn:product")
+            .setBuildInfo(buildInfo)
+            .setIdentityValidator(identityValidator)
+            .setEncodingLimits(encodingLimits)
+            .setLimits(limits)
+            .setCertificateManager(certificateManager)
+            .setRoleMapper(roleMapper)
+            .setSecurityKeysListener(securityKeysListener)
+            .setExecutor(executor)
+            .setScheduledExecutor(scheduledExecutor)
             .build();
 
     OpcUaServerConfig copy = OpcUaServerConfig.copy(original).build();
 
-    assertEquals(original.getIdentityValidator(), copy.getIdentityValidator());
-    assertEquals(original.getBuildInfo(), copy.getBuildInfo());
-    assertEquals(original.getLimits(), copy.getLimits());
-    assertEquals(original.getScheduledExecutorService(), copy.getScheduledExecutorService());
+    assertSame(original.getEndpoints(), copy.getEndpoints());
+    assertSame(original.getApplicationName(), copy.getApplicationName());
+    assertEquals(original.getApplicationUri(), copy.getApplicationUri());
+    assertEquals(original.getProductUri(), copy.getProductUri());
+    assertSame(original.getBuildInfo(), copy.getBuildInfo());
+    assertSame(original.getIdentityValidator(), copy.getIdentityValidator());
+    assertSame(original.getEncodingLimits(), copy.getEncodingLimits());
+    assertSame(original.getLimits(), copy.getLimits());
+    assertSame(original.getCertificateManager(), copy.getCertificateManager());
+    assertSame(original.getRoleMapper().orElseThrow(), copy.getRoleMapper().orElseThrow());
+    assertSame(
+        original.getSecurityKeysListener().orElseThrow(),
+        copy.getSecurityKeysListener().orElseThrow());
+    assertSame(original.getExecutor(), copy.getExecutor());
+    assertSame(original.getScheduledExecutorService(), copy.getScheduledExecutorService());
   }
 }

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/servicesets/impl/DefaultAccessControllerTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/servicesets/impl/DefaultAccessControllerTest.java
@@ -18,6 +18,9 @@ import java.util.Map;
 import java.util.Optional;
 import org.eclipse.milo.opcua.sdk.core.AccessLevel;
 import org.eclipse.milo.opcua.sdk.core.WriteMask;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServerConfig;
+import org.eclipse.milo.opcua.sdk.server.RoleMapper;
+import org.eclipse.milo.opcua.sdk.server.identity.Identity;
 import org.eclipse.milo.opcua.sdk.server.servicesets.impl.AccessController.AccessResult;
 import org.eclipse.milo.opcua.sdk.server.servicesets.impl.DefaultAccessController.AccessControlAttributes;
 import org.eclipse.milo.opcua.sdk.server.servicesets.impl.DefaultAccessController.AccessControlContext;
@@ -1054,6 +1057,33 @@ class DefaultAccessControllerTest {
         AccessResult.DENIED_USER_ACCESS,
         DefaultAccessController.checkDeleteReferencesAccess(context, List.of(deleteReferencesItem))
             .get(deleteReferencesItem));
+  }
+
+  @Test
+  void copiedConfigPreservesRoleBasedAuthorizationBehavior() {
+    Identity identity = Mockito.mock(Identity.class);
+    RoleMapper roleMapper = ignored -> List.of(ROLE_B);
+    OpcUaServerConfig directConfig = OpcUaServerConfig.builder().setRoleMapper(roleMapper).build();
+    OpcUaServerConfig copiedConfig = OpcUaServerConfig.copy(directConfig).build();
+
+    var nodeId = new NodeId(1, "browse");
+    attributesMap.put(
+        nodeId,
+        new AccessControlAttributes(
+            null, null, null, null, null, rolePermissions(PermissionType.Field.Browse)));
+
+    Mockito.when(context.getRoleIds())
+        .thenReturn(
+            directConfig.getRoleMapper().map(mapper -> mapper.getRoleIds(identity)),
+            copiedConfig.getRoleMapper().map(mapper -> mapper.getRoleIds(identity)));
+
+    AccessResult directResult =
+        DefaultAccessController.checkBrowseAccess(context, List.of(nodeId)).get(nodeId);
+    AccessResult copiedResult =
+        DefaultAccessController.checkBrowseAccess(context, List.of(nodeId)).get(nodeId);
+
+    assertEquals(AccessResult.DENIED_USER_ACCESS, directResult);
+    assertEquals(directResult, copiedResult);
   }
 
   private static RolePermissionType[] rolePermissions(PermissionType.Field field) {


### PR DESCRIPTION
## Summary

- preserve the configured `RoleMapper` when copying an `OpcUaServerConfig`
- keep direct and copied server configurations authorization-equivalent
- expand copy-completeness coverage and add a focused role-authorization regression test

## Root cause

`OpcUaServerConfig.copy()` transferred the other server configuration fields but omitted the optional role mapper. A copied role-enabled configuration therefore lost its role mapping and could skip configured role-permission checks.

The fix copies the existing mapper through the repository's builder API without changing the behavior of configurations that intentionally have no mapper.

## Verification

- `mise exec -- mvn -q spotless:apply`
- `mise exec -- mvn -q clean compile`
- `mise exec -- mvn -q -pl opc-ua-sdk/sdk-server -am test -Dtest=OpcUaServerConfigTest,DefaultAccessControllerTest -Dsurefire.failIfNoSpecifiedTests=false`
- `mise exec -- mvn -q -pl opc-ua-sdk/sdk-server -am test`
- independent focused security review: approved with no actionable findings
