### PR TITLE
Reject X.509 user token policies using SecurityPolicy.None

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/EndpointConfig.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/EndpointConfig.java
@@ -57,6 +57,8 @@ public class EndpointConfig {
     this.securityPolicy = securityPolicy;
     this.securityMode = securityMode;
     this.tokenPolicies = List.copyOf(tokenPolicies);
+
+    validateTokenPolicies();
   }
 
   public TransportProfile getTransportProfile() {
@@ -94,6 +96,25 @@ public class EndpointConfig {
 
   public List<UserTokenPolicy> getTokenPolicies() {
     return tokenPolicies;
+  }
+
+  String getEffectiveTokenSecurityPolicyUri(UserTokenPolicy tokenPolicy) {
+    String securityPolicyUri = tokenPolicy.getSecurityPolicyUri();
+
+    return securityPolicyUri == null || securityPolicyUri.isEmpty()
+        ? securityPolicy.getUri()
+        : securityPolicyUri;
+  }
+
+  private void validateTokenPolicies() {
+    for (UserTokenPolicy tokenPolicy : tokenPolicies) {
+      if (tokenPolicy.getTokenType() == UserTokenType.Certificate
+          && SecurityPolicy.None.getUri().equals(getEffectiveTokenSecurityPolicyUri(tokenPolicy))) {
+
+        throw new IllegalArgumentException(
+            "X.509 user token policy cannot use SecurityPolicy.None: " + tokenPolicy.getPolicyId());
+      }
+    }
   }
 
   public String getEndpointUrl() {

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServer.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServer.java
@@ -955,20 +955,13 @@ public class OpcUaServer extends AbstractServiceHandler {
 
       static UserTokenPolicyKey from(EndpointConfig endpoint, UserTokenPolicy tokenPolicy) {
         String policyId = tokenPolicy.getPolicyId();
-        String securityPolicyUri = tokenPolicy.getSecurityPolicyUri();
 
         return new UserTokenPolicyKey(
             policyId == null ? "" : policyId,
             tokenPolicy.getTokenType(),
             tokenPolicy.getIssuedTokenType(),
             tokenPolicy.getIssuerEndpointUrl(),
-            isNullOrEmpty(securityPolicyUri)
-                ? endpoint.getSecurityPolicy().getUri()
-                : securityPolicyUri);
-      }
-
-      private static boolean isNullOrEmpty(@Nullable String value) {
-        return value == null || value.isEmpty();
+            endpoint.getEffectiveTokenSecurityPolicyUri(tokenPolicy));
       }
     }
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractX509IdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractX509IdentityValidator.java
@@ -102,8 +102,9 @@ public abstract class AbstractX509IdentityValidator extends AbstractIdentityVali
   /**
    * Create and return an {@link X509UserIdentity} for the user identified by {@code certificate}.
    *
-   * <p>Possession of the private key associated with this certificate has been verified prior to
-   * this call.
+   * <p>Server configuration rejects X.509 user token policies whose effective {@link
+   * SecurityPolicy} is {@link SecurityPolicy#None}, so possession of the private key associated
+   * with this certificate has been verified prior to this call.
    *
    * @param session the {@link Session} being activated.
    * @param certificate the {@link X509Certificate} identifying the user.

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/EndpointConfigTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/EndpointConfigTest.java
@@ -10,13 +10,17 @@
 
 package org.eclipse.milo.opcua.sdk.server;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
 
+import java.security.cert.X509Certificate;
 import java.util.List;
 import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
 import org.eclipse.milo.opcua.stack.core.transport.TransportProfile;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.MessageSecurityMode;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.UserTokenType;
 import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
 import org.junit.jupiter.api.Test;
 
@@ -86,5 +90,54 @@ public class EndpointConfigTest {
     List<UserTokenPolicy> tokenPolicies = endpointConfig.getTokenPolicies();
     assertEquals(1, tokenPolicies.size());
     assertEquals(EndpointConfig.Builder.USER_TOKEN_POLICY_ANONYMOUS, tokenPolicies.get(0));
+  }
+
+  @Test
+  public void x509TokenPolicyWithExplicitNoneThrows() {
+    UserTokenPolicy tokenPolicy =
+        new UserTokenPolicy(
+            "certificate", UserTokenType.Certificate, null, null, SecurityPolicy.None.getUri());
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            EndpointConfig.newBuilder()
+                .setCertificate(mock(X509Certificate.class))
+                .setSecurityPolicy(SecurityPolicy.Basic256Sha256)
+                .setSecurityMode(MessageSecurityMode.SignAndEncrypt)
+                .addTokenPolicy(tokenPolicy)
+                .build());
+  }
+
+  @Test
+  public void x509TokenPolicyInheritingNoneThrows() {
+    UserTokenPolicy tokenPolicy =
+        new UserTokenPolicy("certificate", UserTokenType.Certificate, null, null, null);
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> EndpointConfig.newBuilder().addTokenPolicy(tokenPolicy).build());
+  }
+
+  @Test
+  public void x509TokenPolicyWithBasic256Sha256IsAccepted() {
+    UserTokenPolicy tokenPolicy =
+        new UserTokenPolicy(
+            "certificate",
+            UserTokenType.Certificate,
+            null,
+            null,
+            SecurityPolicy.Basic256Sha256.getUri());
+
+    assertDoesNotThrow(() -> EndpointConfig.newBuilder().addTokenPolicy(tokenPolicy).build());
+  }
+
+  @Test
+  public void nonX509TokenPolicyWithNoneIsAccepted() {
+    UserTokenPolicy tokenPolicy =
+        new UserTokenPolicy(
+            "username", UserTokenType.UserName, null, null, SecurityPolicy.None.getUri());
+
+    assertDoesNotThrow(() -> EndpointConfig.newBuilder().addTokenPolicy(tokenPolicy).build());
   }
 }


### PR DESCRIPTION
## Summary

- reject X.509 user identity token policies when their effective security policy is `SecurityPolicy.None`
- resolve null or empty token policy URIs through the endpoint policy at endpoint construction, using the same resolution helper used for endpoint descriptions
- clarify the X.509 validator contract and add focused accepted/rejected configuration coverage

## Rationale

An X.509 user certificate is public and is not sufficient proof of identity by itself. When the effective token policy is `None`, no signing algorithm is available to prove possession of the associated private key before the certificate is mapped to a user.

Invalid configurations now fail fast during `EndpointConfig` construction with an `IllegalArgumentException`, before server startup or session activation.

## Compatibility

Non-X.509 token policies using `SecurityPolicy.None` remain accepted. X.509 token policies using a signing-capable policy such as `Basic256Sha256` also remain accepted.

## Verification

- `mise exec -- mvn -q spotless:apply`
- `mise exec -- mvn -q clean compile`
- `mise exec -- mvn -q -pl opc-ua-sdk/sdk-server -am test -Dtest=EndpointConfigTest,OpcUaServerEndpointDescriptionTest -Dsurefire.failIfNoSpecifiedTests=false` (9 tests, 0 failures)
