### PR TITLE
Handle concurrent monitored item resets

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaMonitoredItemTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaMonitoredItemTest.java
@@ -18,12 +18,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 import org.eclipse.milo.opcua.sdk.test.AbstractClientServerTest;
 import org.eclipse.milo.opcua.stack.core.AttributeId;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.MonitoringMode;
 import org.eclipse.milo.opcua.stack.core.types.structured.ReadValueId;
 import org.junit.jupiter.api.AfterEach;
@@ -119,6 +123,90 @@ public class OpcUaMonitoredItemTest extends AbstractClientServerTest {
     assertTrue(deleted.get(0).serviceResult().isGood());
     assertTrue(deleted.get(0).operationResult().orElseThrow().isGood());
     assertEquals(OpcUaMonitoredItem.SyncState.INITIAL, monitoredItem.getSyncState());
+  }
+
+  @Test
+  void deleteMonitoredItemsHandlesClearedItemServerState() {
+    var validItem = OpcUaMonitoredItem.newDataItem(NodeIds.Server_ServerStatus_CurrentTime);
+    var resetItem = new ResetOnMonitoredItemIdRead();
+
+    subscription.addMonitoredItems(List.of(validItem, resetItem));
+    subscription.createMonitoredItems();
+
+    subscription.removeMonitoredItems(List.of(validItem, resetItem));
+    resetItem.resetOnNextMonitoredItemIdRead();
+
+    List<MonitoredItemServiceOperationResult> results = subscription.deleteMonitoredItems();
+
+    assertEquals(2, results.size());
+
+    MonitoredItemServiceOperationResult validResult =
+        results.stream()
+            .filter(result -> result.monitoredItem() == validItem)
+            .findFirst()
+            .orElseThrow();
+    assertEquals(StatusCode.GOOD, validResult.serviceResult());
+    assertTrue(validResult.operationResult().orElseThrow().isGood());
+
+    MonitoredItemServiceOperationResult resetResult =
+        results.stream()
+            .filter(result -> result.monitoredItem() == resetItem)
+            .findFirst()
+            .orElseThrow();
+    assertEquals(new StatusCode(StatusCodes.Bad_InvalidState), resetResult.serviceResult());
+    assertTrue(resetResult.operationResult().isEmpty());
+  }
+
+  @Test
+  void setMonitoringModeHandlesClearedItemServerState() {
+    var validItem = OpcUaMonitoredItem.newDataItem(NodeIds.Server_ServerStatus_CurrentTime);
+    var resetBeforeCallItem =
+        OpcUaMonitoredItem.newDataItem(NodeIds.Server_ServerStatus_CurrentTime);
+    var resetOnReadItem = new ResetOnMonitoredItemIdRead();
+
+    subscription.addMonitoredItems(List.of(validItem, resetBeforeCallItem, resetOnReadItem));
+    subscription.createMonitoredItems();
+
+    resetBeforeCallItem.reset();
+    resetOnReadItem.resetOnNextMonitoredItemIdRead();
+
+    List<MonitoredItemServiceOperationResult> results =
+        subscription.setMonitoringMode(
+            MonitoringMode.Disabled, List.of(validItem, resetBeforeCallItem, resetOnReadItem));
+
+    assertEquals(3, results.size());
+
+    MonitoredItemServiceOperationResult validResult = results.get(0);
+    assertEquals(validItem, validResult.monitoredItem());
+    assertEquals(StatusCode.GOOD, validResult.serviceResult());
+    assertTrue(validResult.operationResult().orElseThrow().isGood());
+    assertEquals(MonitoringMode.Disabled, validItem.getMonitoringMode());
+
+    MonitoredItemServiceOperationResult resetBeforeCallResult = results.get(1);
+    assertEquals(resetBeforeCallItem, resetBeforeCallResult.monitoredItem());
+    assertEquals(
+        new StatusCode(StatusCodes.Bad_InvalidState), resetBeforeCallResult.serviceResult());
+    assertTrue(resetBeforeCallResult.operationResult().isEmpty());
+    assertEquals(MonitoringMode.Reporting, resetBeforeCallItem.getMonitoringMode());
+
+    MonitoredItemServiceOperationResult resetOnReadResult = results.get(2);
+    assertEquals(resetOnReadItem, resetOnReadResult.monitoredItem());
+    assertEquals(new StatusCode(StatusCodes.Bad_InvalidState), resetOnReadResult.serviceResult());
+    assertTrue(resetOnReadResult.operationResult().isEmpty());
+    assertEquals(MonitoringMode.Reporting, resetOnReadItem.getMonitoringMode());
+  }
+
+  @Test
+  void setMonitoringModeReturnsInvalidStateForNeverCreatedItem() {
+    var monitoredItem = OpcUaMonitoredItem.newDataItem(NodeIds.Server_ServerStatus_CurrentTime);
+
+    List<MonitoredItemServiceOperationResult> results =
+        subscription.setMonitoringMode(MonitoringMode.Disabled, List.of(monitoredItem));
+
+    assertEquals(1, results.size());
+    assertEquals(monitoredItem, results.get(0).monitoredItem());
+    assertEquals(new StatusCode(StatusCodes.Bad_InvalidState), results.get(0).serviceResult());
+    assertTrue(results.get(0).operationResult().isEmpty());
   }
 
   @Test
