### PR TITLE
Fix deadlock when session is lost during DataTypeTree build

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/DataTypeTreeCacheTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/DataTypeTreeCacheTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.eclipse.milo.opcua.sdk.client.typetree.DataTypeTreeBuilder;
+import org.eclipse.milo.opcua.sdk.client.typetree.DataTypeTreeFactory;
+import org.eclipse.milo.opcua.sdk.core.typetree.DataTypeTree;
+import org.eclipse.milo.opcua.sdk.test.AbstractClientServerTest;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for https://github.com/eclipse-milo/milo/issues/1812: resetting the cached
+ * DataTypeTree must never block behind an in-progress build, because the reset happens in a
+ * SessionInitializer during session establishment and blocking there wedges reconnection.
+ */
+public class DataTypeTreeCacheTest extends AbstractClientServerTest {
+
+  // Tests share a per-class client; the tree cache must be empty at the start of each test so
+  // the factory installed by the test is actually invoked, regardless of test execution order.
+  @BeforeEach
+  void resetCachedTree() {
+    client.resetDataTypeTree();
+  }
+
+  @AfterEach
+  void restoreDefaultFactory() {
+    client.setDataTypeTreeFactory(DataTypeTreeFactory.eager());
+    client.resetDataTypeTree();
+  }
+
+  @Test
+  void resetDoesNotBlockWhileBuildInProgress() throws Exception {
+    var buildStarted = new CountDownLatch(1);
+    var buildRelease = new CountDownLatch(1);
+
+    client.setDataTypeTreeFactory(
+        c -> {
+          buildStarted.countDown();
+          try {
+            buildRelease.await();
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new UaException(StatusCodes.Bad_UnexpectedError, e);
+          }
+          return DataTypeTreeBuilder.build(c);
+        });
+
+    ExecutorService executor = Executors.newCachedThreadPool();
+    try {
+      Future<DataTypeTree> building = executor.submit(() -> client.getDataTypeTree());
+
+      assertTrue(buildStarted.await(5, TimeUnit.SECONDS));
+
+      var resetDone = new CountDownLatch(1);
+      executor.submit(
+          () -> {
+            client.resetDataTypeTree();
+            resetDone.countDown();
+          });
+
+      assertTrue(
+          resetDone.await(2, TimeUnit.SECONDS),
+          "resetDataTypeTree() blocked behind an in-progress build");
+
+      buildRelease.countDown();
+
+      assertNotNull(building.get(10, TimeUnit.SECONDS));
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  @Test
+  void failedBuildIsNotCached() throws Exception {
+    var attempts = new AtomicInteger(0);
+
+    client.setDataTypeTreeFactory(
+        c -> {
+          if (attempts.incrementAndGet() == 1) {
+            throw new UaException(StatusCodes.Bad_SessionClosed, "simulated session loss");
+          }
+          return DataTypeTreeBuilder.build(c);
+        });
+
+    assertThrows(UaException.class, () -> client.getDataTypeTree());
+
+    assertNotNull(client.getDataTypeTree());
+    assertEquals(2, attempts.get());
+  }
+}

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClient.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClient.java
@@ -153,11 +153,11 @@ import org.eclipse.milo.opcua.stack.core.types.structured.WriteRequest;
 import org.eclipse.milo.opcua.stack.core.types.structured.WriteResponse;
 import org.eclipse.milo.opcua.stack.core.types.structured.WriteValue;
 import org.eclipse.milo.opcua.stack.core.util.ExecutionQueue;
-import org.eclipse.milo.opcua.stack.core.util.Lazy;
 import org.eclipse.milo.opcua.stack.core.util.Lists;
 import org.eclipse.milo.opcua.stack.core.util.LongSequence;
 import org.eclipse.milo.opcua.stack.core.util.ManifestUtil;
 import org.eclipse.milo.opcua.stack.core.util.Namespaces;
+import org.eclipse.milo.opcua.stack.core.util.NonBlockingLazy;
 import org.eclipse.milo.opcua.stack.core.util.Unit;
 import org.eclipse.milo.opcua.stack.transport.client.ClientApplicationContext;
 import org.eclipse.milo.opcua.stack.transport.client.OpcClientTransport;
@@ -323,7 +323,7 @@ public class OpcUaClient {
   private final NamespaceTable namespaceTable = new NamespaceTable();
   private final ServerTable serverTable = new ServerTable();
 
-  private final Lazy<OperationLimits> operationLimits = new Lazy<>();
+  private final NonBlockingLazy<OperationLimits> operationLimits = new NonBlockingLazy<>();
 
   private final ObjectTypeManager objectTypeManager = new ObjectTypeManager();
 
@@ -339,12 +339,15 @@ public class OpcUaClient {
       DefaultDataTypeManager.createAndInitialize(namespaceTable);
   private final EncodingContext staticEncodingContext;
 
-  private final Lazy<DataTypeManager> dynamicDataTypeManager = new Lazy<>();
-  private final Lazy<EncodingContext> dynamicEncodingContext = new Lazy<>();
+  // These caches are computed via unbounded network I/O and reset by a SessionInitializer during
+  // session establishment. NonBlockingLazy computes without holding a lock, so resetting never
+  // blocks session establishment behind an in-progress computation.
+  private final NonBlockingLazy<DataTypeManager> dynamicDataTypeManager = new NonBlockingLazy<>();
+  private final NonBlockingLazy<EncodingContext> dynamicEncodingContext = new NonBlockingLazy<>();
 
-  private final Lazy<DataTypeTree> dataTypeTree = new Lazy<>();
-  private final Lazy<ObjectTypeTree> objectTypeTree = new Lazy<>();
-  private final Lazy<VariableTypeTree> variableTypeTree = new Lazy<>();
+  private final NonBlockingLazy<DataTypeTree> dataTypeTree = new NonBlockingLazy<>();
+  private final NonBlockingLazy<ObjectTypeTree> objectTypeTree = new NonBlockingLazy<>();
+  private final NonBlockingLazy<VariableTypeTree> variableTypeTree = new NonBlockingLazy<>();
 
   private final PublishingManager publishingManager;
   private final Map<UInteger, OpcUaSubscription> subscriptions = new ConcurrentHashMap<>();

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/typetree/ClientBrowseUtils.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/typetree/ClientBrowseUtils.java
@@ -18,10 +18,13 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.client.OpcUaSession;
 import org.eclipse.milo.opcua.sdk.client.OperationLimits;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.TimestampsToReturn;
 import org.eclipse.milo.opcua.stack.core.types.structured.BrowseDescription;
@@ -30,11 +33,16 @@ import org.eclipse.milo.opcua.stack.core.types.structured.BrowseResult;
 import org.eclipse.milo.opcua.stack.core.types.structured.ReadResponse;
 import org.eclipse.milo.opcua.stack.core.types.structured.ReadValueId;
 import org.eclipse.milo.opcua.stack.core.types.structured.ReferenceDescription;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Shared utility methods for client-side browse and read operations with operation limit handling.
+ *
+ * <p>Service-level failures propagate as {@link UaException} so that callers building type trees
+ * fail rather than silently caching incomplete results. Operation-level failures (bad status on an
+ * individual node) are still tolerated and yield empty/bad results for that node only.
  */
 final class ClientBrowseUtils {
 
@@ -43,15 +51,43 @@ final class ClientBrowseUtils {
   private ClientBrowseUtils() {}
 
   /**
+   * Check that the client's currently-active session is the session identified by {@code
+   * sessionId}.
+   *
+   * <p>Used to pin a multi-request type tree build to the session it started on, so that losing the
+   * session aborts the build instead of letting it silently span sessions.
+   *
+   * @param client the OPC UA client.
+   * @param sessionId the id of the session the operation started on.
+   * @throws UaException with {@link StatusCodes#Bad_SessionClosed} if there is no active session or
+   *     the active session is not the expected one.
+   */
+  static void checkSessionUnchanged(OpcUaClient client, NodeId sessionId) throws UaException {
+    OpcUaSession session;
+    try {
+      session = client.getSessionAsync().getNow(null);
+    } catch (RuntimeException e) {
+      session = null;
+    }
+
+    if (session == null || !sessionId.equals(session.getSessionId())) {
+      throw new UaException(
+          StatusCodes.Bad_SessionClosed, "session closed or changed during type tree build");
+    }
+  }
+
+  /**
    * Read values with operation limits, partitioning requests as necessary.
    *
    * @param client the OPC UA client.
    * @param readValueIds the list of ReadValueIds to read.
    * @param limits the operation limits from the server.
    * @return the list of DataValues corresponding to the read requests.
+   * @throws UaException if a service-level error occurs.
    */
   static List<DataValue> readWithOperationLimits(
-      OpcUaClient client, List<ReadValueId> readValueIds, OperationLimits limits) {
+      OpcUaClient client, List<ReadValueId> readValueIds, OperationLimits limits)
+      throws UaException {
 
     if (readValueIds.isEmpty()) {
       return List.of();
@@ -68,19 +104,11 @@ final class ClientBrowseUtils {
 
     var values = new ArrayList<DataValue>();
 
-    partition(readValueIds, partitionSize)
-        .forEach(
-            partitionList -> {
-              try {
-                ReadResponse response = client.read(0.0, TimestampsToReturn.Neither, partitionList);
-                DataValue[] results = response.getResults();
-                Collections.addAll(values, requireNonNull(results));
-              } catch (UaException e) {
-                LOGGER.debug("Read failed: {}", e.getMessage(), e);
-                var value = new DataValue(e.getStatusCode());
-                values.addAll(Collections.nCopies(partitionList.size(), value));
-              }
-            });
+    for (List<ReadValueId> partitionList : partition(readValueIds, partitionSize).toList()) {
+      ReadResponse response = client.read(0.0, TimestampsToReturn.Neither, partitionList);
+      DataValue[] results = response.getResults();
+      Collections.addAll(values, requireNonNull(results));
+    }
 
     return values;
   }
@@ -92,9 +120,11 @@ final class ClientBrowseUtils {
    * @param browseDescriptions the list of BrowseDescriptions.
    * @param limits the operation limits from the server.
    * @return the list of reference description lists corresponding to each browse request.
+   * @throws UaException if a service-level error occurs.
    */
   static List<List<ReferenceDescription>> browseWithOperationLimits(
-      OpcUaClient client, List<BrowseDescription> browseDescriptions, OperationLimits limits) {
+      OpcUaClient client, List<BrowseDescription> browseDescriptions, OperationLimits limits)
+      throws UaException {
 
     if (browseDescriptions.isEmpty()) {
       return List.of();
@@ -111,8 +141,10 @@ final class ClientBrowseUtils {
 
     var references = new ArrayList<List<ReferenceDescription>>();
 
-    partition(browseDescriptions, partitionSize)
-        .forEach(partitionList -> references.addAll(browse(client, partitionList)));
+    for (List<BrowseDescription> partitionList :
+        partition(browseDescriptions, partitionSize).toList()) {
+      references.addAll(browse(client, partitionList));
+    }
 
     return references;
   }
@@ -123,9 +155,10 @@ final class ClientBrowseUtils {
    * @param client the OPC UA client.
    * @param browseDescriptions the list of BrowseDescriptions.
    * @return a list of reference description lists, one per browse description.
+   * @throws UaException if a service-level error occurs.
    */
   static List<List<ReferenceDescription>> browse(
-      OpcUaClient client, List<BrowseDescription> browseDescriptions) {
+      OpcUaClient client, List<BrowseDescription> browseDescriptions) throws UaException {
 
     if (browseDescriptions.isEmpty()) {
       return List.of();
@@ -133,29 +166,22 @@ final class ClientBrowseUtils {
 
     final var referenceDescriptionLists = new ArrayList<List<ReferenceDescription>>();
 
-    try {
-      client
-          .browse(browseDescriptions)
-          .forEach(
-              result -> {
-                if (result.getStatusCode().isGood()) {
-                  var references = new ArrayList<ReferenceDescription>();
+    for (BrowseResult result : client.browse(browseDescriptions)) {
+      if (result.getStatusCode().isGood()) {
+        var references = new ArrayList<ReferenceDescription>();
 
-                  ReferenceDescription[] refs =
-                      requireNonNullElse(result.getReferences(), new ReferenceDescription[0]);
-                  Collections.addAll(references, refs);
+        ReferenceDescription[] refs =
+            requireNonNullElse(result.getReferences(), new ReferenceDescription[0]);
+        Collections.addAll(references, refs);
 
-                  ByteString continuationPoint = result.getContinuationPoint();
-                  List<ReferenceDescription> nextRefs = maybeBrowseNext(client, continuationPoint);
-                  references.addAll(nextRefs);
+        ByteString continuationPoint = result.getContinuationPoint();
+        List<ReferenceDescription> nextRefs = maybeBrowseNext(client, continuationPoint);
+        references.addAll(nextRefs);
 
-                  referenceDescriptionLists.add(references);
-                } else {
-                  referenceDescriptionLists.add(List.of());
-                }
-              });
-    } catch (UaException e) {
-      referenceDescriptionLists.addAll(Collections.nCopies(browseDescriptions.size(), List.of()));
+        referenceDescriptionLists.add(references);
+      } else {
+        referenceDescriptionLists.add(List.of());
+      }
     }
 
     return referenceDescriptionLists;
@@ -167,28 +193,24 @@ final class ClientBrowseUtils {
    * @param client the OPC UA client.
    * @param continuationPoint the continuation point from a previous browse.
    * @return the list of additional reference descriptions.
+   * @throws UaException if a service-level error occurs.
    */
   static List<ReferenceDescription> maybeBrowseNext(
-      OpcUaClient client, ByteString continuationPoint) {
+      OpcUaClient client, @Nullable ByteString continuationPoint) throws UaException {
 
     var references = new ArrayList<ReferenceDescription>();
 
     while (continuationPoint != null && continuationPoint.isNotNull()) {
-      try {
-        BrowseNextResponse response = client.browseNext(false, List.of(continuationPoint));
+      BrowseNextResponse response = client.browseNext(false, List.of(continuationPoint));
 
-        BrowseResult result = requireNonNull(response.getResults())[0];
+      BrowseResult result = requireNonNull(response.getResults())[0];
 
-        ReferenceDescription[] rds =
-            requireNonNullElse(result.getReferences(), new ReferenceDescription[0]);
+      ReferenceDescription[] rds =
+          requireNonNullElse(result.getReferences(), new ReferenceDescription[0]);
 
-        references.addAll(List.of(rds));
+      references.addAll(List.of(rds));
 
-        continuationPoint = result.getContinuationPoint();
-      } catch (Exception e) {
-        LOGGER.warn("BrowseNext failed: {}", e.getMessage(), e);
-        return references;
-      }
+      continuationPoint = result.getContinuationPoint();
     }
 
     return references;

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/typetree/DataTypeTreeBuilder.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/typetree/DataTypeTreeBuilder.java
@@ -71,11 +71,21 @@ public class DataTypeTreeBuilder {
                 null,
                 true));
 
+    // The build is pinned to the session it starts on: if the session closes or changes mid-build
+    // the build fails instead of silently continuing (and caching an incomplete tree) on a session
+    // it didn't start on.
+    NodeId sessionId = client.getSession().getSessionId();
+
     NamespaceTable namespaceTable = client.readNamespaceTable();
 
     OperationLimits operationLimits = client.getOperationLimits();
 
-    addChildren(List.of(root), client, namespaceTable, operationLimits);
+    addChildren(List.of(root), client, sessionId, namespaceTable, operationLimits);
+
+    // Final check: the last batch of requests could have been issued just as the session changed
+    // and succeeded against the new session; don't return a tree partially read from another
+    // session.
+    ClientBrowseUtils.checkSessionUnchanged(client, sessionId);
 
     return new DataTypeTree(root);
   }
@@ -103,8 +113,12 @@ public class DataTypeTreeBuilder {
   private static void addChildren(
       List<Tree<DataType>> parentTypes,
       OpcUaClient client,
+      NodeId sessionId,
       NamespaceTable namespaceTable,
-      OperationLimits operationLimits) {
+      OperationLimits operationLimits)
+      throws UaException {
+
+    ClientBrowseUtils.checkSessionUnchanged(client, sessionId);
 
     List<List<ReferenceDescription>> parentSubtypes =
         ClientBrowseUtils.browseWithOperationLimits(
@@ -136,10 +150,10 @@ public class DataTypeTreeBuilder {
               .collect(Collectors.toList());
 
       List<List<ReferenceDescription>> encodingReferences =
-          browseEncodings(client, dataTypeIds, operationLimits);
+          browseEncodings(client, sessionId, dataTypeIds, operationLimits);
 
       List<Attributes> dataTypeAttributes =
-          readDataTypeAttributes(client, dataTypeIds, operationLimits);
+          readDataTypeAttributes(client, sessionId, dataTypeIds, operationLimits);
 
       assert subtypes.size() == dataTypeIds.size()
           && subtypes.size() == encodingReferences.size()
@@ -200,12 +214,18 @@ public class DataTypeTreeBuilder {
     }
 
     if (!childTypes.isEmpty()) {
-      addChildren(childTypes, client, namespaceTable, operationLimits);
+      addChildren(childTypes, client, sessionId, namespaceTable, operationLimits);
     }
   }
 
   private static List<List<ReferenceDescription>> browseEncodings(
-      OpcUaClient client, List<NodeId> dataTypeIds, OperationLimits operationLimits) {
+      OpcUaClient client,
+      NodeId sessionId,
+      List<NodeId> dataTypeIds,
+      OperationLimits operationLimits)
+      throws UaException {
+
+    ClientBrowseUtils.checkSessionUnchanged(client, sessionId);
 
     List<BrowseDescription> browseDescriptions =
         dataTypeIds.stream()
@@ -224,11 +244,17 @@ public class DataTypeTreeBuilder {
   }
 
   private static List<@Nullable Attributes> readDataTypeAttributes(
-      OpcUaClient client, List<NodeId> dataTypeIds, OperationLimits operationLimits) {
+      OpcUaClient client,
+      NodeId sessionId,
+      List<NodeId> dataTypeIds,
+      OperationLimits operationLimits)
+      throws UaException {
 
     if (dataTypeIds.isEmpty()) {
       return List.of();
     }
+
+    ClientBrowseUtils.checkSessionUnchanged(client, sessionId);
 
     var readValueIds = new ArrayList<ReadValueId>();
 

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/typetree/DataTypeTreeBuilder.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/typetree/DataTypeTreeBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 the Eclipse Milo Authors
+ * Copyright (c) 2026 the Eclipse Milo Authors
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -302,13 +302,5 @@ public class DataTypeTreeBuilder {
     return attributes;
   }
 
-  private static class Attributes {
-    final Boolean isAbstract;
-    final DataTypeDefinition definition;
-
-    private Attributes(Boolean isAbstract, DataTypeDefinition definition) {
-      this.isAbstract = isAbstract;
-      this.definition = definition;
-    }
-  }
+  private record Attributes(Boolean isAbstract, DataTypeDefinition definition) {}
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/typetree/LazyClientDataTypeTree.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/typetree/LazyClientDataTypeTree.java
@@ -270,7 +270,7 @@ public class LazyClientDataTypeTree extends DataTypeTree {
   }
 
   private List<ClientDataType> fetchDataTypeInfoBatch(
-      List<NodeId> nodeIds, NamespaceTable nsTable, OperationLimits limits) {
+      List<NodeId> nodeIds, NamespaceTable nsTable, OperationLimits limits) throws UaException {
 
     // Read attributes: BrowseName, IsAbstract, DataTypeDefinition
     var readValueIds = new ArrayList<ReadValueId>();
@@ -394,7 +394,7 @@ public class LazyClientDataTypeTree extends DataTypeTree {
   }
 
   private List<List<ReferenceDescription>> browseEncodings(
-      List<NodeId> dataTypeIds, OperationLimits limits) {
+      List<NodeId> dataTypeIds, OperationLimits limits) throws UaException {
 
     List<BrowseDescription> browseDescriptions =
         dataTypeIds.stream()

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/typetree/ObjectTypeTreeBuilder.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/typetree/ObjectTypeTreeBuilder.java
@@ -60,11 +60,21 @@ public class ObjectTypeTreeBuilder {
             new ClientObjectType(
                 QualifiedName.parse("0:BaseObjectType"), NodeIds.BaseObjectType, false));
 
+    // The build is pinned to the session it starts on: if the session closes or changes mid-build
+    // the build fails instead of silently continuing (and caching an incomplete tree) on a session
+    // it didn't start on.
+    NodeId sessionId = client.getSession().getSessionId();
+
     NamespaceTable namespaceTable = client.readNamespaceTable();
 
     OperationLimits operationLimits = client.getOperationLimits();
 
-    addChildren(List.of(root), client, namespaceTable, operationLimits);
+    addChildren(List.of(root), client, sessionId, namespaceTable, operationLimits);
+
+    // Final check: the last batch of requests could have been issued just as the session changed
+    // and succeeded against the new session; don't return a tree partially read from another
+    // session.
+    ClientBrowseUtils.checkSessionUnchanged(client, sessionId);
 
     return new ObjectTypeTree(root);
   }
@@ -92,8 +102,12 @@ public class ObjectTypeTreeBuilder {
   private static void addChildren(
       List<Tree<ObjectType>> parentTypes,
       OpcUaClient client,
+      NodeId sessionId,
       NamespaceTable namespaceTable,
-      OperationLimits operationLimits) {
+      OperationLimits operationLimits)
+      throws UaException {
+
+    ClientBrowseUtils.checkSessionUnchanged(client, sessionId);
 
     List<List<ReferenceDescription>> parentSubtypes =
         ClientBrowseUtils.browseWithOperationLimits(
@@ -125,7 +139,7 @@ public class ObjectTypeTreeBuilder {
               .collect(Collectors.toList());
 
       List<Boolean> isAbstractValues =
-          readIsAbstractAttributes(client, objectTypeIds, operationLimits);
+          readIsAbstractAttributes(client, sessionId, objectTypeIds, operationLimits);
 
       assert subtypes.size() == objectTypeIds.size() && subtypes.size() == isAbstractValues.size();
 
@@ -151,16 +165,22 @@ public class ObjectTypeTreeBuilder {
     }
 
     if (!childTypes.isEmpty()) {
-      addChildren(childTypes, client, namespaceTable, operationLimits);
+      addChildren(childTypes, client, sessionId, namespaceTable, operationLimits);
     }
   }
 
   private static List<Boolean> readIsAbstractAttributes(
-      OpcUaClient client, List<NodeId> objectTypeIds, OperationLimits operationLimits) {
+      OpcUaClient client,
+      NodeId sessionId,
+      List<NodeId> objectTypeIds,
+      OperationLimits operationLimits)
+      throws UaException {
 
     if (objectTypeIds.isEmpty()) {
       return List.of();
     }
+
+    ClientBrowseUtils.checkSessionUnchanged(client, sessionId);
 
     var readValueIds = new ArrayList<ReadValueId>();
 

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/typetree/VariableTypeTreeBuilder.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/typetree/VariableTypeTreeBuilder.java
@@ -70,11 +70,21 @@ public class VariableTypeTreeBuilder {
                 null,
                 true));
 
+    // The build is pinned to the session it starts on: if the session closes or changes mid-build
+    // the build fails instead of silently continuing (and caching an incomplete tree) on a session
+    // it didn't start on.
+    NodeId sessionId = client.getSession().getSessionId();
+
     NamespaceTable namespaceTable = client.readNamespaceTable();
 
     OperationLimits operationLimits = client.getOperationLimits();
 
-    addChildren(List.of(root), client, namespaceTable, operationLimits);
+    addChildren(List.of(root), client, sessionId, namespaceTable, operationLimits);
+
+    // Final check: the last batch of requests could have been issued just as the session changed
+    // and succeeded against the new session; don't return a tree partially read from another
+    // session.
+    ClientBrowseUtils.checkSessionUnchanged(client, sessionId);
 
     return new VariableTypeTree(root);
   }
@@ -102,8 +112,12 @@ public class VariableTypeTreeBuilder {
   private static void addChildren(
       List<Tree<VariableType>> parentTypes,
       OpcUaClient client,
+      NodeId sessionId,
       NamespaceTable namespaceTable,
-      OperationLimits operationLimits) {
+      OperationLimits operationLimits)
+      throws UaException {
+
+    ClientBrowseUtils.checkSessionUnchanged(client, sessionId);
 
     List<List<ReferenceDescription>> parentSubtypes =
         ClientBrowseUtils.browseWithOperationLimits(
@@ -135,7 +149,7 @@ public class VariableTypeTreeBuilder {
               .collect(Collectors.toList());
 
       List<Attributes> variableTypeAttributes =
-          readVariableTypeAttributes(client, variableTypeIds, operationLimits);
+          readVariableTypeAttributes(client, sessionId, variableTypeIds, operationLimits);
 
       assert subtypes.size() == variableTypeIds.size()
           && subtypes.size() == variableTypeAttributes.size();
@@ -170,16 +184,22 @@ public class VariableTypeTreeBuilder {
     }
 
     if (!childTypes.isEmpty()) {
-      addChildren(childTypes, client, namespaceTable, operationLimits);
+      addChildren(childTypes, client, sessionId, namespaceTable, operationLimits);
     }
   }
 
   private static List<Attributes> readVariableTypeAttributes(
-      OpcUaClient client, List<NodeId> variableTypeIds, OperationLimits operationLimits) {
+      OpcUaClient client,
+      NodeId sessionId,
+      List<NodeId> variableTypeIds,
+      OperationLimits operationLimits)
+      throws UaException {
 
     if (variableTypeIds.isEmpty()) {
       return List.of();
     }
+
+    ClientBrowseUtils.checkSessionUnchanged(client, sessionId);
 
     var readValueIds = new ArrayList<ReadValueId>();
 

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/NonBlockingLazy.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/NonBlockingLazy.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.core.util;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+/**
+ * Thread-safe holder for a lazily-computed value, computed without holding a lock.
+ *
+ * <p>Unlike {@link Lazy}, no lock is held while the value is computed: {@link #reset()} and {@link
+ * #set(Object)} always return immediately, even while a computation is in progress. This makes it
+ * safe to reset from threads that must never block, e.g. while another thread's computation
+ * performs unbounded network I/O.
+ *
+ * <p>At most one computation is in progress per generation; concurrent callers wait for the
+ * in-progress computation and receive its value, or its exception if it fails. A failed computation
+ * is not cached: a subsequent call computes again.
+ *
+ * <p>{@link #reset()} starts a new generation. If a computation is in progress when {@link
+ * #reset()} is called, its result is discarded once complete — though it is still delivered to the
+ * caller that computed it and to any callers already waiting on it — and the next call computes a
+ * fresh value, possibly overlapping the still-running discarded computation.
+ *
+ * <p>All callers of a given instance should use a consistent exception type {@code E}: a caller
+ * that waits on another thread's in-progress computation rethrows that computation's exception
+ * as-is, which may be a checked exception the waiting caller's own signature does not declare.
+ *
+ * @param <T> the type of value computed and held.
+ */
+public final class NonBlockingLazy<T> {
+
+  private final AtomicReference<CompletableFuture<T>> ref = new AtomicReference<>();
+
+  /**
+   * Get the lazily computed value, computing it if necessary using {@code supplier}.
+   *
+   * <p>{@code null} values returned by the supplier are not held, i.e. the next call will compute
+   * the value again.
+   *
+   * @param supplier a {@link Supplier} that computes the value if necessary.
+   * @return the lazily computed value.
+   */
+  public T get(Supplier<T> supplier) {
+    return this.getOrThrow(supplier::get);
+  }
+
+  /**
+   * Get the lazily computed value, computing it if necessary using {@code supplier}.
+   *
+   * <p>{@code null} values returned by the supplier are not held, i.e. the next call will compute
+   * the value again.
+   *
+   * @param supplier a {@link Lazy.ThrowingSupplier} that computes the value if necessary.
+   * @return the lazily computed value.
+   * @throws E if the supplier throws an exception, or if the in-progress computation this call
+   *     waited on threw an exception.
+   */
+  public <E extends Exception> T getOrThrow(Lazy.ThrowingSupplier<E, T> supplier) throws E {
+    while (true) {
+      CompletableFuture<T> existing = ref.get();
+
+      if (existing == null) {
+        var future = new CompletableFuture<T>();
+
+        if (!ref.compareAndSet(null, future)) {
+          continue;
+        }
+
+        T value;
+        try {
+          value = supplier.get();
+        } catch (RuntimeException | Error e) {
+          ref.compareAndSet(future, null);
+          future.completeExceptionally(e);
+          throw e;
+        } catch (Exception e) {
+          ref.compareAndSet(future, null);
+          future.completeExceptionally(e);
+          @SuppressWarnings("unchecked")
+          E checked = (E) e;
+          throw checked;
+        }
+
+        if (value == null) {
+          // null values are not held; clear before completing so waiters
+          // that observe null re-attempt computation against a cleared ref.
+          ref.compareAndSet(future, null);
+        }
+        future.complete(value);
+        return value;
+      } else {
+        try {
+          T value = existing.join();
+          if (value != null) {
+            return value;
+          }
+          // the computing thread got null; not held, try computing again
+        } catch (CompletionException e) {
+          Throwable cause = e.getCause();
+          if (cause instanceof RuntimeException re) {
+            throw re;
+          }
+          if (cause instanceof Error error) {
+            throw error;
+          }
+          @SuppressWarnings("unchecked")
+          E checked = (E) cause;
+          throw checked;
+        }
+      }
+    }
+  }
+
+  /**
+   * Set the value.
+   *
+   * @param value the value to set.
+   */
+  public void set(T value) {
+    ref.set(CompletableFuture.completedFuture(value));
+  }
+
+  /**
+   * Reset the value to {@code null}.
+   *
+   * <p>This never blocks, even if a computation is in progress; the in-progress result is discarded
+   * once complete.
+   */
+  public void reset() {
+    ref.set(null);
+  }
+}

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/util/NonBlockingLazyTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/util/NonBlockingLazyTest.java
@@ -36,7 +36,7 @@ public class NonBlockingLazyTest {
   }
 
   @Test
-  void getOrThrow() throws Exception {
+  void getOrThrow() {
     var lazy = new NonBlockingLazy<>();
 
     assertThrows(
@@ -107,10 +107,11 @@ public class NonBlockingLazyTest {
 
           @Override
           public Object get() {
-            return switch (count.incrementAndGet()) {
-              case 1 -> instance1;
-              default -> instance2;
-            };
+            if (count.incrementAndGet() == 1) {
+              return instance1;
+            } else {
+              return instance2;
+            }
           }
         };
 
@@ -133,7 +134,7 @@ public class NonBlockingLazyTest {
   }
 
   @Test
-  void failedComputationIsNotCached() throws Exception {
+  void failedComputationIsNotCached() {
     var lazy = new NonBlockingLazy<String>();
 
     assertThrows(

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/util/NonBlockingLazyTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/util/NonBlockingLazyTest.java
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.core.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+
+public class NonBlockingLazyTest {
+
+  @Test
+  void get() {
+    var lazy = new NonBlockingLazy<>();
+
+    assertEquals("foo", lazy.get(() -> "foo"));
+  }
+
+  @Test
+  void getOrThrow() throws Exception {
+    var lazy = new NonBlockingLazy<>();
+
+    assertThrows(
+        Exception.class,
+        () ->
+            lazy.getOrThrow(
+                () -> {
+                  throw new Exception();
+                }));
+
+    assertEquals("foo", lazy.getOrThrow(() -> "foo"));
+  }
+
+  @Test
+  void retainsNonNullValue() {
+    NonBlockingLazy<Object> lazy = new NonBlockingLazy<>();
+
+    Object instance = new Object();
+
+    assertSame(instance, lazy.get(() -> instance));
+    assertSame(instance, lazy.get(() -> instance));
+  }
+
+  @Test
+  void doesNotRetainNullValue() {
+    NonBlockingLazy<Object> lazy = new NonBlockingLazy<>();
+
+    assertNull(lazy.get(() -> null));
+
+    Object instance = new Object();
+    assertSame(instance, lazy.get(() -> instance));
+  }
+
+  @Test
+  void onlyComputesOnce() {
+    var lazy = new NonBlockingLazy<>();
+
+    final var instance = new Object();
+
+    Supplier<Object> supplier =
+        new Supplier<>() {
+          final AtomicInteger count = new AtomicInteger(0);
+
+          @Override
+          public Object get() {
+            if (count.incrementAndGet() != 1) {
+              throw new IllegalStateException();
+            } else {
+              return instance;
+            }
+          }
+        };
+
+    assertSame(instance, lazy.get(supplier));
+    assertSame(instance, lazy.get(supplier));
+  }
+
+  @Test
+  void isResettable() {
+    var lazy = new NonBlockingLazy<>();
+
+    final Object instance1 = new Object();
+    final Object instance2 = new Object();
+
+    Supplier<Object> supplier =
+        new Supplier<>() {
+          final AtomicInteger count = new AtomicInteger(0);
+
+          @Override
+          public Object get() {
+            return switch (count.incrementAndGet()) {
+              case 1 -> instance1;
+              default -> instance2;
+            };
+          }
+        };
+
+    assertSame(instance1, lazy.get(supplier));
+
+    lazy.reset();
+
+    assertSame(instance2, lazy.get(supplier));
+  }
+
+  @Test
+  void set() {
+    var lazy = new NonBlockingLazy<>();
+
+    assertEquals("foo", lazy.get(() -> "foo"));
+
+    var instance = new Object();
+    lazy.set(instance);
+    assertSame(instance, lazy.get(() -> null));
+  }
+
+  @Test
+  void failedComputationIsNotCached() throws Exception {
+    var lazy = new NonBlockingLazy<String>();
+
+    assertThrows(
+        Exception.class,
+        () ->
+            lazy.getOrThrow(
+                () -> {
+                  throw new Exception("boom");
+                }));
+
+    assertEquals("foo", lazy.getOrThrow(() -> "foo"));
+  }
+
+  @Test
+  void resetDoesNotBlockWhileComputationInProgress() throws Exception {
+    var lazy = new NonBlockingLazy<String>();
+
+    var computeStarted = new CountDownLatch(1);
+    var computeRelease = new CountDownLatch(1);
+
+    ExecutorService executor = Executors.newCachedThreadPool();
+    try {
+      Future<String> computing =
+          executor.submit(
+              () ->
+                  lazy.get(
+                      () -> {
+                        computeStarted.countDown();
+                        try {
+                          computeRelease.await();
+                        } catch (InterruptedException e) {
+                          throw new RuntimeException(e);
+                        }
+                        return "stale";
+                      }));
+
+      assertTrue(computeStarted.await(5, TimeUnit.SECONDS));
+
+      // reset() must return promptly even though a computation is in progress
+      var resetDone = new CountDownLatch(1);
+      executor.submit(
+          () -> {
+            lazy.reset();
+            resetDone.countDown();
+          });
+
+      assertTrue(
+          resetDone.await(1, TimeUnit.SECONDS),
+          "reset() blocked behind an in-progress computation");
+
+      computeRelease.countDown();
+
+      // the computing caller still receives the value it computed...
+      assertEquals("stale", computing.get(5, TimeUnit.SECONDS));
+
+      // ...but the reset discarded it, so the next call computes fresh
+      assertEquals("fresh", lazy.get(() -> "fresh"));
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  @Test
+  void waitersReceiveValueFromInProgressComputation() throws Exception {
+    var lazy = new NonBlockingLazy<String>();
+
+    var computeStarted = new CountDownLatch(1);
+    var computeRelease = new CountDownLatch(1);
+    var supplierInvocations = new AtomicInteger(0);
+
+    ExecutorService executor = Executors.newCachedThreadPool();
+    try {
+      Future<String> computing =
+          executor.submit(
+              () ->
+                  lazy.get(
+                      () -> {
+                        supplierInvocations.incrementAndGet();
+                        computeStarted.countDown();
+                        try {
+                          computeRelease.await();
+                        } catch (InterruptedException e) {
+                          throw new RuntimeException(e);
+                        }
+                        return "value";
+                      }));
+
+      assertTrue(computeStarted.await(5, TimeUnit.SECONDS));
+
+      Future<String> waiting = executor.submit(() -> lazy.get(() -> "unexpected"));
+
+      computeRelease.countDown();
+
+      assertEquals("value", computing.get(5, TimeUnit.SECONDS));
+      assertEquals("value", waiting.get(5, TimeUnit.SECONDS));
+      assertEquals(1, supplierInvocations.get());
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  @Test
+  void waitersReceiveExceptionFromInProgressComputation() throws Exception {
+    var lazy = new NonBlockingLazy<String>();
+
+    var computeStarted = new CountDownLatch(1);
+    var computeRelease = new CountDownLatch(1);
+
+    ExecutorService executor = Executors.newCachedThreadPool();
+    try {
+      Future<?> computing =
+          executor.submit(
+              () ->
+                  lazy.getOrThrow(
+                      () -> {
+                        computeStarted.countDown();
+                        try {
+                          computeRelease.await();
+                        } catch (InterruptedException e) {
+                          throw new RuntimeException(e);
+                        }
+                        throw new Exception("boom");
+                      }));
+
+      assertTrue(computeStarted.await(5, TimeUnit.SECONDS));
+
+      Future<String> waiting =
+          executor.submit(() -> lazy.<Exception>getOrThrow(() -> "after failure"));
+
+      computeRelease.countDown();
+
+      assertThrows(Exception.class, () -> computing.get(5, TimeUnit.SECONDS));
+
+      // The waiter either observes the failure, or raced past it and computed (and cached) a
+      // fresh value. Either way the failure itself is never cached.
+      try {
+        assertEquals("after failure", waiting.get(5, TimeUnit.SECONDS));
+        assertEquals("after failure", lazy.getOrThrow(() -> "recovered"));
+      } catch (ExecutionException e) {
+        assertEquals("boom", e.getCause().getMessage());
+        assertEquals("recovered", lazy.getOrThrow(() -> "recovered"));
+      }
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+}


### PR DESCRIPTION
Fixes a deadlock where a client that loses its session while `OpcUaClient.getDataTypeTree()` is building can wedge reconnection permanently: the build holds the `Lazy` monitor across unbounded network I/O, and the reconnect's `SessionInitializer` blocks forever trying to reset that same lock.

- **Compute type-tree/encoding caches without holding a lock** — replaced the `Lazy` holders for the data type tree, object/variable type trees, dynamic `DataTypeManager`/`EncodingContext`, and operation limits with a new `NonBlockingLazy`, so `reset()` during session establishment never blocks behind an in-progress build.
- **Pin each type-tree build to the session it started on** — builds now capture the session id up front and abort with `Bad_SessionClosed` if the session closes or changes mid-build, instead of silently spanning sessions and caching an incomplete tree.
- **Propagate service-level browse/read failures instead of swallowing them** — `ClientBrowseUtils` no longer substitutes empty results for a failed service call, so a build fails (and is not cached) rather than completing against a dead session.

## Key Changes

- **`NonBlockingLazy` (new, stack-core):** A thread-safe lazy holder backed by an `AtomicReference<CompletableFuture<T>>` that computes the value *without* holding a lock. `reset()` and `set()` return immediately even while a computation is in progress; the in-progress result is discarded on reset but still returned to the thread that computed it. Only one thread computes at a time, concurrent callers wait on the in-progress future, and failed computations are not cached. This is the core fix — it breaks the lock edge that caused the deadlock.
- **`OpcUaClient` cache holders:** Swapped six `Lazy` fields to `NonBlockingLazy`. The two edges of the deadlock (the build in `Lazy.getOrThrow` and the reconnect's `resetDataTypeTree()` → `Lazy.reset()`) can no longer contend on a monitor.
- **Session pinning in the type-tree builders:** `DataTypeTreeBuilder`, `ObjectTypeTreeBuilder`, and `VariableTypeTreeBuilder` capture `sessionId` before building and call `ClientBrowseUtils.checkSessionUnchanged(...)` at each recursion/batch boundary, throwing `Bad_SessionClosed` if the active session no longer matches. The `addChildren`/attribute-read helpers now declare `throws UaException`.
- **`ClientBrowseUtils` error handling:** `readWithOperationLimits`, `browseWithOperationLimits`, `browse`, and `maybeBrowseNext` now let `UaException` propagate on service-level failures rather than catching it and filling empty/bad results. Operation-level failures (a bad status on an individual node) are still tolerated per-node. Added the `checkSessionUnchanged` helper.
- **`LazyClientDataTypeTree`:** `fetchDataTypeInfoBatch` and `browseEncodings` updated to declare `throws UaException` to match the propagating contract.

## Testing

- **`NonBlockingLazyTest`** (stack-core) — unit coverage for the new holder: caching, null handling, single-computation, resettability, failed-computation-not-cached, and the concurrency invariants (`reset()` doesn't block an in-progress compute; waiters receive the in-progress value or exception).
- **`DataTypeTreeCacheTest`** (integration-tests) — regression tests for #1812: `resetDataTypeTree()` does not block while a build is in progress, and a failed build is not cached (a retry recomputes).
- Verification: `mise exec -- mvn -q clean verify`

## References

Closes #1812.