### PR TITLE
Restrict session security diagnostics access

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServerConfig.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServerConfig.java
@@ -15,6 +15,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
+import org.eclipse.milo.opcua.sdk.server.diagnostics.SessionSecurityDiagnosticsAccessMode;
 import org.eclipse.milo.opcua.sdk.server.identity.AnonymousIdentityValidator;
 import org.eclipse.milo.opcua.sdk.server.identity.CompositeValidator;
 import org.eclipse.milo.opcua.sdk.server.identity.IdentityValidator;
@@ -118,6 +119,15 @@ public interface OpcUaServerConfig {
   Optional<RoleMapper> getRoleMapper();
 
   /**
+   * Get the authorization mode for Session security diagnostics and the diagnostics enabled flag.
+   *
+   * @return the configured access mode.
+   */
+  default SessionSecurityDiagnosticsAccessMode getSessionSecurityDiagnosticsAccessMode() {
+    return SessionSecurityDiagnosticsAccessMode.RESTRICTED;
+  }
+
+  /**
    * Get the {@link SecurityKeysListener} to be notified when symmetric security keys are derived
    * during OpenSecureChannel handshakes.
    *
@@ -165,6 +175,8 @@ public interface OpcUaServerConfig {
     builder.setIdentityValidator(config.getIdentityValidator());
     builder.setCertificateManager(config.getCertificateManager());
     config.getRoleMapper().ifPresent(builder::setRoleMapper);
+    builder.setSessionSecurityDiagnosticsAccessMode(
+        config.getSessionSecurityDiagnosticsAccessMode());
     builder.setExecutor(config.getExecutor());
     builder.setScheduledExecutor(config.getScheduledExecutorService());
     config.getSecurityKeysListener().ifPresent(builder::setSecurityKeysListener);

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServerConfigBuilder.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServerConfigBuilder.java
@@ -10,11 +10,14 @@
 
 package org.eclipse.milo.opcua.sdk.server;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
+import org.eclipse.milo.opcua.sdk.server.diagnostics.SessionSecurityDiagnosticsAccessMode;
 import org.eclipse.milo.opcua.sdk.server.identity.AnonymousIdentityValidator;
 import org.eclipse.milo.opcua.sdk.server.identity.IdentityValidator;
 import org.eclipse.milo.opcua.stack.core.Stack;
@@ -48,6 +51,9 @@ public class OpcUaServerConfigBuilder {
   private CertificateManager certificateManager;
 
   private RoleMapper roleMapper;
+
+  private SessionSecurityDiagnosticsAccessMode sessionSecurityDiagnosticsAccessMode =
+      SessionSecurityDiagnosticsAccessMode.RESTRICTED;
 
   private @Nullable SecurityKeysListener securityKeysListener;
 
@@ -104,6 +110,19 @@ public class OpcUaServerConfigBuilder {
     return this;
   }
 
+  /**
+   * Set the authorization mode for Session security diagnostics and the diagnostics enabled flag.
+   *
+   * @param accessMode the authorization mode.
+   * @return this builder.
+   */
+  public OpcUaServerConfigBuilder setSessionSecurityDiagnosticsAccessMode(
+      SessionSecurityDiagnosticsAccessMode accessMode) {
+
+    this.sessionSecurityDiagnosticsAccessMode = requireNonNull(accessMode);
+    return this;
+  }
+
   public OpcUaServerConfigBuilder setSecurityKeysListener(
       @Nullable SecurityKeysListener securityKeysListener) {
     this.securityKeysListener = securityKeysListener;
@@ -139,6 +158,7 @@ public class OpcUaServerConfigBuilder {
         limits,
         certificateManager,
         roleMapper,
+        sessionSecurityDiagnosticsAccessMode,
         securityKeysListener,
         executor,
         scheduledExecutor);
@@ -156,6 +176,7 @@ public class OpcUaServerConfigBuilder {
     private final OpcUaServerConfigLimits limits;
     private final CertificateManager certificateManager;
     private final RoleMapper roleMapper;
+    private final SessionSecurityDiagnosticsAccessMode sessionSecurityDiagnosticsAccessMode;
     private final @Nullable SecurityKeysListener securityKeysListener;
     private final ExecutorService executor;
     private final ScheduledExecutorService scheduledExecutorService;
@@ -175,6 +196,39 @@ public class OpcUaServerConfigBuilder {
         ExecutorService executor,
         ScheduledExecutorService scheduledExecutorService) {
 
+      this(
+          endpoints,
+          applicationName,
+          applicationUri,
+          productUri,
+          buildInfo,
+          identityValidator,
+          encodingLimits,
+          limits,
+          certificateManager,
+          roleMapper,
+          SessionSecurityDiagnosticsAccessMode.RESTRICTED,
+          securityKeysListener,
+          executor,
+          scheduledExecutorService);
+    }
+
+    public OpcUaServerConfigImpl(
+        Set<EndpointConfig> endpoints,
+        LocalizedText applicationName,
+        String applicationUri,
+        String productUri,
+        BuildInfo buildInfo,
+        IdentityValidator identityValidator,
+        EncodingLimits encodingLimits,
+        OpcUaServerConfigLimits limits,
+        CertificateManager certificateManager,
+        RoleMapper roleMapper,
+        SessionSecurityDiagnosticsAccessMode sessionSecurityDiagnosticsAccessMode,
+        @Nullable SecurityKeysListener securityKeysListener,
+        ExecutorService executor,
+        ScheduledExecutorService scheduledExecutorService) {
+
       this.endpoints = endpoints;
       this.applicationName = applicationName;
       this.applicationUri = applicationUri;
@@ -185,6 +239,8 @@ public class OpcUaServerConfigBuilder {
       this.limits = limits;
       this.certificateManager = certificateManager;
       this.roleMapper = roleMapper;
+      this.sessionSecurityDiagnosticsAccessMode =
+          requireNonNull(sessionSecurityDiagnosticsAccessMode);
       this.securityKeysListener = securityKeysListener;
       this.executor = executor;
       this.scheduledExecutorService = scheduledExecutorService;
@@ -238,6 +294,11 @@ public class OpcUaServerConfigBuilder {
     @Override
     public Optional<RoleMapper> getRoleMapper() {
       return Optional.ofNullable(roleMapper);
+    }
+
+    @Override
+    public SessionSecurityDiagnosticsAccessMode getSessionSecurityDiagnosticsAccessMode() {
+      return sessionSecurityDiagnosticsAccessMode;
     }
 
     @Override

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/SessionSecurityDiagnosticsAccessMode.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/SessionSecurityDiagnosticsAccessMode.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.diagnostics;
+
+/** Controls authorization for Session security diagnostics and the diagnostics enabled flag. */
+public enum SessionSecurityDiagnosticsAccessMode {
+
+  /**
+   * Derive access from the standard diagnostics nodes' RolePermissions. Session security
+   * diagnostics are readable only by SecurityAdmin or an explicitly configured equivalent role,
+   * while diagnostics may be enabled or disabled only by ConfigureAdmin, SecurityAdmin, or an
+   * explicitly configured equivalent role.
+   */
+  RESTRICTED,
+
+  /**
+   * Preserve the previous authorization behavior without requiring role mapping. All Sessions may
+   * read Session security diagnostics and enable or disable diagnostics.
+   *
+   * <p>AccessRestrictions, including signing and encryption requirements, remain enforced. This
+   * mode is provided for compatibility and is less secure than {@link #RESTRICTED}.
+   */
+  LEGACY
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/objects/SessionsDiagnosticsSummaryObject.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/objects/SessionsDiagnosticsSummaryObject.java
@@ -23,17 +23,29 @@ import org.eclipse.milo.opcua.sdk.server.diagnostics.variables.SessionDiagnostic
 import org.eclipse.milo.opcua.sdk.server.diagnostics.variables.SessionSecurityDiagnosticsVariableArray;
 import org.eclipse.milo.opcua.sdk.server.model.objects.SessionDiagnosticsObjectTypeNode;
 import org.eclipse.milo.opcua.sdk.server.model.objects.SessionsDiagnosticsSummaryTypeNode;
+import org.eclipse.milo.opcua.sdk.server.model.variables.SessionSecurityDiagnosticsArrayTypeNode;
+import org.eclipse.milo.opcua.sdk.server.model.variables.SessionSecurityDiagnosticsTypeNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaNodeContext;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.factories.NodeFactory;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Manages the standard diagnostics arrays and the per-Session diagnostics Objects beneath the
+ * server's SessionsDiagnosticsSummary node.
+ *
+ * <p>Ordinary session diagnostics and security diagnostics share a lifecycle but retain distinct
+ * authorization policies. Security metadata is propagated only to each dynamically instantiated
+ * security diagnostics subtree.
+ */
 public class SessionsDiagnosticsSummaryObject extends AbstractLifecycle {
 
   static final int MAX_BROWSE_NAME_LENGTH = 512;
@@ -125,7 +137,9 @@ public class SessionsDiagnosticsSummaryObject extends AbstractLifecycle {
       SessionDiagnosticsObjectTypeNode sdoNode =
           (SessionDiagnosticsObjectTypeNode)
               nodeFactory.createNode(
-                  new NodeId(1, UUID.randomUUID()), NodeIds.SessionDiagnosticsObjectType);
+                  new NodeId(1, UUID.randomUUID()),
+                  NodeIds.SessionDiagnosticsObjectType,
+                  securityDiagnosticsAccessControl(node));
       sdoNode.setBrowseName(browseName);
       sdoNode.setDisplayName(LocalizedText.english(sessionName));
 
@@ -145,6 +159,36 @@ public class SessionsDiagnosticsSummaryObject extends AbstractLifecycle {
     } catch (UaException e) {
       LoggerFactory.getLogger(getClass()).warn("Failed to create SessionDiagnosticsObject", e);
     }
+  }
+
+  /**
+   * Creates a callback that applies the standard security diagnostics array's access policy only to
+   * the security diagnostics subtree of a dynamically instantiated Session diagnostics Object.
+   *
+   * @param summaryNode the standard summary node containing the security diagnostics array.
+   * @return a callback that applies security attributes to security diagnostics Variables.
+   */
+  static NodeFactory.InstantiationCallback securityDiagnosticsAccessControl(
+      SessionsDiagnosticsSummaryTypeNode summaryNode) {
+
+    return new NodeFactory.InstantiationCallback() {
+      @Override
+      public void onVariableAdded(
+          @Nullable UaNode parent, UaVariableNode instance, NodeId typeDefinitionId) {
+
+        if (instance instanceof SessionSecurityDiagnosticsTypeNode
+            || parent instanceof SessionSecurityDiagnosticsTypeNode) {
+
+          // Ordinary SessionDiagnostics intentionally retain their separate standard permissions.
+          SessionSecurityDiagnosticsArrayTypeNode securityArray =
+              summaryNode.getSessionSecurityDiagnosticsArrayNode();
+
+          instance.setRolePermissions(securityArray.getRolePermissions());
+          instance.setUserRolePermissions(securityArray.getUserRolePermissions());
+          instance.setAccessRestrictions(securityArray.getAccessRestrictions());
+        }
+      }
+    };
   }
 
   static String sessionNameBrowseName(String sessionName) {

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/SessionSecurityDiagnosticsVariable.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/SessionSecurityDiagnosticsVariable.java
@@ -11,12 +11,16 @@
 package org.eclipse.milo.opcua.sdk.server.diagnostics.variables;
 
 import static org.eclipse.milo.opcua.sdk.server.diagnostics.variables.Util.diagnosticValueFilter;
+import static org.eclipse.milo.opcua.sdk.server.diagnostics.variables.Util.roleBasedUserAccessLevelFilter;
+import static org.eclipse.milo.opcua.sdk.server.diagnostics.variables.Util.roleBasedUserRolePermissionsFilter;
 
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.eclipse.milo.opcua.sdk.server.AbstractLifecycle;
 import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
 import org.eclipse.milo.opcua.sdk.server.Session;
+import org.eclipse.milo.opcua.sdk.server.diagnostics.SessionSecurityDiagnosticsAccessMode;
 import org.eclipse.milo.opcua.sdk.server.model.objects.ServerDiagnosticsTypeNode;
 import org.eclipse.milo.opcua.sdk.server.model.variables.SessionSecurityDiagnosticsTypeNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.AttributeObserver;
@@ -29,6 +33,14 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.MessageSecurityMode;
 
+/**
+ * Publishes the security diagnostics for one Session through a dynamically created diagnostics
+ * Variable.
+ *
+ * <p>The Variable and each of its fields follow the server-wide diagnostics enabled flag. In
+ * restricted access mode, Session-specific access attributes are derived from the role metadata
+ * copied onto the nodes when they are instantiated.
+ */
 public class SessionSecurityDiagnosticsVariable extends AbstractLifecycle {
 
   private final AtomicBoolean diagnosticsEnabled = new AtomicBoolean(false);
@@ -68,6 +80,30 @@ public class SessionSecurityDiagnosticsVariable extends AbstractLifecycle {
                         new NoSuchElementException("NodeId: " + NodeIds.Server_ServerDiagnostics));
 
     diagnosticsEnabled.set(diagnosticsNode.getEnabledFlag());
+
+    if (server.getConfig().getSessionSecurityDiagnosticsAccessMode()
+        == SessionSecurityDiagnosticsAccessMode.RESTRICTED) {
+
+      // Value access is reflected in UserAccessLevel; UserRolePermissions supplies the same
+      // session-specific policy to authorization checks for other node operations such as Browse.
+      List.of(
+              node,
+              node.getSessionIdNode(),
+              node.getClientUserIdOfSessionNode(),
+              node.getClientUserIdHistoryNode(),
+              node.getAuthenticationMechanismNode(),
+              node.getEncodingNode(),
+              node.getTransportProtocolNode(),
+              node.getSecurityModeNode(),
+              node.getSecurityPolicyUriNode(),
+              node.getClientCertificateNode())
+          .forEach(
+              securityNode ->
+                  securityNode
+                      .getFilterChain()
+                      .addLast(
+                          roleBasedUserAccessLevelFilter(), roleBasedUserRolePermissionsFilter()));
+    }
 
     attributeObserver =
         (node, attributeId, value) -> {

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/SessionSecurityDiagnosticsVariableArray.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/SessionSecurityDiagnosticsVariableArray.java
@@ -11,6 +11,8 @@
 package org.eclipse.milo.opcua.sdk.server.diagnostics.variables;
 
 import static org.eclipse.milo.opcua.sdk.server.diagnostics.variables.Util.diagnosticValueFilter;
+import static org.eclipse.milo.opcua.sdk.server.diagnostics.variables.Util.roleBasedUserAccessLevelFilter;
+import static org.eclipse.milo.opcua.sdk.server.diagnostics.variables.Util.roleBasedUserRolePermissionsFilter;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -26,13 +28,16 @@ import org.eclipse.milo.opcua.sdk.server.NodeManager;
 import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
 import org.eclipse.milo.opcua.sdk.server.Session;
 import org.eclipse.milo.opcua.sdk.server.SessionListener;
+import org.eclipse.milo.opcua.sdk.server.diagnostics.SessionSecurityDiagnosticsAccessMode;
 import org.eclipse.milo.opcua.sdk.server.model.objects.ServerDiagnosticsTypeNode;
 import org.eclipse.milo.opcua.sdk.server.model.variables.SessionSecurityDiagnosticsArrayTypeNode;
 import org.eclipse.milo.opcua.sdk.server.model.variables.SessionSecurityDiagnosticsTypeNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.AttributeObserver;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaNodeContext;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.factories.NodeFactory;
+import org.eclipse.milo.opcua.sdk.server.nodes.filters.AttributeFilter;
 import org.eclipse.milo.opcua.stack.core.AttributeId;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
 import org.eclipse.milo.opcua.stack.core.UaException;
@@ -43,9 +48,18 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.structured.SessionSecurityDiagnosticsDataType;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Publishes security diagnostics for all active Sessions and manages the per-Session Variables
+ * created beneath the standard diagnostics array.
+ *
+ * <p>Elements are created and removed as Sessions enter and leave the server. Access to the array,
+ * its runtime-created elements, and the diagnostics enabled flag is derived from the standard
+ * nodes' role metadata unless legacy access is explicitly configured.
+ */
 public class SessionSecurityDiagnosticsVariableArray extends AbstractLifecycle {
 
   private final Logger logger = LoggerFactory.getLogger(getClass());
@@ -57,6 +71,7 @@ public class SessionSecurityDiagnosticsVariableArray extends AbstractLifecycle {
 
   private AttributeObserver attributeObserver;
   private SessionListener sessionListener;
+  private AttributeFilter enabledFlagAccessFilter;
 
   private final OpcUaServer server;
   private final NodeFactory nodeFactory;
@@ -99,6 +114,19 @@ public class SessionSecurityDiagnosticsVariableArray extends AbstractLifecycle {
                         new NoSuchElementException("NodeId: " + NodeIds.Server_ServerDiagnostics));
 
     diagnosticsEnabled.set(diagnosticsNode.getEnabledFlag());
+
+    if (server.getConfig().getSessionSecurityDiagnosticsAccessMode()
+        == SessionSecurityDiagnosticsAccessMode.RESTRICTED) {
+
+      // EnabledFlag grants read access broadly but reserves writes for ConfigureAdmin and
+      // SecurityAdmin. Derive UserAccessLevel from those standard RolePermissions.
+      enabledFlagAccessFilter = roleBasedUserAccessLevelFilter();
+      diagnosticsNode.getEnabledFlagNode().getFilterChain().addLast(enabledFlagAccessFilter);
+
+      // Apply the array's restricted role policy to Value access and to other node operations.
+      node.getFilterChain()
+          .addLast(roleBasedUserAccessLevelFilter(), roleBasedUserRolePermissionsFilter());
+    }
 
     if (diagnosticsEnabled.get()) {
       addSessionListener();
@@ -188,7 +216,10 @@ public class SessionSecurityDiagnosticsVariableArray extends AbstractLifecycle {
 
       SessionSecurityDiagnosticsTypeNode elementNode =
           (SessionSecurityDiagnosticsTypeNode)
-              nodeFactory.createNode(elementNodeId, NodeIds.SessionSecurityDiagnosticsType);
+              nodeFactory.createNode(
+                  elementNodeId,
+                  NodeIds.SessionSecurityDiagnosticsType,
+                  securityAccessControl(node));
 
       elementNode.setBrowseName(new QualifiedName(1, "SessionSecurityDiagnostics"));
       elementNode.setDisplayName(
@@ -220,10 +251,37 @@ public class SessionSecurityDiagnosticsVariableArray extends AbstractLifecycle {
     }
   }
 
+  /**
+   * Creates a callback that copies the standard array instance's security attributes to dynamically
+   * instantiated element Variables and their fields.
+   *
+   * <p>The type definition describes the element shape, but the runtime nodes must carry the array
+   * instance's authorization and secure-channel requirements.
+   *
+   * @param arrayNode the standard array node that supplies the security attributes.
+   * @return a callback that applies those attributes to instantiated Variables.
+   */
+  static NodeFactory.InstantiationCallback securityAccessControl(
+      SessionSecurityDiagnosticsArrayTypeNode arrayNode) {
+
+    return new NodeFactory.InstantiationCallback() {
+      @Override
+      public void onVariableAdded(
+          @Nullable UaNode parent, UaVariableNode instance, NodeId typeDefinitionId) {
+
+        instance.setRolePermissions(arrayNode.getRolePermissions());
+        instance.setUserRolePermissions(arrayNode.getUserRolePermissions());
+        instance.setAccessRestrictions(arrayNode.getAccessRestrictions());
+      }
+    };
+  }
+
   @Override
   protected void onShutdown() {
+    AttributeFilter accessFilter = enabledFlagAccessFilter;
     AttributeObserver observer = attributeObserver;
-    if (observer != null) {
+
+    if (accessFilter != null || observer != null) {
       ServerDiagnosticsTypeNode diagnosticsNode =
           (ServerDiagnosticsTypeNode)
               server
@@ -234,8 +292,15 @@ public class SessionSecurityDiagnosticsVariableArray extends AbstractLifecycle {
                           new NoSuchElementException(
                               "NodeId: " + NodeIds.Server_ServerDiagnostics));
 
-      diagnosticsNode.getEnabledFlagNode().removeAttributeObserver(observer);
-      attributeObserver = null;
+      if (accessFilter != null) {
+        diagnosticsNode.getEnabledFlagNode().getFilterChain().remove(accessFilter);
+        enabledFlagAccessFilter = null;
+      }
+
+      if (observer != null) {
+        diagnosticsNode.getEnabledFlagNode().removeAttributeObserver(observer);
+        attributeObserver = null;
+      }
     }
 
     if (sessionListener != null) {

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/Util.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/Util.java
@@ -12,23 +12,33 @@ package org.eclipse.milo.opcua.sdk.server.diagnostics.variables;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
+import java.util.stream.Stream;
+import org.eclipse.milo.opcua.sdk.core.AccessLevel;
 import org.eclipse.milo.opcua.sdk.core.Reference;
 import org.eclipse.milo.opcua.sdk.core.typetree.ReferenceTypeTree;
+import org.eclipse.milo.opcua.sdk.server.Session;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.filters.AttributeFilter;
 import org.eclipse.milo.opcua.sdk.server.nodes.filters.AttributeFilterContext;
 import org.eclipse.milo.opcua.sdk.server.nodes.filters.AttributeFilters;
+import org.eclipse.milo.opcua.stack.core.AttributeId;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
+import org.eclipse.milo.opcua.stack.core.types.structured.RolePermissionType;
 
+/** Internal helpers shared by the diagnostics node lifecycle implementations. */
 class Util {
 
   private Util() {}
@@ -80,5 +90,90 @@ class Util {
                 Variant.NULL_VALUE, new StatusCode(StatusCodes.Bad_NotReadable), DateTime.now());
           }
         });
+  }
+
+  /**
+   * Creates a filter that derives {@link AttributeId#UserAccessLevel} from the current Session's
+   * effective {@link AttributeId#RolePermissions}.
+   *
+   * <p>The node's configured access level remains the upper bound. The filter only removes read or
+   * write access when none of the Session's roles has the corresponding permission. Internal reads
+   * without a Session receive the unfiltered attribute value.
+   *
+   * @return a filter that exposes a Session-specific UserAccessLevel.
+   */
+  static AttributeFilter roleBasedUserAccessLevelFilter() {
+    return new AttributeFilter() {
+      @Override
+      public Object getAttribute(AttributeFilterContext ctx, AttributeId attributeId) {
+        if (attributeId != AttributeId.UserAccessLevel || ctx.getSession().isEmpty()) {
+          return ctx.getAttribute(attributeId);
+        }
+
+        var userAccessLevels =
+            AccessLevel.fromValue((UByte) ctx.getAttribute(AttributeId.UserAccessLevel));
+        RolePermissionType[] userRolePermissions = getUserRolePermissions(ctx);
+
+        // RolePermissions can remove rights from the configured AccessLevel, but never add them.
+        if (!hasReadPermission(userRolePermissions)) {
+          userAccessLevels.remove(AccessLevel.CurrentRead);
+        }
+        if (!hasWritePermission(userRolePermissions)) {
+          userAccessLevels.remove(AccessLevel.CurrentWrite);
+        }
+
+        return AccessLevel.toValue(userAccessLevels);
+      }
+    };
+  }
+
+  /**
+   * Creates a filter that exposes only the {@link AttributeId#RolePermissions} applicable to the
+   * current Session as {@link AttributeId#UserRolePermissions}.
+   *
+   * <p>This lets the server's normal access controller authorize operations such as Browse using
+   * the same role metadata that controls Value access. Internal reads without a Session receive the
+   * unfiltered attribute value.
+   *
+   * @return a filter that exposes Session-specific UserRolePermissions.
+   */
+  static AttributeFilter roleBasedUserRolePermissionsFilter() {
+    return new AttributeFilter() {
+      @Override
+      public Object getAttribute(AttributeFilterContext ctx, AttributeId attributeId) {
+        if (attributeId == AttributeId.UserRolePermissions && ctx.getSession().isPresent()) {
+          return getUserRolePermissions(ctx);
+        } else {
+          return ctx.getAttribute(attributeId);
+        }
+      }
+    };
+  }
+
+  private static RolePermissionType[] getUserRolePermissions(AttributeFilterContext ctx) {
+    // OPC UA assigns the Anonymous Role to every Session, including authenticated Sessions.
+    Set<NodeId> roleIds = new HashSet<>();
+    roleIds.add(NodeIds.WellKnownRole_Anonymous);
+    ctx.getSession().flatMap(Session::getRoleIds).ifPresent(roleIds::addAll);
+
+    Object value = ctx.getAttribute(AttributeId.RolePermissions);
+    if (value instanceof RolePermissionType[] rolePermissions) {
+      return Stream.of(rolePermissions)
+          .filter(rolePermission -> roleIds.contains(rolePermission.getRoleId()))
+          .toArray(RolePermissionType[]::new);
+    } else {
+      // Missing or malformed role metadata must not grant access.
+      return new RolePermissionType[0];
+    }
+  }
+
+  private static boolean hasReadPermission(RolePermissionType[] rolePermissions) {
+    return Stream.of(rolePermissions)
+        .anyMatch(rolePermission -> rolePermission.getPermissions().getRead());
+  }
+
+  private static boolean hasWritePermission(RolePermissionType[] rolePermissions) {
+    return Stream.of(rolePermissions)
+        .anyMatch(rolePermission -> rolePermission.getPermissions().getWrite());
   }
 }

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/diagnostics/objects/SessionsDiagnosticsSummaryObjectTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/diagnostics/objects/SessionsDiagnosticsSummaryObjectTest.java
@@ -13,8 +13,22 @@ package org.eclipse.milo.opcua.sdk.server.diagnostics.objects;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
+import org.eclipse.milo.opcua.sdk.server.model.objects.SessionsDiagnosticsSummaryTypeNode;
+import org.eclipse.milo.opcua.sdk.server.model.variables.SessionDiagnosticsVariableTypeNode;
+import org.eclipse.milo.opcua.sdk.server.model.variables.SessionSecurityDiagnosticsArrayTypeNode;
+import org.eclipse.milo.opcua.sdk.server.model.variables.SessionSecurityDiagnosticsTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.factories.NodeFactory;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.structured.AccessRestrictionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.PermissionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.RolePermissionType;
 import org.junit.jupiter.api.Test;
 
 class SessionsDiagnosticsSummaryObjectTest {
@@ -34,5 +48,45 @@ class SessionsDiagnosticsSummaryObjectTest {
 
     assertEquals(SessionsDiagnosticsSummaryObject.MAX_BROWSE_NAME_LENGTH, browseName.length());
     assertDoesNotThrow(() -> new QualifiedName(1, browseName));
+  }
+
+  @Test
+  void securityDiagnosticsAccessControlProtectsOnlySecurityDiagnosticsSubtree() {
+    var summaryNode = mock(SessionsDiagnosticsSummaryTypeNode.class);
+    var securityArray = mock(SessionSecurityDiagnosticsArrayTypeNode.class);
+    var securityDiagnostics = mock(SessionSecurityDiagnosticsTypeNode.class);
+    var securityField = mock(UaVariableNode.class);
+    var ordinaryDiagnostics = mock(SessionDiagnosticsVariableTypeNode.class);
+    var ordinaryField = mock(UaVariableNode.class);
+    var rolePermissions =
+        new RolePermissionType[] {
+          new RolePermissionType(
+              NodeIds.WellKnownRole_SecurityAdmin,
+              PermissionType.of(PermissionType.Field.Browse, PermissionType.Field.Read))
+        };
+    var accessRestrictions =
+        AccessRestrictionType.of(
+            AccessRestrictionType.Field.SigningRequired,
+            AccessRestrictionType.Field.EncryptionRequired);
+
+    when(summaryNode.getSessionSecurityDiagnosticsArrayNode()).thenReturn(securityArray);
+    when(securityArray.getRolePermissions()).thenReturn(rolePermissions);
+    when(securityArray.getAccessRestrictions()).thenReturn(accessRestrictions);
+
+    NodeFactory.InstantiationCallback callback =
+        SessionsDiagnosticsSummaryObject.securityDiagnosticsAccessControl(summaryNode);
+
+    callback.onVariableAdded(null, securityDiagnostics, NodeIds.SessionSecurityDiagnosticsType);
+    callback.onVariableAdded(securityDiagnostics, securityField, NodeIds.BaseDataVariableType);
+    callback.onVariableAdded(null, ordinaryDiagnostics, NodeIds.SessionDiagnosticsVariableType);
+    callback.onVariableAdded(ordinaryDiagnostics, ordinaryField, NodeIds.BaseDataVariableType);
+
+    verify(securityDiagnostics).setRolePermissions(rolePermissions);
+    verify(securityDiagnostics).setUserRolePermissions(null);
+    verify(securityDiagnostics).setAccessRestrictions(accessRestrictions);
+    verify(securityField).setRolePermissions(rolePermissions);
+    verify(securityField).setUserRolePermissions(null);
+    verify(securityField).setAccessRestrictions(accessRestrictions);
+    verifyNoInteractions(ordinaryDiagnostics, ordinaryField);
   }
 }

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/SessionSecurityDiagnosticsAccessModeTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/SessionSecurityDiagnosticsAccessModeTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.diagnostics.variables;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.eclipse.milo.opcua.sdk.core.AccessLevel;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServerConfig;
+import org.eclipse.milo.opcua.sdk.server.Session;
+import org.eclipse.milo.opcua.sdk.server.diagnostics.SessionSecurityDiagnosticsAccessMode;
+import org.eclipse.milo.opcua.sdk.server.model.objects.ServerDiagnosticsTypeNode;
+import org.eclipse.milo.opcua.sdk.server.model.variables.SessionSecurityDiagnosticsArrayTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableNode;
+import org.eclipse.milo.opcua.stack.core.AttributeId;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.security.DefaultCertificateManager;
+import org.eclipse.milo.opcua.stack.core.security.MemoryCertificateQuarantine;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
+import org.junit.jupiter.api.Test;
+
+class SessionSecurityDiagnosticsAccessModeTest {
+
+  @Test
+  void restrictedModeIsDefaultAndRestrictsAnonymousAccess() throws Exception {
+    OpcUaServerConfig config = newConfig();
+
+    assertEquals(
+        SessionSecurityDiagnosticsAccessMode.RESTRICTED,
+        config.getSessionSecurityDiagnosticsAccessMode());
+
+    OpcUaServer server = new OpcUaServer(config, transportProfile -> null);
+    Session session = mock(Session.class);
+    when(session.getRoleIds()).thenReturn(Optional.empty());
+
+    ServerDiagnosticsTypeNode diagnosticsNode = getDiagnosticsNode(server);
+    SessionSecurityDiagnosticsArrayTypeNode securityArray =
+        diagnosticsNode
+            .getSessionsDiagnosticsSummaryNode()
+            .getSessionSecurityDiagnosticsArrayNode();
+
+    assertEquals(
+        AccessLevel.toValue(AccessLevel.NONE), readUserAccessLevel(session, securityArray));
+    assertEquals(
+        AccessLevel.toValue(AccessLevel.READ_ONLY),
+        readUserAccessLevel(session, diagnosticsNode.getEnabledFlagNode()));
+    assertTrue(securityArray.getAccessRestrictions().getSigningRequired());
+    assertTrue(securityArray.getAccessRestrictions().getEncryptionRequired());
+  }
+
+  @Test
+  void legacyModeRestoresPreviousAccessWithoutRoleMapping() throws Exception {
+    OpcUaServerConfig config = newConfig(SessionSecurityDiagnosticsAccessMode.LEGACY);
+
+    OpcUaServer server = new OpcUaServer(config, transportProfile -> null);
+    Session session = mock(Session.class);
+    ServerDiagnosticsTypeNode diagnosticsNode = getDiagnosticsNode(server);
+    SessionSecurityDiagnosticsArrayTypeNode securityArray =
+        diagnosticsNode
+            .getSessionsDiagnosticsSummaryNode()
+            .getSessionSecurityDiagnosticsArrayNode();
+
+    assertEquals(
+        AccessLevel.toValue(AccessLevel.READ_ONLY), readUserAccessLevel(session, securityArray));
+    assertEquals(
+        AccessLevel.toValue(AccessLevel.READ_WRITE),
+        readUserAccessLevel(session, diagnosticsNode.getEnabledFlagNode()));
+    assertTrue(securityArray.getAccessRestrictions().getSigningRequired());
+    assertTrue(securityArray.getAccessRestrictions().getEncryptionRequired());
+  }
+
+  @Test
+  void copyPreservesConfiguredAccessMode() {
+    OpcUaServerConfig config = newConfig(SessionSecurityDiagnosticsAccessMode.LEGACY);
+
+    OpcUaServerConfig copiedConfig = OpcUaServerConfig.copy(config).build();
+
+    assertEquals(
+        SessionSecurityDiagnosticsAccessMode.LEGACY,
+        copiedConfig.getSessionSecurityDiagnosticsAccessMode());
+  }
+
+  private static OpcUaServerConfig newConfig(SessionSecurityDiagnosticsAccessMode accessMode) {
+    return OpcUaServerConfig.builder()
+        .setCertificateManager(new DefaultCertificateManager(new MemoryCertificateQuarantine()))
+        .setSessionSecurityDiagnosticsAccessMode(accessMode)
+        .build();
+  }
+
+  private static OpcUaServerConfig newConfig() {
+    return OpcUaServerConfig.builder()
+        .setCertificateManager(new DefaultCertificateManager(new MemoryCertificateQuarantine()))
+        .build();
+  }
+
+  private static ServerDiagnosticsTypeNode getDiagnosticsNode(OpcUaServer server) {
+    return (ServerDiagnosticsTypeNode)
+        server
+            .getAddressSpaceManager()
+            .getManagedNode(NodeIds.Server_ServerDiagnostics)
+            .orElseThrow();
+  }
+
+  private static UByte readUserAccessLevel(Session session, UaVariableNode node) throws Exception {
+    return (UByte) node.getFilterChain().readAttribute(session, node, AttributeId.UserAccessLevel);
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/SessionSecurityDiagnosticsVariableArrayTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/SessionSecurityDiagnosticsVariableArrayTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.diagnostics.variables;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.milo.opcua.sdk.server.model.variables.SessionSecurityDiagnosticsArrayTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.factories.NodeFactory;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.types.structured.AccessRestrictionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.PermissionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.RolePermissionType;
+import org.junit.jupiter.api.Test;
+
+class SessionSecurityDiagnosticsVariableArrayTest {
+
+  @Test
+  void securityAccessControlAppliesArrayMetadataToElementAndFieldNodes() {
+    var arrayNode = mock(SessionSecurityDiagnosticsArrayTypeNode.class);
+    var elementNode = mock(UaVariableNode.class);
+    var fieldNode = mock(UaVariableNode.class);
+    var rolePermissions =
+        new RolePermissionType[] {
+          new RolePermissionType(
+              NodeIds.WellKnownRole_SecurityAdmin,
+              PermissionType.of(PermissionType.Field.Browse, PermissionType.Field.Read))
+        };
+    var accessRestrictions =
+        AccessRestrictionType.of(
+            AccessRestrictionType.Field.SigningRequired,
+            AccessRestrictionType.Field.EncryptionRequired);
+
+    when(arrayNode.getRolePermissions()).thenReturn(rolePermissions);
+    when(arrayNode.getAccessRestrictions()).thenReturn(accessRestrictions);
+
+    NodeFactory.InstantiationCallback callback =
+        SessionSecurityDiagnosticsVariableArray.securityAccessControl(arrayNode);
+
+    callback.onVariableAdded(null, elementNode, NodeIds.SessionSecurityDiagnosticsType);
+    callback.onVariableAdded(elementNode, fieldNode, NodeIds.BaseDataVariableType);
+
+    verify(elementNode).setRolePermissions(rolePermissions);
+    verify(elementNode).setUserRolePermissions(null);
+    verify(elementNode).setAccessRestrictions(accessRestrictions);
+    verify(fieldNode).setRolePermissions(rolePermissions);
+    verify(fieldNode).setUserRolePermissions(null);
+    verify(fieldNode).setAccessRestrictions(accessRestrictions);
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/UtilTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/UtilTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.diagnostics.variables;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import org.eclipse.milo.opcua.sdk.core.AccessLevel;
+import org.eclipse.milo.opcua.sdk.server.Session;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.filters.AttributeFilterChain;
+import org.eclipse.milo.opcua.stack.core.AttributeId;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.structured.PermissionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.RolePermissionType;
+import org.junit.jupiter.api.Test;
+
+class UtilTest {
+
+  @Test
+  void roleBasedFiltersRestrictSecurityDiagnosticsToConfiguredRoles() throws UaException {
+    var node = mock(UaVariableNode.class);
+    var session = mock(Session.class);
+    var equivalentRole = new NodeId(1, "SecurityDiagnosticsAdmin");
+    var readOnly = AccessLevel.toValue(AccessLevel.READ_ONLY);
+    var noAccess = AccessLevel.toValue(AccessLevel.NONE);
+    var securityAdminPermissions =
+        new RolePermissionType(
+            NodeIds.WellKnownRole_SecurityAdmin,
+            PermissionType.of(
+                PermissionType.Field.Browse,
+                PermissionType.Field.Read,
+                PermissionType.Field.Write,
+                PermissionType.Field.ReadRolePermissions));
+    var equivalentRolePermissions =
+        new RolePermissionType(
+            equivalentRole,
+            PermissionType.of(PermissionType.Field.Browse, PermissionType.Field.Read));
+    var rolePermissions =
+        new RolePermissionType[] {securityAdminPermissions, equivalentRolePermissions};
+    var filterChain =
+        new AttributeFilterChain(
+            List.of(
+                Util.roleBasedUserAccessLevelFilter(), Util.roleBasedUserRolePermissionsFilter()));
+
+    when(node.getAttribute(AttributeId.UserAccessLevel)).thenReturn(readOnly);
+    when(node.getAttribute(AttributeId.RolePermissions)).thenReturn(rolePermissions);
+
+    assertEquals(readOnly, filterChain.readAttribute(null, node, AttributeId.UserAccessLevel));
+
+    when(session.getRoleIds()).thenReturn(Optional.empty());
+    assertEquals(noAccess, filterChain.readAttribute(session, node, AttributeId.UserAccessLevel));
+    assertArrayEquals(
+        new RolePermissionType[0],
+        (RolePermissionType[])
+            filterChain.readAttribute(session, node, AttributeId.UserRolePermissions));
+
+    when(session.getRoleIds())
+        .thenReturn(Optional.of(List.of(NodeIds.WellKnownRole_AuthenticatedUser)));
+    assertEquals(noAccess, filterChain.readAttribute(session, node, AttributeId.UserAccessLevel));
+
+    when(session.getRoleIds())
+        .thenReturn(Optional.of(List.of(NodeIds.WellKnownRole_SecurityAdmin)));
+    assertEquals(readOnly, filterChain.readAttribute(session, node, AttributeId.UserAccessLevel));
+    assertArrayEquals(
+        new RolePermissionType[] {securityAdminPermissions},
+        (RolePermissionType[])
+            filterChain.readAttribute(session, node, AttributeId.UserRolePermissions));
+
+    when(session.getRoleIds()).thenReturn(Optional.of(List.of(equivalentRole)));
+    assertEquals(readOnly, filterChain.readAttribute(session, node, AttributeId.UserAccessLevel));
+    assertArrayEquals(
+        new RolePermissionType[] {equivalentRolePermissions},
+        (RolePermissionType[])
+            filterChain.readAttribute(session, node, AttributeId.UserRolePermissions));
+  }
+
+  @Test
+  void roleBasedUserAccessLevelFilterUsesEnabledFlagRolePermissions() throws UaException {
+    var node = mock(UaVariableNode.class);
+    var session = mock(Session.class);
+    var readWrite = AccessLevel.toValue(AccessLevel.READ_WRITE);
+    var readOnly = AccessLevel.toValue(AccessLevel.READ_ONLY);
+    var rolePermissions =
+        new RolePermissionType[] {
+          new RolePermissionType(
+              NodeIds.WellKnownRole_Anonymous,
+              PermissionType.of(PermissionType.Field.Browse, PermissionType.Field.Read)),
+          new RolePermissionType(
+              NodeIds.WellKnownRole_ConfigureAdmin,
+              PermissionType.of(
+                  PermissionType.Field.Browse,
+                  PermissionType.Field.Read,
+                  PermissionType.Field.Write)),
+          new RolePermissionType(
+              NodeIds.WellKnownRole_SecurityAdmin,
+              PermissionType.of(
+                  PermissionType.Field.Browse,
+                  PermissionType.Field.Read,
+                  PermissionType.Field.Write))
+        };
+    var filterChain = new AttributeFilterChain(Util.roleBasedUserAccessLevelFilter());
+
+    when(node.getAttribute(AttributeId.UserAccessLevel)).thenReturn(readWrite);
+    when(node.getAttribute(AttributeId.RolePermissions)).thenReturn(rolePermissions);
+    when(session.getRoleIds()).thenReturn(Optional.empty());
+
+    assertEquals(readOnly, filterChain.readAttribute(session, node, AttributeId.UserAccessLevel));
+
+    when(session.getRoleIds())
+        .thenReturn(Optional.of(List.of(NodeIds.WellKnownRole_ConfigureAdmin)));
+    assertEquals(readWrite, filterChain.readAttribute(session, node, AttributeId.UserAccessLevel));
+
+    when(session.getRoleIds())
+        .thenReturn(Optional.of(List.of(NodeIds.WellKnownRole_SecurityAdmin)));
+    assertEquals(readWrite, filterChain.readAttribute(session, node, AttributeId.UserAccessLevel));
+  }
+}


### PR DESCRIPTION
## Summary

- enforce the standard `RolePermissions` for cross-session security diagnostics and diagnostics `EnabledFlag` writes in the default `RESTRICTED` mode
- propagate `RolePermissions`, `UserRolePermissions`, and protected-channel `AccessRestrictions` to runtime-created security-diagnostics nodes
- add an explicit `LEGACY` access mode for servers that need the previous diagnostics authorization behavior without configuring a `RoleMapper`
- keep ordinary `SessionDiagnostics` behavior and `DefaultAccessController` unchanged

## Behavior

In `RESTRICTED` mode, session-specific `UserAccessLevel` and `UserRolePermissions` are derived from the standard node metadata. `SecurityAdmin` or an explicitly configured equivalent role can read session security diagnostics; `ConfigureAdmin`, `SecurityAdmin`, or an explicitly configured equivalent role can write the diagnostics enabled flag. Without a `RoleMapper`, sensitive Value reads fail closed and the enabled flag remains read-only.

`LEGACY` mode preserves the previous authorization behavior without requiring role mapping. Signing and encryption restrictions continue to be propagated to runtime-created security-diagnostics nodes in both modes.

Role-based Browse behavior continues to follow the generic access controller's existing `RoleMapper` semantics; this change adds no diagnostics-specific controller behavior.

## Regression coverage

Focused tests cover:

- restricted access for unmapped and non-admin sessions
- `SecurityAdmin`, `ConfigureAdmin`, and explicitly authorized equivalent roles
- legacy access without a `RoleMapper`
- access-mode config defaults and copy behavior
- metadata propagation to dynamic array elements and per-session security subtrees
- separation from ordinary session diagnostics
- signing and encryption restrictions

## Verification

- `mise exec -- mvn -q spotless:apply`
- `mise exec -- mvn -q -pl opc-ua-sdk/sdk-server -am test -Dtest=SessionSecurityDiagnosticsAccessModeTest,UtilTest,SessionsDiagnosticsSummaryObjectTest,SessionSecurityDiagnosticsVariableArrayTest -Dsurefire.failIfNoSpecifiedTests=false`
- `mise exec -- mvn -q clean compile`
