### PR TITLE
Close username-token padding oracle

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractUsernameIdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractUsernameIdentityValidator.java
@@ -73,7 +73,18 @@ public abstract class AbstractUsernameIdentityValidator extends AbstractIdentity
     byte[] tokenBytes = token.getPassword().bytesOrEmpty();
 
     if (algorithm != SecurityAlgorithm.None) {
-      byte[] plainTextBytes = decryptTokenData(session, algorithm, tokenBytes);
+      // Decrypting attacker-controlled RSA PKCS#1 v1.5 ciphertext can expose a padding oracle.
+      if (algorithm == SecurityAlgorithm.Rsa15) {
+        throw new UaException(StatusCodes.Bad_IdentityTokenInvalid);
+      }
+
+      byte[] plainTextBytes;
+
+      try {
+        plainTextBytes = decryptTokenData(session, algorithm, tokenBytes);
+      } catch (UaException ignored) {
+        throw new UaException(StatusCodes.Bad_IdentityTokenInvalid);
+      }
 
       if (plainTextBytes.length < 4) {
         throw new UaException(StatusCodes.Bad_IdentityTokenInvalid, "invalid token data");
@@ -100,7 +111,7 @@ public abstract class AbstractUsernameIdentityValidator extends AbstractIdentity
       if (passwordLength
           > session.getServer().getConfig().getLimits().getMaxPasswordLength().longValue()) {
         throw new UaException(
-            StatusCodes.Bad_EncodingLimitsExceeded, "password length exceeds limits");
+            StatusCodes.Bad_IdentityTokenInvalid, "password length exceeds limits");
       }
 
       byte[] passwordBytes = new byte[passwordLength];
@@ -111,8 +122,13 @@ public abstract class AbstractUsernameIdentityValidator extends AbstractIdentity
 
       if (MessageDigest.isEqual(lastNonce.bytes(), nonceBytes)) {
         String password = new String(passwordBytes, StandardCharsets.UTF_8);
+        UsernameIdentity identity = authenticateUsernamePassword(session, username, password);
 
-        return authenticateUsernameOrThrow(session, username, password);
+        if (identity != null) {
+          return identity;
+        } else {
+          throw new UaException(StatusCodes.Bad_IdentityTokenInvalid);
+        }
       } else {
         throw new UaException(StatusCodes.Bad_IdentityTokenInvalid);
       }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractUsernameIdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractUsernameIdentityValidator.java
@@ -73,11 +73,6 @@ public abstract class AbstractUsernameIdentityValidator extends AbstractIdentity
     byte[] tokenBytes = token.getPassword().bytesOrEmpty();
 
     if (algorithm != SecurityAlgorithm.None) {
-      // Decrypting attacker-controlled RSA PKCS#1 v1.5 ciphertext can expose a padding oracle.
-      if (algorithm == SecurityAlgorithm.Rsa15) {
-        throw new UaException(StatusCodes.Bad_IdentityTokenInvalid);
-      }
-
       byte[] plainTextBytes;
 
       try {

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractUsernameIdentityValidatorTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractUsernameIdentityValidatorTest.java
@@ -12,14 +12,21 @@ package org.eclipse.milo.opcua.sdk.server.identity;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.cert.X509Certificate;
 import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import javax.crypto.Cipher;
 import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
 import org.eclipse.milo.opcua.sdk.server.OpcUaServerConfig;
 import org.eclipse.milo.opcua.sdk.server.OpcUaServerConfigLimits;
@@ -28,15 +35,20 @@ import org.eclipse.milo.opcua.sdk.server.Session;
 import org.eclipse.milo.opcua.sdk.server.identity.Identity.UsernameIdentity;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.security.CertificateManager;
 import org.eclipse.milo.opcua.stack.core.security.SecurityAlgorithm;
 import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.MessageSecurityMode;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.UserTokenType;
+import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
 import org.eclipse.milo.opcua.stack.core.types.structured.SignatureData;
 import org.eclipse.milo.opcua.stack.core.types.structured.UserNameIdentityToken;
 import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
+import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateBuilder;
+import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateGenerator;
 import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 class AbstractUsernameIdentityValidatorTest {
@@ -56,6 +68,18 @@ class AbstractUsernameIdentityValidatorTest {
           "username", UserTokenType.UserName, null, null, SecurityPolicy.Basic256Sha256.getUri());
   private static final SignatureData NO_SIGNATURE = new SignatureData(null, null);
 
+  private static KeyPair keyPair;
+  private static X509Certificate certificate;
+
+  @BeforeAll
+  static void setUpCryptography() throws Exception {
+    keyPair = SelfSignedCertificateGenerator.generateRsaKeyPair(2048);
+    certificate =
+        new SelfSignedCertificateBuilder(keyPair)
+            .setApplicationUri("urn:eclipse:milo:test")
+            .build();
+  }
+
   @Test
   void emptyEncryptedPasswordWithoutNonceReturnsIdentityTokenInvalid() {
     TestUsernameIdentityValidator validator =
@@ -66,6 +90,7 @@ class AbstractUsernameIdentityValidatorTest {
             UaException.class, () -> validator.validate(encryptedSession(), encryptedToken()));
 
     assertEquals(StatusCodes.Bad_IdentityTokenInvalid, exception.getStatusCode().value());
+    assertNull(exception.getCause());
     assertEquals(0, validator.authenticateCount);
   }
 
@@ -79,6 +104,7 @@ class AbstractUsernameIdentityValidatorTest {
             UaException.class, () -> validator.validate(encryptedSession(), encryptedToken()));
 
     assertEquals(StatusCodes.Bad_IdentityTokenInvalid, exception.getStatusCode().value());
+    assertNull(exception.getCause());
     assertEquals(0, validator.authenticateCount);
   }
 
@@ -91,11 +117,27 @@ class AbstractUsernameIdentityValidatorTest {
             UaException.class, () -> validator.validate(encryptedSession(), encryptedToken()));
 
     assertEquals(StatusCodes.Bad_IdentityTokenInvalid, exception.getStatusCode().value());
+    assertNull(exception.getCause());
     assertEquals(0, validator.authenticateCount);
   }
 
   @Test
-  void wrongEncryptedPasswordWithValidNonceReturnsUserAccessDenied() {
+  void oversizedEncryptedPasswordReturnsIdentityTokenInvalid() {
+    String password = "x".repeat(1025);
+    TestUsernameIdentityValidator validator =
+        new TestUsernameIdentityValidator(tokenData(password, SERVER_NONCE.bytesOrEmpty()), true);
+
+    UaException exception =
+        assertThrows(
+            UaException.class, () -> validator.validate(encryptedSession(), encryptedToken()));
+
+    assertEquals(StatusCodes.Bad_IdentityTokenInvalid, exception.getStatusCode().value());
+    assertNull(exception.getCause());
+    assertEquals(0, validator.authenticateCount);
+  }
+
+  @Test
+  void wrongEncryptedPasswordWithValidNonceReturnsIdentityTokenInvalid() {
     TestUsernameIdentityValidator validator =
         new TestUsernameIdentityValidator(tokenData("wrong", SERVER_NONCE.bytesOrEmpty()), false);
 
@@ -103,9 +145,72 @@ class AbstractUsernameIdentityValidatorTest {
         assertThrows(
             UaException.class, () -> validator.validate(encryptedSession(), encryptedToken()));
 
-    assertEquals(StatusCodes.Bad_UserAccessDenied, exception.getStatusCode().value());
+    assertEquals(StatusCodes.Bad_IdentityTokenInvalid, exception.getStatusCode().value());
+    assertNull(exception.getCause());
     assertEquals(USERNAME, validator.username);
     assertEquals("wrong", validator.password);
+    assertEquals(1, validator.authenticateCount);
+  }
+
+  @Test
+  void rsa15CiphertextsAreRejectedWithoutDecryption() throws Exception {
+    CryptoUsernameIdentityValidator validator = new CryptoUsernameIdentityValidator(true);
+    byte[] validCiphertext =
+        encrypt(SecurityPolicy.Basic128Rsa15, tokenData(PASSWORD, SERVER_NONCE.bytesOrEmpty()));
+
+    for (byte[] ciphertext : List.of(validCiphertext, zeroedCopy(validCiphertext))) {
+      UaException exception =
+          assertThrows(
+              UaException.class,
+              () ->
+                  validator.validate(
+                      encryptedSession(SecurityPolicy.Basic128Rsa15),
+                      encryptedToken(SecurityPolicy.Basic128Rsa15, ciphertext)));
+
+      assertUniformEncryptedTokenFailure(exception);
+    }
+
+    assertEquals(0, validator.decryptCount);
+    assertEquals(0, validator.authenticateCount);
+  }
+
+  @Test
+  void oaepCiphertextFailuresHaveUniformStatusAndNoCause() throws Exception {
+    CryptoUsernameIdentityValidator validator = new CryptoUsernameIdentityValidator(false);
+    byte[] validCiphertext =
+        encrypt(SecurityPolicy.Basic256Sha256, tokenData(PASSWORD, SERVER_NONCE.bytesOrEmpty()));
+    byte[] wrongPasswordCiphertext =
+        encrypt(SecurityPolicy.Basic256Sha256, tokenData("wrong", SERVER_NONCE.bytesOrEmpty()));
+
+    for (byte[] ciphertext : List.of(wrongPasswordCiphertext, zeroedCopy(validCiphertext))) {
+      UaException exception =
+          assertThrows(
+              UaException.class,
+              () ->
+                  validator.validate(
+                      encryptedSession(SecurityPolicy.Basic256Sha256),
+                      encryptedToken(SecurityPolicy.Basic256Sha256, ciphertext)));
+
+      assertUniformEncryptedTokenFailure(exception);
+    }
+
+    assertEquals(2, validator.decryptCount);
+    assertEquals(1, validator.authenticateCount);
+  }
+
+  @Test
+  void oaepEncryptedPasswordStillAuthenticates() throws Exception {
+    CryptoUsernameIdentityValidator validator = new CryptoUsernameIdentityValidator(true);
+    byte[] ciphertext =
+        encrypt(SecurityPolicy.Basic256Sha256, tokenData(PASSWORD, SERVER_NONCE.bytesOrEmpty()));
+
+    UsernameIdentity identity =
+        validator.validate(
+            encryptedSession(SecurityPolicy.Basic256Sha256),
+            encryptedToken(SecurityPolicy.Basic256Sha256, ciphertext));
+
+    assertEquals(USERNAME, identity.getUsername());
+    assertEquals(1, validator.decryptCount);
     assertEquals(1, validator.authenticateCount);
   }
 
@@ -146,6 +251,30 @@ class AbstractUsernameIdentityValidatorTest {
     return session(SecurityPolicy.Basic256Sha256);
   }
 
+  private static Session encryptedSession(SecurityPolicy securityPolicy) throws Exception {
+    CertificateManager certificateManager = mock(CertificateManager.class);
+    when(certificateManager.getKeyPair(any())).thenReturn(Optional.of(keyPair));
+
+    OpcUaServer server = mock(OpcUaServer.class);
+    OpcUaServerConfig config = mock(OpcUaServerConfig.class);
+    when(config.getCertificateManager()).thenReturn(certificateManager);
+    when(config.getLimits()).thenReturn(new OpcUaServerConfigLimits() {});
+    when(server.getConfig()).thenReturn(config);
+
+    EndpointDescription endpoint = mock(EndpointDescription.class);
+    when(endpoint.getServerCertificate()).thenReturn(ByteString.of(certificate.getEncoded()));
+
+    Session session = mock(Session.class);
+    when(session.getEndpoint()).thenReturn(endpoint);
+    when(session.getLastNonce()).thenReturn(SERVER_NONCE);
+    when(session.getServer()).thenReturn(server);
+    when(session.getSecurityConfiguration())
+        .thenReturn(
+            new SecurityConfiguration(
+                securityPolicy, MessageSecurityMode.SignAndEncrypt, null, null, null, null, null));
+    return session;
+  }
+
   private static Session noneSession() {
     return session(SecurityPolicy.None);
   }
@@ -167,10 +296,33 @@ class AbstractUsernameIdentityValidatorTest {
   }
 
   private static UserNameIdentityToken encryptedToken() {
-    SecurityAlgorithm algorithm = SecurityPolicy.Basic256Sha256.getAsymmetricEncryptionAlgorithm();
+    return encryptedToken(SecurityPolicy.Basic256Sha256, new byte[0]);
+  }
+
+  private static UserNameIdentityToken encryptedToken(
+      SecurityPolicy securityPolicy, byte[] ciphertext) {
+    SecurityAlgorithm algorithm = securityPolicy.getAsymmetricEncryptionAlgorithm();
 
     return new UserNameIdentityToken(
-        "username", USERNAME, ByteString.of(new byte[0]), algorithm.getUri());
+        "username", USERNAME, ByteString.of(ciphertext), algorithm.getUri());
+  }
+
+  private static byte[] encrypt(SecurityPolicy securityPolicy, byte[] plainText) throws Exception {
+    SecurityAlgorithm algorithm = securityPolicy.getAsymmetricEncryptionAlgorithm();
+    Cipher cipher = Cipher.getInstance(algorithm.getTransformation());
+    cipher.init(Cipher.ENCRYPT_MODE, certificate.getPublicKey());
+    return cipher.doFinal(plainText);
+  }
+
+  private static byte[] zeroedCopy(byte[] bytes) {
+    byte[] copy = bytes.clone();
+    Arrays.fill(copy, (byte) 0);
+    return copy;
+  }
+
+  private static void assertUniformEncryptedTokenFailure(UaException exception) {
+    assertEquals(StatusCodes.Bad_IdentityTokenInvalid, exception.getStatusCode().value());
+    assertNull(exception.getCause());
   }
 
   private static byte[] tokenData(String password, byte[] nonce) {
@@ -231,6 +383,46 @@ class AbstractUsernameIdentityValidatorTest {
       this.username = username;
       this.password = password;
 
+      return authenticate ? new DefaultUsernameIdentity(username) : null;
+    }
+  }
+
+  private static final class CryptoUsernameIdentityValidator
+      extends AbstractUsernameIdentityValidator {
+
+    private final boolean authenticate;
+
+    private int decryptCount;
+    private int authenticateCount;
+
+    private CryptoUsernameIdentityValidator(boolean authenticate) {
+      this.authenticate = authenticate;
+    }
+
+    private UsernameIdentity validate(Session session, UserNameIdentityToken token)
+        throws UaException {
+      UserTokenPolicy policy =
+          new UserTokenPolicy(
+              "username",
+              UserTokenType.UserName,
+              null,
+              null,
+              session.getSecurityConfiguration().getSecurityPolicy().getUri());
+
+      return validateUsernameToken(session, token, policy, NO_SIGNATURE);
+    }
+
+    @Override
+    protected byte[] decryptTokenData(
+        Session session, SecurityAlgorithm algorithm, byte[] dataBytes) throws UaException {
+      decryptCount++;
+      return super.decryptTokenData(session, algorithm, dataBytes);
+    }
+
+    @Override
+    protected @Nullable UsernameIdentity authenticateUsernamePassword(
+        Session session, String username, String password) {
+      authenticateCount++;
       return authenticate ? new DefaultUsernameIdentity(username) : null;
     }
   }

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractUsernameIdentityValidatorTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractUsernameIdentityValidatorTest.java
@@ -153,12 +153,14 @@ class AbstractUsernameIdentityValidatorTest {
   }
 
   @Test
-  void rsa15CiphertextsAreRejectedWithoutDecryption() throws Exception {
-    CryptoUsernameIdentityValidator validator = new CryptoUsernameIdentityValidator(true);
+  void rsa15CiphertextFailuresHaveUniformStatusAndNoCause() throws Exception {
+    CryptoUsernameIdentityValidator validator = new CryptoUsernameIdentityValidator(false);
     byte[] validCiphertext =
         encrypt(SecurityPolicy.Basic128Rsa15, tokenData(PASSWORD, SERVER_NONCE.bytesOrEmpty()));
+    byte[] wrongPasswordCiphertext =
+        encrypt(SecurityPolicy.Basic128Rsa15, tokenData("wrong", SERVER_NONCE.bytesOrEmpty()));
 
-    for (byte[] ciphertext : List.of(validCiphertext, zeroedCopy(validCiphertext))) {
+    for (byte[] ciphertext : List.of(wrongPasswordCiphertext, zeroedCopy(validCiphertext))) {
       UaException exception =
           assertThrows(
               UaException.class,
@@ -170,8 +172,24 @@ class AbstractUsernameIdentityValidatorTest {
       assertUniformEncryptedTokenFailure(exception);
     }
 
-    assertEquals(0, validator.decryptCount);
-    assertEquals(0, validator.authenticateCount);
+    assertEquals(2, validator.decryptCount);
+    assertEquals(1, validator.authenticateCount);
+  }
+
+  @Test
+  void rsa15EncryptedPasswordStillAuthenticates() throws Exception {
+    CryptoUsernameIdentityValidator validator = new CryptoUsernameIdentityValidator(true);
+    byte[] ciphertext =
+        encrypt(SecurityPolicy.Basic128Rsa15, tokenData(PASSWORD, SERVER_NONCE.bytesOrEmpty()));
+
+    UsernameIdentity identity =
+        validator.validate(
+            encryptedSession(SecurityPolicy.Basic128Rsa15),
+            encryptedToken(SecurityPolicy.Basic128Rsa15, ciphertext));
+
+    assertEquals(USERNAME, identity.getUsername());
+    assertEquals(1, validator.decryptCount);
+    assertEquals(1, validator.authenticateCount);
   }
 
   @Test


### PR DESCRIPTION
## Summary

- reject RSA PKCS#1 v1.5 username tokens before private-key decryption
- normalize encrypted username-token decryption, structure, nonce, length-limit, and credential failures to a cause-free `Bad_IdentityTokenInvalid`
- add focused RSA/OAEP regression coverage using real keys, certificates, and ciphertext mutations

## Root cause and invariant

The ActivateSession username-token path exposed different service statuses for RSA decryption failures and failures reached after successful decryption. Encrypted username-token failures must not reveal cryptographic validity through response status, nested causes, or alternate validation paths.

The fix rejects the vulnerable RSA15 algorithm before processing ciphertext and preserves successful OAEP and unencrypted username authentication behavior. Basic128Rsa15 username-token authentication is intentionally rejected.

## Verification

- `mise exec -- mvn -q -pl opc-ua-sdk/sdk-server -am test -Dtest=AbstractUsernameIdentityValidatorTest -Dsurefire.failIfNoSpecifiedTests=false` — 10 tests, 0 failures/errors/skips
- `mise exec -- mvn -q -pl opc-ua-sdk/sdk-server -am test`
- `mise exec -- mvn -q spotless:apply`
- `mise exec -- mvn -q clean compile`
