### PR TITLE
Make monitored-item quota exception-safe

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/subscriptions/SubscriptionManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/subscriptions/SubscriptionManager.java
@@ -412,74 +412,60 @@ public class SubscriptionManager {
     long globalMax = server.getConfig().getLimits().getMaxMonitoredItems().longValue();
     long sessionMax = server.getConfig().getLimits().getMaxMonitoredItemsPerSession().longValue();
 
-    boolean monitoredItemsCommitted = false;
-    try {
-      for (MonitoredItemCreateRequest request : requests) {
-        boolean globalCountIncremented = false;
-        boolean sessionCountIncremented = false;
-        boolean creationSucceeded = false;
+    for (MonitoredItemCreateRequest request : requests) {
+      long globalCount = server.getMonitoredItemCount().incrementAndGet();
+      long sessionCount = monitoredItemCount.incrementAndGet();
+      boolean created = false;
 
-        try {
-          long globalCount = server.getMonitoredItemCount().incrementAndGet();
-          globalCountIncremented = true;
-          long sessionCount = monitoredItemCount.incrementAndGet();
-          sessionCountIncremented = true;
-
-          if (globalCount <= globalMax && sessionCount <= sessionMax) {
-            BaseMonitoredItem<?> monitoredItem;
-
-            boolean isValueAttribute =
-                request.getItemToMonitor().getAttributeId().equals(AttributeId.Value.uid());
-
-            AttributesResponse attributesResponse =
-                (isValueAttribute && hasPercentDeadbandFilter(request))
-                    ? analogItemAttributes.get(request.getItemToMonitor().getNodeId())
-                    : regularAttributes.get(request.getItemToMonitor().getNodeId());
-
-            monitoredItem =
-                createMonitoredItem(request, subscription, timestamps, attributesResponse);
-
-            monitoredItems.add(monitoredItem);
-            creationSucceeded = true;
-
-            results.add(
-                new MonitoredItemCreateResult(
-                    StatusCode.GOOD,
-                    monitoredItem.getId(),
-                    monitoredItem.getSamplingInterval(),
-                    uint(monitoredItem.getQueueSize()),
-                    monitoredItem.getFilterResult()));
-          } else {
-            throw new UaException(StatusCodes.Bad_TooManyMonitoredItems);
-          }
-        } catch (UaException e) {
-          results.add(
-              new MonitoredItemCreateResult(
-                  e.getStatusCode(), UInteger.MIN, 0.0, UInteger.MIN, null));
-        } finally {
-          if (!creationSucceeded) {
-            if (sessionCountIncremented) {
-              monitoredItemCount.decrementAndGet();
-            }
-            if (globalCountIncremented) {
-              server.getMonitoredItemCount().decrementAndGet();
-            }
-          }
+      try {
+        if (globalCount > globalMax || sessionCount > sessionMax) {
+          throw new UaException(StatusCodes.Bad_TooManyMonitoredItems);
         }
-      }
 
-      subscription.addMonitoredItems(monitoredItems);
-      monitoredItemsCommitted = true;
-    } finally {
-      if (!monitoredItemsCommitted && !monitoredItems.isEmpty()) {
-        try {
-          subscription.removeMonitoredItems(monitoredItems);
-        } finally {
-          monitoredItemCount.addAndGet(-monitoredItems.size());
-          server.getMonitoredItemCount().addAndGet(-monitoredItems.size());
+        boolean isValueAttribute =
+            request.getItemToMonitor().getAttributeId().equals(AttributeId.Value.uid());
+
+        AttributesResponse attributesResponse =
+            (isValueAttribute && hasPercentDeadbandFilter(request))
+                ? analogItemAttributes.get(request.getItemToMonitor().getNodeId())
+                : regularAttributes.get(request.getItemToMonitor().getNodeId());
+
+        BaseMonitoredItem<?> monitoredItem =
+            createMonitoredItem(request, subscription, timestamps, attributesResponse);
+
+        // Build the result before adding the item to monitoredItems; if it throws, the
+        // item must not be committed to the subscription or counted against the quotas.
+        MonitoredItemCreateResult result =
+            new MonitoredItemCreateResult(
+                StatusCode.GOOD,
+                monitoredItem.getId(),
+                monitoredItem.getSamplingInterval(),
+                uint(monitoredItem.getQueueSize()),
+                monitoredItem.getFilterResult());
+
+        monitoredItems.add(monitoredItem);
+        results.add(result);
+        created = true;
+      } catch (Exception e) {
+        StatusCode statusCode;
+        if (e instanceof UaException ue) {
+          statusCode = ue.getStatusCode();
+        } else {
+          logger.error("Unexpected error creating MonitoredItem", e);
+          statusCode = new StatusCode(StatusCodes.Bad_InternalError);
+        }
+
+        results.add(
+            new MonitoredItemCreateResult(statusCode, UInteger.MIN, 0.0, UInteger.MIN, null));
+      } finally {
+        if (!created) {
+          monitoredItemCount.decrementAndGet();
+          server.getMonitoredItemCount().decrementAndGet();
         }
       }
     }
+
+    subscription.addMonitoredItems(monitoredItems);
 
     byMonitoredItemType(
         monitoredItems,
@@ -613,10 +599,23 @@ public class SubscriptionManager {
       throw new UaException(StatusCodes.Bad_AttributeIdInvalid);
     }
 
-    Object filterObject =
-        request.getRequestedParameters().getFilter().decode(server.getStaticEncodingContext());
+    MonitoringFilter filter;
 
-    MonitoringFilter filter = validateEventItemFilter(filterObject);
+    try {
+      ExtensionObject filterXo = request.getRequestedParameters().getFilter();
+
+      if (filterXo == null || filterXo.isNull()) {
+        throw new UaException(StatusCodes.Bad_MonitoredItemFilterInvalid);
+      }
+
+      Object filterObject = filterXo.decode(server.getStaticEncodingContext());
+
+      filter = validateEventItemFilter(filterObject);
+    } catch (UaSerializationException e) {
+      logger.debug("error decoding MonitoringFilter", e);
+
+      throw new UaException(StatusCodes.Bad_MonitoredItemFilterInvalid, e);
+    }
 
     RevisedEventItemParameters revisedParameters;
 
@@ -862,10 +861,23 @@ public class SubscriptionManager {
     }
 
     if (attributeId == AttributeId.EventNotifier) {
-      Object filterObject =
-          request.getRequestedParameters().getFilter().decode(server.getStaticEncodingContext());
+      MonitoringFilter filter;
 
-      MonitoringFilter filter = validateEventItemFilter(filterObject);
+      try {
+        ExtensionObject filterXo = request.getRequestedParameters().getFilter();
+
+        if (filterXo == null || filterXo.isNull()) {
+          throw new UaException(StatusCodes.Bad_MonitoredItemFilterInvalid);
+        }
+
+        Object filterObject = filterXo.decode(server.getStaticEncodingContext());
+
+        filter = validateEventItemFilter(filterObject);
+      } catch (UaSerializationException e) {
+        logger.debug("error decoding MonitoringFilter", e);
+
+        throw new UaException(StatusCodes.Bad_MonitoredItemFilterInvalid, e);
+      }
 
       RevisedEventItemParameters revisedParameters;
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/subscriptions/SubscriptionManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/subscriptions/SubscriptionManager.java
@@ -433,8 +433,9 @@ public class SubscriptionManager {
         BaseMonitoredItem<?> monitoredItem =
             createMonitoredItem(request, subscription, timestamps, attributesResponse);
 
-        // Build the result before adding the item to monitoredItems; if it throws, the
-        // item must not be committed to the subscription or counted against the quotas.
+        // getFilterResult() can throw while encoding the filter result, so it must be
+        // called before the item is added to monitoredItems; otherwise a failure would
+        // commit an item to the subscription after its quota reservation is released.
         MonitoredItemCreateResult result =
             new MonitoredItemCreateResult(
                 StatusCode.GOOD,

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/subscriptions/SubscriptionManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/subscriptions/SubscriptionManager.java
@@ -412,48 +412,74 @@ public class SubscriptionManager {
     long globalMax = server.getConfig().getLimits().getMaxMonitoredItems().longValue();
     long sessionMax = server.getConfig().getLimits().getMaxMonitoredItemsPerSession().longValue();
 
-    for (MonitoredItemCreateRequest request : requests) {
-      try {
-        long globalCount = server.getMonitoredItemCount().incrementAndGet();
-        long sessionCount = monitoredItemCount.incrementAndGet();
+    boolean monitoredItemsCommitted = false;
+    try {
+      for (MonitoredItemCreateRequest request : requests) {
+        boolean globalCountIncremented = false;
+        boolean sessionCountIncremented = false;
+        boolean creationSucceeded = false;
 
-        if (globalCount <= globalMax && sessionCount <= sessionMax) {
-          BaseMonitoredItem<?> monitoredItem;
+        try {
+          long globalCount = server.getMonitoredItemCount().incrementAndGet();
+          globalCountIncremented = true;
+          long sessionCount = monitoredItemCount.incrementAndGet();
+          sessionCountIncremented = true;
 
-          boolean isValueAttribute =
-              request.getItemToMonitor().getAttributeId().equals(AttributeId.Value.uid());
+          if (globalCount <= globalMax && sessionCount <= sessionMax) {
+            BaseMonitoredItem<?> monitoredItem;
 
-          AttributesResponse attributesResponse =
-              (isValueAttribute && hasPercentDeadbandFilter(request))
-                  ? analogItemAttributes.get(request.getItemToMonitor().getNodeId())
-                  : regularAttributes.get(request.getItemToMonitor().getNodeId());
+            boolean isValueAttribute =
+                request.getItemToMonitor().getAttributeId().equals(AttributeId.Value.uid());
 
-          monitoredItem =
-              createMonitoredItem(request, subscription, timestamps, attributesResponse);
+            AttributesResponse attributesResponse =
+                (isValueAttribute && hasPercentDeadbandFilter(request))
+                    ? analogItemAttributes.get(request.getItemToMonitor().getNodeId())
+                    : regularAttributes.get(request.getItemToMonitor().getNodeId());
 
-          monitoredItems.add(monitoredItem);
+            monitoredItem =
+                createMonitoredItem(request, subscription, timestamps, attributesResponse);
 
+            monitoredItems.add(monitoredItem);
+            creationSucceeded = true;
+
+            results.add(
+                new MonitoredItemCreateResult(
+                    StatusCode.GOOD,
+                    monitoredItem.getId(),
+                    monitoredItem.getSamplingInterval(),
+                    uint(monitoredItem.getQueueSize()),
+                    monitoredItem.getFilterResult()));
+          } else {
+            throw new UaException(StatusCodes.Bad_TooManyMonitoredItems);
+          }
+        } catch (UaException e) {
           results.add(
               new MonitoredItemCreateResult(
-                  StatusCode.GOOD,
-                  monitoredItem.getId(),
-                  monitoredItem.getSamplingInterval(),
-                  uint(monitoredItem.getQueueSize()),
-                  monitoredItem.getFilterResult()));
-        } else {
-          throw new UaException(StatusCodes.Bad_TooManyMonitoredItems);
+                  e.getStatusCode(), UInteger.MIN, 0.0, UInteger.MIN, null));
+        } finally {
+          if (!creationSucceeded) {
+            if (sessionCountIncremented) {
+              monitoredItemCount.decrementAndGet();
+            }
+            if (globalCountIncremented) {
+              server.getMonitoredItemCount().decrementAndGet();
+            }
+          }
         }
-      } catch (UaException e) {
-        monitoredItemCount.decrementAndGet();
-        server.getMonitoredItemCount().decrementAndGet();
+      }
 
-        results.add(
-            new MonitoredItemCreateResult(
-                e.getStatusCode(), UInteger.MIN, 0.0, UInteger.MIN, null));
+      subscription.addMonitoredItems(monitoredItems);
+      monitoredItemsCommitted = true;
+    } finally {
+      if (!monitoredItemsCommitted && !monitoredItems.isEmpty()) {
+        try {
+          subscription.removeMonitoredItems(monitoredItems);
+        } finally {
+          monitoredItemCount.addAndGet(-monitoredItems.size());
+          server.getMonitoredItemCount().addAndGet(-monitoredItems.size());
+        }
       }
     }
-
-    subscription.addMonitoredItems(monitoredItems);
 
     byMonitoredItemType(
         monitoredItems,

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/subscriptions/SubscriptionManagerQuotaTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/subscriptions/SubscriptionManagerQuotaTest.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.subscriptions;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ubyte;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicLong;
+import org.eclipse.milo.opcua.sdk.server.AddressSpace.RevisedEventItemParameters;
+import org.eclipse.milo.opcua.sdk.server.AddressSpaceManager;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServerConfig;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServerConfigLimits;
+import org.eclipse.milo.opcua.sdk.server.Session;
+import org.eclipse.milo.opcua.sdk.server.items.BaseMonitoredItem;
+import org.eclipse.milo.opcua.sdk.server.servicesets.impl.AccessController;
+import org.eclipse.milo.opcua.sdk.server.servicesets.impl.AccessController.AccessResult;
+import org.eclipse.milo.opcua.stack.core.AttributeId;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.UaSerializationException;
+import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
+import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.MonitoringMode;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.TimestampsToReturn;
+import org.eclipse.milo.opcua.stack.core.types.structured.ContentFilter;
+import org.eclipse.milo.opcua.stack.core.types.structured.CreateMonitoredItemsRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.EventFilter;
+import org.eclipse.milo.opcua.stack.core.types.structured.MonitoredItemCreateRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.MonitoringParameters;
+import org.eclipse.milo.opcua.stack.core.types.structured.ReadValueId;
+import org.eclipse.milo.opcua.stack.core.types.structured.RequestHeader;
+import org.eclipse.milo.opcua.stack.core.types.structured.SimpleAttributeOperand;
+import org.eclipse.milo.opcua.stack.transport.server.ServiceRequestContext;
+import org.junit.jupiter.api.Test;
+
+class SubscriptionManagerQuotaTest {
+
+  @Test
+  void failedCreationDoesNotLeakMonitoredItemQuota() throws Exception {
+    UInteger subscriptionId = uint(1);
+    AtomicLong globalMonitoredItemCount = new AtomicLong();
+
+    OpcUaServerConfigLimits limits =
+        new OpcUaServerConfigLimits() {
+          @Override
+          public UInteger getMaxMonitoredItems() {
+            return uint(2);
+          }
+
+          @Override
+          public UInteger getMaxMonitoredItemsPerSession() {
+            return uint(2);
+          }
+        };
+
+    OpcUaServerConfig config = mock(OpcUaServerConfig.class);
+    when(config.getExecutor()).thenReturn(mock(ExecutorService.class));
+    when(config.getLimits()).thenReturn(limits);
+
+    AccessController accessController = mock(AccessController.class);
+    AddressSpaceManager addressSpaceManager = mock(AddressSpaceManager.class);
+    Session session = mock(Session.class);
+    OpcUaServer server = mock(OpcUaServer.class);
+    when(server.getConfig()).thenReturn(config);
+    when(server.getAccessController()).thenReturn(accessController);
+    when(server.getAddressSpaceManager()).thenReturn(addressSpaceManager);
+    when(server.getStaticEncodingContext()).thenReturn(DefaultEncodingContext.INSTANCE);
+    when(server.getMonitoredItemCount()).thenReturn(globalMonitoredItemCount);
+
+    SubscriptionManager manager = new SubscriptionManager(session, server);
+    Subscription subscription = mock(Subscription.class);
+    Map<UInteger, BaseMonitoredItem<?>> ownedMonitoredItems = new HashMap<>();
+    when(subscription.getId()).thenReturn(subscriptionId);
+    when(subscription.getMonitoredItems()).thenReturn(ownedMonitoredItems);
+    when(subscription.nextItemId()).thenReturn(1L);
+    doAnswer(
+            invocation -> {
+              List<BaseMonitoredItem<?>> items = invocation.getArgument(0);
+              items.forEach(item -> ownedMonitoredItems.put(item.getId(), item));
+              return null;
+            })
+        .when(subscription)
+        .addMonitoredItems(anyList());
+    doAnswer(
+            invocation -> {
+              List<BaseMonitoredItem<?>> items = invocation.getArgument(0);
+              items.forEach(item -> ownedMonitoredItems.remove(item.getId()));
+              return null;
+            })
+        .when(subscription)
+        .removeMonitoredItems(anyList());
+    subscriptions(manager).put(subscriptionId, subscription);
+
+    NodeId nodeId = new NodeId(2, "event-source");
+    ReadValueId itemToMonitor =
+        new ReadValueId(nodeId, AttributeId.EventNotifier.uid(), null, QualifiedName.NULL_VALUE);
+    when(accessController.checkReadAccess(eq(session), anyList()))
+        .thenReturn(Map.of(itemToMonitor, AccessResult.ALLOWED));
+    when(addressSpaceManager.read(any(), eq(0.0), eq(TimestampsToReturn.Neither), anyList()))
+        .thenReturn(
+            List.of(
+                new DataValue(new Variant(NodeClass.Object)),
+                new DataValue(new Variant(ubyte(1))),
+                new DataValue(new Variant(NodeIds.BaseDataType)),
+                new DataValue(new Variant(0.0))));
+    when(addressSpaceManager.onCreateEventItem(itemToMonitor, uint(1)))
+        .thenReturn(new RevisedEventItemParameters(uint(1)));
+
+    var selectClause =
+        new SimpleAttributeOperand(
+            NodeIds.BaseEventType,
+            new QualifiedName[] {new QualifiedName(0, "Message")},
+            AttributeId.Value.uid(),
+            null);
+    ExtensionObject validFilter =
+        ExtensionObject.encode(
+            DefaultEncodingContext.INSTANCE,
+            new EventFilter(new SimpleAttributeOperand[] {selectClause}, new ContentFilter(null)));
+    ExtensionObject invalidFilter =
+        ExtensionObject.of(ByteString.of(new byte[] {0}), new NodeId(2, 999));
+    MonitoringParameters validParameters =
+        new MonitoringParameters(uint(1), 0.0, validFilter, uint(1), true);
+    MonitoringParameters invalidParameters =
+        new MonitoringParameters(uint(1), 0.0, invalidFilter, uint(1), true);
+    MonitoredItemCreateRequest validItem =
+        new MonitoredItemCreateRequest(itemToMonitor, MonitoringMode.Reporting, validParameters);
+    MonitoredItemCreateRequest invalidItem =
+        new MonitoredItemCreateRequest(itemToMonitor, MonitoringMode.Reporting, invalidParameters);
+    RequestHeader header =
+        new RequestHeader(NodeId.NULL_VALUE, DateTime.now(), uint(1), uint(0), null, uint(0), null);
+    CreateMonitoredItemsRequest request =
+        new CreateMonitoredItemsRequest(
+            header,
+            subscriptionId,
+            TimestampsToReturn.Both,
+            new MonitoredItemCreateRequest[] {validItem, invalidItem});
+    ServiceRequestContext context = mock(ServiceRequestContext.class);
+
+    assertThrows(
+        UaSerializationException.class, () -> manager.createMonitoredItems(context, request));
+    assertEquals(0, globalMonitoredItemCount.get());
+    assertEquals(0, monitoredItemCount(manager).get());
+    assertEquals(0, ownedMonitoredItems.size());
+
+    EncodingContext failingEncodingContext = mock(EncodingContext.class);
+    when(failingEncodingContext.getNamespaceTable())
+        .thenThrow(new IllegalStateException("post-append result failure"));
+    when(server.getStaticEncodingContext()).thenReturn(failingEncodingContext);
+
+    IllegalStateException exception =
+        assertThrows(
+            IllegalStateException.class, () -> manager.createMonitoredItems(context, request));
+    assertEquals("post-append result failure", exception.getMessage());
+    assertEquals(0, globalMonitoredItemCount.get());
+    assertEquals(0, monitoredItemCount(manager).get());
+    assertEquals(0, ownedMonitoredItems.size());
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<UInteger, Subscription> subscriptions(SubscriptionManager manager)
+      throws ReflectiveOperationException {
+
+    Field field = SubscriptionManager.class.getDeclaredField("subscriptions");
+    field.setAccessible(true);
+    return (Map<UInteger, Subscription>) field.get(manager);
+  }
+
+  private static AtomicLong monitoredItemCount(SubscriptionManager manager)
+      throws ReflectiveOperationException {
+
+    Field field = SubscriptionManager.class.getDeclaredField("monitoredItemCount");
+    field.setAccessible(true);
+    return (AtomicLong) field.get(manager);
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/subscriptions/SubscriptionManagerQuotaTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/subscriptions/SubscriptionManagerQuotaTest.java
@@ -13,7 +13,6 @@ package org.eclipse.milo.opcua.sdk.server.subscriptions;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ubyte;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
@@ -38,7 +37,7 @@ import org.eclipse.milo.opcua.sdk.server.servicesets.impl.AccessController;
 import org.eclipse.milo.opcua.sdk.server.servicesets.impl.AccessController.AccessResult;
 import org.eclipse.milo.opcua.stack.core.AttributeId;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
-import org.eclipse.milo.opcua.stack.core.UaSerializationException;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
 import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
@@ -47,6 +46,7 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.MonitoringMode;
@@ -54,22 +54,42 @@ import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.TimestampsToReturn;
 import org.eclipse.milo.opcua.stack.core.types.structured.ContentFilter;
 import org.eclipse.milo.opcua.stack.core.types.structured.CreateMonitoredItemsRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.CreateMonitoredItemsResponse;
 import org.eclipse.milo.opcua.stack.core.types.structured.EventFilter;
 import org.eclipse.milo.opcua.stack.core.types.structured.MonitoredItemCreateRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.MonitoredItemCreateResult;
 import org.eclipse.milo.opcua.stack.core.types.structured.MonitoringParameters;
 import org.eclipse.milo.opcua.stack.core.types.structured.ReadValueId;
 import org.eclipse.milo.opcua.stack.core.types.structured.RequestHeader;
 import org.eclipse.milo.opcua.stack.core.types.structured.SimpleAttributeOperand;
 import org.eclipse.milo.opcua.stack.transport.server.ServiceRequestContext;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class SubscriptionManagerQuotaTest {
 
-  @Test
-  void failedCreationDoesNotLeakMonitoredItemQuota() throws Exception {
-    UInteger subscriptionId = uint(1);
-    AtomicLong globalMonitoredItemCount = new AtomicLong();
+  private static final UInteger SUBSCRIPTION_ID = uint(1);
 
+  private final AtomicLong globalMonitoredItemCount = new AtomicLong();
+  private final Map<UInteger, BaseMonitoredItem<?>> ownedMonitoredItems = new HashMap<>();
+
+  private final OpcUaServer server = mock(OpcUaServer.class);
+  private final AccessController accessController = mock(AccessController.class);
+  private final AddressSpaceManager addressSpaceManager = mock(AddressSpaceManager.class);
+  private final Session session = mock(Session.class);
+  private final ServiceRequestContext context = mock(ServiceRequestContext.class);
+
+  private final ReadValueId itemToMonitor =
+      new ReadValueId(
+          new NodeId(2, "event-source"),
+          AttributeId.EventNotifier.uid(),
+          null,
+          QualifiedName.NULL_VALUE);
+
+  private SubscriptionManager manager;
+
+  @BeforeEach
+  void setUp() throws Exception {
     OpcUaServerConfigLimits limits =
         new OpcUaServerConfigLimits() {
           @Override
@@ -87,20 +107,16 @@ class SubscriptionManagerQuotaTest {
     when(config.getExecutor()).thenReturn(mock(ExecutorService.class));
     when(config.getLimits()).thenReturn(limits);
 
-    AccessController accessController = mock(AccessController.class);
-    AddressSpaceManager addressSpaceManager = mock(AddressSpaceManager.class);
-    Session session = mock(Session.class);
-    OpcUaServer server = mock(OpcUaServer.class);
     when(server.getConfig()).thenReturn(config);
     when(server.getAccessController()).thenReturn(accessController);
     when(server.getAddressSpaceManager()).thenReturn(addressSpaceManager);
     when(server.getStaticEncodingContext()).thenReturn(DefaultEncodingContext.INSTANCE);
     when(server.getMonitoredItemCount()).thenReturn(globalMonitoredItemCount);
 
-    SubscriptionManager manager = new SubscriptionManager(session, server);
+    manager = new SubscriptionManager(session, server);
+
     Subscription subscription = mock(Subscription.class);
-    Map<UInteger, BaseMonitoredItem<?>> ownedMonitoredItems = new HashMap<>();
-    when(subscription.getId()).thenReturn(subscriptionId);
+    when(subscription.getId()).thenReturn(SUBSCRIPTION_ID);
     when(subscription.getMonitoredItems()).thenReturn(ownedMonitoredItems);
     when(subscription.nextItemId()).thenReturn(1L);
     doAnswer(
@@ -119,11 +135,8 @@ class SubscriptionManagerQuotaTest {
             })
         .when(subscription)
         .removeMonitoredItems(anyList());
-    subscriptions(manager).put(subscriptionId, subscription);
+    subscriptions(manager).put(SUBSCRIPTION_ID, subscription);
 
-    NodeId nodeId = new NodeId(2, "event-source");
-    ReadValueId itemToMonitor =
-        new ReadValueId(nodeId, AttributeId.EventNotifier.uid(), null, QualifiedName.NULL_VALUE);
     when(accessController.checkReadAccess(eq(session), anyList()))
         .thenReturn(Map.of(itemToMonitor, AccessResult.ALLOWED));
     when(addressSpaceManager.read(any(), eq(0.0), eq(TimestampsToReturn.Neither), anyList()))
@@ -135,55 +148,96 @@ class SubscriptionManagerQuotaTest {
                 new DataValue(new Variant(0.0))));
     when(addressSpaceManager.onCreateEventItem(itemToMonitor, uint(1)))
         .thenReturn(new RevisedEventItemParameters(uint(1)));
+  }
 
+  @Test
+  void invalidFilterFailsItemAndReleasesQuota() throws Exception {
+    ExtensionObject invalidFilter =
+        ExtensionObject.of(ByteString.of(new byte[] {0}), new NodeId(2, 999));
+
+    CreateMonitoredItemsResponse response =
+        manager.createMonitoredItems(
+            context, createRequest(createItem(validEventFilter()), createItem(invalidFilter)));
+
+    MonitoredItemCreateResult[] results = response.getResults();
+    assertEquals(2, results.length);
+    assertEquals(StatusCode.GOOD, results[0].getStatusCode());
+    assertEquals(
+        new StatusCode(StatusCodes.Bad_MonitoredItemFilterInvalid), results[1].getStatusCode());
+
+    assertEquals(1, globalMonitoredItemCount.get());
+    assertEquals(1, monitoredItemCount(manager).get());
+    assertEquals(1, ownedMonitoredItems.size());
+  }
+
+  @Test
+  void missingEventFilterFailsItemAndReleasesQuota() throws Exception {
+    CreateMonitoredItemsResponse response =
+        manager.createMonitoredItems(context, createRequest(createItem(null)));
+
+    MonitoredItemCreateResult[] results = response.getResults();
+    assertEquals(1, results.length);
+    assertEquals(
+        new StatusCode(StatusCodes.Bad_MonitoredItemFilterInvalid), results[0].getStatusCode());
+
+    assertEquals(0, globalMonitoredItemCount.get());
+    assertEquals(0, monitoredItemCount(manager).get());
+    assertEquals(0, ownedMonitoredItems.size());
+  }
+
+  @Test
+  void unexpectedExceptionFailsItemAndReleasesQuota() throws Exception {
+    ExtensionObject validFilter = validEventFilter();
+    // Prime the decode cache so filter decoding succeeds and the failure surfaces after the
+    // item is created, while the GOOD result is being built: getFilterResult() encodes with
+    // the static encoding context, which is stubbed below to fail.
+    validFilter.decode(DefaultEncodingContext.INSTANCE);
+
+    EncodingContext failingEncodingContext = mock(EncodingContext.class);
+    when(failingEncodingContext.getNamespaceTable())
+        .thenThrow(new IllegalStateException("result encoding failure"));
+    when(server.getStaticEncodingContext()).thenReturn(failingEncodingContext);
+
+    CreateMonitoredItemsResponse response =
+        manager.createMonitoredItems(context, createRequest(createItem(validFilter)));
+
+    MonitoredItemCreateResult[] results = response.getResults();
+    assertEquals(1, results.length);
+    assertEquals(new StatusCode(StatusCodes.Bad_InternalError), results[0].getStatusCode());
+
+    assertEquals(0, globalMonitoredItemCount.get());
+    assertEquals(0, monitoredItemCount(manager).get());
+    assertEquals(0, ownedMonitoredItems.size());
+  }
+
+  private static ExtensionObject validEventFilter() {
     var selectClause =
         new SimpleAttributeOperand(
             NodeIds.BaseEventType,
             new QualifiedName[] {new QualifiedName(0, "Message")},
             AttributeId.Value.uid(),
             null);
-    ExtensionObject validFilter =
-        ExtensionObject.encode(
-            DefaultEncodingContext.INSTANCE,
-            new EventFilter(new SimpleAttributeOperand[] {selectClause}, new ContentFilter(null)));
-    ExtensionObject invalidFilter =
-        ExtensionObject.of(ByteString.of(new byte[] {0}), new NodeId(2, 999));
-    MonitoringParameters validParameters =
-        new MonitoringParameters(uint(1), 0.0, validFilter, uint(1), true);
-    MonitoringParameters invalidParameters =
-        new MonitoringParameters(uint(1), 0.0, invalidFilter, uint(1), true);
-    MonitoredItemCreateRequest validItem =
-        new MonitoredItemCreateRequest(itemToMonitor, MonitoringMode.Reporting, validParameters);
-    MonitoredItemCreateRequest invalidItem =
-        new MonitoredItemCreateRequest(itemToMonitor, MonitoringMode.Reporting, invalidParameters);
+
+    return ExtensionObject.encode(
+        DefaultEncodingContext.INSTANCE,
+        new EventFilter(new SimpleAttributeOperand[] {selectClause}, new ContentFilter(null)));
+  }
+
+  private MonitoredItemCreateRequest createItem(ExtensionObject filter) {
+    return new MonitoredItemCreateRequest(
+        itemToMonitor,
+        MonitoringMode.Reporting,
+        new MonitoringParameters(uint(1), 0.0, filter, uint(1), true));
+  }
+
+  private static CreateMonitoredItemsRequest createRequest(
+      MonitoredItemCreateRequest... itemsToCreate) {
+
     RequestHeader header =
         new RequestHeader(NodeId.NULL_VALUE, DateTime.now(), uint(1), uint(0), null, uint(0), null);
-    CreateMonitoredItemsRequest request =
-        new CreateMonitoredItemsRequest(
-            header,
-            subscriptionId,
-            TimestampsToReturn.Both,
-            new MonitoredItemCreateRequest[] {validItem, invalidItem});
-    ServiceRequestContext context = mock(ServiceRequestContext.class);
 
-    assertThrows(
-        UaSerializationException.class, () -> manager.createMonitoredItems(context, request));
-    assertEquals(0, globalMonitoredItemCount.get());
-    assertEquals(0, monitoredItemCount(manager).get());
-    assertEquals(0, ownedMonitoredItems.size());
-
-    EncodingContext failingEncodingContext = mock(EncodingContext.class);
-    when(failingEncodingContext.getNamespaceTable())
-        .thenThrow(new IllegalStateException("post-append result failure"));
-    when(server.getStaticEncodingContext()).thenReturn(failingEncodingContext);
-
-    IllegalStateException exception =
-        assertThrows(
-            IllegalStateException.class, () -> manager.createMonitoredItems(context, request));
-    assertEquals("post-append result failure", exception.getMessage());
-    assertEquals(0, globalMonitoredItemCount.get());
-    assertEquals(0, monitoredItemCount(manager).get());
-    assertEquals(0, ownedMonitoredItems.size());
+    return new CreateMonitoredItemsRequest(
+        header, SUBSCRIPTION_ID, TimestampsToReturn.Both, itemsToCreate);
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Summary

- treat every monitored-item creation failure as a per-item result so quota reservations can never leak
- translate event filter decode failures to `Bad_MonitoredItemFilterInvalid` in the create and modify paths, mirroring the existing data item paths
- reject missing event filters with `Bad_MonitoredItemFilterInvalid` instead of throwing NPE
- add focused regression coverage for invalid-filter, missing-filter, and unexpected-exception paths

## Root cause

Monitored-item quota counters are reserved before filter decoding and item construction, but the per-item error handling only caught `UaException`. An unchecked exception — e.g. `UaSerializationException` from the untranslated event filter decode in `createMonitoredEventItem` (the data item path already translated it), or a failure while encoding the filter result for the GOOD result — escaped the loop, faulted the whole service, and left counters incremented for items that were never committed to the subscription. #1806 widened this surface: `ExtensionObject.decode()` now also throws `UaSerializationException` for over-deep nested payloads.

## Fix

Instead of adding commit/rollback bookkeeping around the batch, no exception escapes the per-item loop anymore:

- `createMonitoredEventItem` and the event branch of `modifyMonitoredItem` translate `UaSerializationException` to `UaException(Bad_MonitoredItemFilterInvalid)`, the same as the data item paths, and handle null filters (event items require a filter).
- The creation loop catches all exceptions per item: `UaException` maps to its status code, anything else logs and maps to `Bad_InternalError`, consistent with how `onCreateDataItem`/`onCreateEventItem` already wrap `Throwable`. Quota release happens in a single `finally` keyed on one flag.
- The GOOD result is built before the item is added to the batch, so a result-encoding failure cannot commit an item whose quota reservation was released.

Since `subscription.addMonitoredItems()` is now always reached, no batch rollback is needed. This also changes behavior for the better: one bad item in a batch yields a per-item error result (as the spec intends for CreateMonitoredItems) instead of faulting the entire service and discarding the other items.

## Verification

- `mise exec -- mvn -q spotless:apply`
- `mise exec -- mvn -q -pl opc-ua-sdk/sdk-server -am test -Dtest=SubscriptionManagerQuotaTest -Dsurefire.failIfNoSpecifiedTests=false`
- `mise exec -- mvn -q -pl opc-ua-sdk/sdk-server -am test`
