### PR TITLE
Update Maven dependencies (2026-07-13)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,14 +58,14 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
     <!-- Dependency Versions -->
-    <bouncycastle.version>1.84</bouncycastle.version>
+    <bouncycastle.version>1.85</bouncycastle.version>
     <data-type-test.version>0.3</data-type-test.version>
     <gson.version>2.14.0</gson.version>
     <guava.version>33.6.0-jre</guava.version>
     <jakarta-activation.version>2.0.1</jakarta-activation.version>
     <jakarta-xml-bind-api.version>4.0.5</jakarta-xml-bind-api.version>
     <jaxb.version>4.0.9</jaxb.version>
-    <netty.version>4.1.135.Final</netty.version>
+    <netty.version>4.1.136.Final</netty.version>
     <netty-channel-fsm.version>1.0.2</netty-channel-fsm.version>
     <slf4j.version>2.0.18</slf4j.version>
     <jspecify.version>1.0.0</jspecify.version>
@@ -99,7 +99,7 @@
     <flatten-maven-plugin.version>1.7.3</flatten-maven-plugin.version>
 
     <!-- Test Dependency Versions -->
-    <junit.version>6.1.1</junit.version>
+    <junit.version>6.1.2</junit.version>
     <mockito.version>5.23.0</mockito.version>
   </properties>
 


### PR DESCRIPTION
## Updated dependencies

- `org.bouncycastle:bcpkix-jdk18on` / `org.bouncycastle:bcprov-jdk18on`: `1.84` -> `1.85` via `bouncycastle.version`
- `io.netty:*` modules using `netty.version`: `4.1.135.Final` -> `4.1.136.Final`
- JUnit/JUnit Platform artifacts using `junit.version`: `6.1.1` -> `6.1.2`

## Updated plugins

- None. `versions:display-plugin-updates` reported all specified plugins are already on latest versions.

## Skipped prerelease/non-stable suggestions

- None reported after applying the repository's versions-maven-plugin ignore rules.
- Existing repository rules still intentionally ignore Netty `4.2.0+` and Checkstyle `13.0.0+` lines.

## Verification

- `mise exec -- mvn versions:display-dependency-updates` succeeded: `/tmp/maven_dependency_updates_20260713090628.log`
- `mise exec -- mvn versions:display-plugin-updates` succeeded: `/tmp/maven_plugin_updates_20260713090638.log`
- `mise exec -- mvn -q dependency:resolve` succeeded: `/tmp/maven_dependency_resolve_20260713090929.log`
- `mise exec -- mvn -q spotless:apply` succeeded: `/tmp/maven_spotless_apply_20260713091011.log`
- `mise exec -- mvn -q clean compile` succeeded: `/tmp/maven_compile_20260713091041.log`
- `mise exec -- mvn -q clean verify` succeeded: `/tmp/maven_verify_20260713091100.log`

## Review

- Codex review subagent: APPROVED.
