### PR TITLE
Add session ID to client log context

### DIFF
--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmFactory.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmFactory.java
@@ -61,6 +61,7 @@ import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
@@ -296,16 +297,15 @@ public class SessionFsmFactory {
                   .whenComplete(
                       (csr, ex) -> {
                         if (csr != null) {
-                          try (MDCCloseable ignored =
-                              MDC.putCloseable("instance-id", ctx.getUserContext().toString())) {
+                          try (MDCCloseable ignoredInstanceId = putInstanceId(ctx);
+                              MDCCloseable ignoredSessionId = putSessionId(csr.getSessionId())) {
 
                             LOGGER.debug("CreateSession succeeded: {}", csr.getSessionId());
                           }
 
                           ctx.fireEvent(new Event.CreateSessionSuccess(csr));
                         } else {
-                          try (MDCCloseable ignored =
-                              MDC.putCloseable("instance-id", ctx.getUserContext().toString())) {
+                          try (MDCCloseable ignored = putInstanceId(ctx)) {
 
                             LOGGER.debug("CreateSession failed: {}", ex.getMessage(), ex);
                           }
@@ -325,16 +325,15 @@ public class SessionFsmFactory {
                   .whenComplete(
                       (csr, ex) -> {
                         if (csr != null) {
-                          try (MDCCloseable ignored =
-                              MDC.putCloseable("instance-id", ctx.getUserContext().toString())) {
+                          try (MDCCloseable ignoredInstanceId = putInstanceId(ctx);
+                              MDCCloseable ignoredSessionId = putSessionId(csr.getSessionId())) {
 
                             LOGGER.debug("CreateSession succeeded: {}", csr.getSessionId());
                           }
 
                           ctx.fireEvent(new Event.CreateSessionSuccess(csr));
                         } else {
-                          try (MDCCloseable ignored =
-                              MDC.putCloseable("instance-id", ctx.getUserContext().toString())) {
+                          try (MDCCloseable ignored = putInstanceId(ctx)) {
 
                             LOGGER.debug("CreateSession failed: {}", ex.getMessage(), ex);
                           }
@@ -389,16 +388,17 @@ public class SessionFsmFactory {
                   .whenComplete(
                       (session, ex) -> {
                         if (session != null) {
-                          try (MDCCloseable ignored =
-                              MDC.putCloseable("instance-id", ctx.getUserContext().toString())) {
+                          try (MDCCloseable ignoredInstanceId = putInstanceId(ctx);
+                              MDCCloseable ignoredSessionId = putSessionId(session)) {
 
                             LOGGER.debug("Session activated: {}", session);
                           }
 
                           ctx.fireEvent(new Event.ActivateSessionSuccess(session));
                         } else {
-                          try (MDCCloseable ignored =
-                              MDC.putCloseable("instance-id", ctx.getUserContext().toString())) {
+                          try (MDCCloseable ignoredInstanceId = putInstanceId(ctx);
+                              MDCCloseable ignoredSessionId =
+                                  putSessionId(event.response.getSessionId())) {
 
                             LOGGER.debug("ActivateSession failed: {}", ex.getMessage(), ex);
                           }
@@ -454,16 +454,16 @@ public class SessionFsmFactory {
                   .whenComplete(
                       (u, ex) -> {
                         if (u != null) {
-                          try (MDCCloseable ignored =
-                              MDC.putCloseable("instance-id", ctx.getUserContext().toString())) {
+                          try (MDCCloseable ignoredInstanceId = putInstanceId(ctx);
+                              MDCCloseable ignoredSessionId = putSessionId(event.session)) {
 
                             LOGGER.debug("TransferSubscriptions succeeded");
                           }
 
                           ctx.fireEvent(new Event.TransferSubscriptionsSuccess(event.session));
                         } else {
-                          try (MDCCloseable ignored =
-                              MDC.putCloseable("instance-id", ctx.getUserContext().toString())) {
+                          try (MDCCloseable ignoredInstanceId = putInstanceId(ctx);
+                              MDCCloseable ignoredSessionId = putSessionId(event.session)) {
 
                             LOGGER.debug("TransferSubscriptions failed: {}", ex.getMessage(), ex);
                           }
@@ -519,16 +519,16 @@ public class SessionFsmFactory {
                   .whenComplete(
                       (u, ex) -> {
                         if (u != null) {
-                          try (MDCCloseable ignored =
-                              MDC.putCloseable("instance-id", ctx.getUserContext().toString())) {
+                          try (MDCCloseable ignoredInstanceId = putInstanceId(ctx);
+                              MDCCloseable ignoredSessionId = putSessionId(session)) {
 
                             LOGGER.debug("Initialization succeeded: {}", session);
                           }
 
                           ctx.fireEvent(new Event.InitializeSuccess(session));
                         } else {
-                          try (MDCCloseable ignored =
-                              MDC.putCloseable("instance-id", ctx.getUserContext().toString())) {
+                          try (MDCCloseable ignoredInstanceId = putInstanceId(ctx);
+                              MDCCloseable ignoredSessionId = putSessionId(session)) {
 
                             LOGGER.warn("Initialization failed: {}", session, ex);
                           }
@@ -551,16 +551,16 @@ public class SessionFsmFactory {
                   .whenComplete(
                       (u, ex) -> {
                         if (u != null) {
-                          try (MDCCloseable ignored =
-                              MDC.putCloseable("instance-id", ctx.getUserContext().toString())) {
+                          try (MDCCloseable ignoredInstanceId = putInstanceId(ctx);
+                              MDCCloseable ignoredSessionId = putSessionId(session)) {
 
                             LOGGER.debug("Initialization succeeded: {}", session);
                           }
 
                           ctx.fireEvent(new Event.InitializeSuccess(session));
                         } else {
-                          try (MDCCloseable ignored =
-                              MDC.putCloseable("instance-id", ctx.getUserContext().toString())) {
+                          try (MDCCloseable ignoredInstanceId = putInstanceId(ctx);
+                              MDCCloseable ignoredSessionId = putSessionId(session)) {
 
                             LOGGER.warn("Initialization failed: {}", session, ex);
                           }
@@ -645,8 +645,8 @@ public class SessionFsmFactory {
                         if (from == com.digitalpetri.netty.fsm.State.Connected
                             && to != com.digitalpetri.netty.fsm.State.Connected) {
 
-                          try (MDCCloseable ignored =
-                              MDC.putCloseable("instance-id", ctx.getUserContext().toString())) {
+                          try (MDCCloseable ignoredInstanceId = putInstanceId(ctx);
+                              MDCCloseable ignoredSessionId = putSessionId(event.session)) {
 
                             LOGGER.debug(
                                 "ChannelFsm transition from={} to={} via={}", from, to, via);
@@ -756,9 +756,8 @@ public class SessionFsmFactory {
                             if (value instanceof Integer) {
                               ServerState state = ServerState.from((Integer) value);
 
-                              try (MDCCloseable ignored =
-                                  MDC.putCloseable(
-                                      "instance-id", ctx.getUserContext().toString())) {
+                              try (MDCCloseable ignoredInstanceId = putInstanceId(ctx);
+                                  MDCCloseable ignoredSessionId = putSessionId(event.session)) {
 
                                 LOGGER.debug("ServerState: {}", state);
                               }
@@ -781,8 +780,8 @@ public class SessionFsmFactory {
                               client.getConfig().getKeepAliveFailuresAllowed().longValue();
 
                           if (keepAliveFailureCount > keepAliveFailuresAllowed) {
-                            try (MDCCloseable ignored =
-                                MDC.putCloseable("instance-id", ctx.getUserContext().toString())) {
+                            try (MDCCloseable ignoredInstanceId = putInstanceId(ctx);
+                                MDCCloseable ignoredSessionId = putSessionId(event.session)) {
 
                               LOGGER.warn(
                                   "Keep Alive failureCount={} exceeds failuresAllowed={}",
@@ -806,8 +805,8 @@ public class SessionFsmFactory {
                               }
                             }
                           } else {
-                            try (MDCCloseable ignored =
-                                MDC.putCloseable("instance-id", ctx.getUserContext().toString())) {
+                            try (MDCCloseable ignoredInstanceId = putInstanceId(ctx);
+                                MDCCloseable ignoredSessionId = putSessionId(event.session)) {
 
                               LOGGER.debug("Keep Alive failureCount={}", keepAliveFailureCount, ex);
                             }
@@ -848,8 +847,8 @@ public class SessionFsmFactory {
               closeSession(ctx, client, session)
                   .whenComplete(
                       (u, ex) -> {
-                        try (MDCCloseable ignored =
-                            MDC.putCloseable("instance-id", ctx.getUserContext().toString())) {
+                        try (MDCCloseable ignoredInstanceId = putInstanceId(ctx);
+                            MDCCloseable ignoredSessionId = putSessionId(session)) {
 
                           if (u != null) {
                             LOGGER.debug("Session closed: {}", session);
@@ -1013,20 +1012,22 @@ public class SessionFsmFactory {
         .via(Event.ReactivatingWaitExpired.class)
         .execute(
             ctx -> {
+              OpcUaSession currentSession = KEY_SESSION.get(ctx);
+
               reactivateSession(ctx, client)
                   .whenComplete(
                       (session, ex) -> {
                         if (session != null) {
-                          try (MDCCloseable ignored =
-                              MDC.putCloseable("instance-id", ctx.getUserContext().toString())) {
+                          try (MDCCloseable ignoredInstanceId = putInstanceId(ctx);
+                              MDCCloseable ignoredSessionId = putSessionId(session)) {
 
                             LOGGER.debug("Session reactivated: {}", session);
                           }
 
                           ctx.fireEvent(new Event.ReactivateSessionSuccess(session));
                         } else {
-                          try (MDCCloseable ignored =
-                              MDC.putCloseable("instance-id", ctx.getUserContext().toString())) {
+                          try (MDCCloseable ignoredInstanceId = putInstanceId(ctx);
+                              MDCCloseable ignoredSessionId = putSessionId(currentSession)) {
 
                             LOGGER.debug("Reactivation failed: {}", ex.getMessage(), ex);
                           }
@@ -1056,6 +1057,18 @@ public class SessionFsmFactory {
 
     Event.GetSession event = (Event.GetSession) ctx.event();
     complete(event.future).with(sessionFuture);
+  }
+
+  private static MDCCloseable putInstanceId(FsmContext<State, Event> ctx) {
+    return MDC.putCloseable("instance-id", ctx.getUserContext().toString());
+  }
+
+  private static MDCCloseable putSessionId(OpcUaSession session) {
+    return putSessionId(session.getSessionId());
+  }
+
+  private static MDCCloseable putSessionId(NodeId sessionId) {
+    return MDC.putCloseable("session-id", sessionId.toParseableString());
   }
 
   private static void handleOpenSessionEvent(ActionContext<State, Event> ctx) {
@@ -1089,7 +1102,8 @@ public class SessionFsmFactory {
 
     CloseSessionRequest request = new CloseSessionRequest(requestHeader, true);
 
-    try (MDCCloseable ignored = MDC.putCloseable("instance-id", ctx.getUserContext().toString())) {
+    try (MDCCloseable ignoredInstanceId = putInstanceId(ctx);
+        MDCCloseable ignoredSessionId = putSessionId(session)) {
 
       LOGGER.debug("Sending CloseSessionRequest...");
     }
@@ -1157,7 +1171,7 @@ public class SessionFsmFactory {
             client.getConfig().getSessionTimeout().doubleValue(),
             client.getConfig().getMaxResponseMessageSize());
 
-    try (MDCCloseable ignored = MDC.putCloseable("instance-id", ctx.getUserContext().toString())) {
+    try (MDCCloseable ignored = putInstanceId(ctx)) {
 
       LOGGER.debug("Sending CreateSessionRequest...");
     }
@@ -1336,8 +1350,8 @@ public class SessionFsmFactory {
               ExtensionObject.encode(client.getStaticEncodingContext(), userIdentityToken),
               userTokenSignature);
 
-      try (MDCCloseable ignored =
-          MDC.putCloseable("instance-id", ctx.getUserContext().toString())) {
+      try (MDCCloseable ignoredInstanceId = putInstanceId(ctx);
+          MDCCloseable ignoredSessionId = putSessionId(csr.getSessionId())) {
 
         LOGGER.debug("Sending ActivateSessionRequest...");
       }
@@ -1399,8 +1413,8 @@ public class SessionFsmFactory {
               ExtensionObject.encode(client.getStaticEncodingContext(), userIdentityToken),
               userTokenSignature);
 
-      try (MDCCloseable ignored =
-          MDC.putCloseable("instance-id", ctx.getUserContext().toString())) {
+      try (MDCCloseable ignoredInstanceId = putInstanceId(ctx);
+          MDCCloseable ignoredSessionId = putSessionId(session)) {
 
         LOGGER.debug("Sending ActivateSessionRequest...");
       }
@@ -1443,7 +1457,8 @@ public class SessionFsmFactory {
         new TransferSubscriptionsRequest(
             client.newRequestHeader(session.getAuthenticationToken()), subscriptionIdsArray, true);
 
-    try (MDCCloseable ignored = MDC.putCloseable("instance-id", ctx.getUserContext().toString())) {
+    try (MDCCloseable ignoredInstanceId = putInstanceId(ctx);
+        MDCCloseable ignoredSessionId = putSessionId(session)) {
 
       LOGGER.debug("Sending TransferSubscriptionsRequest...");
     }
@@ -1457,8 +1472,8 @@ public class SessionFsmFactory {
               if (tsr != null) {
                 TransferResult[] results = requireNonNull(tsr.getResults());
 
-                try (MDCCloseable ignored =
-                    MDC.putCloseable("instance-id", ctx.getUserContext().toString())) {
+                try (MDCCloseable ignoredInstanceId = putInstanceId(ctx);
+                    MDCCloseable ignoredSessionId = putSessionId(session)) {
 
                   LOGGER.debug(
                       "TransferSubscriptions supported: {}",
@@ -1516,7 +1531,11 @@ public class SessionFsmFactory {
                 StatusCode statusCode =
                     UaException.extract(ex).map(UaException::getStatusCode).orElse(StatusCode.BAD);
 
-                LOGGER.debug("TransferSubscriptions not supported: {}", statusCode);
+                try (MDCCloseable ignoredInstanceId = putInstanceId(ctx);
+                    MDCCloseable ignoredSessionId = putSessionId(session)) {
+
+                  LOGGER.debug("TransferSubscriptions not supported: {}", statusCode);
+                }
 
                 client
                     .getTransport()
@@ -1584,8 +1603,8 @@ public class SessionFsmFactory {
           .initialize(client, session)
           .exceptionally(
               ex -> {
-                try (MDCCloseable ignored =
-                    MDC.putCloseable("instance-id", ctx.getUserContext().toString())) {
+                try (MDCCloseable ignoredInstanceId = putInstanceId(ctx);
+                    MDCCloseable ignoredSessionId = putSessionId(session)) {
 
                   LOGGER.error(
                       "Uncaught initialization error: {}",


### PR DESCRIPTION
## Summary

- add the OPC UA session identifier to MDC whenever it is available during client session FSM logging
- centralize `instance-id` and `session-id` MDC setup in scoped helpers

## Why

Concurrent client session activity can otherwise be difficult to correlate from logs using only the FSM instance identifier. The session identifier provides a direct link between lifecycle, keep-alive, transfer, initialization, reactivation, and close messages.

## Validation

- `mise exec -- mvn -q spotless:apply`
- `mise exec -- mvn -q clean compile`

No unit tests were added or run for this change.