@@ -229,5 +317,33 @@ public class OpcUaMonitoredItemTest extends AbstractClientServerTest {
     assertEquals(0.0, monitoredItem.getSamplingInterval());
     // Verify the filter is null as specified
     assertNull(monitoredItem.getFilter());
+  }
+
+  private static final class ResetOnMonitoredItemIdRead extends OpcUaMonitoredItem {
+
+    private boolean resetOnNextMonitoredItemIdRead;
+
+    private ResetOnMonitoredItemIdRead() {
+      super(
+          new ReadValueId(
+              NodeIds.Server_ServerStatus_CurrentTime,
+              AttributeId.Value.uid(),
+              null,
+              QualifiedName.NULL_VALUE));
+    }
+
+    private void resetOnNextMonitoredItemIdRead() {
+      resetOnNextMonitoredItemIdRead = true;
+    }
+
+    @Override
+    public Optional<UInteger> getMonitoredItemId() {
+      if (resetOnNextMonitoredItemIdRead) {
+        resetOnNextMonitoredItemIdRead = false;
+        reset();
+      }
+
+      return super.getMonitoredItemId();
+    }
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscription.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscription.java
@@ -17,8 +17,18 @@ import static org.eclipse.milo.opcua.stack.core.util.FutureUtils.supplyAsyncComp
 
 import com.google.common.primitives.Ints;
 import java.math.BigInteger;
-import java.util.*;
-import java.util.concurrent.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.StringJoiner;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -36,7 +46,18 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.MonitoringMode;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.TimestampsToReturn;
-import org.eclipse.milo.opcua.stack.core.types.structured.*;
+import org.eclipse.milo.opcua.stack.core.types.structured.CreateMonitoredItemsResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.CreateSubscriptionResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.DeleteMonitoredItemsResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.DeleteSubscriptionsResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.EventFieldList;
+import org.eclipse.milo.opcua.stack.core.types.structured.ModifyMonitoredItemsResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.ModifySubscriptionResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.MonitoredItemCreateResult;
+import org.eclipse.milo.opcua.stack.core.types.structured.MonitoredItemModifyResult;
+import org.eclipse.milo.opcua.stack.core.types.structured.MonitoredItemNotification;
+import org.eclipse.milo.opcua.stack.core.types.structured.SetMonitoringModeResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.SetPublishingModeResponse;
 import org.eclipse.milo.opcua.stack.core.util.Lazy;
 import org.eclipse.milo.opcua.stack.core.util.Lists;
 import org.eclipse.milo.opcua.stack.core.util.TaskQueue;
@@ -356,12 +377,7 @@ public class OpcUaSubscription {
    * @param item the MonitoredItem to remove.
    */
   public void removeMonitoredItem(OpcUaMonitoredItem item) {
-    OpcUaMonitoredItem removedItem =
-        item.getClientHandle().map(monitoredItems::remove).orElse(null);
-
-    if (removedItem != null) {
-      itemsToDelete.add(removedItem);
-    }
+    item.getClientHandle().map(monitoredItems::remove).ifPresent(itemsToDelete::add);
   }
 
   /**

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscription.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscription.java
@@ -654,6 +654,28 @@ public class OpcUaSubscription {
         Lists.partition(itemsToDelete, partitionSize.intValue()).toList();
 
     for (List<OpcUaMonitoredItem> partition : partitions) {
+      // Server state may be cleared concurrently, so read each item id only once.
+      //noinspection DuplicatedCode
+      var monitoredItemIds = new ArrayList<UInteger>(partition.size());
+      var itemIds = new ArrayList<Optional<UInteger>>(partition.size());
+
+      for (OpcUaMonitoredItem item : partition) {
+        Optional<UInteger> itemId = item.getMonitoredItemId();
+
+        itemIds.add(itemId);
+        itemId.ifPresent(monitoredItemIds::add);
+      }
+
+      if (monitoredItemIds.isEmpty()) {
+        for (OpcUaMonitoredItem item : partition) {
+          serviceOperationsResults.add(
+              new MonitoredItemServiceOperationResult(
+                  item, new StatusCode(StatusCodes.Bad_InvalidState), null));
+        }
+
+        continue;
+      }
+
       try {
         logger.debug(
             "id={}, deleteMonitoredItems partition.size(): {}",
@@ -661,26 +683,39 @@ public class OpcUaSubscription {
             partition.size());
 
         DeleteMonitoredItemsResponse response =
-            client.deleteMonitoredItems(
-                serverState.getSubscriptionId(),
-                partition.stream()
-                    .map(item -> item.getMonitoredItemId().orElseThrow())
-                    .collect(Collectors.toList()));
+            client.deleteMonitoredItems(serverState.getSubscriptionId(), monitoredItemIds);
 
         StatusCode[] results = requireNonNull(response.getResults());
 
-        for (int i = 0; i < results.length; i++) {
-          StatusCode result = results[i];
+        int resultIndex = 0;
+        for (int i = 0; i < partition.size(); i++) {
+          OpcUaMonitoredItem item = partition.get(i);
 
-          partition.get(i).applyDeleteResult(result);
+          if (itemIds.get(i).isPresent()) {
+            StatusCode result = results[resultIndex++];
 
-          serviceOperationsResults.add(
-              new MonitoredItemServiceOperationResult(partition.get(i), StatusCode.GOOD, result));
+            item.applyDeleteResult(result);
+
+            serviceOperationsResults.add(
+                new MonitoredItemServiceOperationResult(item, StatusCode.GOOD, result));
+          } else {
+            serviceOperationsResults.add(
+                new MonitoredItemServiceOperationResult(
+                    item, new StatusCode(StatusCodes.Bad_InvalidState), null));
+          }
         }
       } catch (UaException e) {
-        for (OpcUaMonitoredItem item : partition) {
-          serviceOperationsResults.add(
-              new MonitoredItemServiceOperationResult(item, e.getStatusCode(), null));
+        for (int i = 0; i < partition.size(); i++) {
+          OpcUaMonitoredItem item = partition.get(i);
+
+          if (itemIds.get(i).isPresent()) {
+            serviceOperationsResults.add(
+                new MonitoredItemServiceOperationResult(item, e.getStatusCode(), null));
+          } else {
+            serviceOperationsResults.add(
+                new MonitoredItemServiceOperationResult(
+                    item, new StatusCode(StatusCodes.Bad_InvalidState), null));
+          }
         }
       }
     }
@@ -717,7 +752,8 @@ public class OpcUaSubscription {
   /**
    * Set the {@link MonitoringMode} for a group of MonitoredItems.
    *
-   * <p>These MonitoredItems must exist on the Server before setting the MonitoringMode.
+   * <p>A MonitoredItem that does not exist on the Server produces a {@code Bad_InvalidState}
+   * service result.
    *
    * @param monitoringMode the MonitoringMode to set.
    * @param monitoredItems the MonitoredItems to set the MonitoringMode for.
@@ -730,12 +766,6 @@ public class OpcUaSubscription {
 
     if (monitoredItems.isEmpty()) {
       return Collections.emptyList();
-    }
-
-    if (monitoredItems.stream()
-        .anyMatch(item -> item.getSyncState() == OpcUaMonitoredItem.SyncState.INITIAL)) {
-
-      throw new IllegalArgumentException("MonitoredItems must exist before setting MonitoringMode");
     }
 
     var serviceOperationResults =
@@ -757,6 +787,28 @@ public class OpcUaSubscription {
         Lists.partition(monitoredItems, partitionSize.intValue()).toList();
 
     for (List<OpcUaMonitoredItem> partition : partitions) {
+      // Server state may be cleared concurrently, so read each item id only once.
+      //noinspection DuplicatedCode
+      var monitoredItemIds = new ArrayList<UInteger>(partition.size());
+      var itemIds = new ArrayList<Optional<UInteger>>(partition.size());
+
+      for (OpcUaMonitoredItem item : partition) {
+        Optional<UInteger> itemId = item.getMonitoredItemId();
+
+        itemIds.add(itemId);
+        itemId.ifPresent(monitoredItemIds::add);
+      }
+
+      if (monitoredItemIds.isEmpty()) {
+        for (OpcUaMonitoredItem item : partition) {
+          serviceOperationResults.add(
+              new MonitoredItemServiceOperationResult(
+                  item, new StatusCode(StatusCodes.Bad_InvalidState), null));
+        }
+
+        continue;
+      }
+
       try {
         logger.debug(
             "id={}, setMonitoringMode partition.size(): {}",
@@ -765,32 +817,43 @@ public class OpcUaSubscription {
 
         SetMonitoringModeResponse response =
             client.setMonitoringMode(
-                serverState.getSubscriptionId(),
-                monitoringMode,
-                partition.stream()
-                    .map(item -> item.getMonitoredItemId().orElseThrow())
-                    .collect(Collectors.toList()));
+                serverState.getSubscriptionId(), monitoringMode, monitoredItemIds);
 
         StatusCode[] results = requireNonNull(response.getResults());
 
-        for (int i = 0; i < results.length; i++) {
-          StatusCode result = results[i];
-
+        int resultIndex = 0;
+        for (int i = 0; i < partition.size(); i++) {
           OpcUaMonitoredItem item = partition.get(i);
 
-          item.applySetMonitoringModeResult(result);
-          if (result.isGood()) {
-            item.setMonitoringMode(monitoringMode);
+          if (itemIds.get(i).isPresent()) {
+            StatusCode result = results[resultIndex++];
+
+            item.applySetMonitoringModeResult(result);
+            if (result.isGood()) {
+              item.setMonitoringMode(monitoringMode);
+            }
+            serviceOperationResults.add(
+                new MonitoredItemServiceOperationResult(item, StatusCode.GOOD, result));
+          } else {
+            serviceOperationResults.add(
+                new MonitoredItemServiceOperationResult(
+                    item, new StatusCode(StatusCodes.Bad_InvalidState), null));
           }
-          serviceOperationResults.add(
-              new MonitoredItemServiceOperationResult(item, StatusCode.GOOD, result));
         }
       } catch (UaException e) {
-        for (OpcUaMonitoredItem item : partition) {
-          item.applySetMonitoringModeResult(e.getStatusCode());
+        for (int i = 0; i < partition.size(); i++) {
+          OpcUaMonitoredItem item = partition.get(i);
 
-          serviceOperationResults.add(
-              new MonitoredItemServiceOperationResult(item, e.getStatusCode(), null));
+          if (itemIds.get(i).isPresent()) {
+            item.applySetMonitoringModeResult(e.getStatusCode());
+
+            serviceOperationResults.add(
+                new MonitoredItemServiceOperationResult(item, e.getStatusCode(), null));
+          } else {
+            serviceOperationResults.add(
+                new MonitoredItemServiceOperationResult(
+                    item, new StatusCode(StatusCodes.Bad_InvalidState), null));
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

- return per-item `Bad_InvalidState` results when monitored item server state disappears during `SetMonitoringMode` or `DeleteMonitoredItems` request construction
- continue processing valid items while preserving caller-order result alignment
- document the non-throwing behavior for items without server state
- add deterministic regression coverage for both reset timing windows, never-created items, and the sibling deletion race

## Root cause

A monitored item's `syncState` and `serverState` are separate volatile fields. Session reactivation or concurrent deletion can clear them between `setMonitoringMode()` validation and the later monitored-item ID lookup, causing either `IllegalArgumentException` or `NoSuchElementException`. The deletion path used the same throwing ID lookup pattern.

## Impact

Callers now receive a `Bad_InvalidState` service result for each affected item instead of a race-dependent exception. Valid items in the same request are still sent to the server and their results remain aligned with the original input list.

## Validation

- `mise exec -- mvn -q spotless:apply`
- `mise exec -- mvn -q -pl opc-ua-sdk/integration-tests -am test -Dtest=OpcUaMonitoredItemTest -Dsurefire.failIfNoSpecifiedTests=false`
- `mise exec -- mvn -q clean compile`

Fixes #1814
