### PR TITLE
Add NodeInstantiator engine and deprecate the legacy node factory

### DIFF
--- a/docs/features/node-instantiation-migration.md
+++ b/docs/features/node-instantiation-migration.md
@@ -1,0 +1,484 @@
+# Node Instantiation Migration Guide
+
+The legacy type-instantiation subsystem — `NodeFactory`, `InstanceDeclarationHierarchy`,
+`NodeFactory.InstantiationCallback`, `EventFactory`, and
+`ManagedAddressSpace.getNodeFactory()` — is deprecated, replaced by the
+`org.eclipse.milo.opcua.sdk.server.nodes.instantiation` package. The legacy
+implementation is retained with frozen behavior for the deprecation period; its removal
+is a future major-version decision. This guide maps every legacy usage pattern to the
+new API and lists every behavior that changes when you move.
+
+The new package ships as **experimental** for one minor release: the API may adjust
+based on in-tree migrations and placeholder validation against real companion-spec
+workloads, then freezes.
+
+* * *
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Quick Start: the 90% Case](#quick-start-the-90-case)
+- [Legacy Pattern Mappings](#legacy-pattern-mappings)
+  - [1. `instanceNodeId` overrides → `nodeIdStrategy`](#1-instancenodeid-overrides--nodeidstrategy)
+  - [2. Path-string id pinning → `assignNodeId`](#2-path-string-id-pinning--assignnodeid)
+  - [3. `includeOptionalNode` → include paths or a predicate](#3-includeoptionalnode--include-paths-or-a-predicate)
+  - [4. The callback trio → `onNode` and `bindMethod`](#4-the-callback-trio--onnode-and-bindmethod)
+  - [5. Post-creation deletion → request-time exclusion](#5-post-creation-deletion--request-time-exclusion)
+  - [6. Post-hoc fixup → request identity and placement](#6-post-hoc-fixup--request-identity-and-placement)
+- [Events: `EventFactory` → `EventInstantiator`](#events-eventfactory--eventinstantiator)
+- [Changed Behavior](#changed-behavior)
+- [Experimental Status](#experimental-status)
+
+* * *
+
+## Overview
+
+The replacement is a server-scoped facade, `NodeInstantiator`, obtained from
+`OpcUaServer.getNodeInstantiator()`. Everything about an instantiation — identity,
+placement, attribute values, optional-member selection, NodeId allocation, placeholder
+expansion, and behavior hooks — is described up front by an immutable
+`InstantiationRequest`, built with `InstantiationRequest.of(rootClass,
+typeDefinitionId)`.
+
+The facade splits instantiation into three phases you can use separately or together:
+
+- `describe(typeDefinitionId)` returns the type's compiled `TypeInstantiationModel` —
+  the fully-inherited instance declaration hierarchy as an immutable, cacheable
+  snapshot, keyed by `BrowsePath`.
+- `plan(request)` joins the request with the model into a pure-data
+  `InstantiationPlan`: every declaration accounted for, all NodeIds allocated and
+  collision-checked, every reference resolved. Nothing is constructed or mutated.
+- `apply(plan)` materializes the plan into the request's target `NodeManager` as a
+  staged, journaled unit, returning a typed `InstantiationResult`.
+
+`instantiate(request)` wraps plan and apply in one call and is what most code should
+use. The result exposes the typed root (`result.root()`), per-path lookups
+(`result.node(path)`, `result.require(path, type)`), the exact set of created nodes and
+references, and `result.deleteCreated()` — cleanup that removes exactly what this
+instantiation created, never nodes it reused.
+
+Note on imports: the new package has its own `BrowsePath`
+(`org.eclipse.milo.opcua.sdk.server.nodes.instantiation.BrowsePath`), a public
+structured path built from `QualifiedName` elements. It is unrelated to the legacy
+`org.eclipse.milo.opcua.sdk.server.nodes.factories.BrowsePath`; watch the import when
+migrating a class that used the legacy type.
+
+* * *
+
+## Quick Start: the 90% Case
+
+Legacy:
+
+```java
+UaObjectNode node =
+    (UaObjectNode)
+        getNodeFactory()
+            .createNode(new NodeId(2, "Demo/MyObject"), NodeIds.FolderType);
+
+node.setBrowseName(new QualifiedName(2, "MyObject"));
+node.setDisplayName(LocalizedText.english("MyObject"));
+
+getNodeManager().addNode(node);
+
+node.addReference(
+    new Reference(
+        node.getNodeId(), NodeIds.Organizes, parentNodeId.expanded(), false));
+```
+
+New API — one request describes the whole instance, and the root class is validated at
+plan time instead of cast afterwards:
+
+```java
+InstantiationRequest<UaObjectNode> request =
+    InstantiationRequest.of(UaObjectNode.class, NodeIds.FolderType)
+        .nodeId(new NodeId(2, "Demo/MyObject"))
+        .browseName(new QualifiedName(2, "MyObject"))
+        .displayName(LocalizedText.english("MyObject"))
+        .parent(parentNodeId, NodeIds.Organizes)
+        .target(getNodeManager())
+        .build();
+
+UaObjectNode node = getServer().getNodeInstantiator().instantiate(request).root();
+```
+
+Inside a `ManagedAddressSpace`, replace `getNodeFactory()` with
+`getServer().getNodeInstantiator()` targeted at `getNodeManager()`, as above.
+
+* * *
+
+## Legacy Pattern Mappings
+
+### 1. `instanceNodeId` overrides → `nodeIdStrategy`
+
+Subclassing `NodeFactory` to control member NodeId derivation:
+
+```java
+NodeFactory factory =
+    new NodeFactory(getNodeContext()) {
+      @Override
+      protected NodeId instanceNodeId(
+          NodeId rootNodeId, org.eclipse.milo.opcua.sdk.server.nodes.factories.BrowsePath browsePath) {
+        return deriveCustomNodeId(rootNodeId, browsePath.join());
+      }
+    };
+```
+
+becomes a `nodeIdStrategy` on the request. The strategy receives a `NodeIdContext` —
+the root's NodeId, the occurrence's `BrowsePath`, and the `InstanceDeclaration` being
+realized — and may return any identifier type; every produced id is collision-checked
+before anything is constructed:
+
+```java
+InstantiationRequest.of(UaObjectNode.class, typeDefinitionId)
+    .nodeId(rootNodeId)
+    .nodeIdStrategy(ctx -> deriveCustomNodeId(ctx.rootNodeId(), ctx.path().toString()))
+    .target(nodeManager)
+    .build();
+```
+
+`NodeIdContext.defaultNodeId()` and `NodeIdContext.legacyNodeId()` expose the built-in
+derivations, so a strategy can special-case some paths and fall back for the rest.
+
+**Keeping identical derived ids.** Derived NodeIds are persisted identity for existing
+deployments. If your code relied on the legacy formula (root identifier string +
+`/<namespaceIndex>:<name>` per path element, unescaped), set
+`Builder.legacyPathStrings()` and unpinned, non-strategy ids are derived with the
+legacy formula verbatim. The new default derivation is similar but
+collision-resistant — it escapes `\`, `/`, and `:` and marks non-String root
+identifiers — so freshly migrated code that never persisted ids should prefer the
+default.
+
+### 2. Path-string id pinning → `assignNodeId`
+
+Pinning specific members to fixed NodeIds by string-matching the browse path inside an
+`instanceNodeId` override:
+
+```java
+NodeFactory factory =
+    new NodeFactory(getNodeContext()) {
+      @Override
+      protected NodeId instanceNodeId(
+          NodeId rootNodeId, org.eclipse.milo.opcua.sdk.server.nodes.factories.BrowsePath browsePath) {
+        if ("/2:Measurement".equals(browsePath.join())) {
+          return new NodeId(2, "Well-Known/Measurement");
+        }
+        return super.instanceNodeId(rootNodeId, browsePath);
+      }
+    };
+```
+
+becomes a structured per-path assignment:
+
+```java
+InstantiationRequest.of(UaObjectNode.class, typeDefinitionId)
+    .nodeId(rootNodeId)
+    .assignNodeId(
+        BrowsePath.of(new QualifiedName(2, "Measurement")),
+        new NodeId(2, "Well-Known/Measurement"))
+    .target(nodeManager)
+    .build();
+```
+
+Assigned ids win over the strategy and the default derivation; they are
+collision-checked like every other id in the plan.
+
+### 3. `includeOptionalNode` → include paths or a predicate
+
+The legacy callback was consulted per optional member (except Methods — see
+[Changed Behavior](#changed-behavior)) with only the declaring type and BrowseName:
+
+```java
+UaNode node =
+    factory.createNode(
+        nodeId,
+        NodeIds.AnalogItemType,
+        new NodeFactory.InstantiationCallback() {
+          @Override
+          public boolean includeOptionalNode(
+              NodeId typeDefinitionId, QualifiedName browseName) {
+            return browseName.equals(new QualifiedName(0, "InstrumentRange"));
+          }
+        });
+```
+
+The request replaces it with declarative selection:
+
+```java
+// Exact paths:
+InstantiationRequest.of(AnalogItemTypeNode.class, NodeIds.AnalogItemType)
+    .nodeId(nodeId)
+    .includeOptional(BrowsePath.of(new QualifiedName(0, "InstrumentRange")))
+    .target(nodeManager)
+    .build();
+
+// Everything:
+InstantiationRequest.of(AnalogItemTypeNode.class, NodeIds.AnalogItemType)
+    .nodeId(nodeId)
+    .includeAllOptionals()
+    .target(nodeManager)
+    .build();
+
+// Or a predicate over the full declaration (path, rule, type, attributes):
+InstantiationRequest.of(AnalogItemTypeNode.class, NodeIds.AnalogItemType)
+    .nodeId(nodeId)
+    .includeOptionals(declaration -> declaration.browsePath().depth() == 1)
+    .target(nodeManager)
+    .build();
+```
+
+Two same-named optionals at different paths are selected independently — the selection
+key is the full `BrowsePath`, not the BrowseName.
+
+### 4. The callback trio → `onNode` and `bindMethod`
+
+`onObjectAdded`/`onVariableAdded`/`onMethodAdded` fired per node, mid-instantiation, on
+nodes already stored in the NodeManager:
+
+```java
+UaNode node =
+    factory.createNode(
+        nodeId,
+        typeDefinitionId,
+        new NodeFactory.InstantiationCallback() {
+          @Override
+          public void onVariableAdded(
+              @Nullable UaNode parent, UaVariableNode instance, NodeId typeDefinitionId) {
+            instance.setValue(new DataValue(new Variant(0.0d)));
+          }
+
+          @Override
+          public void onMethodAdded(@Nullable UaObjectNode parent, UaMethodNode instance) {
+            instance.setInvocationHandler(handlerFor(instance));
+          }
+        });
+```
+
+The replacement is two hooks with distinct timing:
+
+- `onNode` runs during apply, after the **complete staged graph** is constructed and
+  before anything is committed or published. It receives the declaration occurrence
+  being realized (`null` for the root), the staged node, its staged parent, and a
+  read-only `StagedGraph` for cross-node wiring. Configure node-local state here —
+  values, filters, permissions — instead of mutating nodes after creation.
+- `bindMethod` attaches an invocation handler to a Method at a specific path, after
+  commit (a handler observable via the address space should not be callable before its
+  node exists there).
+
+```java
+InstantiationRequest.of(UaObjectNode.class, typeDefinitionId)
+    .nodeId(nodeId)
+    .onNode(
+        (declaration, node, parent, graph) -> {
+          if (declaration != null
+              && declaration.browseName().equals(new QualifiedName(0, "SetPoint"))
+              && node instanceof UaVariableNode variableNode) {
+            variableNode.setValue(new DataValue(new Variant(0.0d)));
+          }
+        })
+    .bindMethod(
+        BrowsePath.of(new QualifiedName(2, "Start")),
+        methodNode -> methodNode.setInvocationHandler(handlerFor(methodNode)))
+    .target(nodeManager)
+    .build();
+```
+
+One caution carried over from the legacy world in a new form: `onNode` hooks should
+configure node-local state only. Graph-mutating conveniences (`addReference`,
+`setProperty`, `addComponent`, …) write through the node's context straight into the
+live target NodeManager — outside the journaled batch — so they are not rolled back on
+failure and not removed by `InstantiationResult.deleteCreated()`. Structure belongs in
+the request.
+
+### 5. Post-creation deletion → request-time exclusion
+
+Deleting unwanted members after instantiation:
+
+```java
+UaObjectNode node = (UaObjectNode) factory.createNode(nodeId, typeDefinitionId);
+
+node.findNode(new QualifiedName(0, "Unwanted")).ifPresent(UaNode::delete);
+```
+
+becomes exclusion in the request, so the unwanted member — and its entire subtree — is
+never created at all:
+
+```java
+InstantiationRequest.of(UaObjectNode.class, typeDefinitionId)
+    .nodeId(nodeId)
+    .includeAllOptionals()
+    .excludeOptional(BrowsePath.of(new QualifiedName(0, "Unwanted")))
+    .target(nodeManager)
+    .build();
+```
+
+Exclusions prune subtrees and win over broader inclusion (`includeAllOptionals` or a
+predicate). Note that excluding an omitted-by-default optional is a no-op — exclusion
+exists to carve exceptions out of broad inclusion. Mandatory members cannot be
+excluded; a plan that omits a Mandatory declaration carries an error and is refused by
+apply. Every excluded or omitted declaration is reported in
+`InstantiationResult.skippedDeclarations()` with a machine-readable reason.
+
+### 6. Post-hoc fixup → request identity and placement
+
+Renaming and re-parenting after creation:
+
+```java
+UaObjectNode node = (UaObjectNode) factory.createNode(nodeId, typeDefinitionId);
+
+node.setBrowseName(new QualifiedName(2, "Pump01"));
+node.setDisplayName(LocalizedText.english("Pump 01"));
+
+getNodeManager().addNode(node);
+
+node.addReference(
+    new Reference(
+        node.getNodeId(), NodeIds.HasComponent, parentNodeId.expanded(), false));
+```
+
+is part of the request — the instance is born with its identity and placement, and the
+parent reference is committed in the same journaled batch as the nodes:
+
+```java
+InstantiationRequest.of(UaObjectNode.class, typeDefinitionId)
+    .nodeId(nodeId)
+    .browseName(new QualifiedName(2, "Pump01"))
+    .displayName(LocalizedText.english("Pump 01"))
+    .parent(parentNodeId, NodeIds.HasComponent)
+    .target(nodeManager)
+    .build();
+```
+
+Parent attachment is optional: omit `parent(...)` to create an unattached instance and
+wire it up yourself. Root attribute values beyond the common ones have a general form,
+`rootAttribute(AttributeId, value)`, and `value(...)`/`rootAttribute(...)` set initial
+values without post-creation mutation.
+
+* * *
+
+## Events: `EventFactory` → `EventInstantiator`
+
+`OpcUaServer.getEventFactory()` is deprecated; use
+`OpcUaServer.getEventInstantiator()`. The surface is the same two-argument
+`createEvent`, plus a typed overload that replaces the legacy post-construction cast:
+
+```java
+BaseEventTypeNode event =
+    server
+        .getEventInstantiator()
+        .createEvent(new NodeId(2, UUID.randomUUID()), NodeIds.BaseEventType);
+
+// Typed — the expected class is validated at plan time, before any node is created:
+SystemEventTypeNode systemEvent =
+    server
+        .getEventInstantiator()
+        .createEvent(
+            SystemEventTypeNode.class, new NodeId(2, UUID.randomUUID()), NodeIds.SystemEventType);
+```
+
+Behavior differences from the legacy factory:
+
+- **Typed preflight instead of a cast.** The legacy factory cast the created node to
+  `BaseEventTypeNode` after its nodes were already stored; a custom event type with no
+  registered Java class threw `ClassCastException` and left residue. The replacement
+  validates the expected class at plan time; failure creates nothing. An unregistered
+  custom event type resolves to its nearest registered ancestor's class instead of
+  failing.
+- **Private, registered node manager.** Event nodes are created in the
+  `EventInstantiator`'s private `UaNodeManager`, registered with the server's
+  `AddressSpaceManager` while the server is running, so event fields resolve during
+  filter evaluation without the events being reachable from the server's hierarchy.
+- **No post-creation mutation.** The `EventType` Property is set during instantiation,
+  not by mutating the created node afterwards.
+- **Cleanup is still yours.** As with the legacy factory, delete event nodes
+  (`UaNode.delete()`) once they have been posted to the event bus.
+
+**Abstract event types and `allowAbstractType`.** The new engine rejects an abstract
+root type at plan time (`ABSTRACT_TYPE`) — a check the legacy factory never made, which
+is why legacy code could instantiate `BaseEventType` at all. The event workload is the
+legitimate exception: transient events are values, never part of the server's
+hierarchy, and `BaseEventType` itself is abstract. `Builder.allowAbstractType()`
+(default off) bypasses only the root abstractness error — member-level abstractness
+still requires a `concreteType` selection — and `EventInstantiator` sets it internally.
+If you build transient event-like instances with `InstantiationRequest` directly, set
+it yourself; leave it unset for anything that becomes part of the address space.
+
+* * *
+
+## Changed Behavior
+
+Moving to the new API is an opt-in behavior change. The legacy implementation keeps its
+frozen behavior — including the defects below, which are documented in its deprecation
+Javadoc rather than fixed. The differences you can observe:
+
+**Optional-Method selection.** Legacy created optional Methods unconditionally;
+`includeOptionalNode` was never consulted for them. The new engine selects optional
+Methods exactly like any other optional member. Migrating code that relied on optional
+Methods appearing "for free" must include them (a `bindMethod` path is not a selection
+— add the path via `includeOptional` or a predicate).
+
+**Collision failure.** Legacy silently replaced an existing node at the same NodeId and
+left the previous node's reference rows in place. The new engine's default policy
+(`ConflictPolicy.FAIL`) fails the plan with `NODE_ID_COLLISION` before anything is
+constructed. `ConflictPolicy.REUSE_COMPATIBLE` reuses an existing node only after
+validating namespace-qualified BrowseName, NodeClass, and TypeDefinition compatibility;
+an incompatible node fails with `INCOMPATIBLE_REUSE` rather than being adopted or
+replaced. Reused nodes are never deleted by `deleteCreated()`.
+
+**Attribute completeness — including security attributes.** Legacy attribute
+propagation from declarations was incomplete: `MinimumSamplingInterval`, `Historizing`,
+`AccessLevelEx`, `RolePermissions`, `UserRolePermissions`, and `AccessRestrictions`
+were not copied. The new engine copies the full attribute set, preserving
+absent/null/value distinctions. The security-relevant consequence:
+**instances of security-modeled types now come up with their modeled
+`RolePermissions`/`UserRolePermissions`/`AccessRestrictions`, where legacy instances
+silently defaulted to unrestricted.** If your deployment depended on instances of such
+types being unrestricted, that was the legacy defect, not a contract — but audit for it
+before migrating.
+
+**Publication timing.** Legacy stored nodes into the NodeManager one at a time during
+construction — each node publicly visible before the instance was complete — and fired
+its callbacks afterwards, on already-published nodes. The new engine
+stages the complete graph unpublished, runs `onNode` hooks against the staged graph,
+then commits nodes and references as one journaled batch; `bindMethod` binders run
+after commit. Nothing is observable in the target until commit, and `afterCommit`
+observers see only fully committed results.
+
+**Reference reconstruction.** Non-hierarchical declaration references are re-mapped
+among instantiated members (internal) or copied verbatim (external) under a named
+policy, `ReferenceReplicationPolicy`, and land exactly once in each observable
+direction, with no edges to omitted targets. Legacy behavior — a full-list scan with
+order-dependent quirks — left inverse-only rows and edges to nodes that were never
+created reachable in some shapes.
+
+**Error shapes.** Legacy failures surfaced as generic `UaException`s, or as
+`ClassCastException` after nodes were stored, with partial instance trees left behind.
+New-engine failures are `InstantiationException` (itself a `UaException`) carrying the
+lifecycle phase (`PLAN`/`APPLY`) and structured `InstantiationDiagnostic`s naming each
+finding per declaration path. A failed plan mutates nothing; a failed apply rolls back
+exactly its journaled additions. The two documented exceptions: a failed rollback is
+reported loudly with `ROLLBACK_FAILED` diagnostics carrying what could not be removed,
+and mutations a hook made to reused/shared nodes are not this instantiation's to undo.
+
+**Cleanup ownership.** Legacy offered no cleanup; callers deleted recursively from the
+root and — because excluding an optional member still created and stored its mandatory
+descendants, unreachable from the instance root — orphans could survive anyway. The new
+result is ownership-explicit: `materializedNodes()` distinguishes CREATED from REUSED,
+and `deleteCreated()` removes exactly what the instantiation created. The
+excluded-subtree defect does not exist in the new engine: exclusion prunes the subtree
+at plan time.
+
+Two further legacy defects fixed (not just changed) in the new engine, for
+completeness: a member typed as a subtype of its declaring type now receives that
+subtype's inherited mandatory members, and an on-declaration override of a child the
+type also declares now wins over the type's entry instead of being discarded.
+
+* * *
+
+## Experimental Status
+
+The `org.eclipse.milo.opcua.sdk.server.nodes.instantiation` package is experimental for
+one minor release. The API may adjust — in particular the `BrowsePath` representation
+(namespace-index-based today, resolved against the model snapshot's namespace table)
+and the placeholder surface (`forPlaceholder`, `expandPlaceholder`), which is being
+validated against real companion-specification workloads — then freezes. The legacy
+subsystem remains available, unchanged, for the whole deprecation period.

--- a/milo-examples/server-examples/src/main/java/org/eclipse/milo/examples/server/ExampleNamespace.java
+++ b/milo-examples/server-examples/src/main/java/org/eclipse/milo/examples/server/ExampleNamespace.java
@@ -51,8 +51,8 @@ import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectTypeNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableNode;
-import org.eclipse.milo.opcua.sdk.server.nodes.factories.NodeFactory;
 import org.eclipse.milo.opcua.sdk.server.nodes.filters.AttributeFilters;
+import org.eclipse.milo.opcua.sdk.server.nodes.instantiation.InstantiationRequest;
 import org.eclipse.milo.opcua.sdk.server.util.SubscriptionModel;
 import org.eclipse.milo.opcua.stack.core.AttributeId;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
@@ -192,7 +192,7 @@ public class ExampleNamespace extends ManagedNamespaceWithLifecycle {
                   try {
                     BaseEventTypeNode eventNode =
                         getServer()
-                            .getEventFactory()
+                            .getEventInstantiator()
                             .createEvent(newNodeId(UUID.randomUUID()), NodeIds.BaseEventType);
 
                     eventNode.setBrowseName(new QualifiedName(1, "foo"));
@@ -543,29 +543,31 @@ public class ExampleNamespace extends ManagedNamespaceWithLifecycle {
     rootNode.addOrganizes(dataAccessFolder);
 
     try {
-      AnalogItemTypeNode node =
-          (AnalogItemTypeNode)
-              getNodeFactory()
-                  .createNode(
-                      newNodeId("HelloWorld/DataAccess/AnalogValue"),
-                      NodeIds.AnalogItemType,
-                      new NodeFactory.InstantiationCallback() {
-                        @Override
-                        public boolean includeOptionalNode(
-                            NodeId typeDefinitionId, QualifiedName browseName) {
-                          return true;
-                        }
-                      });
+      // The whole instance is described by one request: identity, placement, attribute values,
+      // optional-member selection, and member initialization (EURange, via an onNode hook against
+      // the staged graph) — no mutation of the created nodes afterwards.
+      InstantiationRequest<AnalogItemTypeNode> request =
+          InstantiationRequest.of(AnalogItemTypeNode.class, NodeIds.AnalogItemType)
+              .nodeId(newNodeId("HelloWorld/DataAccess/AnalogValue"))
+              .browseName(newQualifiedName("AnalogValue"))
+              .displayName(LocalizedText.english("AnalogValue"))
+              .rootAttribute(AttributeId.DataType, NodeIds.Double)
+              .value(new DataValue(new Variant(3.14d)))
+              .includeAllOptionals()
+              .parent(dataAccessFolder.getNodeId(), NodeIds.Organizes)
+              .target(getNodeManager())
+              .onNode(
+                  (declaration, node, parent, graph) -> {
+                    if (declaration != null
+                        && declaration.browseName().equals(new QualifiedName(0, "EURange"))
+                        && node instanceof UaVariableNode variableNode) {
 
-      node.setBrowseName(newQualifiedName("AnalogValue"));
-      node.setDisplayName(LocalizedText.english("AnalogValue"));
-      node.setDataType(NodeIds.Double);
-      node.setValue(new DataValue(new Variant(3.14d)));
+                      variableNode.setValue(new DataValue(new Variant(new Range(0.0, 100.0))));
+                    }
+                  })
+              .build();
 
-      node.setEuRange(new Range(0.0, 100.0));
-
-      getNodeManager().addNode(node);
-      dataAccessFolder.addOrganizes(node);
+      getServer().getNodeInstantiator().instantiate(request);
     } catch (UaException e) {
       logger.error("Error creating AnalogItemType instance: {}", e.getMessage(), e);
     }
@@ -680,7 +682,8 @@ public class ExampleNamespace extends ManagedNamespaceWithLifecycle {
     objectTypeNode.addComponent(bar);
 
     // Tell the ObjectTypeManager about our new type.
-    // This lets us use NodeFactory to instantiate instances of the type.
+    // This lets the instantiation engine construct instances of the type with a registered Java
+    // class instead of the base node class.
     getServer()
         .getObjectTypeManager()
         .registerObjectType(
@@ -709,23 +712,20 @@ public class ExampleNamespace extends ManagedNamespaceWithLifecycle {
     getNodeManager().addNode(foo);
     getNodeManager().addNode(bar);
 
-    // Use NodeFactory to create instance of MyObjectType called "MyObject".
-    // NodeFactory takes care of recursively instantiating MyObject member nodes
-    // as well as adding all nodes to the address space.
+    // Create an instance of MyObjectType called "MyObject" through the NodeInstantiator.
+    // One request describes the whole instance — identity, placement under the root folder, and
+    // the recursively instantiated member nodes — committed to the address space as a unit.
     try {
-      UaObjectNode myObject =
-          (UaObjectNode)
-              getNodeFactory()
-                  .createNode(newNodeId("HelloWorld/MyObject"), objectTypeNode.getNodeId());
-      myObject.setBrowseName(newQualifiedName("MyObject"));
-      myObject.setDisplayName(LocalizedText.english("MyObject"));
+      InstantiationRequest<UaObjectNode> request =
+          InstantiationRequest.of(UaObjectNode.class, objectTypeNode.getNodeId())
+              .nodeId(newNodeId("HelloWorld/MyObject"))
+              .browseName(newQualifiedName("MyObject"))
+              .displayName(LocalizedText.english("MyObject"))
+              .parent(rootFolder.getNodeId(), NodeIds.Organizes)
+              .target(getNodeManager())
+              .build();
 
-      // Add forward and inverse references from the root folder.
-      rootFolder.addOrganizes(myObject);
-
-      myObject.addReference(
-          new Reference(
-              myObject.getNodeId(), NodeIds.Organizes, rootFolder.getNodeId().expanded(), false));
+      getServer().getNodeInstantiator().instantiate(request);
     } catch (UaException e) {
       logger.error("Error creating MyObjectType instance: {}", e.getMessage(), e);
     }

--- a/milo-examples/server-examples/src/main/java/org/eclipse/milo/examples/server/methods/GenerateEventMethod.java
+++ b/milo-examples/server-examples/src/main/java/org/eclipse/milo/examples/server/methods/GenerateEventMethod.java
@@ -10,6 +10,7 @@
 
 package org.eclipse.milo.examples.server.methods;
 
+import static java.util.Objects.requireNonNull;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
 
 import java.util.UUID;
@@ -59,10 +60,10 @@ public class GenerateEventMethod extends AbstractMethodInvocationHandler {
   @Override
   protected Variant[] invoke(InvocationContext invocationContext, Variant[] inputValues)
       throws UaException {
-    NodeId eventTypeId = (NodeId) inputValues[0].value();
+    NodeId eventTypeId = (NodeId) requireNonNull(inputValues[0].value());
 
     BaseEventTypeNode eventNode =
-        server.getEventFactory().createEvent(new NodeId(1, UUID.randomUUID()), eventTypeId);
+        server.getEventInstantiator().createEvent(new NodeId(1, UUID.randomUUID()), eventTypeId);
 
     eventNode.setBrowseName(new QualifiedName(1, "foo"));
     eventNode.setDisplayName(LocalizedText.english("foo"));

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/subscriptions/EventFilterWhereClauseOperatorTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/subscriptions/EventFilterWhereClauseOperatorTest.java
@@ -277,7 +277,7 @@ public class EventFilterWhereClauseOperatorTest extends AbstractClientServerTest
     UUID eventId = UUID.randomUUID();
     BaseEventTypeNode eventNode =
         server
-            .getEventFactory()
+            .getEventInstantiator()
             .createEvent(
                 newNodeId("EventFilterWhereClauseOperatorTest/" + eventId), NodeIds.BaseEventType);
 

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/subscriptions/PercentDeadbandTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/subscriptions/PercentDeadbandTest.java
@@ -25,9 +25,8 @@ import org.eclipse.milo.opcua.sdk.client.subscriptions.MonitoredItemSynchronizat
 import org.eclipse.milo.opcua.sdk.client.subscriptions.OpcUaMonitoredItem;
 import org.eclipse.milo.opcua.sdk.client.subscriptions.OpcUaSubscription;
 import org.eclipse.milo.opcua.sdk.core.AccessLevel;
-import org.eclipse.milo.opcua.sdk.core.Reference;
 import org.eclipse.milo.opcua.sdk.server.model.variables.AnalogItemTypeNode;
-import org.eclipse.milo.opcua.sdk.server.nodes.factories.NodeFactory;
+import org.eclipse.milo.opcua.sdk.server.nodes.instantiation.InstantiationRequest;
 import org.eclipse.milo.opcua.sdk.test.AbstractClientServerTest;
 import org.eclipse.milo.opcua.sdk.test.TestNamespace;
 import org.eclipse.milo.opcua.stack.core.AttributeId;
@@ -1029,37 +1028,22 @@ public class PercentDeadbandTest extends AbstractClientServerTest {
 
     var nodeId = new NodeId(namespace.getNamespaceIndex(), identifier);
 
-    AnalogItemTypeNode node =
-        (AnalogItemTypeNode)
-            namespace
-                .getNodeFactory()
-                .createNode(
-                    nodeId,
-                    NodeIds.AnalogItemType,
-                    new NodeFactory.InstantiationCallback() {
-                      @Override
-                      public boolean includeOptionalNode(
-                          NodeId typeDefinitionId, QualifiedName browseName) {
-                        return true;
-                      }
-                    });
+    InstantiationRequest<AnalogItemTypeNode> request =
+        InstantiationRequest.of(AnalogItemTypeNode.class, NodeIds.AnalogItemType)
+            .nodeId(nodeId)
+            .browseName(new QualifiedName(namespace.getNamespaceIndex(), identifier))
+            .displayName(LocalizedText.english(identifier))
+            .rootAttribute(AttributeId.DataType, NodeIds.Double)
+            .value(new DataValue(new Variant(initialValue)))
+            .rootAttribute(AttributeId.AccessLevel, AccessLevel.toValue(AccessLevel.READ_WRITE))
+            .rootAttribute(AttributeId.UserAccessLevel, AccessLevel.toValue(AccessLevel.READ_WRITE))
+            .includeAllOptionals()
+            .parent(NodeIds.ObjectsFolder, NodeIds.HasComponent)
+            .target(namespace.getNodeManager())
+            .onNode(euRangeInitializer(euRange))
+            .build();
 
-    node.setBrowseName(new QualifiedName(namespace.getNamespaceIndex(), identifier));
-    node.setDisplayName(LocalizedText.english(identifier));
-    node.setDataType(NodeIds.Double);
-    node.setValue(new DataValue(new Variant(initialValue)));
-    node.setAccessLevel(AccessLevel.toValue(AccessLevel.READ_WRITE));
-    node.setUserAccessLevel(AccessLevel.toValue(AccessLevel.READ_WRITE));
-    node.setEuRange(euRange);
-
-    node.addReference(
-        new Reference(
-            node.getNodeId(),
-            NodeIds.HasComponent,
-            NodeIds.ObjectsFolder.expanded(),
-            Reference.Direction.INVERSE));
-
-    namespace.getNodeManager().addNode(node);
+    namespace.getNodeContext().getServer().getNodeInstantiator().instantiate(request);
   }
 
   private void createAnalogItemArrayNode(
@@ -1072,38 +1056,35 @@ public class PercentDeadbandTest extends AbstractClientServerTest {
 
     var nodeId = new NodeId(namespace.getNamespaceIndex(), identifier);
 
-    AnalogItemTypeNode node =
-        (AnalogItemTypeNode)
-            namespace
-                .getNodeFactory()
-                .createNode(
-                    nodeId,
-                    NodeIds.AnalogItemType,
-                    new NodeFactory.InstantiationCallback() {
-                      @Override
-                      public boolean includeOptionalNode(
-                          NodeId typeDefinitionId, QualifiedName browseName) {
-                        return true;
-                      }
-                    });
+    InstantiationRequest<AnalogItemTypeNode> request =
+        InstantiationRequest.of(AnalogItemTypeNode.class, NodeIds.AnalogItemType)
+            .nodeId(nodeId)
+            .browseName(new QualifiedName(namespace.getNamespaceIndex(), identifier))
+            .displayName(LocalizedText.english(identifier))
+            .rootAttribute(AttributeId.DataType, dataType)
+            .rootAttribute(AttributeId.ValueRank, 1) // One-dimensional array
+            .value(new DataValue(new Variant(initialValue)))
+            .rootAttribute(AttributeId.AccessLevel, AccessLevel.toValue(AccessLevel.READ_WRITE))
+            .rootAttribute(AttributeId.UserAccessLevel, AccessLevel.toValue(AccessLevel.READ_WRITE))
+            .includeAllOptionals()
+            .parent(NodeIds.ObjectsFolder, NodeIds.HasComponent)
+            .target(namespace.getNodeManager())
+            .onNode(euRangeInitializer(euRange))
+            .build();
 
-    node.setBrowseName(new QualifiedName(namespace.getNamespaceIndex(), identifier));
-    node.setDisplayName(LocalizedText.english(identifier));
-    node.setDataType(dataType);
-    node.setValueRank(1); // One-dimensional array
-    node.setValue(new DataValue(new Variant(initialValue)));
-    node.setAccessLevel(AccessLevel.toValue(AccessLevel.READ_WRITE));
-    node.setUserAccessLevel(AccessLevel.toValue(AccessLevel.READ_WRITE));
-    node.setEuRange(euRange);
+    namespace.getNodeContext().getServer().getNodeInstantiator().instantiate(request);
+  }
 
-    node.addReference(
-        new Reference(
-            node.getNodeId(),
-            NodeIds.HasComponent,
-            NodeIds.ObjectsFolder.expanded(),
-            Reference.Direction.INVERSE));
+  /** Initializes the EURange property of a staged AnalogItem instance before it is published. */
+  private static InstantiationRequest.OnNode euRangeInitializer(Range euRange) {
+    return (declaration, node, parent, graph) -> {
+      if (declaration != null
+          && declaration.browseName().equals(new QualifiedName(0, "EURange"))
+          && node instanceof org.eclipse.milo.opcua.sdk.server.nodes.UaVariableNode variableNode) {
 
-    namespace.getNodeManager().addNode(node);
+        variableNode.setValue(new DataValue(new Variant(euRange)));
+      }
+    };
   }
 
   private void resetNodeValues() throws Exception {

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/test/TestNamespace.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/test/TestNamespace.java
@@ -37,7 +37,7 @@ import org.eclipse.milo.opcua.sdk.server.nodes.UaMethodNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaNodeContext;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableNode;
-import org.eclipse.milo.opcua.sdk.server.nodes.factories.NodeFactory;
+import org.eclipse.milo.opcua.sdk.server.nodes.instantiation.InstantiationRequest;
 import org.eclipse.milo.opcua.sdk.server.util.SubscriptionModel;
 import org.eclipse.milo.opcua.stack.core.AttributeId;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
@@ -145,28 +145,30 @@ public class TestNamespace extends ManagedNamespaceWithLifecycle {
         .addStartupTask(
             () -> {
               try {
-                AnalogItemTypeNode node =
-                    (AnalogItemTypeNode)
-                        getNodeFactory()
-                            .createNode(
-                                newNodeId("TestAnalogValue"),
-                                NodeIds.AnalogItemType,
-                                new NodeFactory.InstantiationCallback() {
-                                  @Override
-                                  public boolean includeOptionalNode(
-                                      NodeId typeDefinitionId, QualifiedName browseName) {
-                                    return true;
-                                  }
-                                });
+                InstantiationRequest<AnalogItemTypeNode> request =
+                    InstantiationRequest.of(AnalogItemTypeNode.class, NodeIds.AnalogItemType)
+                        .nodeId(newNodeId("TestAnalogValue"))
+                        .browseName(newQualifiedName("TestAnalogValue"))
+                        .displayName(LocalizedText.english("TestAnalogValue"))
+                        .rootAttribute(AttributeId.DataType, NodeIds.Double)
+                        .value(new DataValue(new Variant(3.14d)))
+                        .includeAllOptionals()
+                        .target(getNodeManager())
+                        .onNode(
+                            (declaration, node, parent, graph) -> {
+                              if (declaration != null
+                                  && declaration
+                                      .browseName()
+                                      .equals(new QualifiedName(0, "EURange"))
+                                  && node instanceof UaVariableNode variableNode) {
 
-                node.setBrowseName(newQualifiedName("TestAnalogValue"));
-                node.setDisplayName(LocalizedText.english("TestAnalogValue"));
-                node.setDataType(NodeIds.Double);
-                node.setValue(new DataValue(new Variant(3.14d)));
+                                variableNode.setValue(
+                                    new DataValue(new Variant(new Range(0.0, 100.0))));
+                              }
+                            })
+                        .build();
 
-                node.setEuRange(new Range(0.0, 100.0));
-
-                getNodeManager().addNode(node);
+                getServer().getNodeInstantiator().instantiate(request);
               } catch (UaException e) {
                 throw new RuntimeException(e);
               }
@@ -486,7 +488,7 @@ public class TestNamespace extends ManagedNamespaceWithLifecycle {
                   try {
                     BaseEventTypeNode eventNode =
                         getServer()
-                            .getEventFactory()
+                            .getEventInstantiator()
                             .createEvent(newNodeId(UUID.randomUUID()), NodeIds.BaseEventType);
 
                     eventNode.setBrowseName(new QualifiedName(1, "foo"));

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/AbstractNodeManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/AbstractNodeManager.java
@@ -226,6 +226,24 @@ public class AbstractNodeManager<T extends Node> implements NodeManager<T> {
       }
     }
 
+    // Only a commit that actually changes state bumps the generation; a no-op commit (empty
+    // batch, reuse-only, or References all already present) must leave outstanding handles
+    // current, like the other mutation methods. The bump happens BEFORE the apply loop — and is
+    // deliberately not undone by rollback — so a lock-free reader that observes any mid-commit
+    // (or rolled-back) state can never also observe a still-current generation.
+    boolean mutates =
+        !batch.getNodeAdditions().isEmpty()
+            || batch.getReferenceAdditions().stream()
+                .anyMatch(
+                    reference -> {
+                      LinkedHashMultiset<Reference> references =
+                          referenceMap.get(reference.getSourceNodeId());
+                      return references == null || !references.contains(reference);
+                    });
+    if (mutates) {
+      generation++;
+    }
+
     // Validation is complete; apply, undoing all applied additions if a mutation fails.
     List<NodeId> addedNodes = new ArrayList<>();
     List<Reference> addedReferences = new ArrayList<>();
@@ -256,13 +274,6 @@ public class AbstractNodeManager<T extends Node> implements NodeManager<T> {
           "batch commit failed and was rolled back",
           e,
           nothingApplied);
-    }
-
-    // Only a commit that actually changed state bumps the generation; a no-op commit (empty batch,
-    // reuse-only, or References all already present) must leave outstanding handles current, like
-    // the other mutation methods.
-    if (!addedNodes.isEmpty() || !addedReferences.isEmpty()) {
-      generation++;
     }
 
     return new CommitResult(addedNodes, addedReferences);

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/AbstractNodeManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/AbstractNodeManager.java
@@ -15,12 +15,14 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.function.Predicate;
 import org.eclipse.milo.opcua.sdk.core.Reference;
 import org.eclipse.milo.opcua.sdk.core.nodes.Node;
 import org.eclipse.milo.opcua.stack.core.NamespaceTable;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 
@@ -29,6 +31,10 @@ public class AbstractNodeManager<T extends Node> implements NodeManager<T> {
   private final ConcurrentMap<NodeId, T> nodeMap = new ConcurrentHashMap<>();
   private final ConcurrentMap<NodeId, LinkedHashMultiset<Reference>> referenceMap =
       new ConcurrentHashMap<>();
+
+  // Bumped by every mutation under the instance monitor; read lock-free (volatile) by
+  // getGeneration().
+  private volatile long generation = 0L;
 
   /**
    * Get the backing {@link ConcurrentMap} holding this {@link NodeManager}'s Nodes.
@@ -77,8 +83,20 @@ public class AbstractNodeManager<T extends Node> implements NodeManager<T> {
   }
 
   @Override
-  public Optional<T> addNode(T node) {
+  public synchronized Optional<T> addNode(T node) {
+    generation++;
     return Optional.ofNullable(nodeMap.put(node.getNodeId(), node));
+  }
+
+  @Override
+  public synchronized boolean addNodeIfAbsent(T node) {
+    if (nodeMap.containsKey(node.getNodeId())) {
+      return false;
+    } else {
+      nodeMap.put(node.getNodeId(), node);
+      generation++;
+      return true;
+    }
   }
 
   @Override
@@ -92,8 +110,12 @@ public class AbstractNodeManager<T extends Node> implements NodeManager<T> {
   }
 
   @Override
-  public Optional<T> removeNode(NodeId nodeId) {
-    return Optional.ofNullable(nodeMap.remove(nodeId));
+  public synchronized Optional<T> removeNode(NodeId nodeId) {
+    T removed = nodeMap.remove(nodeId);
+    if (removed != null) {
+      generation++;
+    }
+    return Optional.ofNullable(removed);
   }
 
   @Override
@@ -108,6 +130,7 @@ public class AbstractNodeManager<T extends Node> implements NodeManager<T> {
             reference.getSourceNodeId(), nodeId -> LinkedHashMultiset.create());
 
     references.add(reference);
+    generation++;
   }
 
   @Override
@@ -119,14 +142,8 @@ public class AbstractNodeManager<T extends Node> implements NodeManager<T> {
 
   @Override
   public synchronized void removeReference(Reference reference) {
-    LinkedHashMultiset<Reference> references = referenceMap.get(reference.getSourceNodeId());
-
-    if (references != null) {
-      references.remove(reference);
-
-      if (references.isEmpty()) {
-        referenceMap.remove(reference.getSourceNodeId());
-      }
+    if (removeReferenceOccurrence(reference)) {
+      generation++;
     }
   }
 
@@ -135,6 +152,26 @@ public class AbstractNodeManager<T extends Node> implements NodeManager<T> {
     removeReference(reference);
 
     reference.invert(namespaceTable).ifPresent(this::removeReference);
+  }
+
+  /**
+   * Remove one occurrence of {@code reference} from the reference map, dropping the source Node's
+   * multiset once it becomes empty. Does not bump the generation, so callers own that decision.
+   *
+   * @param reference the {@link Reference} occurrence to remove.
+   * @return {@code true} if an occurrence was removed.
+   */
+  private boolean removeReferenceOccurrence(Reference reference) {
+    LinkedHashMultiset<Reference> references = referenceMap.get(reference.getSourceNodeId());
+    if (references == null) {
+      return false;
+    }
+
+    boolean removed = references.remove(reference);
+    if (references.isEmpty()) {
+      referenceMap.remove(reference.getSourceNodeId());
+    }
+    return removed;
   }
 
   @Override
@@ -155,5 +192,101 @@ public class AbstractNodeManager<T extends Node> implements NodeManager<T> {
     return references != null
         ? references.stream().filter(filter).toList()
         : Collections.emptyList();
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>This implementation is atomic: the batch is validated in full before anything is applied,
+   * and a failed commit leaves the maps exactly as they were before the call. Synchronizing on the
+   * instance makes the commit exclusive with the other mutation methods, which share the same
+   * monitor.
+   */
+  @Override
+  public synchronized CommitResult commit(NodeManagerBatch<T> batch)
+      throws NodeManagerBatchException {
+
+    CommitResult nothingApplied = new CommitResult(List.of(), List.of());
+
+    OptionalLong expectedGeneration = batch.getExpectedGeneration();
+    if (expectedGeneration.isPresent() && expectedGeneration.getAsLong() != generation) {
+      throw NodeManagerBatchException.staleGeneration(
+          expectedGeneration.getAsLong(), generation, nothingApplied);
+    }
+
+    for (NodeId reusedNodeId : batch.getReusedNodeIds()) {
+      if (!nodeMap.containsKey(reusedNodeId)) {
+        throw NodeManagerBatchException.reusedNodeUnknown(reusedNodeId, nothingApplied);
+      }
+    }
+
+    for (T node : batch.getNodeAdditions()) {
+      if (nodeMap.containsKey(node.getNodeId())) {
+        throw NodeManagerBatchException.nodeExists(node.getNodeId(), nothingApplied);
+      }
+    }
+
+    // Validation is complete; apply, undoing all applied additions if a mutation fails.
+    List<NodeId> addedNodes = new ArrayList<>();
+    List<Reference> addedReferences = new ArrayList<>();
+    try {
+      for (T node : batch.getNodeAdditions()) {
+        nodeMap.put(node.getNodeId(), node);
+        addedNodes.add(node.getNodeId());
+      }
+      // Logical deduplication: only References not already present get a new occurrence.
+      for (Reference reference : batch.getReferenceAdditions()) {
+        LinkedHashMultiset<Reference> references =
+            referenceMap.computeIfAbsent(
+                reference.getSourceNodeId(), nodeId -> LinkedHashMultiset.create());
+        if (!references.contains(reference)) {
+          references.add(reference);
+          addedReferences.add(reference);
+        }
+      }
+    } catch (RuntimeException e) {
+      for (Reference reference : addedReferences) {
+        removeReferenceOccurrence(reference);
+      }
+      for (NodeId nodeId : addedNodes) {
+        nodeMap.remove(nodeId);
+      }
+      throw new NodeManagerBatchException(
+          StatusCodes.Bad_InternalError,
+          "batch commit failed and was rolled back",
+          e,
+          nothingApplied);
+    }
+
+    // Only a commit that actually changed state bumps the generation; a no-op commit (empty batch,
+    // reuse-only, or References all already present) must leave outstanding handles current, like
+    // the other mutation methods.
+    if (!addedNodes.isEmpty() || !addedReferences.isEmpty()) {
+      generation++;
+    }
+
+    return new CommitResult(addedNodes, addedReferences);
+  }
+
+  @Override
+  public Generation getGeneration() {
+    long value = generation;
+
+    return new Generation() {
+      @Override
+      public long value() {
+        return value;
+      }
+
+      @Override
+      public boolean isCurrent() {
+        return value == generation;
+      }
+    };
+  }
+
+  @Override
+  public StorageGuarantee getStorageGuarantee() {
+    return StorageGuarantee.ATOMIC;
   }
 }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/AddressSpaceManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/AddressSpaceManager.java
@@ -41,6 +41,7 @@ public class AddressSpaceManager extends AddressSpaceComposite {
   public synchronized void register(NodeManager<UaNode> nodeManager) {
     if (!nodeManagers.contains(nodeManager)) {
       nodeManagers.add(nodeManager);
+      invalidateTypeModels();
     } else {
       logger.warn("NodeManager already registered: {}", nodeManager);
     }
@@ -49,14 +50,23 @@ public class AddressSpaceManager extends AddressSpaceComposite {
   /**
    * Unregister a {@link NodeManager} with this {@link AddressSpaceManager}.
    *
-   * @param nodeManager the {@link NodeManager} to register.
+   * @param nodeManager the {@link NodeManager} to unregister.
    */
   public synchronized void unregister(NodeManager<UaNode> nodeManager) {
     if (nodeManagers.contains(nodeManager)) {
       nodeManagers.remove(nodeManager);
+      invalidateTypeModels();
     } else {
       logger.warn("NodeManager not registered: {}", nodeManager);
     }
+  }
+
+  /**
+   * Conservatively invalidate all cached type instantiation models: a registration change can add
+   * or remove any node a cached model was compiled from.
+   */
+  private void invalidateTypeModels() {
+    getServer().getTypeModelCache().invalidateAll();
   }
 
   /**

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/ManagedAddressSpace.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/ManagedAddressSpace.java
@@ -74,6 +74,13 @@ public abstract class ManagedAddressSpace implements AddressSpace {
     nodeFactory = createNodeFactory();
   }
 
+  /**
+   * @deprecated the legacy {@link NodeFactory} is replaced by {@link
+   *     org.eclipse.milo.opcua.sdk.server.nodes.instantiation.NodeInstantiator}, obtained from
+   *     {@code getServer().getNodeInstantiator()} and targeted at {@link #getNodeManager()}. See
+   *     {@code docs/features/node-instantiation-migration.md}.
+   */
+  @Deprecated
   protected NodeFactory createNodeFactory() {
     return new NodeFactory(nodeContext);
   }
@@ -86,6 +93,13 @@ public abstract class ManagedAddressSpace implements AddressSpace {
     return nodeContext;
   }
 
+  /**
+   * @deprecated the legacy {@link NodeFactory} is replaced by {@link
+   *     org.eclipse.milo.opcua.sdk.server.nodes.instantiation.NodeInstantiator}, obtained from
+   *     {@code getServer().getNodeInstantiator()} and targeted at {@link #getNodeManager()}. See
+   *     {@code docs/features/node-instantiation-migration.md}.
+   */
+  @Deprecated
   public NodeFactory getNodeFactory() {
     return nodeFactory;
   }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/NodeManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/NodeManager.java
@@ -356,6 +356,11 @@ public interface NodeManager<T extends Node> {
      * Return {@code true} if the {@link NodeManager} has not been mutated since this handle was
      * acquired.
      *
+     * <p>This is an advisory, lock-free check: a mutation in progress on another thread may not be
+     * reflected yet. The authoritative staleness check is {@link
+     * NodeManagerBatch.Builder#expectGeneration(long)}, which a supporting {@link
+     * NodeManager#commit(NodeManagerBatch)} evaluates atomically with the commit itself.
+     *
      * @return {@code true} if the {@link NodeManager} has not been mutated since this handle was
      *     acquired.
      */

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/NodeManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/NodeManager.java
@@ -10,12 +10,15 @@
 
 package org.eclipse.milo.opcua.sdk.server;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.function.Predicate;
 import org.eclipse.milo.opcua.sdk.core.Reference;
 import org.eclipse.milo.opcua.sdk.core.nodes.Node;
 import org.eclipse.milo.opcua.stack.core.NamespaceTable;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.jspecify.annotations.Nullable;
@@ -186,5 +189,211 @@ public interface NodeManager<T extends Node> {
    */
   default Optional<T> removeNode(T node) {
     return removeNode(node.getNodeId());
+  }
+
+  /**
+   * Add {@code node} to this {@link NodeManager} only if no Node identified by the same {@link
+   * NodeId} is already present.
+   *
+   * <p>Unlike {@link #addNode(Node)}, this method never replaces an existing Node, making
+   * fail-on-collision semantics possible without a separate check-then-act race at the storage
+   * layer.
+   *
+   * <p>The default implementation is a sequential composition of {@link #containsNode(NodeId)} and
+   * {@link #addNode(Node)}. It is correct when this manager has a single writer, but it is not
+   * atomic: a concurrent direct write between the check and the add can be replaced.
+   * Implementations that can perform the check and add atomically should override this method and
+   * report {@link StorageGuarantee#ATOMIC} from {@link #getStorageGuarantee()}.
+   *
+   * @param node the {@link Node} to add.
+   * @return {@code true} if {@code node} was added, or {@code false} if a Node identified by the
+   *     same {@link NodeId} was already present (in which case nothing changed).
+   */
+  default boolean addNodeIfAbsent(T node) {
+    if (containsNode(node.getNodeId())) {
+      return false;
+    } else {
+      addNode(node);
+      return true;
+    }
+  }
+
+  /**
+   * Apply the Node and {@link Reference} additions in {@code batch} to this {@link NodeManager} as
+   * one unit.
+   *
+   * <p>Semantics common to all implementations:
+   *
+   * <ul>
+   *   <li>Node additions are conditional: a batch fails with {@link StatusCodes#Bad_NodeIdExists}
+   *       rather than replacing an existing Node.
+   *   <li>Reused Nodes declared via {@link NodeManagerBatch.Builder#reuseNode(NodeId)} must be
+   *       present, otherwise the batch fails with {@link StatusCodes#Bad_NodeIdUnknown}.
+   *   <li>Reference additions are <em>logically</em> deduplicated: a Reference that is already
+   *       present (by equality) is not added again and does not appear in the returned journal.
+   *       References are stored as a multiset, so duplicate-occurrence prevention must happen here
+   *       — after the fact, a cleanup pass cannot tell which duplicate occurrence it owns.
+   *   <li>If {@code batch} carries an expected generation and it does not match this manager's
+   *       current generation, the batch fails with {@link StatusCodes#Bad_InvalidState} before
+   *       anything is applied.
+   *   <li>The returned {@link CommitResult} is the exact journal of what was applied; callers roll
+   *       a committed batch back by removing exactly those additions and nothing else.
+   * </ul>
+   *
+   * <p>The default implementation applies the batch as a sequential composition of the existing
+   * methods. It is correct when this manager has a single writer, but it is <em>not atomic</em>: a
+   * failure mid-batch leaves the additions applied so far in place, reported by {@link
+   * NodeManagerBatchException#getApplied()} so callers can attempt best-effort removal.
+   * Implementations that can apply a batch all-or-nothing should override this method, guarantee
+   * that a failed commit leaves storage exactly as it was, and report {@link
+   * StorageGuarantee#ATOMIC} from {@link #getStorageGuarantee()}.
+   *
+   * @param batch the {@link NodeManagerBatch} to apply.
+   * @return a {@link CommitResult} journaling exactly what was applied.
+   * @throws NodeManagerBatchException if the batch could not be applied in full.
+   */
+  default CommitResult commit(NodeManagerBatch<T> batch) throws NodeManagerBatchException {
+    List<NodeId> addedNodes = new ArrayList<>();
+    List<Reference> addedReferences = new ArrayList<>();
+
+    OptionalLong expectedGeneration = batch.getExpectedGeneration();
+    if (expectedGeneration.isPresent()) {
+      long currentGeneration = getGeneration().value();
+      if (expectedGeneration.getAsLong() != currentGeneration) {
+        throw NodeManagerBatchException.staleGeneration(
+            expectedGeneration.getAsLong(),
+            currentGeneration,
+            new CommitResult(addedNodes, addedReferences));
+      }
+    }
+
+    for (NodeId reusedNodeId : batch.getReusedNodeIds()) {
+      if (!containsNode(reusedNodeId)) {
+        throw NodeManagerBatchException.reusedNodeUnknown(
+            reusedNodeId, new CommitResult(addedNodes, addedReferences));
+      }
+    }
+
+    for (T node : batch.getNodeAdditions()) {
+      if (addNodeIfAbsent(node)) {
+        addedNodes.add(node.getNodeId());
+      } else {
+        throw NodeManagerBatchException.nodeExists(
+            node.getNodeId(), new CommitResult(addedNodes, addedReferences));
+      }
+    }
+
+    for (Reference reference : batch.getReferenceAdditions()) {
+      if (!getReferences(reference.getSourceNodeId()).contains(reference)) {
+        addReference(reference);
+        addedReferences.add(reference);
+      }
+    }
+
+    return new CommitResult(addedNodes, addedReferences);
+  }
+
+  /**
+   * Get a {@link Generation} handle over this {@link NodeManager}'s write generation, captured at
+   * the time of the call.
+   *
+   * <p>The handle supports staleness detection: {@link Generation#isCurrent()} returns {@code
+   * false} once this manager has been mutated after the handle was acquired. Passing the handle's
+   * {@link Generation#value()} to {@link NodeManagerBatch.Builder#expectGeneration(long)} makes the
+   * staleness check part of {@link #commit(NodeManagerBatch)} itself, so a supporting manager
+   * checks and commits atomically.
+   *
+   * <p>The default implementation performs no tracking: {@code value()} is always {@code 0} and
+   * {@code isCurrent()} is always {@code true}, which is correct only when this manager has a
+   * single writer. Implementations that track mutations should override this method.
+   *
+   * @return a {@link Generation} handle captured at the time of the call.
+   */
+  default Generation getGeneration() {
+    return new Generation() {
+      @Override
+      public long value() {
+        return 0L;
+      }
+
+      @Override
+      public boolean isCurrent() {
+        return true;
+      }
+    };
+  }
+
+  /**
+   * Report the guarantee this {@link NodeManager}'s storage primitives provide.
+   *
+   * <p>The default implementations of {@link #addNodeIfAbsent(Node)}, {@link
+   * #commit(NodeManagerBatch)}, and {@link #getGeneration()} are sequential emulations that are
+   * correct only with a single writer, so the default answer is {@link
+   * StorageGuarantee#BEST_EFFORT}. Implementations overriding the primitives with atomic semantics
+   * must also override this method; callers use it to report the commit guarantee they actually
+   * achieved rather than silently assuming atomicity.
+   *
+   * @return the {@link StorageGuarantee} this manager's primitives provide.
+   */
+  default StorageGuarantee getStorageGuarantee() {
+    return StorageGuarantee.BEST_EFFORT;
+  }
+
+  /**
+   * A snapshot of a {@link NodeManager}'s write generation, used to detect that a manager was
+   * mutated between the time the snapshot was acquired and the time it is checked.
+   */
+  interface Generation {
+
+    /**
+     * Get the generation value captured when this handle was acquired.
+     *
+     * @return the generation value captured when this handle was acquired.
+     */
+    long value();
+
+    /**
+     * Return {@code true} if the {@link NodeManager} has not been mutated since this handle was
+     * acquired.
+     *
+     * @return {@code true} if the {@link NodeManager} has not been mutated since this handle was
+     *     acquired.
+     */
+    boolean isCurrent();
+  }
+
+  /** The guarantee a {@link NodeManager}'s storage primitives provide. */
+  enum StorageGuarantee {
+
+    /**
+     * The primitives are atomic: {@link #addNodeIfAbsent(Node)} is check-and-act without a race
+     * window, a failed {@link #commit(NodeManagerBatch)} leaves storage exactly as it was, and
+     * {@link #getGeneration()} tracks mutations.
+     */
+    ATOMIC,
+
+    /**
+     * The primitives are sequential emulations: correct with a single writer, unprotected against
+     * concurrent direct writes, and a failed {@link #commit(NodeManagerBatch)} may leave a partial
+     * batch applied.
+     */
+    BEST_EFFORT
+  }
+
+  /**
+   * The journal of what a {@link #commit(NodeManagerBatch)} actually applied: the {@link NodeId}s
+   * of the Nodes added and the {@link Reference}s physically added (batch References that were
+   * already logically present are excluded). Rolling back a committed batch means removing exactly
+   * these additions.
+   *
+   * @param addedNodes the {@link NodeId}s of the Nodes added by the commit.
+   * @param addedReferences the {@link Reference}s added by the commit.
+   */
+  record CommitResult(List<NodeId> addedNodes, List<Reference> addedReferences) {
+
+    public CommitResult {
+      addedNodes = List.copyOf(addedNodes);
+      addedReferences = List.copyOf(addedReferences);
+    }
   }
 }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/NodeManagerBatch.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/NodeManagerBatch.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.OptionalLong;
+import org.eclipse.milo.opcua.sdk.core.Reference;
+import org.eclipse.milo.opcua.sdk.core.nodes.Node;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * An immutable batch of Node and {@link Reference} additions to be applied to a {@link NodeManager}
+ * as one unit via {@link NodeManager#commit(NodeManagerBatch)}.
+ *
+ * <p>A batch distinguishes Nodes it <em>adds</em> from Nodes it <em>reuses</em>: added Nodes must
+ * not exist yet and become part of the commit's journal (they are what a rollback removes), while
+ * reused Nodes must already exist and are never touched — the distinction is what lets a caller
+ * that reused an existing Node roll back or delete its own additions without deleting Nodes it does
+ * not own.
+ *
+ * <p>Reference additions are deduplicated by equality at build time; {@link
+ * NodeManager#commit(NodeManagerBatch)} additionally skips References already present in the
+ * manager, so committing a batch never creates a duplicate Reference occurrence.
+ *
+ * @param <T> the type of {@link Node} the target {@link NodeManager} manages.
+ */
+public final class NodeManagerBatch<T extends Node> {
+
+  private final List<T> nodeAdditions;
+  private final List<NodeId> reusedNodeIds;
+  private final List<Reference> referenceAdditions;
+  private final @Nullable Long expectedGeneration;
+
+  private NodeManagerBatch(
+      List<T> nodeAdditions,
+      List<NodeId> reusedNodeIds,
+      List<Reference> referenceAdditions,
+      @Nullable Long expectedGeneration) {
+
+    this.nodeAdditions = nodeAdditions;
+    this.reusedNodeIds = reusedNodeIds;
+    this.referenceAdditions = referenceAdditions;
+    this.expectedGeneration = expectedGeneration;
+  }
+
+  /**
+   * Get the Nodes this batch adds, in insertion order.
+   *
+   * @return the Nodes this batch adds, in insertion order.
+   */
+  public List<T> getNodeAdditions() {
+    return nodeAdditions;
+  }
+
+  /**
+   * Get the {@link NodeId}s of existing Nodes this batch reuses, in insertion order.
+   *
+   * @return the {@link NodeId}s of existing Nodes this batch reuses, in insertion order.
+   */
+  public List<NodeId> getReusedNodeIds() {
+    return reusedNodeIds;
+  }
+
+  /**
+   * Get the {@link Reference}s this batch adds, deduplicated by equality, in insertion order.
+   *
+   * @return the {@link Reference}s this batch adds, deduplicated by equality, in insertion order.
+   */
+  public List<Reference> getReferenceAdditions() {
+    return referenceAdditions;
+  }
+
+  /**
+   * Get the {@link NodeManager} generation this batch expects at commit time, if one was set.
+   *
+   * @return the {@link NodeManager} generation this batch expects at commit time, if one was set.
+   * @see Builder#expectGeneration(long)
+   */
+  public OptionalLong getExpectedGeneration() {
+    return expectedGeneration != null ? OptionalLong.of(expectedGeneration) : OptionalLong.empty();
+  }
+
+  /**
+   * Create a new {@link Builder}.
+   *
+   * @param <T> the type of {@link Node} the target {@link NodeManager} manages.
+   * @return a new {@link Builder}.
+   */
+  public static <T extends Node> Builder<T> builder() {
+    return new Builder<>();
+  }
+
+  /**
+   * A builder of {@link NodeManagerBatch} instances.
+   *
+   * @param <T> the type of {@link Node} the target {@link NodeManager} manages.
+   */
+  public static final class Builder<T extends Node> {
+
+    private final LinkedHashMap<NodeId, T> nodeAdditions = new LinkedHashMap<>();
+    private final LinkedHashSet<NodeId> reusedNodeIds = new LinkedHashSet<>();
+    private final LinkedHashSet<Reference> referenceAdditions = new LinkedHashSet<>();
+    private @Nullable Long expectedGeneration;
+
+    private Builder() {}
+
+    /**
+     * Add {@code node} to the batch. At commit time no Node identified by the same {@link NodeId}
+     * may exist.
+     *
+     * @param node the {@link Node} to add.
+     * @return this {@link Builder}.
+     * @throws IllegalArgumentException if the batch already adds or reuses a Node identified by the
+     *     same {@link NodeId}.
+     */
+    public Builder<T> addNode(T node) {
+      NodeId nodeId = node.getNodeId();
+      if (nodeAdditions.containsKey(nodeId)) {
+        throw new IllegalArgumentException("batch already adds Node: " + nodeId);
+      }
+      if (reusedNodeIds.contains(nodeId)) {
+        throw new IllegalArgumentException("batch already reuses Node: " + nodeId);
+      }
+      nodeAdditions.put(nodeId, node);
+      return this;
+    }
+
+    /**
+     * Declare that the batch reuses the existing Node identified by {@code nodeId}. At commit time
+     * the Node must exist; it is not modified, and it is not part of the commit's journal.
+     *
+     * @param nodeId the {@link NodeId} of the existing Node.
+     * @return this {@link Builder}.
+     * @throws IllegalArgumentException if the batch already adds a Node identified by {@code
+     *     nodeId}.
+     */
+    public Builder<T> reuseNode(NodeId nodeId) {
+      if (nodeAdditions.containsKey(nodeId)) {
+        throw new IllegalArgumentException("batch already adds Node: " + nodeId);
+      }
+      reusedNodeIds.add(nodeId);
+      return this;
+    }
+
+    /**
+     * Add {@code reference} to the batch. Equal References are collapsed to a single addition.
+     *
+     * @param reference the {@link Reference} to add.
+     * @return this {@link Builder}.
+     */
+    public Builder<T> addReference(Reference reference) {
+      referenceAdditions.add(reference);
+      return this;
+    }
+
+    /**
+     * Require the target {@link NodeManager}'s generation to equal {@code generation} at commit
+     * time, failing the commit before anything is applied otherwise.
+     *
+     * <p>Capture the value from {@link NodeManager#getGeneration()} when the batch's contents are
+     * decided; the commit then detects any mutation of the manager in between.
+     *
+     * @param generation the expected generation, from {@link NodeManager.Generation#value()}.
+     * @return this {@link Builder}.
+     */
+    public Builder<T> expectGeneration(long generation) {
+      this.expectedGeneration = generation;
+      return this;
+    }
+
+    /**
+     * Build the immutable {@link NodeManagerBatch}.
+     *
+     * @return the immutable {@link NodeManagerBatch}.
+     */
+    public NodeManagerBatch<T> build() {
+      return new NodeManagerBatch<>(
+          List.copyOf(nodeAdditions.values()),
+          List.copyOf(reusedNodeIds),
+          List.copyOf(referenceAdditions),
+          expectedGeneration);
+    }
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/NodeManagerBatchException.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/NodeManagerBatchException.java
@@ -26,10 +26,12 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 public class NodeManagerBatchException extends UaException {
 
   private final CommitResult applied;
+  private final boolean staleGeneration;
 
   public NodeManagerBatchException(long statusCode, String message, CommitResult applied) {
     super(statusCode, message);
     this.applied = applied;
+    this.staleGeneration = false;
   }
 
   public NodeManagerBatchException(
@@ -37,24 +39,50 @@ public class NodeManagerBatchException extends UaException {
 
     super(statusCode, message, cause);
     this.applied = applied;
+    this.staleGeneration = false;
+  }
+
+  private NodeManagerBatchException(
+      long statusCode, String message, CommitResult applied, boolean staleGeneration) {
+
+    super(statusCode, message);
+    this.applied = applied;
+    this.staleGeneration = staleGeneration;
   }
 
   /**
    * Create an exception for a batch whose declared expected generation no longer matches the target
    * {@link NodeManager}, indicating the manager was mutated since the batch was planned.
    *
+   * <p>Public so that any {@link NodeManager#commit(NodeManagerBatch)} implementation can report
+   * staleness in the form retrying callers recognize via {@link #isStaleGeneration()}.
+   *
    * @param expected the generation the batch expected.
    * @param actual the manager's current generation.
    * @param applied the journal of additions applied before the failure.
    * @return a {@link NodeManagerBatchException} with status {@link StatusCodes#Bad_InvalidState}.
    */
-  static NodeManagerBatchException staleGeneration(
+  public static NodeManagerBatchException staleGeneration(
       long expected, long actual, CommitResult applied) {
 
     return new NodeManagerBatchException(
         StatusCodes.Bad_InvalidState,
         "expected generation %s but was %s".formatted(expected, actual),
-        applied);
+        applied,
+        true);
+  }
+
+  /**
+   * Distinguishes a generation-mismatch rejection — safely retryable after re-reading the target,
+   * because nothing was applied — from every other commit failure. A status code alone cannot make
+   * this distinction: implementations may use {@link StatusCodes#Bad_InvalidState} for unrelated
+   * failures.
+   *
+   * @return {@code true} if this failure is a generation mismatch created by {@link
+   *     #staleGeneration(long, long, CommitResult)}.
+   */
+  public boolean isStaleGeneration() {
+    return staleGeneration;
   }
 
   /**

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/NodeManagerBatchException.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/NodeManagerBatchException.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server;
+
+import org.eclipse.milo.opcua.sdk.server.NodeManager.CommitResult;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+
+/**
+ * Thrown when {@link NodeManager#commit(NodeManagerBatch)} cannot apply a batch in full.
+ *
+ * <p>{@link #getApplied()} journals the additions that were applied before the failure. A manager
+ * whose commit is atomic always reports an empty journal — a failed commit changed nothing. A
+ * manager using the sequential default emulation may report a partial journal; callers can attempt
+ * best-effort removal of exactly those additions.
+ */
+public class NodeManagerBatchException extends UaException {
+
+  private final CommitResult applied;
+
+  public NodeManagerBatchException(long statusCode, String message, CommitResult applied) {
+    super(statusCode, message);
+    this.applied = applied;
+  }
+
+  public NodeManagerBatchException(
+      long statusCode, String message, Throwable cause, CommitResult applied) {
+
+    super(statusCode, message, cause);
+    this.applied = applied;
+  }
+
+  /**
+   * Create an exception for a batch whose declared expected generation no longer matches the target
+   * {@link NodeManager}, indicating the manager was mutated since the batch was planned.
+   *
+   * @param expected the generation the batch expected.
+   * @param actual the manager's current generation.
+   * @param applied the journal of additions applied before the failure.
+   * @return a {@link NodeManagerBatchException} with status {@link StatusCodes#Bad_InvalidState}.
+   */
+  static NodeManagerBatchException staleGeneration(
+      long expected, long actual, CommitResult applied) {
+
+    return new NodeManagerBatchException(
+        StatusCodes.Bad_InvalidState,
+        "expected generation %s but was %s".formatted(expected, actual),
+        applied);
+  }
+
+  /**
+   * Create an exception for a batch that reuses a Node not present in the target {@link
+   * NodeManager}.
+   *
+   * @param nodeId the {@link NodeId} of the missing reused Node.
+   * @param applied the journal of additions applied before the failure.
+   * @return a {@link NodeManagerBatchException} with status {@link StatusCodes#Bad_NodeIdUnknown}.
+   */
+  static NodeManagerBatchException reusedNodeUnknown(NodeId nodeId, CommitResult applied) {
+    return new NodeManagerBatchException(
+        StatusCodes.Bad_NodeIdUnknown, "reused Node not present: " + nodeId, applied);
+  }
+
+  /**
+   * Create an exception for a batch that would add a Node already present in the target {@link
+   * NodeManager}.
+   *
+   * @param nodeId the {@link NodeId} of the colliding Node.
+   * @param applied the journal of additions applied before the failure.
+   * @return a {@link NodeManagerBatchException} with status {@link StatusCodes#Bad_NodeIdExists}.
+   */
+  static NodeManagerBatchException nodeExists(NodeId nodeId, CommitResult applied) {
+    return new NodeManagerBatchException(
+        StatusCodes.Bad_NodeIdExists, "Node already exists: " + nodeId, applied);
+  }
+
+  /**
+   * Get the journal of additions that were applied before the commit failed.
+   *
+   * @return the journal of additions that were applied before the commit failed; empty if the
+   *     failed commit changed nothing.
+   */
+  public CommitResult getApplied() {
+    return applied;
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/ObjectTypeManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/ObjectTypeManager.java
@@ -76,24 +76,18 @@ public class ObjectTypeManager {
       LegacyObjectNodeConstructor objectNodeConstructor) {
 
     ObjectNodeConstructor adapted =
-        new ObjectNodeConstructor() {
-          @Override
-          public UaObjectNode apply(
-              UaNodeContext context,
-              NodeId nodeId,
-              QualifiedName browseName,
-              LocalizedText displayName,
-              LocalizedText description,
-              UInteger writeMask,
-              UInteger userWriteMask,
-              RolePermissionType[] rolePermissions,
-              RolePermissionType[] userRolePermissions,
-              AccessRestrictionType accessRestrictions) {
-
-            return objectNodeConstructor.apply(
+        (context,
+            nodeId,
+            browseName,
+            displayName,
+            description,
+            writeMask,
+            userWriteMask,
+            rolePermissions,
+            userRolePermissions,
+            accessRestrictions) ->
+            objectNodeConstructor.apply(
                 context, nodeId, browseName, displayName, description, writeMask, userWriteMask);
-          }
-        };
 
     typeDefinitions.compute(
         typeDefinition,
@@ -128,21 +122,10 @@ public class ObjectTypeManager {
         .map(d -> new RegisteredObjectType(d.nodeClass, d.nodeConstructor, d.snapshotConstructor));
   }
 
-  private static class ObjectTypeDefinition {
-    final Class<? extends UaObjectNode> nodeClass;
-    final @Nullable ObjectNodeConstructor nodeConstructor;
-    final @Nullable SnapshotConstructor snapshotConstructor;
-
-    private ObjectTypeDefinition(
-        Class<? extends UaObjectNode> nodeClass,
-        @Nullable ObjectNodeConstructor nodeConstructor,
-        @Nullable SnapshotConstructor snapshotConstructor) {
-
-      this.nodeClass = nodeClass;
-      this.nodeConstructor = nodeConstructor;
-      this.snapshotConstructor = snapshotConstructor;
-    }
-  }
+  private record ObjectTypeDefinition(
+      Class<? extends UaObjectNode> nodeClass,
+      @Nullable ObjectNodeConstructor nodeConstructor,
+      @Nullable SnapshotConstructor snapshotConstructor) {}
 
   /**
    * An ObjectType registration: the Java class instances are constructed as, plus the constructor
@@ -189,6 +172,11 @@ public class ObjectTypeManager {
   /**
    * Constructs a {@link UaObjectNode} from the planned {@link AttributeSnapshot} instead of a fixed
    * attribute tuple, so newly modeled attributes propagate without signature changes.
+   *
+   * <p>The constructor owns attribute application: the instantiation engine applies nothing after a
+   * snapshot constructor returns, so any planned attribute the constructor does not read from
+   * {@code attributes} and set on the node is dropped. (Tuple-signature registrations, by contrast,
+   * receive an engine overlay of the attributes their signature cannot carry.)
    */
   @FunctionalInterface
   public interface SnapshotConstructor {

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/ObjectTypeManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/ObjectTypeManager.java
@@ -34,8 +34,11 @@ public class ObjectTypeManager {
       Class<? extends UaObjectNode> nodeClass,
       ObjectNodeConstructor objectNodeConstructor) {
 
-    typeDefinitions.put(
-        typeDefinition, new ObjectTypeDefinition(nodeClass, objectNodeConstructor, null));
+    typeDefinitions.compute(
+        typeDefinition,
+        (id, prev) ->
+            new ObjectTypeDefinition(
+                nodeClass, objectNodeConstructor, prev != null ? prev.snapshotConstructor : null));
   }
 
   /**
@@ -47,6 +50,10 @@ public class ObjectTypeManager {
    * node-instantiation engine; the legacy {@code NodeFactory} lookup path ({@link
    * #getNodeConstructor(NodeId)}) does not see them and falls back to its default construction.
    *
+   * <p>Each overload replaces only its own constructor form: registering a snapshot constructor for
+   * a type that already has a tuple registration (or vice versa) keeps the other form intact, so
+   * neither lookup path silently loses its typed construction.
+   *
    * @param typeDefinition the {@link NodeId} of the ObjectType.
    * @param nodeClass the Java class instances of the type are constructed as.
    * @param snapshotConstructor the snapshot-consuming constructor.
@@ -56,8 +63,11 @@ public class ObjectTypeManager {
       Class<? extends UaObjectNode> nodeClass,
       SnapshotConstructor snapshotConstructor) {
 
-    typeDefinitions.put(
-        typeDefinition, new ObjectTypeDefinition(nodeClass, null, snapshotConstructor));
+    typeDefinitions.compute(
+        typeDefinition,
+        (id, prev) ->
+            new ObjectTypeDefinition(
+                nodeClass, prev != null ? prev.nodeConstructor : null, snapshotConstructor));
   }
 
   public void registerObjectType(
@@ -85,7 +95,11 @@ public class ObjectTypeManager {
           }
         };
 
-    typeDefinitions.put(typeDefinition, new ObjectTypeDefinition(nodeClass, adapted, null));
+    typeDefinitions.compute(
+        typeDefinition,
+        (id, prev) ->
+            new ObjectTypeDefinition(
+                nodeClass, adapted, prev != null ? prev.snapshotConstructor : null));
   }
 
   public Optional<ObjectNodeConstructor> getNodeConstructor(NodeId typeDefinition) {
@@ -100,8 +114,9 @@ public class ObjectTypeManager {
    *
    * <p>This is the node-instantiation engine's lookup: exposing the {@link Class} enables plan-time
    * expected-class checks and nearest-registered-ancestor fallback along the {@code HasSubtype}
-   * chain. Exactly one of {@link RegisteredObjectType#nodeConstructor()} and {@link
-   * RegisteredObjectType#snapshotConstructor()} is non-null.
+   * chain. At least one of {@link RegisteredObjectType#nodeConstructor()} and {@link
+   * RegisteredObjectType#snapshotConstructor()} is non-null; both are when the type was registered
+   * through both overload forms.
    *
    * @param typeDefinition the {@link NodeId} of the ObjectType.
    * @return the registration, if one exists.
@@ -130,8 +145,8 @@ public class ObjectTypeManager {
   }
 
   /**
-   * An ObjectType registration: the Java class instances are constructed as, plus whichever
-   * constructor form the registration supplied (exactly one is non-null).
+   * An ObjectType registration: the Java class instances are constructed as, plus the constructor
+   * form(s) the registrations supplied (at least one is non-null).
    *
    * @param nodeClass the registered Java class.
    * @param nodeConstructor the tuple-signature constructor, if registered with one.

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/ObjectTypeManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/ObjectTypeManager.java
@@ -13,15 +13,16 @@ package org.eclipse.milo.opcua.sdk.server;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaNodeContext;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.instantiation.AttributeSnapshot;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.structured.AccessRestrictionType;
 import org.eclipse.milo.opcua.stack.core.types.structured.RolePermissionType;
+import org.jspecify.annotations.Nullable;
 
 public class ObjectTypeManager {
 
@@ -33,7 +34,30 @@ public class ObjectTypeManager {
       Class<? extends UaObjectNode> nodeClass,
       ObjectNodeConstructor objectNodeConstructor) {
 
-    typeDefinitions.put(typeDefinition, new ObjectTypeDefinition(nodeClass, objectNodeConstructor));
+    typeDefinitions.put(
+        typeDefinition, new ObjectTypeDefinition(nodeClass, objectNodeConstructor, null));
+  }
+
+  /**
+   * Register {@code nodeClass} and a snapshot-consuming constructor for {@code typeDefinition}.
+   *
+   * <p>Unlike the tuple-signature forms, a {@link SnapshotConstructor} receives the full planned
+   * {@link AttributeSnapshot}, so attributes added to the model in future versions propagate
+   * without constructor signature changes. Registrations made through this overload are used by the
+   * node-instantiation engine; the legacy {@code NodeFactory} lookup path ({@link
+   * #getNodeConstructor(NodeId)}) does not see them and falls back to its default construction.
+   *
+   * @param typeDefinition the {@link NodeId} of the ObjectType.
+   * @param nodeClass the Java class instances of the type are constructed as.
+   * @param snapshotConstructor the snapshot-consuming constructor.
+   */
+  public void registerObjectType(
+      NodeId typeDefinition,
+      Class<? extends UaObjectNode> nodeClass,
+      SnapshotConstructor snapshotConstructor) {
+
+    typeDefinitions.put(
+        typeDefinition, new ObjectTypeDefinition(nodeClass, null, snapshotConstructor));
   }
 
   public void registerObjectType(
@@ -61,7 +85,7 @@ public class ObjectTypeManager {
           }
         };
 
-    typeDefinitions.put(typeDefinition, new ObjectTypeDefinition(nodeClass, adapted));
+    typeDefinitions.put(typeDefinition, new ObjectTypeDefinition(nodeClass, adapted, null));
   }
 
   public Optional<ObjectNodeConstructor> getNodeConstructor(NodeId typeDefinition) {
@@ -70,17 +94,53 @@ public class ObjectTypeManager {
     return Optional.ofNullable(def).map(d -> d.nodeConstructor);
   }
 
+  /**
+   * Get the full registration for {@code typeDefinition}, if one exists: the registered Java class
+   * plus whichever constructor form the registration supplied.
+   *
+   * <p>This is the node-instantiation engine's lookup: exposing the {@link Class} enables plan-time
+   * expected-class checks and nearest-registered-ancestor fallback along the {@code HasSubtype}
+   * chain. Exactly one of {@link RegisteredObjectType#nodeConstructor()} and {@link
+   * RegisteredObjectType#snapshotConstructor()} is non-null.
+   *
+   * @param typeDefinition the {@link NodeId} of the ObjectType.
+   * @return the registration, if one exists.
+   */
+  public Optional<RegisteredObjectType> getRegisteredType(NodeId typeDefinition) {
+    ObjectTypeDefinition def = typeDefinitions.get(typeDefinition);
+
+    return Optional.ofNullable(def)
+        .map(d -> new RegisteredObjectType(d.nodeClass, d.nodeConstructor, d.snapshotConstructor));
+  }
+
   private static class ObjectTypeDefinition {
-    final Class<? extends UaNode> nodeClass;
-    final ObjectNodeConstructor nodeConstructor;
+    final Class<? extends UaObjectNode> nodeClass;
+    final @Nullable ObjectNodeConstructor nodeConstructor;
+    final @Nullable SnapshotConstructor snapshotConstructor;
 
     private ObjectTypeDefinition(
-        Class<? extends UaNode> nodeClass, ObjectNodeConstructor nodeConstructor) {
+        Class<? extends UaObjectNode> nodeClass,
+        @Nullable ObjectNodeConstructor nodeConstructor,
+        @Nullable SnapshotConstructor snapshotConstructor) {
 
       this.nodeClass = nodeClass;
       this.nodeConstructor = nodeConstructor;
+      this.snapshotConstructor = snapshotConstructor;
     }
   }
+
+  /**
+   * An ObjectType registration: the Java class instances are constructed as, plus whichever
+   * constructor form the registration supplied (exactly one is non-null).
+   *
+   * @param nodeClass the registered Java class.
+   * @param nodeConstructor the tuple-signature constructor, if registered with one.
+   * @param snapshotConstructor the snapshot-consuming constructor, if registered with one.
+   */
+  public record RegisteredObjectType(
+      Class<? extends UaObjectNode> nodeClass,
+      @Nullable ObjectNodeConstructor nodeConstructor,
+      @Nullable SnapshotConstructor snapshotConstructor) {}
 
   @FunctionalInterface
   public interface ObjectNodeConstructor {
@@ -109,5 +169,24 @@ public class ObjectTypeManager {
         LocalizedText description,
         UInteger writeMask,
         UInteger userWriteMask);
+  }
+
+  /**
+   * Constructs a {@link UaObjectNode} from the planned {@link AttributeSnapshot} instead of a fixed
+   * attribute tuple, so newly modeled attributes propagate without signature changes.
+   */
+  @FunctionalInterface
+  public interface SnapshotConstructor {
+
+    /**
+     * Construct an instance node.
+     *
+     * @param context the {@link UaNodeContext} the node is constructed with.
+     * @param nodeId the instance {@link NodeId}.
+     * @param attributes the effective attributes planned for the instance, absent/null/value
+     *     distinction preserved.
+     * @return the constructed node.
+     */
+    UaObjectNode apply(UaNodeContext context, NodeId nodeId, AttributeSnapshot attributes);
   }
 }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServer.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServer.java
@@ -43,6 +43,7 @@ import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
 import org.eclipse.milo.opcua.sdk.server.namespaces.OpcUaNamespace;
 import org.eclipse.milo.opcua.sdk.server.namespaces.ServerNamespace;
 import org.eclipse.milo.opcua.sdk.server.nodes.factories.EventFactory;
+import org.eclipse.milo.opcua.sdk.server.nodes.instantiation.TypeModelCache;
 import org.eclipse.milo.opcua.sdk.server.reverse.ReverseConnectTarget;
 import org.eclipse.milo.opcua.sdk.server.reverse.ReverseConnectTargetHandle;
 import org.eclipse.milo.opcua.sdk.server.reverse.ReverseConnectTargetListener;
@@ -138,6 +139,8 @@ public class OpcUaServer extends AbstractServiceHandler {
 
   private final ObjectTypeManager objectTypeManager = new ObjectTypeManager();
   private final VariableTypeManager variableTypeManager = new VariableTypeManager();
+
+  private final TypeModelCache typeModelCache = new TypeModelCache(this);
 
   private final Lazy<DataTypeTree> dataTypeTree = new Lazy<>();
   private final Lazy<ObjectTypeTree> objectTypeTree = new Lazy<>();
@@ -583,6 +586,17 @@ public class OpcUaServer extends AbstractServiceHandler {
 
   public VariableTypeManager getVariableTypeManager() {
     return variableTypeManager;
+  }
+
+  /**
+   * Get the Server's {@link TypeModelCache}, holding compiled {@link
+   * org.eclipse.milo.opcua.sdk.server.nodes.instantiation.TypeInstantiationModel}s of this Server's
+   * TypeDefinitions.
+   *
+   * @return the Server's {@link TypeModelCache}.
+   */
+  public TypeModelCache getTypeModelCache() {
+    return typeModelCache;
   }
 
   /**

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServer.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServer.java
@@ -43,6 +43,7 @@ import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
 import org.eclipse.milo.opcua.sdk.server.namespaces.OpcUaNamespace;
 import org.eclipse.milo.opcua.sdk.server.namespaces.ServerNamespace;
 import org.eclipse.milo.opcua.sdk.server.nodes.factories.EventFactory;
+import org.eclipse.milo.opcua.sdk.server.nodes.instantiation.EventInstantiator;
 import org.eclipse.milo.opcua.sdk.server.nodes.instantiation.NodeInstantiator;
 import org.eclipse.milo.opcua.sdk.server.nodes.instantiation.TypeModelCache;
 import org.eclipse.milo.opcua.sdk.server.reverse.ReverseConnectTarget;
@@ -189,6 +190,7 @@ public class OpcUaServer extends AbstractServiceHandler {
 
   private final EventBus eventBus = new EventBus("server");
   private final EventFactory eventFactory = new EventFactory(this);
+  private final EventInstantiator eventInstantiator = new EventInstantiator(this);
   private final EventNotifier eventNotifier = new ServerEventNotifier();
 
   private final EncodingContext staticEncodingContext;
@@ -346,6 +348,7 @@ public class OpcUaServer extends AbstractServiceHandler {
 
   public CompletableFuture<OpcUaServer> startup() {
     eventFactory.startup();
+    eventInstantiator.startup();
 
     getResolvedEndpoints().stream()
         .sorted(Comparator.comparing(e -> e.endpointConfig().getTransportProfile()))
@@ -465,6 +468,7 @@ public class OpcUaServer extends AbstractServiceHandler {
     serverNamespace.shutdown();
     opcUaNamespace.shutdown();
 
+    eventInstantiator.shutdown();
     eventFactory.shutdown();
 
     subscriptions.values().forEach(Subscription::deleteSubscription);
@@ -473,6 +477,7 @@ public class OpcUaServer extends AbstractServiceHandler {
   private void rollbackStartup() {
     reverseConnectTargetManager.shutdown();
     unbindTransports();
+    eventInstantiator.shutdown();
     eventFactory.shutdown();
   }
 
@@ -568,9 +573,22 @@ public class OpcUaServer extends AbstractServiceHandler {
    * Get the shared {@link EventFactory}.
    *
    * @return the shared {@link EventFactory}.
+   * @deprecated use {@link #getEventInstantiator()}, which validates the expected Java class at
+   *     plan time instead of casting after creation. See {@code
+   *     docs/features/node-instantiation-migration.md}.
    */
+  @Deprecated
   public EventFactory getEventFactory() {
     return eventFactory;
+  }
+
+  /**
+   * Get the shared {@link EventInstantiator}, used to create transient Event instances.
+   *
+   * @return the shared {@link EventInstantiator}.
+   */
+  public EventInstantiator getEventInstantiator() {
+    return eventInstantiator;
   }
 
   /**

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServer.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServer.java
@@ -43,6 +43,7 @@ import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
 import org.eclipse.milo.opcua.sdk.server.namespaces.OpcUaNamespace;
 import org.eclipse.milo.opcua.sdk.server.namespaces.ServerNamespace;
 import org.eclipse.milo.opcua.sdk.server.nodes.factories.EventFactory;
+import org.eclipse.milo.opcua.sdk.server.nodes.instantiation.NodeInstantiator;
 import org.eclipse.milo.opcua.sdk.server.nodes.instantiation.TypeModelCache;
 import org.eclipse.milo.opcua.sdk.server.reverse.ReverseConnectTarget;
 import org.eclipse.milo.opcua.sdk.server.reverse.ReverseConnectTargetHandle;
@@ -141,6 +142,7 @@ public class OpcUaServer extends AbstractServiceHandler {
   private final VariableTypeManager variableTypeManager = new VariableTypeManager();
 
   private final TypeModelCache typeModelCache = new TypeModelCache(this);
+  private final NodeInstantiator nodeInstantiator = new NodeInstantiator(this);
 
   private final Lazy<DataTypeTree> dataTypeTree = new Lazy<>();
   private final Lazy<ObjectTypeTree> objectTypeTree = new Lazy<>();
@@ -597,6 +599,16 @@ public class OpcUaServer extends AbstractServiceHandler {
    */
   public TypeModelCache getTypeModelCache() {
     return typeModelCache;
+  }
+
+  /**
+   * Get the Server's {@link NodeInstantiator}, the facade for describing, planning, and applying
+   * TypeDefinition instantiations.
+   *
+   * @return the Server's {@link NodeInstantiator}.
+   */
+  public NodeInstantiator getNodeInstantiator() {
+    return nodeInstantiator;
   }
 
   /**

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/VariableTypeManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/VariableTypeManager.java
@@ -35,8 +35,13 @@ public class VariableTypeManager {
       Class<? extends UaVariableNode> nodeClass,
       VariableNodeConstructor variableNodeConstructor) {
 
-    typeDefinitions.put(
-        typeDefinition, new VariableTypeDefinition(nodeClass, variableNodeConstructor, null));
+    typeDefinitions.compute(
+        typeDefinition,
+        (id, prev) ->
+            new VariableTypeDefinition(
+                nodeClass,
+                variableNodeConstructor,
+                prev != null ? prev.snapshotConstructor : null));
   }
 
   /**
@@ -48,6 +53,10 @@ public class VariableTypeManager {
    * node-instantiation engine; the legacy {@code NodeFactory} lookup path ({@link
    * #getNodeConstructor(NodeId)}) does not see them and falls back to its default construction.
    *
+   * <p>Each overload replaces only its own constructor form: registering a snapshot constructor for
+   * a type that already has a tuple registration (or vice versa) keeps the other form intact, so
+   * neither lookup path silently loses its typed construction.
+   *
    * @param typeDefinition the {@link NodeId} of the VariableType.
    * @param nodeClass the Java class instances of the type are constructed as.
    * @param snapshotConstructor the snapshot-consuming constructor.
@@ -57,8 +66,11 @@ public class VariableTypeManager {
       Class<? extends UaVariableNode> nodeClass,
       SnapshotConstructor snapshotConstructor) {
 
-    typeDefinitions.put(
-        typeDefinition, new VariableTypeDefinition(nodeClass, null, snapshotConstructor));
+    typeDefinitions.compute(
+        typeDefinition,
+        (id, prev) ->
+            new VariableTypeDefinition(
+                nodeClass, prev != null ? prev.nodeConstructor : null, snapshotConstructor));
   }
 
   public void registerVariableType(
@@ -90,7 +102,11 @@ public class VariableTypeManager {
           }
         };
 
-    typeDefinitions.put(typeDefinition, new VariableTypeDefinition(nodeClass, adapted, null));
+    typeDefinitions.compute(
+        typeDefinition,
+        (id, prev) ->
+            new VariableTypeDefinition(
+                nodeClass, adapted, prev != null ? prev.snapshotConstructor : null));
   }
 
   public Optional<VariableNodeConstructor> getNodeConstructor(NodeId typeDefinition) {
@@ -105,8 +121,9 @@ public class VariableTypeManager {
    *
    * <p>This is the node-instantiation engine's lookup: exposing the {@link Class} enables plan-time
    * expected-class checks and nearest-registered-ancestor fallback along the {@code HasSubtype}
-   * chain. Exactly one of {@link RegisteredVariableType#nodeConstructor()} and {@link
-   * RegisteredVariableType#snapshotConstructor()} is non-null.
+   * chain. At least one of {@link RegisteredVariableType#nodeConstructor()} and {@link
+   * RegisteredVariableType#snapshotConstructor()} is non-null; both are when the type was
+   * registered through both overload forms.
    *
    * @param typeDefinition the {@link NodeId} of the VariableType.
    * @return the registration, if one exists.
@@ -136,8 +153,8 @@ public class VariableTypeManager {
   }
 
   /**
-   * A VariableType registration: the Java class instances are constructed as, plus whichever
-   * constructor form the registration supplied (exactly one is non-null).
+   * A VariableType registration: the Java class instances are constructed as, plus the constructor
+   * form(s) the registrations supplied (at least one is non-null).
    *
    * @param nodeClass the registered Java class.
    * @param nodeConstructor the tuple-signature constructor, if registered with one.

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/VariableTypeManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/VariableTypeManager.java
@@ -79,28 +79,22 @@ public class VariableTypeManager {
       LegacyVariableNodeConstructor variableNodeConstructor) {
 
     VariableNodeConstructor adapted =
-        new VariableNodeConstructor() {
-          @Override
-          public UaVariableNode apply(
-              UaNodeContext context,
-              NodeId nodeId,
-              QualifiedName browseName,
-              LocalizedText displayName,
-              LocalizedText description,
-              UInteger writeMask,
-              UInteger userWriteMask,
-              RolePermissionType[] rolePermissions,
-              RolePermissionType[] userRolePermissions,
-              AccessRestrictionType accessRestrictions,
-              DataValue value,
-              NodeId dataType,
-              Integer valueRank,
-              UInteger[] arrayDimensions) {
-
-            return variableNodeConstructor.apply(
+        (context,
+            nodeId,
+            browseName,
+            displayName,
+            description,
+            writeMask,
+            userWriteMask,
+            rolePermissions,
+            userRolePermissions,
+            accessRestrictions,
+            value,
+            dataType,
+            valueRank,
+            arrayDimensions) ->
+            variableNodeConstructor.apply(
                 context, nodeId, browseName, displayName, description, writeMask, userWriteMask);
-          }
-        };
 
     typeDefinitions.compute(
         typeDefinition,
@@ -136,21 +130,10 @@ public class VariableTypeManager {
             d -> new RegisteredVariableType(d.nodeClass, d.nodeConstructor, d.snapshotConstructor));
   }
 
-  private static class VariableTypeDefinition {
-    final Class<? extends UaVariableNode> nodeClass;
-    final @Nullable VariableNodeConstructor nodeConstructor;
-    final @Nullable SnapshotConstructor snapshotConstructor;
-
-    private VariableTypeDefinition(
-        Class<? extends UaVariableNode> nodeClass,
-        @Nullable VariableNodeConstructor nodeConstructor,
-        @Nullable SnapshotConstructor snapshotConstructor) {
-
-      this.nodeClass = nodeClass;
-      this.nodeConstructor = nodeConstructor;
-      this.snapshotConstructor = snapshotConstructor;
-    }
-  }
+  private record VariableTypeDefinition(
+      Class<? extends UaVariableNode> nodeClass,
+      @Nullable VariableNodeConstructor nodeConstructor,
+      @Nullable SnapshotConstructor snapshotConstructor) {}
 
   /**
    * A VariableType registration: the Java class instances are constructed as, plus the constructor
@@ -201,6 +184,14 @@ public class VariableTypeManager {
   /**
    * Constructs a {@link UaVariableNode} from the planned {@link AttributeSnapshot} instead of a
    * fixed attribute tuple, so newly modeled attributes propagate without signature changes.
+   *
+   * <p>The constructor owns attribute application with one exception: the instantiation engine
+   * applies nothing after a snapshot constructor returns — any planned attribute the constructor
+   * does not read from {@code attributes} and set on the node is dropped — except Value, which the
+   * engine always overwrites with the declaration's value re-stamped at apply time (or the
+   * Bad_NoValue convention when unset). A constructor-computed initial Value does not survive.
+   * (Tuple-signature registrations, by contrast, receive an engine overlay of the attributes their
+   * signature cannot carry.)
    */
   @FunctionalInterface
   public interface SnapshotConstructor {

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/VariableTypeManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/VariableTypeManager.java
@@ -15,6 +15,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaNodeContext;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.instantiation.AttributeSnapshot;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
@@ -22,6 +23,7 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.structured.AccessRestrictionType;
 import org.eclipse.milo.opcua.stack.core.types.structured.RolePermissionType;
+import org.jspecify.annotations.Nullable;
 
 public class VariableTypeManager {
 
@@ -34,7 +36,29 @@ public class VariableTypeManager {
       VariableNodeConstructor variableNodeConstructor) {
 
     typeDefinitions.put(
-        typeDefinition, new VariableTypeDefinition(nodeClass, variableNodeConstructor));
+        typeDefinition, new VariableTypeDefinition(nodeClass, variableNodeConstructor, null));
+  }
+
+  /**
+   * Register {@code nodeClass} and a snapshot-consuming constructor for {@code typeDefinition}.
+   *
+   * <p>Unlike the tuple-signature forms, a {@link SnapshotConstructor} receives the full planned
+   * {@link AttributeSnapshot}, so attributes added to the model in future versions propagate
+   * without constructor signature changes. Registrations made through this overload are used by the
+   * node-instantiation engine; the legacy {@code NodeFactory} lookup path ({@link
+   * #getNodeConstructor(NodeId)}) does not see them and falls back to its default construction.
+   *
+   * @param typeDefinition the {@link NodeId} of the VariableType.
+   * @param nodeClass the Java class instances of the type are constructed as.
+   * @param snapshotConstructor the snapshot-consuming constructor.
+   */
+  public void registerVariableType(
+      NodeId typeDefinition,
+      Class<? extends UaVariableNode> nodeClass,
+      SnapshotConstructor snapshotConstructor) {
+
+    typeDefinitions.put(
+        typeDefinition, new VariableTypeDefinition(nodeClass, null, snapshotConstructor));
   }
 
   public void registerVariableType(
@@ -66,7 +90,7 @@ public class VariableTypeManager {
           }
         };
 
-    typeDefinitions.put(typeDefinition, new VariableTypeDefinition(nodeClass, adapted));
+    typeDefinitions.put(typeDefinition, new VariableTypeDefinition(nodeClass, adapted, null));
   }
 
   public Optional<VariableNodeConstructor> getNodeConstructor(NodeId typeDefinition) {
@@ -75,17 +99,54 @@ public class VariableTypeManager {
     return Optional.ofNullable(def).map(d -> d.nodeConstructor);
   }
 
+  /**
+   * Get the full registration for {@code typeDefinition}, if one exists: the registered Java class
+   * plus whichever constructor form the registration supplied.
+   *
+   * <p>This is the node-instantiation engine's lookup: exposing the {@link Class} enables plan-time
+   * expected-class checks and nearest-registered-ancestor fallback along the {@code HasSubtype}
+   * chain. Exactly one of {@link RegisteredVariableType#nodeConstructor()} and {@link
+   * RegisteredVariableType#snapshotConstructor()} is non-null.
+   *
+   * @param typeDefinition the {@link NodeId} of the VariableType.
+   * @return the registration, if one exists.
+   */
+  public Optional<RegisteredVariableType> getRegisteredType(NodeId typeDefinition) {
+    VariableTypeDefinition def = typeDefinitions.get(typeDefinition);
+
+    return Optional.ofNullable(def)
+        .map(
+            d -> new RegisteredVariableType(d.nodeClass, d.nodeConstructor, d.snapshotConstructor));
+  }
+
   private static class VariableTypeDefinition {
     final Class<? extends UaVariableNode> nodeClass;
-    final VariableNodeConstructor nodeConstructor;
+    final @Nullable VariableNodeConstructor nodeConstructor;
+    final @Nullable SnapshotConstructor snapshotConstructor;
 
     private VariableTypeDefinition(
-        Class<? extends UaVariableNode> nodeClass, VariableNodeConstructor nodeConstructor) {
+        Class<? extends UaVariableNode> nodeClass,
+        @Nullable VariableNodeConstructor nodeConstructor,
+        @Nullable SnapshotConstructor snapshotConstructor) {
 
       this.nodeClass = nodeClass;
       this.nodeConstructor = nodeConstructor;
+      this.snapshotConstructor = snapshotConstructor;
     }
   }
+
+  /**
+   * A VariableType registration: the Java class instances are constructed as, plus whichever
+   * constructor form the registration supplied (exactly one is non-null).
+   *
+   * @param nodeClass the registered Java class.
+   * @param nodeConstructor the tuple-signature constructor, if registered with one.
+   * @param snapshotConstructor the snapshot-consuming constructor, if registered with one.
+   */
+  public record RegisteredVariableType(
+      Class<? extends UaVariableNode> nodeClass,
+      @Nullable VariableNodeConstructor nodeConstructor,
+      @Nullable SnapshotConstructor snapshotConstructor) {}
 
   @FunctionalInterface
   public interface VariableNodeConstructor {
@@ -118,5 +179,24 @@ public class VariableTypeManager {
         LocalizedText description,
         UInteger writeMask,
         UInteger userWriteMask);
+  }
+
+  /**
+   * Constructs a {@link UaVariableNode} from the planned {@link AttributeSnapshot} instead of a
+   * fixed attribute tuple, so newly modeled attributes propagate without signature changes.
+   */
+  @FunctionalInterface
+  public interface SnapshotConstructor {
+
+    /**
+     * Construct an instance node.
+     *
+     * @param context the {@link UaNodeContext} the node is constructed with.
+     * @param nodeId the instance {@link NodeId}.
+     * @param attributes the effective attributes planned for the instance, absent/null/value
+     *     distinction preserved.
+     * @return the constructed node.
+     */
+    UaVariableNode apply(UaNodeContext context, NodeId nodeId, AttributeSnapshot attributes);
   }
 }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/objects/SessionsDiagnosticsSummaryObject.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/objects/SessionsDiagnosticsSummaryObject.java
@@ -13,7 +13,6 @@ package org.eclipse.milo.opcua.sdk.server.diagnostics.objects;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import org.eclipse.milo.opcua.sdk.core.Reference;
 import org.eclipse.milo.opcua.sdk.server.AbstractLifecycle;
 import org.eclipse.milo.opcua.sdk.server.NodeManager;
 import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
@@ -26,15 +25,13 @@ import org.eclipse.milo.opcua.sdk.server.model.objects.SessionsDiagnosticsSummar
 import org.eclipse.milo.opcua.sdk.server.model.variables.SessionSecurityDiagnosticsArrayTypeNode;
 import org.eclipse.milo.opcua.sdk.server.model.variables.SessionSecurityDiagnosticsTypeNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
-import org.eclipse.milo.opcua.sdk.server.nodes.UaNodeContext;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableNode;
-import org.eclipse.milo.opcua.sdk.server.nodes.factories.NodeFactory;
+import org.eclipse.milo.opcua.sdk.server.nodes.instantiation.InstantiationRequest;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
-import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,7 +58,6 @@ public class SessionsDiagnosticsSummaryObject extends AbstractLifecycle {
   private SessionListener sessionListener;
 
   private final OpcUaServer server;
-  private final NodeFactory nodeFactory;
   private final NodeManager<UaNode> diagnosticsNodeManager;
 
   private final SessionsDiagnosticsSummaryTypeNode node;
@@ -73,20 +69,6 @@ public class SessionsDiagnosticsSummaryObject extends AbstractLifecycle {
     this.diagnosticsNodeManager = diagnosticsNodeManager;
 
     this.server = node.getNodeContext().getServer();
-
-    this.nodeFactory =
-        new NodeFactory(
-            new UaNodeContext() {
-              @Override
-              public OpcUaServer getServer() {
-                return server;
-              }
-
-              @Override
-              public NodeManager<UaNode> getNodeManager() {
-                return diagnosticsNodeManager;
-              }
-            });
   }
 
   @Override
@@ -134,22 +116,20 @@ public class SessionsDiagnosticsSummaryObject extends AbstractLifecycle {
       String sessionName = session.getSessionName();
       QualifiedName browseName = new QualifiedName(1, sessionNameBrowseName(sessionName));
 
-      SessionDiagnosticsObjectTypeNode sdoNode =
-          (SessionDiagnosticsObjectTypeNode)
-              nodeFactory.createNode(
-                  new NodeId(1, UUID.randomUUID()),
-                  NodeIds.SessionDiagnosticsObjectType,
-                  securityDiagnosticsAccessControl(node));
-      sdoNode.setBrowseName(browseName);
-      sdoNode.setDisplayName(LocalizedText.english(sessionName));
+      InstantiationRequest<SessionDiagnosticsObjectTypeNode> request =
+          InstantiationRequest.of(
+                  SessionDiagnosticsObjectTypeNode.class, NodeIds.SessionDiagnosticsObjectType)
+              .nodeId(new NodeId(1, UUID.randomUUID()))
+              .browseName(browseName)
+              .displayName(LocalizedText.english(sessionName))
+              .parent(node.getNodeId(), NodeIds.HasComponent)
+              .target(diagnosticsNodeManager)
+              .legacyPathStrings()
+              .onNode(securityDiagnosticsAccessControl(node))
+              .build();
 
-      sdoNode.addReference(
-          new Reference(
-              sdoNode.getNodeId(),
-              NodeIds.HasComponent,
-              node.getNodeId().expanded(),
-              Reference.Direction.INVERSE));
-      diagnosticsNodeManager.addNode(sdoNode);
+      SessionDiagnosticsObjectTypeNode sdoNode =
+          server.getNodeInstantiator().instantiate(request).root();
 
       SessionDiagnosticsObject sdo =
           new SessionDiagnosticsObject(sdoNode, session, diagnosticsNodeManager);
@@ -162,31 +142,28 @@ public class SessionsDiagnosticsSummaryObject extends AbstractLifecycle {
   }
 
   /**
-   * Creates a callback that applies the standard security diagnostics array's access policy only to
-   * the security diagnostics subtree of a dynamically instantiated Session diagnostics Object.
+   * Creates a hook that applies the standard security diagnostics array's access policy only to the
+   * security diagnostics subtree of a dynamically instantiated Session diagnostics Object, while
+   * the nodes are still staged — before anything is published.
    *
    * @param summaryNode the standard summary node containing the security diagnostics array.
-   * @return a callback that applies security attributes to security diagnostics Variables.
+   * @return a hook that applies security attributes to security diagnostics Variables.
    */
-  static NodeFactory.InstantiationCallback securityDiagnosticsAccessControl(
+  static InstantiationRequest.OnNode securityDiagnosticsAccessControl(
       SessionsDiagnosticsSummaryTypeNode summaryNode) {
 
-    return new NodeFactory.InstantiationCallback() {
-      @Override
-      public void onVariableAdded(
-          @Nullable UaNode parent, UaVariableNode instance, NodeId typeDefinitionId) {
+    return (declaration, node, parent, graph) -> {
+      if (node instanceof UaVariableNode instance
+          && (instance instanceof SessionSecurityDiagnosticsTypeNode
+              || parent instanceof SessionSecurityDiagnosticsTypeNode)) {
 
-        if (instance instanceof SessionSecurityDiagnosticsTypeNode
-            || parent instanceof SessionSecurityDiagnosticsTypeNode) {
+        // Ordinary SessionDiagnostics intentionally retain their separate standard permissions.
+        SessionSecurityDiagnosticsArrayTypeNode securityArray =
+            summaryNode.getSessionSecurityDiagnosticsArrayNode();
 
-          // Ordinary SessionDiagnostics intentionally retain their separate standard permissions.
-          SessionSecurityDiagnosticsArrayTypeNode securityArray =
-              summaryNode.getSessionSecurityDiagnosticsArrayNode();
-
-          instance.setRolePermissions(securityArray.getRolePermissions());
-          instance.setUserRolePermissions(securityArray.getUserRolePermissions());
-          instance.setAccessRestrictions(securityArray.getAccessRestrictions());
-        }
+        instance.setRolePermissions(securityArray.getRolePermissions());
+        instance.setUserRolePermissions(securityArray.getUserRolePermissions());
+        instance.setAccessRestrictions(securityArray.getAccessRestrictions());
       }
     };
   }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/SessionDiagnosticsVariableArray.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/SessionDiagnosticsVariableArray.java
@@ -18,7 +18,6 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.eclipse.milo.opcua.sdk.core.AccessLevel;
-import org.eclipse.milo.opcua.sdk.core.Reference;
 import org.eclipse.milo.opcua.sdk.core.ValueRank;
 import org.eclipse.milo.opcua.sdk.server.AbstractLifecycle;
 import org.eclipse.milo.opcua.sdk.server.Lifecycle;
@@ -31,8 +30,7 @@ import org.eclipse.milo.opcua.sdk.server.model.variables.SessionDiagnosticsArray
 import org.eclipse.milo.opcua.sdk.server.model.variables.SessionDiagnosticsVariableTypeNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.AttributeObserver;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
-import org.eclipse.milo.opcua.sdk.server.nodes.UaNodeContext;
-import org.eclipse.milo.opcua.sdk.server.nodes.factories.NodeFactory;
+import org.eclipse.milo.opcua.sdk.server.nodes.instantiation.InstantiationRequest;
 import org.eclipse.milo.opcua.stack.core.AttributeId;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
 import org.eclipse.milo.opcua.stack.core.UaException;
@@ -59,7 +57,6 @@ public class SessionDiagnosticsVariableArray extends AbstractLifecycle {
   private SessionListener sessionListener;
 
   private final OpcUaServer server;
-  private final NodeFactory nodeFactory;
 
   private final SessionDiagnosticsArrayTypeNode node;
   private final NodeManager<UaNode> diagnosticsNodeManager;
@@ -71,20 +68,6 @@ public class SessionDiagnosticsVariableArray extends AbstractLifecycle {
     this.diagnosticsNodeManager = diagnosticsNodeManager;
 
     this.server = node.getNodeContext().getServer();
-
-    this.nodeFactory =
-        new NodeFactory(
-            new UaNodeContext() {
-              @Override
-              public OpcUaServer getServer() {
-                return server;
-              }
-
-              @Override
-              public NodeManager<UaNode> getNodeManager() {
-                return diagnosticsNodeManager;
-              }
-            });
   }
 
   @Override
@@ -182,26 +165,25 @@ public class SessionDiagnosticsVariableArray extends AbstractLifecycle {
       String id = Util.buildBrowseNamePath(node) + "[" + index + "]";
       NodeId elementNodeId = new NodeId(1, id);
 
+      InstantiationRequest<SessionDiagnosticsVariableTypeNode> request =
+          InstantiationRequest.of(
+                  SessionDiagnosticsVariableTypeNode.class, NodeIds.SessionDiagnosticsVariableType)
+              .nodeId(elementNodeId)
+              .browseName(new QualifiedName(1, "SessionDiagnostics"))
+              .displayName(new LocalizedText(node.getDisplayName().locale(), "SessionDiagnostics"))
+              .rootAttribute(AttributeId.ArrayDimensions, null)
+              .rootAttribute(AttributeId.ValueRank, ValueRank.Scalar.getValue())
+              .rootAttribute(AttributeId.DataType, NodeIds.SessionDiagnosticsDataType)
+              .rootAttribute(AttributeId.AccessLevel, AccessLevel.toValue(AccessLevel.READ_ONLY))
+              .rootAttribute(
+                  AttributeId.UserAccessLevel, AccessLevel.toValue(AccessLevel.READ_ONLY))
+              .parent(node.getNodeId(), NodeIds.HasComponent)
+              .target(diagnosticsNodeManager)
+              .legacyPathStrings()
+              .build();
+
       SessionDiagnosticsVariableTypeNode elementNode =
-          (SessionDiagnosticsVariableTypeNode)
-              nodeFactory.createNode(elementNodeId, NodeIds.SessionDiagnosticsVariableType);
-
-      elementNode.setBrowseName(new QualifiedName(1, "SessionDiagnostics"));
-      elementNode.setDisplayName(
-          new LocalizedText(node.getDisplayName().locale(), "SessionDiagnostics"));
-      elementNode.setArrayDimensions(null);
-      elementNode.setValueRank(ValueRank.Scalar.getValue());
-      elementNode.setDataType(NodeIds.SessionDiagnosticsDataType);
-      elementNode.setAccessLevel(AccessLevel.toValue(AccessLevel.READ_ONLY));
-      elementNode.setUserAccessLevel(AccessLevel.toValue(AccessLevel.READ_ONLY));
-
-      elementNode.addReference(
-          new Reference(
-              elementNode.getNodeId(),
-              NodeIds.HasComponent,
-              node.getNodeId().expanded(),
-              Reference.Direction.INVERSE));
-      diagnosticsNodeManager.addNode(elementNode);
+          server.getNodeInstantiator().instantiate(request).root();
 
       SessionDiagnosticsVariable sessionDiagnosticsVariable =
           new SessionDiagnosticsVariable(elementNode, session);

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/SessionSecurityDiagnosticsVariableArray.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/SessionSecurityDiagnosticsVariableArray.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.eclipse.milo.opcua.sdk.core.AccessLevel;
-import org.eclipse.milo.opcua.sdk.core.Reference;
 import org.eclipse.milo.opcua.sdk.core.ValueRank;
 import org.eclipse.milo.opcua.sdk.server.AbstractLifecycle;
 import org.eclipse.milo.opcua.sdk.server.Lifecycle;
@@ -34,10 +33,9 @@ import org.eclipse.milo.opcua.sdk.server.model.variables.SessionSecurityDiagnost
 import org.eclipse.milo.opcua.sdk.server.model.variables.SessionSecurityDiagnosticsTypeNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.AttributeObserver;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
-import org.eclipse.milo.opcua.sdk.server.nodes.UaNodeContext;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableNode;
-import org.eclipse.milo.opcua.sdk.server.nodes.factories.NodeFactory;
 import org.eclipse.milo.opcua.sdk.server.nodes.filters.AttributeFilter;
+import org.eclipse.milo.opcua.sdk.server.nodes.instantiation.InstantiationRequest;
 import org.eclipse.milo.opcua.stack.core.AttributeId;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
 import org.eclipse.milo.opcua.stack.core.UaException;
@@ -48,7 +46,6 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.structured.SessionSecurityDiagnosticsDataType;
-import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -74,7 +71,6 @@ public class SessionSecurityDiagnosticsVariableArray extends AbstractLifecycle {
   private AttributeFilter enabledFlagAccessFilter;
 
   private final OpcUaServer server;
-  private final NodeFactory nodeFactory;
 
   private final SessionSecurityDiagnosticsArrayTypeNode node;
   private final NodeManager<UaNode> diagnosticsNodeManager;
@@ -86,20 +82,6 @@ public class SessionSecurityDiagnosticsVariableArray extends AbstractLifecycle {
     this.diagnosticsNodeManager = diagnosticsNodeManager;
 
     this.server = node.getNodeContext().getServer();
-
-    this.nodeFactory =
-        new NodeFactory(
-            new UaNodeContext() {
-              @Override
-              public OpcUaServer getServer() {
-                return server;
-              }
-
-              @Override
-              public NodeManager<UaNode> getNodeManager() {
-                return diagnosticsNodeManager;
-              }
-            });
   }
 
   @Override
@@ -214,29 +196,27 @@ public class SessionSecurityDiagnosticsVariableArray extends AbstractLifecycle {
       String id = Util.buildBrowseNamePath(node) + "[" + index + "]";
       NodeId elementNodeId = new NodeId(1, id);
 
+      InstantiationRequest<SessionSecurityDiagnosticsTypeNode> request =
+          InstantiationRequest.of(
+                  SessionSecurityDiagnosticsTypeNode.class, NodeIds.SessionSecurityDiagnosticsType)
+              .nodeId(elementNodeId)
+              .browseName(new QualifiedName(1, "SessionSecurityDiagnostics"))
+              .displayName(
+                  new LocalizedText(node.getDisplayName().locale(), "SessionSecurityDiagnostics"))
+              .rootAttribute(AttributeId.ArrayDimensions, null)
+              .rootAttribute(AttributeId.ValueRank, ValueRank.Scalar.getValue())
+              .rootAttribute(AttributeId.DataType, NodeIds.SessionSecurityDiagnosticsDataType)
+              .rootAttribute(AttributeId.AccessLevel, AccessLevel.toValue(AccessLevel.READ_ONLY))
+              .rootAttribute(
+                  AttributeId.UserAccessLevel, AccessLevel.toValue(AccessLevel.READ_ONLY))
+              .parent(node.getNodeId(), NodeIds.HasComponent)
+              .target(diagnosticsNodeManager)
+              .legacyPathStrings()
+              .onNode(securityAccessControl(node))
+              .build();
+
       SessionSecurityDiagnosticsTypeNode elementNode =
-          (SessionSecurityDiagnosticsTypeNode)
-              nodeFactory.createNode(
-                  elementNodeId,
-                  NodeIds.SessionSecurityDiagnosticsType,
-                  securityAccessControl(node));
-
-      elementNode.setBrowseName(new QualifiedName(1, "SessionSecurityDiagnostics"));
-      elementNode.setDisplayName(
-          new LocalizedText(node.getDisplayName().locale(), "SessionSecurityDiagnostics"));
-      elementNode.setArrayDimensions(null);
-      elementNode.setValueRank(ValueRank.Scalar.getValue());
-      elementNode.setDataType(NodeIds.SessionSecurityDiagnosticsDataType);
-      elementNode.setAccessLevel(AccessLevel.toValue(AccessLevel.READ_ONLY));
-      elementNode.setUserAccessLevel(AccessLevel.toValue(AccessLevel.READ_ONLY));
-
-      elementNode.addReference(
-          new Reference(
-              elementNode.getNodeId(),
-              NodeIds.HasComponent,
-              node.getNodeId().expanded(),
-              Reference.Direction.INVERSE));
-      diagnosticsNodeManager.addNode(elementNode);
+          server.getNodeInstantiator().instantiate(request).root();
 
       SessionSecurityDiagnosticsVariable sessionSecurityDiagnosticsVariable =
           new SessionSecurityDiagnosticsVariable(elementNode, session);
@@ -252,23 +232,21 @@ public class SessionSecurityDiagnosticsVariableArray extends AbstractLifecycle {
   }
 
   /**
-   * Creates a callback that copies the standard array instance's security attributes to dynamically
-   * instantiated element Variables and their fields.
+   * Creates a hook that copies the standard array instance's security attributes to dynamically
+   * instantiated element Variables and their fields, while the nodes are still staged — before
+   * anything is published.
    *
    * <p>The type definition describes the element shape, but the runtime nodes must carry the array
    * instance's authorization and secure-channel requirements.
    *
    * @param arrayNode the standard array node that supplies the security attributes.
-   * @return a callback that applies those attributes to instantiated Variables.
+   * @return a hook that applies those attributes to instantiated Variables.
    */
-  static NodeFactory.InstantiationCallback securityAccessControl(
+  static InstantiationRequest.OnNode securityAccessControl(
       SessionSecurityDiagnosticsArrayTypeNode arrayNode) {
 
-    return new NodeFactory.InstantiationCallback() {
-      @Override
-      public void onVariableAdded(
-          @Nullable UaNode parent, UaVariableNode instance, NodeId typeDefinitionId) {
-
+    return (declaration, node, parent, graph) -> {
+      if (node instanceof UaVariableNode instance) {
         instance.setRolePermissions(arrayNode.getRolePermissions());
         instance.setUserRolePermissions(arrayNode.getUserRolePermissions());
         instance.setAccessRestrictions(arrayNode.getAccessRestrictions());

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/SubscriptionDiagnosticsVariableArray.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/SubscriptionDiagnosticsVariableArray.java
@@ -19,7 +19,6 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.eclipse.milo.opcua.sdk.core.AccessLevel;
-import org.eclipse.milo.opcua.sdk.core.Reference;
 import org.eclipse.milo.opcua.sdk.core.ValueRank;
 import org.eclipse.milo.opcua.sdk.server.AbstractLifecycle;
 import org.eclipse.milo.opcua.sdk.server.NodeManager;
@@ -29,8 +28,7 @@ import org.eclipse.milo.opcua.sdk.server.model.variables.SubscriptionDiagnostics
 import org.eclipse.milo.opcua.sdk.server.model.variables.SubscriptionDiagnosticsTypeNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.AttributeObserver;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
-import org.eclipse.milo.opcua.sdk.server.nodes.UaNodeContext;
-import org.eclipse.milo.opcua.sdk.server.nodes.factories.NodeFactory;
+import org.eclipse.milo.opcua.sdk.server.nodes.instantiation.InstantiationRequest;
 import org.eclipse.milo.opcua.sdk.server.subscriptions.Subscription;
 import org.eclipse.milo.opcua.sdk.server.subscriptions.SubscriptionCreatedEvent;
 import org.eclipse.milo.opcua.sdk.server.subscriptions.SubscriptionDeletedEvent;
@@ -60,7 +58,6 @@ public abstract class SubscriptionDiagnosticsVariableArray extends AbstractLifec
       Collections.synchronizedList(new ArrayList<>());
 
   private final OpcUaServer server;
-  private final NodeFactory nodeFactory;
   private final NodeManager<UaNode> diagnosticsNodeManager;
 
   private final SubscriptionDiagnosticsArrayTypeNode node;
@@ -72,20 +69,6 @@ public abstract class SubscriptionDiagnosticsVariableArray extends AbstractLifec
     this.diagnosticsNodeManager = diagnosticsNodeManager;
 
     this.server = node.getNodeContext().getServer();
-
-    this.nodeFactory =
-        new NodeFactory(
-            new UaNodeContext() {
-              @Override
-              public OpcUaServer getServer() {
-                return server;
-              }
-
-              @Override
-              public NodeManager<UaNode> getNodeManager() {
-                return diagnosticsNodeManager;
-              }
-            });
   }
 
   protected abstract List<Subscription> getSubscriptions();
@@ -189,26 +172,27 @@ public abstract class SubscriptionDiagnosticsVariableArray extends AbstractLifec
       String id = Util.buildBrowseNamePath(node) + "[" + index + "]";
       NodeId elementNodeId = new NodeId(1, id);
 
+      InstantiationRequest<SubscriptionDiagnosticsTypeNode> request =
+          InstantiationRequest.of(
+                  SubscriptionDiagnosticsTypeNode.class, NodeIds.SubscriptionDiagnosticsType)
+              .nodeId(elementNodeId)
+              .browseName(new QualifiedName(1, subscription.getId().toString()))
+              .displayName(
+                  new LocalizedText(
+                      node.getDisplayName().locale(), subscription.getId().toString()))
+              .rootAttribute(AttributeId.ArrayDimensions, null)
+              .rootAttribute(AttributeId.ValueRank, ValueRank.Scalar.getValue())
+              .rootAttribute(AttributeId.DataType, NodeIds.SubscriptionDiagnosticsDataType)
+              .rootAttribute(AttributeId.AccessLevel, AccessLevel.toValue(AccessLevel.READ_ONLY))
+              .rootAttribute(
+                  AttributeId.UserAccessLevel, AccessLevel.toValue(AccessLevel.READ_ONLY))
+              .parent(node.getNodeId(), NodeIds.HasComponent)
+              .target(diagnosticsNodeManager)
+              .legacyPathStrings()
+              .build();
+
       SubscriptionDiagnosticsTypeNode elementNode =
-          (SubscriptionDiagnosticsTypeNode)
-              nodeFactory.createNode(elementNodeId, NodeIds.SubscriptionDiagnosticsType);
-
-      elementNode.setBrowseName(new QualifiedName(1, subscription.getId().toString()));
-      elementNode.setDisplayName(
-          new LocalizedText(node.getDisplayName().locale(), subscription.getId().toString()));
-      elementNode.setArrayDimensions(null);
-      elementNode.setValueRank(ValueRank.Scalar.getValue());
-      elementNode.setDataType(NodeIds.SubscriptionDiagnosticsDataType);
-      elementNode.setAccessLevel(AccessLevel.toValue(AccessLevel.READ_ONLY));
-      elementNode.setUserAccessLevel(AccessLevel.toValue(AccessLevel.READ_ONLY));
-
-      elementNode.addReference(
-          new Reference(
-              elementNode.getNodeId(),
-              NodeIds.HasComponent,
-              node.getNodeId().expanded(),
-              Reference.Direction.INVERSE));
-      diagnosticsNodeManager.addNode(elementNode);
+          server.getNodeInstantiator().instantiate(request).root();
 
       SubscriptionDiagnosticsVariable diagnosticsVariable =
           new SubscriptionDiagnosticsVariable(elementNode, subscription);

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/items/MonitoredEventItem.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/items/MonitoredEventItem.java
@@ -188,7 +188,7 @@ public class MonitoredEventItem extends BaseMonitoredItem<Variant[]> implements 
 
       overflowEvent =
           server
-              .getEventFactory()
+              .getEventInstantiator()
               .createEvent(new NodeId(1, eventId), NodeIds.EventQueueOverflowEventType);
 
       overflowEvent.setBrowseName(new QualifiedName(1, "EventQueueOverflow"));

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/namespaces/OpcUaNamespace.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/namespaces/OpcUaNamespace.java
@@ -352,7 +352,7 @@ public class OpcUaNamespace extends ManagedNamespaceWithLifecycle {
         if (subscription != null) {
           BaseEventTypeNode refreshStart =
               server
-                  .getEventFactory()
+                  .getEventInstantiator()
                   .createEvent(new NodeId(1, UUID.randomUUID()), NodeIds.RefreshStartEventType);
 
           refreshStart.setBrowseName(new QualifiedName(1, "RefreshStart"));
@@ -368,7 +368,7 @@ public class OpcUaNamespace extends ManagedNamespaceWithLifecycle {
 
           BaseEventTypeNode refreshEnd =
               server
-                  .getEventFactory()
+                  .getEventInstantiator()
                   .createEvent(new NodeId(1, UUID.randomUUID()), NodeIds.RefreshEndEventType);
 
           refreshEnd.setBrowseName(new QualifiedName(1, "RefreshEnd"));

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/factories/EventFactory.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/factories/EventFactory.java
@@ -25,6 +25,20 @@ import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
 
+/**
+ * Legacy Event instance factory, retained with frozen behavior for compatibility.
+ *
+ * <p>Known limitation, kept as-is rather than fixed: {@link #createEvent} casts the created node to
+ * {@link BaseEventTypeNode}, so creating an event of a custom type whose Java class is not
+ * registered throws {@link ClassCastException} after the event's nodes were already stored, leaving
+ * them behind in the private node manager.
+ *
+ * @deprecated use {@link org.eclipse.milo.opcua.sdk.server.nodes.instantiation.EventInstantiator}
+ *     (obtained from {@code OpcUaServer.getEventInstantiator()}), which validates the expected Java
+ *     class at plan time instead of casting after creation. See {@code
+ *     docs/features/node-instantiation-migration.md}.
+ */
+@Deprecated
 public class EventFactory extends AbstractLifecycle {
 
   private final NodeManager<UaNode> nodeManager = new UaNodeManager();

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/factories/InstanceDeclarationHierarchy.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/factories/InstanceDeclarationHierarchy.java
@@ -22,6 +22,19 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
 
+/**
+ * Legacy instance-declaration hierarchy, retained with frozen behavior for compatibility. It
+ * filters members to the Mandatory and Optional modelling rules, does not recurse into member
+ * types, and caches globally per JVM.
+ *
+ * @deprecated use {@link
+ *     org.eclipse.milo.opcua.sdk.server.nodes.instantiation.TypeInstantiationModel} compiled by
+ *     {@link org.eclipse.milo.opcua.sdk.server.nodes.instantiation.TypeModelCompiler} (cached
+ *     per-server via {@code OpcUaServer.getTypeModelCache()}), which is fully inherited at every
+ *     depth and classifies every modelling rule. See {@code
+ *     docs/features/node-instantiation-migration.md}.
+ */
+@Deprecated
 public class InstanceDeclarationHierarchy {
 
   private final NodeId typeId;

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/factories/NodeFactory.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/factories/NodeFactory.java
@@ -41,6 +41,37 @@ import org.eclipse.milo.opcua.stack.core.util.Tree;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Legacy type-instantiation factory, retained with frozen behavior for compatibility.
+ *
+ * <p>Known limitations, kept as-is rather than fixed (each is a documented behavior of this
+ * implementation; the replacement corrects all of them):
+ *
+ * <ul>
+ *   <li>Excluding an optional member still creates and stores its mandatory descendants,
+ *       unreachable from the instance root.
+ *   <li>A member typed as a subtype of its declaring type is instantiated without the
+ *       supertype-declared mandatory members of that subtype.
+ *   <li>When a type declares a child with the same BrowseName as an on-declaration override, the
+ *       type's entry wins and the override's attributes are discarded.
+ *   <li>Optional Methods are created unconditionally; {@link
+ *       InstantiationCallback#includeOptionalNode} is never consulted for them.
+ *   <li>Instantiating over an existing NodeId silently replaces the node and leaves the previous
+ *       node's reference rows in place.
+ *   <li>Attribute propagation from declarations is incomplete: MinimumSamplingInterval,
+ *       Historizing, AccessLevelEx, RolePermissions, UserRolePermissions, and AccessRestrictions
+ *       are not copied.
+ *   <li>The instance-declaration-hierarchy cache is JVM-global, so servers with colliding type
+ *       NodeIds can observe each other's cached hierarchies.
+ * </ul>
+ *
+ * @deprecated use {@link org.eclipse.milo.opcua.sdk.server.nodes.instantiation.NodeInstantiator}
+ *     (obtained from {@code OpcUaServer.getNodeInstantiator()}) and {@link
+ *     org.eclipse.milo.opcua.sdk.server.nodes.instantiation.InstantiationRequest}. See {@code
+ *     docs/features/node-instantiation-migration.md} for a mapping of every legacy pattern to the
+ *     new API.
+ */
+@Deprecated
 public class NodeFactory {
 
   private static final Cache<NodeId, InstanceDeclarationHierarchy> IDH_CACHE =
@@ -113,13 +144,18 @@ public class NodeFactory {
     return createNode(rootNodeId, localTypeDefinitionId, instantiationCallback);
   }
 
+  /**
+   * @deprecated use {@link org.eclipse.milo.opcua.sdk.server.nodes.instantiation.NodeInstantiator}
+   *     and inspect the returned {@code InstantiationResult} instead of a node tree.
+   */
+  @Deprecated
   public Tree<UaNode> createNodeTree(
       NodeId rootNodeId, NodeId typeDefinitionId, InstantiationCallback instantiationCallback)
       throws UaException {
 
     AddressSpaceManager addressSpaceManager = context.getServer().getAddressSpaceManager();
 
-    if (!addressSpaceManager.getManagedNode(typeDefinitionId).isPresent()) {
+    if (addressSpaceManager.getManagedNode(typeDefinitionId).isEmpty()) {
       throw new UaException(
           StatusCodes.Bad_NodeIdUnknown, "unknown type definition: " + typeDefinitionId);
     }
@@ -397,6 +433,14 @@ public class NodeFactory {
         .orElse(ExpandedNodeId.NULL_VALUE);
   }
 
+  /**
+   * @deprecated the replacement API configures optional-member selection declaratively on {@code
+   *     InstantiationRequest} (include/exclude paths, {@code includeAllOptionals}, or a selection
+   *     predicate) and replaces the added-node callbacks with {@code onNode} and {@code bindMethod}
+   *     hooks that run against the staged graph before publication. See {@code
+   *     docs/features/node-instantiation-migration.md}.
+   */
+  @Deprecated
   public interface InstantiationCallback {
 
     /**

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/AttributeSnapshot.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/AttributeSnapshot.java
@@ -1,0 +1,382 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
+
+import java.lang.reflect.Array;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaMethodNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableTypeNode;
+import org.eclipse.milo.opcua.stack.core.AttributeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * An immutable snapshot of a node's attributes, covering the full OPC UA 1.04+ attribute set and
+ * preserving the absent / explicit-null / value distinction.
+ *
+ * <p>Each attribute is in exactly one of three states:
+ *
+ * <ul>
+ *   <li><b>absent</b> — the attribute is not provided by the node (an optional attribute the node
+ *       does not carry): {@link #contains} is {@code false};
+ *   <li><b>explicit null</b> — the attribute is provided with a null value: {@link #contains} is
+ *       {@code true}, {@link #isNull} is {@code true};
+ *   <li><b>value</b> — the attribute is provided with a non-null value.
+ * </ul>
+ *
+ * <p>Snapshots taken from {@link UaNode}s ({@link #of(UaNode)}) map a node's optional-per-spec
+ * attributes that are unset ({@code null} fields — e.g. ArrayDimensions, AccessLevelEx,
+ * RolePermissions, a VariableType's Value) to <b>absent</b>; a Variable's Value — a mandatory
+ * attribute — is always present, explicit null if the node stores none. Variable and VariableType
+ * Value snapshots are normalized to carry no server timestamp: {@code UaVariableNode} re-stamps
+ * serverTime on every read, so a snapshot retaining it would never be stable across compilations
+ * (the source-side constituents — Variant, StatusCode, sourceTime — are preserved verbatim).
+ *
+ * <p>Mutable attribute values — arrays (e.g. ArrayDimensions, RolePermissions) and array-valued
+ * {@link DataValue}s — are defensively copied on ingress and egress, so neither later mutation of
+ * the node-owned value nor mutation of a value read from this snapshot can change the snapshot.
+ */
+public final class AttributeSnapshot {
+
+  private static final Object EXPLICIT_NULL = new Object();
+
+  private final Map<AttributeId, Object> values;
+
+  private AttributeSnapshot(EnumMap<AttributeId, Object> values) {
+    this.values = Collections.unmodifiableMap(values);
+  }
+
+  /**
+   * Take a snapshot of {@code node}'s attributes.
+   *
+   * @param node the node to snapshot.
+   * @return an {@link AttributeSnapshot} of the attributes applicable to the node's NodeClass.
+   */
+  public static AttributeSnapshot of(UaNode node) {
+    Builder b = builder();
+
+    copy(b, node, AttributeId.NodeClass);
+    copy(b, node, AttributeId.BrowseName);
+    copy(b, node, AttributeId.DisplayName);
+    copyIfProvided(b, node, AttributeId.Description);
+    copyIfProvided(b, node, AttributeId.WriteMask);
+    copyIfProvided(b, node, AttributeId.UserWriteMask);
+    copyIfProvided(b, node, AttributeId.RolePermissions);
+    copyIfProvided(b, node, AttributeId.UserRolePermissions);
+    copyIfProvided(b, node, AttributeId.AccessRestrictions);
+
+    if (node instanceof UaVariableNode) {
+      b.put(AttributeId.Value, normalizeValue((DataValue) node.getAttribute(AttributeId.Value)));
+      copy(b, node, AttributeId.DataType);
+      copy(b, node, AttributeId.ValueRank);
+      copyIfProvided(b, node, AttributeId.ArrayDimensions);
+      copyIfProvided(b, node, AttributeId.AccessLevel);
+      copyIfProvided(b, node, AttributeId.UserAccessLevel);
+      copyIfProvided(b, node, AttributeId.MinimumSamplingInterval);
+      copyIfProvided(b, node, AttributeId.Historizing);
+      copyIfProvided(b, node, AttributeId.AccessLevelEx);
+    } else if (node instanceof UaVariableTypeNode) {
+      Object value = node.getAttribute(AttributeId.Value);
+      if (value != null) {
+        b.put(AttributeId.Value, normalizeValue((DataValue) value));
+      }
+      copy(b, node, AttributeId.DataType);
+      copy(b, node, AttributeId.ValueRank);
+      copyIfProvided(b, node, AttributeId.ArrayDimensions);
+      copy(b, node, AttributeId.IsAbstract);
+    } else if (node instanceof UaObjectNode) {
+      copyIfProvided(b, node, AttributeId.EventNotifier);
+    } else if (node instanceof UaObjectTypeNode) {
+      copy(b, node, AttributeId.IsAbstract);
+    } else if (node instanceof UaMethodNode) {
+      copyIfProvided(b, node, AttributeId.Executable);
+      copyIfProvided(b, node, AttributeId.UserExecutable);
+    }
+
+    return b.build();
+  }
+
+  /** Record {@code node}'s {@code id} attribute as present (explicit-null if the node has none). */
+  private static void copy(Builder b, UaNode node, AttributeId id) {
+    b.put(id, node.getAttribute(id));
+  }
+
+  /** Record {@code node}'s {@code id} attribute if the node provides one; leave it absent else. */
+  private static void copyIfProvided(Builder b, UaNode node, AttributeId id) {
+    b.putIfProvided(id, node.getAttribute(id));
+  }
+
+  private static @Nullable DataValue normalizeValue(@Nullable DataValue value) {
+    if (value == null) {
+      return null;
+    }
+    if (value.getServerTime() == null && value.getServerPicoseconds() == null) {
+      return value;
+    }
+    return value.copy(
+        b -> {
+          b.setServerTime(null);
+          b.setServerPicoseconds(null);
+        });
+  }
+
+  /**
+   * @return a new {@link Builder}.
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * @return the ids of every attribute present in this snapshot (with a value or explicit null).
+   */
+  public Set<AttributeId> attributeIds() {
+    return values.keySet();
+  }
+
+  /**
+   * @param attributeId the attribute to check.
+   * @return {@code true} if the attribute is present (with a value or explicit null).
+   */
+  public boolean contains(AttributeId attributeId) {
+    return values.containsKey(attributeId);
+  }
+
+  /**
+   * @param attributeId the attribute to check.
+   * @return {@code true} if the attribute is present with an explicit null value.
+   */
+  public boolean isNull(AttributeId attributeId) {
+    return values.get(attributeId) == EXPLICIT_NULL;
+  }
+
+  /**
+   * @param attributeId the attribute to read.
+   * @return the attribute value; {@code null} if the attribute is absent <em>or</em> explicitly
+   *     null (use {@link #contains} / {@link #isNull} to distinguish).
+   */
+  public @Nullable Object getOrNull(AttributeId attributeId) {
+    Object v = values.get(attributeId);
+    return v == null || v == EXPLICIT_NULL ? null : defensiveCopy(v);
+  }
+
+  /**
+   * @param attributeId the attribute to read.
+   * @return the attribute value; empty if the attribute is absent or explicitly null.
+   */
+  public Optional<Object> get(AttributeId attributeId) {
+    return Optional.ofNullable(getOrNull(attributeId));
+  }
+
+  /**
+   * @return the DataType attribute value, or {@code null} if absent or null.
+   */
+  public @Nullable NodeId dataType() {
+    return (NodeId) getOrNull(AttributeId.DataType);
+  }
+
+  /**
+   * @return the ValueRank attribute value, or {@code null} if absent or null.
+   */
+  public @Nullable Integer valueRank() {
+    return (Integer) getOrNull(AttributeId.ValueRank);
+  }
+
+  /**
+   * @return the ArrayDimensions attribute value, or {@code null} if absent or null.
+   */
+  public UInteger @Nullable [] arrayDimensions() {
+    return (UInteger[]) getOrNull(AttributeId.ArrayDimensions);
+  }
+
+  /**
+   * @return the Value attribute value, or {@code null} if absent or null.
+   */
+  public @Nullable DataValue value() {
+    return (DataValue) getOrNull(AttributeId.Value);
+  }
+
+  /**
+   * @return a deterministic content key — attribute ids in enum order paired with a canonical
+   *     (array-aware) string of each value — used to fingerprint a compiled model. Full value
+   *     content is rendered rather than a lossy Java hash so distinct values never collide
+   *     deterministically.
+   */
+  String contentHash() {
+    StringBuilder sb = new StringBuilder();
+    for (Map.Entry<AttributeId, Object> entry : values.entrySet()) {
+      Object v = entry.getValue() == EXPLICIT_NULL ? null : entry.getValue();
+      sb.append(entry.getKey().name()).append('=').append(canonicalString(v)).append(';');
+    }
+    return sb.toString();
+  }
+
+  /**
+   * A canonical, content-complete string of an attribute value. Arrays render element-wise
+   * (identity-based {@code Object.toString} never leaks in: {@link DataValue} and {@link Variant}
+   * are decomposed so contained arrays also render element-wise).
+   */
+  private static String canonicalString(@Nullable Object value) {
+    if (value == null) {
+      return "null";
+    }
+    if (value instanceof Object[] array) {
+      return Arrays.deepToString(array);
+    }
+    if (value.getClass().isArray()) {
+      int length = Array.getLength(value);
+      StringBuilder sb = new StringBuilder("[");
+      for (int i = 0; i < length; i++) {
+        if (i > 0) {
+          sb.append(", ");
+        }
+        sb.append(Array.get(value, i));
+      }
+      return sb.append(']').toString();
+    }
+    if (value instanceof DataValue dataValue) {
+      return "DataValue{"
+          + canonicalString(dataValue.getValue().getValue())
+          + ", status="
+          + dataValue.getStatusCode()
+          + ", sourceTime="
+          + dataValue.getSourceTime()
+          + ", sourcePicoseconds="
+          + dataValue.getSourcePicoseconds()
+          + "}";
+    }
+    if (value instanceof Variant variant) {
+      return "Variant{" + canonicalString(variant.getValue()) + "}";
+    }
+    return String.valueOf(value);
+  }
+
+  /** Array-aware, null-safe hash of an attribute value, used by {@link #hashCode}. */
+  private static int valueHash(@Nullable Object value) {
+    return value instanceof Object[] array ? Arrays.deepHashCode(array) : Objects.hashCode(value);
+  }
+
+  /**
+   * Copy {@code value} if it is mutable: arrays are cloned (element-wise for nested mutability) and
+   * an array-valued {@link DataValue} is rebuilt around a cloned array. Immutable values pass
+   * through.
+   */
+  private static Object defensiveCopy(Object value) {
+    if (value.getClass().isArray()) {
+      return copyArray(value);
+    }
+    if (value instanceof DataValue dataValue) {
+      Object contained = dataValue.getValue().getValue();
+      if (contained != null && contained.getClass().isArray()) {
+        Object containedCopy = copyArray(contained);
+        return dataValue.copy(b -> b.setValue(new Variant(containedCopy)));
+      }
+    }
+    return value;
+  }
+
+  private static Object copyArray(Object array) {
+    int length = Array.getLength(array);
+    Object copy = Array.newInstance(array.getClass().getComponentType(), length);
+    //noinspection SuspiciousSystemArraycopy
+    System.arraycopy(array, 0, copy, 0, length);
+    if (copy instanceof @Nullable Object[] objects) {
+      for (int i = 0; i < objects.length; i++) {
+        Object element = objects[i];
+        if (element != null) {
+          objects[i] = defensiveCopy(element);
+        }
+      }
+    }
+    return copy;
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    if (!(o instanceof AttributeSnapshot other) || !values.keySet().equals(other.values.keySet())) {
+      return false;
+    }
+    for (Map.Entry<AttributeId, Object> entry : values.entrySet()) {
+      if (!Objects.deepEquals(entry.getValue(), other.values.get(entry.getKey()))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int h = 0;
+    for (Map.Entry<AttributeId, Object> entry : values.entrySet()) {
+      h += entry.getKey().hashCode() ^ valueHash(entry.getValue());
+    }
+    return h;
+  }
+
+  @Override
+  public String toString() {
+    return "AttributeSnapshot" + values.keySet();
+  }
+
+  /** Builder for {@link AttributeSnapshot}s. */
+  public static final class Builder {
+
+    private final EnumMap<AttributeId, Object> values = new EnumMap<>(AttributeId.class);
+
+    private Builder() {}
+
+    /**
+     * Record {@code attributeId} as present; a {@code null} value records an explicit null.
+     *
+     * @param attributeId the attribute to record.
+     * @param value the value, or {@code null} for explicit null.
+     * @return this builder.
+     */
+    public Builder put(AttributeId attributeId, @Nullable Object value) {
+      values.put(attributeId, value != null ? defensiveCopy(value) : EXPLICIT_NULL);
+      return this;
+    }
+
+    /**
+     * Record {@code attributeId} with {@code value} if non-null; leave it absent otherwise.
+     *
+     * @param attributeId the attribute to record.
+     * @param value the value, or {@code null} to leave the attribute absent.
+     * @return this builder.
+     */
+    public Builder putIfProvided(AttributeId attributeId, @Nullable Object value) {
+      if (value != null) {
+        values.put(attributeId, defensiveCopy(value));
+      }
+      return this;
+    }
+
+    /**
+     * @return the built {@link AttributeSnapshot}.
+     */
+    public AttributeSnapshot build() {
+      return new AttributeSnapshot(new EnumMap<>(values));
+    }
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/BrowsePath.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/BrowsePath.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A relative sequence of BrowseNames identifying one InstanceDeclaration occurrence within a {@link
+ * TypeInstantiationModel} (OPC UA Part 3 §6.2.5).
+ *
+ * <p>BrowsePath is the model's primary key: a TypeDefinitionNode or InstanceDeclaration never
+ * references two nodes with the same BrowseName by forward hierarchical references (Part 3 §4.6.4,
+ * §6.2.6), so every declaration is uniquely identified by its path from the type root. The same
+ * declaration node reached through multiple BrowsePaths is a distinct occurrence per path (Part 3
+ * §6.3.3.2).
+ *
+ * <p>Elements are {@link QualifiedName}s whose namespace indexes resolve against the namespace
+ * table of the server the owning model snapshot was compiled from. The representation is
+ * deliberately a final class with factory methods rather than a record so a URI-carrying element
+ * form can be added later without breaking callers.
+ *
+ * <p>Ordering is deterministic: element-wise by namespace index then name, with a proper prefix
+ * ordering before its extensions.
+ */
+public final class BrowsePath implements Comparable<BrowsePath> {
+
+  private static final BrowsePath ROOT = new BrowsePath(List.of());
+
+  private static final Comparator<QualifiedName> ELEMENT_COMPARATOR =
+      Comparator.comparing((QualifiedName qn) -> qn.namespaceIndex().intValue())
+          .thenComparing(qn -> qn.name() != null ? qn.name() : "");
+
+  private final List<QualifiedName> elements;
+
+  private BrowsePath(List<QualifiedName> elements) {
+    this.elements = List.copyOf(elements);
+  }
+
+  /**
+   * @return the root path (the type definition node itself; zero elements).
+   */
+  public static BrowsePath root() {
+    return ROOT;
+  }
+
+  /**
+   * Create a path from the given elements.
+   *
+   * @param elements the BrowseName elements, outermost first.
+   * @return a new {@link BrowsePath}.
+   */
+  public static BrowsePath of(QualifiedName... elements) {
+    return elements.length == 0 ? ROOT : new BrowsePath(Arrays.asList(elements));
+  }
+
+  /**
+   * Create a path from the given elements.
+   *
+   * @param elements the BrowseName elements, outermost first.
+   * @return a new {@link BrowsePath}.
+   */
+  public static BrowsePath of(List<QualifiedName> elements) {
+    return elements.isEmpty() ? ROOT : new BrowsePath(elements);
+  }
+
+  /**
+   * @return the BrowseName elements of this path, outermost first; empty for the root path.
+   */
+  public List<QualifiedName> elements() {
+    return elements;
+  }
+
+  /**
+   * @return {@code true} if this is the root path.
+   */
+  public boolean isRoot() {
+    return elements.isEmpty();
+  }
+
+  /**
+   * @return the number of elements in this path.
+   */
+  public int depth() {
+    return elements.size();
+  }
+
+  /**
+   * @return the last element of this path, or {@code null} for the root path.
+   */
+  public @Nullable QualifiedName lastElement() {
+    return elements.isEmpty() ? null : elements.get(elements.size() - 1);
+  }
+
+  /**
+   * @param element the element to append.
+   * @return a new path with {@code element} appended.
+   */
+  public BrowsePath append(QualifiedName element) {
+    List<QualifiedName> newElements = new ArrayList<>(elements.size() + 1);
+    newElements.addAll(elements);
+    newElements.add(element);
+    return new BrowsePath(newElements);
+  }
+
+  /**
+   * @param other the path to append.
+   * @return a new path consisting of this path's elements followed by {@code other}'s.
+   */
+  public BrowsePath concat(BrowsePath other) {
+    if (other.isRoot()) {
+      return this;
+    }
+    if (isRoot()) {
+      return other;
+    }
+    List<QualifiedName> newElements = new ArrayList<>(elements.size() + other.elements.size());
+    newElements.addAll(elements);
+    newElements.addAll(other.elements);
+    return new BrowsePath(newElements);
+  }
+
+  /**
+   * @return the parent path; the root path if this path has one or zero elements.
+   */
+  public BrowsePath parent() {
+    return elements.size() <= 1 ? ROOT : new BrowsePath(elements.subList(0, elements.size() - 1));
+  }
+
+  /**
+   * @param prefix the candidate prefix.
+   * @return {@code true} if this path starts with (or equals) {@code prefix}.
+   */
+  public boolean startsWith(BrowsePath prefix) {
+    if (prefix.elements.size() > elements.size()) {
+      return false;
+    }
+    return elements.subList(0, prefix.elements.size()).equals(prefix.elements);
+  }
+
+  @Override
+  public int compareTo(BrowsePath other) {
+    int commonLength = Math.min(elements.size(), other.elements.size());
+    for (int i = 0; i < commonLength; i++) {
+      int c = ELEMENT_COMPARATOR.compare(elements.get(i), other.elements.get(i));
+      if (c != 0) {
+        return c;
+      }
+    }
+    return Integer.compare(elements.size(), other.elements.size());
+  }
+
+  @Override
+  public boolean equals(@Nullable Object o) {
+    return o instanceof BrowsePath other && elements.equals(other.elements);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(elements);
+  }
+
+  @Override
+  public String toString() {
+    if (elements.isEmpty()) {
+      return "/";
+    }
+    StringBuilder sb = new StringBuilder();
+    for (QualifiedName element : elements) {
+      sb.append('/').append(element.namespaceIndex()).append(':').append(element.name());
+    }
+    return sb.toString();
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/ConflictPolicy.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/ConflictPolicy.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
+
+/**
+ * How a plan treats a planned {@link org.eclipse.milo.opcua.stack.core.types.builtin.NodeId} that
+ * already exists in the request's target {@link org.eclipse.milo.opcua.sdk.server.NodeManager}.
+ *
+ * <p>There is deliberately no silent-replace option: the legacy factory's unconditional replacement
+ * destroyed existing nodes and left their stale reference rows behind.
+ */
+public enum ConflictPolicy {
+
+  /**
+   * Any collision with an existing Node is a plan error ({@link
+   * InstantiationDiagnostic.Code#NODE_ID_COLLISION}). The default.
+   */
+  FAIL,
+
+  /**
+   * A colliding existing Node is adopted (planned as {@link PlannedNode.Materialization#REUSE},
+   * never modified, never deleted by cleanup) if it is compatible: equal namespace-qualified
+   * BrowseName, equal NodeClass, and a TypeDefinition that is the planned type or a subtype. An
+   * incompatible existing Node is a plan error ({@link
+   * InstantiationDiagnostic.Code#INCOMPATIBLE_REUSE}).
+   */
+  REUSE_COMPATIBLE
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/DeclarationEdge.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/DeclarationEdge.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
+
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+
+/**
+ * One hierarchical edge of a {@link TypeInstantiationModel}: a forward hierarchical reference from
+ * the declaration (or type root) at {@code parentPath} to the declaration at {@code childPath}.
+ *
+ * <p>Edges are kept separate from {@link InstanceDeclaration}s because one parent/child pair may be
+ * connected by several references — each with its own ReferenceType — and all of them must map onto
+ * the same realized instance pair (Part 3 §6.4.3). Edges are a logical set: duplicate (parent,
+ * referenceType, child) rows produced by merging are canonicalized to one edge (Part 3 §4.4.4).
+ *
+ * @param parentPath the parent declaration's path; {@link BrowsePath#root()} for direct children of
+ *     the type.
+ * @param referenceTypeId the hierarchical ReferenceType connecting the pair.
+ * @param childPath the child declaration's path.
+ */
+public record DeclarationEdge(
+    BrowsePath parentPath, NodeId referenceTypeId, BrowsePath childPath) {}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/EventInstantiator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/EventInstantiator.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
+
+import org.eclipse.milo.opcua.sdk.server.AbstractLifecycle;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.sdk.server.UaNodeManager;
+import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableNode;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+
+/**
+ * Creates transient Event instances through the {@link NodeInstantiator}, replacing the legacy
+ * {@link org.eclipse.milo.opcua.sdk.server.nodes.factories.EventFactory}.
+ *
+ * <p>Event nodes are created with every optional member included, into a private {@link
+ * UaNodeManager} that is registered with the server's {@link
+ * org.eclipse.milo.opcua.sdk.server.AddressSpaceManager} while this component is running, so event
+ * fields are resolvable during filter evaluation without the events being reachable from the
+ * server's hierarchy. The EventType Property is set as part of the instantiation rather than by
+ * mutating the created node.
+ *
+ * <p>Unlike the legacy factory — which cast the created node to {@link BaseEventTypeNode} after its
+ * nodes were already stored, throwing {@link ClassCastException} and leaving residue for custom
+ * event types with no registered Java class — the expected class here is validated at plan time,
+ * before any node is created.
+ */
+public class EventInstantiator extends AbstractLifecycle {
+
+  private static final BrowsePath EVENT_TYPE_PATH =
+      BrowsePath.of(new QualifiedName(0, "EventType"));
+
+  private final UaNodeManager nodeManager = new UaNodeManager();
+
+  private final OpcUaServer server;
+
+  public EventInstantiator(OpcUaServer server) {
+    this.server = server;
+  }
+
+  @Override
+  protected void onStartup() {
+    server.getAddressSpaceManager().register(nodeManager);
+  }
+
+  @Override
+  protected void onShutdown() {
+    server.getAddressSpaceManager().unregister(nodeManager);
+  }
+
+  /**
+   * Create an Event instance of the type identified by {@code typeDefinitionId}.
+   *
+   * <p>Event nodes must be deleted by the caller ({@link UaNode#delete()}) once they have been
+   * posted to the event bus or their lifetime has otherwise expired.
+   *
+   * @param nodeId the {@link NodeId} to use for the Event instance root.
+   * @param typeDefinitionId the {@link NodeId} of the ObjectType node representing the type
+   *     definition.
+   * @return a {@link BaseEventTypeNode} instance; an unregistered custom event type resolves to its
+   *     nearest registered ancestor's class.
+   * @throws UaException if the type cannot be instantiated, or its resolved Java class is not a
+   *     {@link BaseEventTypeNode} — found at plan time, before any node is created.
+   */
+  public BaseEventTypeNode createEvent(NodeId nodeId, NodeId typeDefinitionId) throws UaException {
+    return createEvent(BaseEventTypeNode.class, nodeId, typeDefinitionId);
+  }
+
+  /**
+   * Create an Event instance of the type identified by {@code typeDefinitionId}, expecting {@code
+   * eventClass} as the root's Java class.
+   *
+   * <p>Event nodes must be deleted by the caller ({@link UaNode#delete()}) once they have been
+   * posted to the event bus or their lifetime has otherwise expired.
+   *
+   * @param eventClass the expected Java class of the Event instance root.
+   * @param nodeId the {@link NodeId} to use for the Event instance root.
+   * @param typeDefinitionId the {@link NodeId} of the ObjectType node representing the type
+   *     definition.
+   * @param <T> the expected root class.
+   * @return an Event instance of {@code eventClass}.
+   * @throws UaException if the type cannot be instantiated, or its resolved Java class is not an
+   *     {@code eventClass} — found at plan time, before any node is created.
+   */
+  public <T extends BaseEventTypeNode> T createEvent(
+      Class<T> eventClass, NodeId nodeId, NodeId typeDefinitionId) throws UaException {
+
+    InstantiationRequest<T> request =
+        InstantiationRequest.of(eventClass, typeDefinitionId)
+            .nodeId(nodeId)
+            .target(nodeManager)
+            .includeAllOptionals()
+            // Event instances are transient values, never part of the server's hierarchy, so
+            // abstract EventTypes (BaseEventType itself is abstract) are legitimate here.
+            .allowAbstractType()
+            .onNode(
+                (declaration, node, parent, graph) -> {
+                  if (declaration != null
+                      && EVENT_TYPE_PATH.equals(declaration.browsePath())
+                      && node instanceof UaVariableNode variableNode) {
+
+                    variableNode.setValue(new DataValue(new Variant(typeDefinitionId)));
+                  }
+                })
+            .build();
+
+    return server.getNodeInstantiator().instantiate(request).root();
+  }
+
+  /**
+   * @return the private {@link UaNodeManager} Event instances are created in.
+   */
+  UaNodeManager getNodeManager() {
+    return nodeManager;
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/InstanceDeclaration.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/InstanceDeclaration.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
+
+import java.util.List;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * One InstanceDeclaration occurrence of a {@link TypeInstantiationModel}, keyed by its {@link
+ * BrowsePath}; a snapshot, not a live node.
+ *
+ * <p>The same declaration node reached through multiple BrowsePaths appears as a distinct
+ * occurrence per path (Part 3 §6.3.3.2). Provenance is preserved for diagnostics: {@code
+ * declaringTypeId} names the type whose walk contributed this entry, and {@code
+ * overriddenDeclarations} is the chain of declaration NodeIds this entry overrode (nearest first,
+ * base-most last) — supertype declarations replaced per Part 3 §6.3.3.3, and same-path member-type
+ * defaults replaced by explicit declarations.
+ *
+ * @param browsePath the occurrence's path relative to the type root; the primary key.
+ * @param browseName the declaration's BrowseName (the last path element).
+ * @param nodeClass the declaration's NodeClass (Object, Variable, or Method).
+ * @param declarationNodeId the NodeId of the declaration node this occurrence resolves to.
+ * @param declaringTypeId the type in the chain that contributed this entry.
+ * @param overriddenDeclarations declaration NodeIds this entry overrode; empty if none.
+ * @param modellingRuleId the raw ModellingRule Object id — vendor rules preserved (Part 3
+ *     §6.4.4.1).
+ * @param rule the {@link ModellingRule} classification of {@code modellingRuleId}.
+ * @param typeDefinitionId the member's TypeDefinition; {@code null} for Methods.
+ * @param attributes the full attribute snapshot, absent/null/value distinction preserved.
+ */
+public record InstanceDeclaration(
+    BrowsePath browsePath,
+    QualifiedName browseName,
+    NodeClass nodeClass,
+    NodeId declarationNodeId,
+    NodeId declaringTypeId,
+    List<NodeId> overriddenDeclarations,
+    NodeId modellingRuleId,
+    ModellingRule rule,
+    @Nullable NodeId typeDefinitionId,
+    AttributeSnapshot attributes) {
+
+  public InstanceDeclaration {
+    overriddenDeclarations = List.copyOf(overriddenDeclarations);
+  }
+
+  /**
+   * @return {@code true} if this declaration is a placeholder extension point.
+   */
+  public boolean isPlaceholder() {
+    return rule.isPlaceholder();
+  }
+
+  /**
+   * @param overriddenDeclarations the override chain to record.
+   * @return a copy of this declaration with its {@link #overriddenDeclarations()} replaced.
+   */
+  InstanceDeclaration withOverridden(List<NodeId> overriddenDeclarations) {
+    return new InstanceDeclaration(
+        browsePath,
+        browseName,
+        nodeClass,
+        declarationNodeId,
+        declaringTypeId,
+        overriddenDeclarations,
+        modellingRuleId,
+        rule,
+        typeDefinitionId,
+        attributes);
+  }
+
+  /**
+   * @param browsePath the path to relocate this declaration to.
+   * @return a copy of this declaration with its {@link #browsePath()} replaced.
+   */
+  InstanceDeclaration withBrowsePath(BrowsePath browsePath) {
+    return new InstanceDeclaration(
+        browsePath,
+        browseName,
+        nodeClass,
+        declarationNodeId,
+        declaringTypeId,
+        overriddenDeclarations,
+        modellingRuleId,
+        rule,
+        typeDefinitionId,
+        attributes);
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/InstantiationDiagnostic.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/InstantiationDiagnostic.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
+
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A structured finding produced while planning or applying one instantiation, carried on the {@link
+ * InstantiationPlan}. Compile-time findings about the <em>type</em> are {@link ModelDiagnostic}s
+ * instead; these are per-request.
+ *
+ * <p>A plan carrying any {@link Severity#ERROR} diagnostic is returned inspectable but refused by
+ * apply — a healthy instantiation is explainable per declaration, and a failed one names its phase
+ * and path.
+ *
+ * @param severity the finding's severity.
+ * @param phase the lifecycle phase that produced the finding.
+ * @param code the machine-readable finding code.
+ * @param message a human-readable description.
+ * @param browsePath the affected occurrence path, if the finding is path-specific.
+ * @param nodeId the affected or attempted {@link NodeId}, if identifiable.
+ */
+public record InstantiationDiagnostic(
+    Severity severity,
+    Phase phase,
+    Code code,
+    String message,
+    @Nullable BrowsePath browsePath,
+    @Nullable NodeId nodeId) {
+
+  /** Severity of an {@link InstantiationDiagnostic}. */
+  public enum Severity {
+    /** A finding on a plan that remains applicable. */
+    WARNING,
+    /** The plan (or apply) cannot proceed as requested. */
+    ERROR
+  }
+
+  /** The lifecycle phase a diagnostic was produced in. */
+  public enum Phase {
+    /** Produced by {@code NodeInstantiator.plan}. */
+    PLAN,
+    /** Produced by {@code NodeInstantiator.apply}. */
+    APPLY
+  }
+
+  /** Machine-readable codes for {@link InstantiationDiagnostic}s. */
+  public enum Code {
+    /**
+     * The registered (or resolved) Java class of the root type is not assignable to the request's
+     * expected root class.
+     */
+    INVALID_ROOT_CLASS,
+    /** The requested root type is abstract; request a concrete subtype instead. */
+    ABSTRACT_TYPE,
+    /**
+     * A planned member's TypeDefinition is abstract and the request supplies no {@code
+     * concreteType} resolution for its path.
+     */
+    ABSTRACT_MEMBER_TYPE,
+    /**
+     * A {@code concreteType} selection is invalid: not the declared member type or a subtype of it,
+     * abstract itself, or of the wrong NodeClass.
+     */
+    CONCRETE_TYPE_INVALID,
+    /**
+     * A {@code concreteType} selection declares members beyond the declared member type's; those
+     * additional members are not expanded by this release (the declared type's members are planned;
+     * the instance's HasTypeDefinition references the concrete type).
+     */
+    CONCRETE_TYPE_NOT_EXPANDED,
+    /**
+     * A Mandatory declaration whose parent path exists was excluded — the one omission Part 3
+     * §6.4.4.4.2 does not permit (pruning an omitted ancestor's subtree is not an error).
+     */
+    MANDATORY_OMITTED,
+    /**
+     * A planned {@link NodeId} collides with another planned node or, under {@link
+     * ConflictPolicy#FAIL}, with an existing node in the target.
+     */
+    NODE_ID_COLLISION,
+    /**
+     * Under {@link ConflictPolicy#REUSE_COMPATIBLE}, an existing node at a planned id is not
+     * compatible (BrowseName, NodeClass, TypeDefinition, or expected Java class).
+     */
+    INCOMPATIBLE_REUSE,
+    /** A request override violates the Variable narrowing rules of Part 3 §6.2.8. */
+    VARIABLE_NARROWING,
+    /** A planned Method's declaration carries a Method signature finding from the model. */
+    METHOD_SIGNATURE_MISMATCH,
+    /**
+     * A request path ({@code includeOptional}, {@code excludeOptional}, {@code assignNodeId},
+     * {@code concreteType}, {@code bindMethod}) matches nothing it can affect in this plan.
+     */
+    UNMATCHED_PATH,
+    /**
+     * An {@code ExposesItsArray} declaration is visible in the model but never materialized;
+     * per-element exposure is out of scope.
+     */
+    EXPOSES_ITS_ARRAY_NOT_MATERIALIZED,
+    /** A MandatoryPlaceholder's ≥1-realization obligation is unsatisfied by the request. */
+    MANDATORY_PLACEHOLDER_UNSATISFIED,
+    /** The type (or a dependency) changed between plan and apply; the plan is stale. */
+    MODEL_CHANGED,
+    /** A node constructor failed during apply. */
+    CONSTRUCTOR_FAILED,
+    /** An {@code onNode} or {@code bindMethod} hook threw during apply. */
+    CUSTOMIZATION_FAILED,
+    /**
+     * The batch commit into the target {@link org.eclipse.milo.opcua.sdk.server.NodeManager}
+     * failed.
+     */
+    COMMIT_FAILED,
+    /**
+     * Rollback of journaled additions failed; the diagnostic carries what could not be removed. The
+     * one state requiring operator attention.
+     */
+    ROLLBACK_FAILED
+  }
+
+  /**
+   * Create a plan-phase {@link Severity#ERROR} diagnostic.
+   *
+   * @param code the finding code.
+   * @param message a human-readable description.
+   * @param browsePath the affected path, or {@code null}.
+   * @param nodeId the affected node, or {@code null}.
+   * @return the diagnostic.
+   */
+  public static InstantiationDiagnostic planError(
+      Code code, String message, @Nullable BrowsePath browsePath, @Nullable NodeId nodeId) {
+    return new InstantiationDiagnostic(
+        Severity.ERROR, Phase.PLAN, code, message, browsePath, nodeId);
+  }
+
+  /**
+   * Create a plan-phase {@link Severity#WARNING} diagnostic.
+   *
+   * @param code the finding code.
+   * @param message a human-readable description.
+   * @param browsePath the affected path, or {@code null}.
+   * @param nodeId the affected node, or {@code null}.
+   * @return the diagnostic.
+   */
+  public static InstantiationDiagnostic planWarning(
+      Code code, String message, @Nullable BrowsePath browsePath, @Nullable NodeId nodeId) {
+    return new InstantiationDiagnostic(
+        Severity.WARNING, Phase.PLAN, code, message, browsePath, nodeId);
+  }
+
+  /**
+   * @return {@code true} if this diagnostic's severity is {@link Severity#ERROR}.
+   */
+  public boolean isError() {
+    return severity == Severity.ERROR;
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/InstantiationDiagnostic.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/InstantiationDiagnostic.java
@@ -120,6 +120,13 @@ public record InstantiationDiagnostic(
     EXPOSES_ITS_ARRAY_NOT_MATERIALIZED,
     /** A MandatoryPlaceholder's ≥1-realization obligation is unsatisfied by the request. */
     MANDATORY_PLACEHOLDER_UNSATISFIED,
+    /**
+     * A placeholder expansion cannot be honored: the bound path names no expandable placeholder in
+     * this plan (mistyped, excluded, or under an omitted ancestor), or a realization's BrowseName
+     * collides with a declared sibling or another realization. Expansion is a directive to create,
+     * so an unhonorable binding is an error, never a silent drop.
+     */
+    PLACEHOLDER_EXPANSION_INVALID,
     /** The type (or a dependency) changed between plan and apply; the plan is stale. */
     MODEL_CHANGED,
     /** A node constructor failed during apply. */

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/InstantiationDiagnostic.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/InstantiationDiagnostic.java
@@ -93,6 +93,12 @@ public record InstantiationDiagnostic(
      * compatible (BrowseName, NodeClass, TypeDefinition, or expected Java class).
      */
     INCOMPATIBLE_REUSE,
+    /**
+     * The requested parent attachment is invalid: the parent ReferenceType is not a hierarchical
+     * ReferenceType (an error; no attachment is planned), or the parent node does not resolve in
+     * the server at plan time (a warning; commit fails if it is still missing at apply).
+     */
+    INVALID_PARENT,
     /** A request override violates the Variable narrowing rules of Part 3 §6.2.8. */
     VARIABLE_NARROWING,
     /** A planned Method's declaration carries a Method signature finding from the model. */

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/InstantiationDiagnostic.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/InstantiationDiagnostic.java
@@ -96,9 +96,14 @@ public record InstantiationDiagnostic(
     /**
      * The requested parent attachment is invalid: the parent ReferenceType is not a hierarchical
      * ReferenceType (an error; no attachment is planned), or the parent node does not resolve in
-     * the server at plan time (a warning; commit fails if it is still missing at apply).
+     * the server at plan time (a warning; the apply-stage recheck fails if it is still missing).
      */
     INVALID_PARENT,
+    /**
+     * A request attribute override is invalid: an explicit null for an attribute that is mandatory
+     * for the instance's NodeClass, which would commit a node no client can read correctly.
+     */
+    INVALID_ATTRIBUTE,
     /** A request override violates the Variable narrowing rules of Part 3 §6.2.8. */
     VARIABLE_NARROWING,
     /** A planned Method's declaration carries a Method signature finding from the model. */
@@ -161,6 +166,21 @@ public record InstantiationDiagnostic(
       Code code, String message, @Nullable BrowsePath browsePath, @Nullable NodeId nodeId) {
     return new InstantiationDiagnostic(
         Severity.WARNING, Phase.PLAN, code, message, browsePath, nodeId);
+  }
+
+  /**
+   * Create an apply-phase {@link Severity#ERROR} diagnostic.
+   *
+   * @param code the finding code.
+   * @param message a human-readable description.
+   * @param browsePath the affected path, or {@code null}.
+   * @param nodeId the affected node, or {@code null}.
+   * @return the diagnostic.
+   */
+  public static InstantiationDiagnostic applyError(
+      Code code, String message, @Nullable BrowsePath browsePath, @Nullable NodeId nodeId) {
+    return new InstantiationDiagnostic(
+        Severity.ERROR, Phase.APPLY, code, message, browsePath, nodeId);
   }
 
   /**

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/InstantiationException.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/InstantiationException.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
+
+import java.util.List;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Thrown when an instantiation cannot proceed: a plan carrying errors was handed to apply, or apply
+ * itself failed at one of its stages. The failure names its {@link InstantiationDiagnostic.Phase}
+ * and carries the structured {@link InstantiationDiagnostic}s that describe it — a failed
+ * instantiation is explainable per declaration path, not a blanket status code.
+ *
+ * <p>Apply-stage failures leave no residue in the target: staging happens before any storage
+ * mutation, and a failed commit — or a failed post-commit method binder — is rolled back to exactly
+ * its journaled additions. The exceptions to that guarantee are a failed rollback, reported loudly
+ * with {@link InstantiationDiagnostic.Code#ROLLBACK_FAILED} diagnostics carrying what could not be
+ * removed, and a mutation a binder made to a reused or shared node before another binder failed,
+ * which is not this instantiation's to undo.
+ */
+public class InstantiationException extends UaException {
+
+  private final InstantiationDiagnostic.Phase phase;
+  private final List<InstantiationDiagnostic> diagnostics;
+
+  /**
+   * @param statusCode the {@link StatusCode} summarizing the failure.
+   * @param phase the lifecycle phase the failure occurred in.
+   * @param diagnostics the findings describing the failure; contains at least one error.
+   * @param cause the causing exception, if any.
+   */
+  public InstantiationException(
+      long statusCode,
+      InstantiationDiagnostic.Phase phase,
+      List<InstantiationDiagnostic> diagnostics,
+      @Nullable Throwable cause) {
+
+    super(statusCode, buildMessage(phase, diagnostics), cause);
+
+    this.phase = phase;
+    this.diagnostics = List.copyOf(diagnostics);
+  }
+
+  /**
+   * @return the lifecycle phase the failure occurred in.
+   */
+  public InstantiationDiagnostic.Phase getPhase() {
+    return phase;
+  }
+
+  /**
+   * @return the findings describing the failure; contains at least one {@link
+   *     InstantiationDiagnostic.Severity#ERROR} entry.
+   */
+  public List<InstantiationDiagnostic> getDiagnostics() {
+    return diagnostics;
+  }
+
+  private static String buildMessage(
+      InstantiationDiagnostic.Phase phase, List<InstantiationDiagnostic> diagnostics) {
+
+    long errorCount = diagnostics.stream().filter(InstantiationDiagnostic::isError).count();
+
+    String firstError =
+        diagnostics.stream()
+            .filter(InstantiationDiagnostic::isError)
+            .findFirst()
+            .map(d -> d.code() + ": " + d.message())
+            .orElse("no error diagnostics");
+
+    return "%s failed (%d error%s): %s"
+        .formatted(
+            phase == InstantiationDiagnostic.Phase.PLAN ? "plan" : "apply",
+            errorCount,
+            errorCount == 1 ? "" : "s",
+            firstError);
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/InstantiationPlan.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/InstantiationPlan.java
@@ -16,6 +16,7 @@ import java.util.Map;
 import java.util.Optional;
 import org.eclipse.milo.opcua.sdk.core.Reference;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 
 /**
  * The pure-data result of joining one {@link InstantiationRequest} with the type's {@link
@@ -38,6 +39,7 @@ public final class InstantiationPlan<T extends UaNode> {
   private final List<SkippedDeclaration> skippedDeclarations;
   private final List<Reference> references;
   private final List<InstantiationDiagnostic> diagnostics;
+  private final Map<NodeId, Long> consultedModelRevisions;
 
   InstantiationPlan(
       InstantiationRequest<T> request,
@@ -45,7 +47,8 @@ public final class InstantiationPlan<T extends UaNode> {
       List<PlannedNode> plannedNodes,
       List<SkippedDeclaration> skippedDeclarations,
       List<Reference> references,
-      List<InstantiationDiagnostic> diagnostics) {
+      List<InstantiationDiagnostic> diagnostics,
+      Map<NodeId, Long> consultedModelRevisions) {
 
     this.request = request;
     this.model = model;
@@ -53,6 +56,7 @@ public final class InstantiationPlan<T extends UaNode> {
     this.skippedDeclarations = List.copyOf(skippedDeclarations);
     this.references = List.copyOf(references);
     this.diagnostics = List.copyOf(diagnostics);
+    this.consultedModelRevisions = Map.copyOf(consultedModelRevisions);
 
     var byPath = new LinkedHashMap<BrowsePath, PlannedNode>();
     for (PlannedNode node : this.plannedNodes) {
@@ -81,6 +85,18 @@ public final class InstantiationPlan<T extends UaNode> {
    */
   public long modelRevision() {
     return model.modelRevision();
+  }
+
+  /**
+   * Every type model this plan was computed from, with the revision consulted: the root type plus
+   * any member models resolved separately (a {@code concreteType} selection outside the root
+   * model's dependency closure has its own cache entry, so the root revision alone cannot vouch for
+   * it). Apply revalidates each entry before constructing anything.
+   *
+   * @return the consulted type models, keyed by type definition {@link NodeId}, mapped to revision.
+   */
+  public Map<NodeId, Long> consultedModelRevisions() {
+    return consultedModelRevisions;
   }
 
   /**
@@ -114,9 +130,10 @@ public final class InstantiationPlan<T extends UaNode> {
   }
 
   /**
-   * @return every reference to be committed, fully resolved to instance ids: the root's
-   *     HasTypeDefinition, the parent attachment (if requested), the realized hierarchy edges, and
-   *     the replicated declaration rows — in that deterministic order.
+   * @return every planned reference, fully resolved to instance ids: the root's HasTypeDefinition,
+   *     the parent attachment (if requested), the realized hierarchy edges, and the replicated
+   *     declaration rows — in that deterministic order. The commit additionally derives and stores
+   *     each row's inverse, so the committed row set is larger than this list.
    */
   public List<Reference> references() {
     return references;

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/InstantiationPlan.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/InstantiationPlan.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.eclipse.milo.opcua.sdk.core.Reference;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
+
+/**
+ * The pure-data result of joining one {@link InstantiationRequest} with the type's {@link
+ * TypeInstantiationModel}: every declaration in the model is accounted for — planned, skipped with
+ * a machine-readable reason, or a placeholder extension point — with all NodeIds allocated and
+ * collision-checked and every reference resolved to instance ids, before anything exists.
+ *
+ * <p>Computing a plan mutates nothing. A plan carrying {@link #errors()} is returned inspectable
+ * but refused by apply. Plans are deterministic: the same model and request produce the same
+ * planned nodes, in the same order, with the same references.
+ *
+ * @param <T> the expected Java class of the instance root.
+ */
+public final class InstantiationPlan<T extends UaNode> {
+
+  private final InstantiationRequest<T> request;
+  private final TypeInstantiationModel model;
+  private final List<PlannedNode> plannedNodes;
+  private final Map<BrowsePath, PlannedNode> plannedByPath;
+  private final List<SkippedDeclaration> skippedDeclarations;
+  private final List<Reference> references;
+  private final List<InstantiationDiagnostic> diagnostics;
+
+  InstantiationPlan(
+      InstantiationRequest<T> request,
+      TypeInstantiationModel model,
+      List<PlannedNode> plannedNodes,
+      List<SkippedDeclaration> skippedDeclarations,
+      List<Reference> references,
+      List<InstantiationDiagnostic> diagnostics) {
+
+    this.request = request;
+    this.model = model;
+    this.plannedNodes = List.copyOf(plannedNodes);
+    this.skippedDeclarations = List.copyOf(skippedDeclarations);
+    this.references = List.copyOf(references);
+    this.diagnostics = List.copyOf(diagnostics);
+
+    var byPath = new LinkedHashMap<BrowsePath, PlannedNode>();
+    for (PlannedNode node : this.plannedNodes) {
+      byPath.put(node.browsePath(), node);
+    }
+    this.plannedByPath = byPath;
+  }
+
+  /**
+   * @return the request this plan was computed from.
+   */
+  public InstantiationRequest<T> request() {
+    return request;
+  }
+
+  /**
+   * @return the model snapshot this plan was computed against; apply revalidates its {@link
+   *     TypeInstantiationModel#modelRevision()} before constructing anything.
+   */
+  public TypeInstantiationModel model() {
+    return model;
+  }
+
+  /**
+   * @return the model revision this plan was computed against.
+   */
+  public long modelRevision() {
+    return model.modelRevision();
+  }
+
+  /**
+   * @return the planned instance root.
+   */
+  public PlannedNode root() {
+    return plannedNodes.get(0);
+  }
+
+  /**
+   * @return every planned node, browse-path ordered, the root first.
+   */
+  public List<PlannedNode> plannedNodes() {
+    return plannedNodes;
+  }
+
+  /**
+   * @param path the occurrence path to look up.
+   * @return the planned node at {@code path}, if one was planned.
+   */
+  public Optional<PlannedNode> plannedNode(BrowsePath path) {
+    return Optional.ofNullable(plannedByPath.get(path));
+  }
+
+  /**
+   * @return every declaration occurrence this plan decided not to realize, with reasons,
+   *     browse-path ordered.
+   */
+  public List<SkippedDeclaration> skippedDeclarations() {
+    return skippedDeclarations;
+  }
+
+  /**
+   * @return every reference to be committed, fully resolved to instance ids: the root's
+   *     HasTypeDefinition, the parent attachment (if requested), the realized hierarchy edges, and
+   *     the replicated declaration rows — in that deterministic order.
+   */
+  public List<Reference> references() {
+    return references;
+  }
+
+  /**
+   * @return every plan finding, errors and warnings.
+   */
+  public List<InstantiationDiagnostic> diagnostics() {
+    return diagnostics;
+  }
+
+  /**
+   * @return the error findings; a plan carrying any is refused by apply.
+   */
+  public List<InstantiationDiagnostic> errors() {
+    return diagnostics.stream().filter(InstantiationDiagnostic::isError).toList();
+  }
+
+  /**
+   * @return the warning findings.
+   */
+  public List<InstantiationDiagnostic> warnings() {
+    return diagnostics.stream().filter(d -> !d.isError()).toList();
+  }
+
+  /**
+   * @return {@code true} if this plan carries at least one error finding.
+   */
+  public boolean hasErrors() {
+    return diagnostics.stream().anyMatch(InstantiationDiagnostic::isError);
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/InstantiationPurpose.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/InstantiationPurpose.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
+
+/**
+ * What the instantiated graph is for, per OPC UA Part 3 §6.4.4.3: ordinary instances carry no
+ * ModellingRules, while instances created to serve as InstanceDeclarations of a new type must
+ * retain them.
+ */
+public enum InstantiationPurpose {
+
+  /** An ordinary instance: {@code HasModellingRule} references are not replicated. The default. */
+  NORMAL_INSTANCE,
+
+  /**
+   * An instance created as an InstanceDeclaration for type-authoring workflows: each realized
+   * declaration keeps its {@code HasModellingRule} reference.
+   */
+  INSTANCE_DECLARATION
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/InstantiationRequest.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/InstantiationRequest.java
@@ -72,6 +72,7 @@ public final class InstantiationRequest<T extends UaNode> {
   private final InstantiationPurpose purpose;
   private final ReferenceReplicationPolicy referenceReplication;
   private final ClassResolution classResolution;
+  private final boolean allowAbstractType;
   private final List<OnNode> onNodeHooks;
   private final Map<BrowsePath, Consumer<UaMethodNode>> methodBinders;
   private final List<Consumer<InstantiationResult<T>>> afterCommitObservers;
@@ -103,6 +104,7 @@ public final class InstantiationRequest<T extends UaNode> {
     this.purpose = builder.purpose;
     this.referenceReplication = builder.referenceReplication;
     this.classResolution = builder.classResolution;
+    this.allowAbstractType = builder.allowAbstractType;
     this.onNodeHooks = List.copyOf(builder.onNodeHooks);
     this.methodBinders = Map.copyOf(builder.methodBinders);
     this.afterCommitObservers = List.copyOf(builder.afterCommitObservers);
@@ -354,6 +356,14 @@ public final class InstantiationRequest<T extends UaNode> {
   }
 
   /**
+   * @return {@code true} if the instantiated root type may be abstract; {@code false} (reject at
+   *     plan time) unless configured otherwise.
+   */
+  public boolean allowAbstractType() {
+    return allowAbstractType;
+  }
+
+  /**
    * @return the {@code onNode} hooks, in registration order.
    */
   public List<OnNode> onNodeHooks() {
@@ -462,6 +472,7 @@ public final class InstantiationRequest<T extends UaNode> {
     private InstantiationPurpose purpose = InstantiationPurpose.NORMAL_INSTANCE;
     private ReferenceReplicationPolicy referenceReplication = ReferenceReplicationPolicy.DEFAULT;
     private ClassResolution classResolution = ClassResolution.NEAREST_ANCESTOR;
+    private boolean allowAbstractType = false;
     private final List<OnNode> onNodeHooks = new ArrayList<>();
     private final Map<BrowsePath, Consumer<UaMethodNode>> methodBinders = new LinkedHashMap<>();
     private final List<Consumer<InstantiationResult<T>>> afterCommitObservers = new ArrayList<>();
@@ -751,6 +762,22 @@ public final class InstantiationRequest<T extends UaNode> {
      */
     public Builder<T> classResolution(ClassResolution classResolution) {
       this.classResolution = requireNonNull(classResolution, "classResolution");
+      return this;
+    }
+
+    /**
+     * Permit the instantiated root type to be abstract instead of rejecting it at plan time.
+     *
+     * <p>Abstract types admit no address-space instances, so plan ordinarily rejects them and
+     * demands a concrete subtype ({@link #concreteType} at {@link BrowsePath#root()}). The
+     * sanctioned exception is transient instances that never join the server's hierarchy — Event
+     * instances of abstract EventTypes (BaseEventType itself is abstract), created into a private
+     * NodeManager and deleted after being fired.
+     *
+     * @return this builder.
+     */
+    public Builder<T> allowAbstractType() {
+      this.allowAbstractType = true;
       return this;
     }
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/InstantiationRequest.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/InstantiationRequest.java
@@ -13,6 +13,7 @@ package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
 import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -66,6 +67,8 @@ public final class InstantiationRequest<T extends UaNode> {
   private final ConflictPolicy conflictPolicy;
   private final MethodInstantiation methodInstantiation;
   private final Map<BrowsePath, NodeId> concreteTypes;
+  private final Map<BrowsePath, List<PlaceholderRealization>> placeholderExpansions;
+  private final @Nullable PlaceholderOrigin placeholderOrigin;
   private final InstantiationPurpose purpose;
   private final ReferenceReplicationPolicy referenceReplication;
   private final ClassResolution classResolution;
@@ -91,6 +94,12 @@ public final class InstantiationRequest<T extends UaNode> {
     this.conflictPolicy = builder.conflictPolicy;
     this.methodInstantiation = builder.methodInstantiation;
     this.concreteTypes = Map.copyOf(builder.concreteTypes);
+
+    var expansions = new LinkedHashMap<BrowsePath, List<PlaceholderRealization>>();
+    builder.placeholderExpansions.forEach((path, list) -> expansions.put(path, List.copyOf(list)));
+    this.placeholderExpansions = Collections.unmodifiableMap(expansions);
+
+    this.placeholderOrigin = builder.placeholderOrigin;
     this.purpose = builder.purpose;
     this.referenceReplication = builder.referenceReplication;
     this.classResolution = builder.classResolution;
@@ -112,6 +121,75 @@ public final class InstantiationRequest<T extends UaNode> {
    */
   public static <T extends UaNode> Builder<T> of(Class<T> rootClass, NodeId typeDefinitionId) {
     return new Builder<>(rootClass, typeDefinitionId);
+  }
+
+  /**
+   * Start a request realizing {@code placeholderDeclaration} under the existing instance node
+   * {@code instanceNodeId} — post-hoc placeholder-driven creation, flowing through the same
+   * plan/apply machinery as any other request.
+   *
+   * <p>The request instantiates the placeholder's declared type; parent placement is preset to
+   * {@code instanceNodeId}, attached with the ReferenceType that connects the placeholder
+   * declaration to its own parent (resolved at plan time; call {@link Builder#parent parent} to
+   * override it). The caller still supplies identity: {@link Builder#nodeId nodeId} and, since a
+   * placeholder's own BrowseName is only a marker, {@link Builder#browseName browseName}.
+   *
+   * <p>To instantiate a concrete subtype of the declared (possibly abstract) placeholder type,
+   * select it with {@link Builder#concreteType concreteType} at {@link BrowsePath#root()}.
+   *
+   * @param instanceNodeId the existing instance node the realization is created under.
+   * @param placeholderDeclaration the placeholder declaration being realized, from {@link
+   *     TypeInstantiationModel#placeholders()}.
+   * @return a new {@link Builder} expecting a {@link UaNode} root; use {@link
+   *     #forPlaceholder(Class, NodeId, InstanceDeclaration)} for a typed root.
+   * @throws IllegalArgumentException if {@code placeholderDeclaration} is not a placeholder or has
+   *     no TypeDefinition (Method placeholders cannot be realized this way).
+   */
+  public static Builder<UaNode> forPlaceholder(
+      NodeId instanceNodeId, InstanceDeclaration placeholderDeclaration) {
+    return forPlaceholder(UaNode.class, instanceNodeId, placeholderDeclaration);
+  }
+
+  /**
+   * Start a request realizing {@code placeholderDeclaration} under the existing instance node
+   * {@code instanceNodeId}, with a typed root — see {@link #forPlaceholder(NodeId,
+   * InstanceDeclaration)}.
+   *
+   * @param rootClass the expected Java class of the realized root, checked at plan time.
+   * @param instanceNodeId the existing instance node the realization is created under.
+   * @param placeholderDeclaration the placeholder declaration being realized.
+   * @param <T> the expected root class.
+   * @return a new {@link Builder}.
+   * @throws IllegalArgumentException if {@code placeholderDeclaration} is not a placeholder or has
+   *     no TypeDefinition (Method placeholders cannot be realized this way).
+   */
+  public static <T extends UaNode> Builder<T> forPlaceholder(
+      Class<T> rootClass, NodeId instanceNodeId, InstanceDeclaration placeholderDeclaration) {
+
+    requireNonNull(instanceNodeId, "instanceNodeId");
+    requireNonNull(placeholderDeclaration, "placeholderDeclaration");
+
+    if (!placeholderDeclaration.isPlaceholder()) {
+      throw new IllegalArgumentException(
+          "declaration at "
+              + placeholderDeclaration.browsePath()
+              + " is not a placeholder (ModellingRule "
+              + placeholderDeclaration.rule()
+              + ")");
+    }
+
+    NodeId typeDefinitionId = placeholderDeclaration.typeDefinitionId();
+    if (typeDefinitionId == null) {
+      throw new IllegalArgumentException(
+          "placeholder declaration at "
+              + placeholderDeclaration.browsePath()
+              + " has no TypeDefinition; Method placeholders cannot be realized by forPlaceholder");
+    }
+
+    Builder<T> builder = new Builder<>(rootClass, typeDefinitionId);
+    builder.parentNodeId = instanceNodeId;
+    builder.placeholderOrigin = new PlaceholderOrigin(instanceNodeId, placeholderDeclaration);
+    return builder;
   }
 
   /**
@@ -238,6 +316,20 @@ public final class InstantiationRequest<T extends UaNode> {
   }
 
   /**
+   * @return the realizations bound to placeholder paths, in registration order per path.
+   */
+  public Map<BrowsePath, List<PlaceholderRealization>> placeholderExpansions() {
+    return placeholderExpansions;
+  }
+
+  /**
+   * @return the placeholder this request realizes, if it was created by {@link #forPlaceholder}.
+   */
+  public Optional<PlaceholderOrigin> placeholderOrigin() {
+    return Optional.ofNullable(placeholderOrigin);
+  }
+
+  /**
    * @return the instantiation purpose; {@link InstantiationPurpose#NORMAL_INSTANCE} unless
    *     configured otherwise.
    */
@@ -301,6 +393,17 @@ public final class InstantiationRequest<T extends UaNode> {
   }
 
   /**
+   * The provenance of a {@link #forPlaceholder} request: the existing instance node the realization
+   * is created under and the placeholder declaration being realized. Carried so plan time can
+   * resolve the parent ReferenceType from the placeholder declaration's own attachment when the
+   * request does not set one explicitly.
+   *
+   * @param instanceNodeId the existing instance node the realization is created under.
+   * @param declaration the placeholder declaration being realized.
+   */
+  public record PlaceholderOrigin(NodeId instanceNodeId, InstanceDeclaration declaration) {}
+
+  /**
    * A per-node behavior hook, run during apply after the complete staged graph is constructed and
    * before anything is committed or published: attach filters, permissions, value sources, and
    * initial state here instead of mutating nodes after creation.
@@ -353,6 +456,9 @@ public final class InstantiationRequest<T extends UaNode> {
     private ConflictPolicy conflictPolicy = ConflictPolicy.FAIL;
     private MethodInstantiation methodInstantiation = MethodInstantiation.COPY;
     private final Map<BrowsePath, NodeId> concreteTypes = new LinkedHashMap<>();
+    private final Map<BrowsePath, List<PlaceholderRealization>> placeholderExpansions =
+        new LinkedHashMap<>();
+    private @Nullable PlaceholderOrigin placeholderOrigin;
     private InstantiationPurpose purpose = InstantiationPurpose.NORMAL_INSTANCE;
     private ReferenceReplicationPolicy referenceReplication = ReferenceReplicationPolicy.DEFAULT;
     private ClassResolution classResolution = ClassResolution.NEAREST_ANCESTOR;
@@ -569,6 +675,10 @@ public final class InstantiationRequest<T extends UaNode> {
      * Choose the concrete subtype instantiated for the (typically abstract-typed) member at {@code
      * path}. Must be the declared member type or a subtype of it.
      *
+     * <p>At {@link BrowsePath#root()}, chooses the concrete subtype the whole request instantiates
+     * in place of its declared type (validated the same way) — this is how a {@link
+     * #forPlaceholder} request selects a concrete subtype of the placeholder's declared type.
+     *
      * @param path the member occurrence path.
      * @param typeDefinitionId the concrete type to instantiate.
      * @return this builder.
@@ -576,6 +686,38 @@ public final class InstantiationRequest<T extends UaNode> {
     public Builder<T> concreteType(BrowsePath path, NodeId typeDefinitionId) {
       concreteTypes.put(
           requireNonNull(path, "path"), requireNonNull(typeDefinitionId, "typeDefinitionId"));
+      return this;
+    }
+
+    /**
+     * Bind realizations to the placeholder declaration at {@code path} — request-time expansion.
+     * Each realization is planned as a sibling of the placeholder (the placeholder's path with its
+     * last element replaced by the realization's BrowseName), with the full member hierarchy of its
+     * (concrete-resolved) type realized beneath it.
+     *
+     * <p>Repeated calls for the same path accumulate. Binding a nested placeholder implies its
+     * ancestors, like {@link #includeOptional}; a MandatoryPlaceholder left without a single
+     * realization is a plan error ({@link
+     * InstantiationDiagnostic.Code#MANDATORY_PLACEHOLDER_UNSATISFIED}); a path naming no expandable
+     * placeholder — mistyped, excluded, or under an omitted ancestor — is a plan error too ({@link
+     * InstantiationDiagnostic.Code#PLACEHOLDER_EXPANSION_INVALID}): expansion is a directive to
+     * create, never silently dropped.
+     *
+     * @param path the placeholder occurrence path (for a placeholder inside another expansion's
+     *     realized subtree: the realized path, e.g. {@code Channel1/<Signal>}).
+     * @param realizations the realizations to bind; at least one.
+     * @return this builder.
+     */
+    public Builder<T> expandPlaceholder(BrowsePath path, PlaceholderRealization... realizations) {
+      requireNonNull(path, "path");
+      if (realizations.length == 0) {
+        throw new IllegalArgumentException("at least one realization is required");
+      }
+      List<PlaceholderRealization> list =
+          placeholderExpansions.computeIfAbsent(path, p -> new ArrayList<>());
+      for (PlaceholderRealization realization : realizations) {
+        list.add(requireNonNull(realization, "realization"));
+      }
       return this;
     }
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/InstantiationRequest.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/InstantiationRequest.java
@@ -1,0 +1,632 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import org.eclipse.milo.opcua.sdk.server.NodeManager;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaMethodNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
+import org.eclipse.milo.opcua.stack.core.AttributeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * An immutable, builder-produced description of one instantiation: what type to instantiate, as
+ * what Java class, with what identity, into which {@link NodeManager}, with which optional members
+ * selected, which NodeIds, and which behavior hooks. Requests are pure data plus behavior hooks —
+ * they perform nothing themselves; {@code NodeInstantiator.plan} joins a request with the type's
+ * {@link TypeInstantiationModel} and {@code apply} materializes the result.
+ *
+ * <p>Structural configuration is declarative (browse paths, policies) so every decision is
+ * inspectable in the resulting {@link InstantiationPlan}; the two hooks ({@link Builder#onNode
+ * onNode}, {@link Builder#bindMethod bindMethod}) exist for <em>behavior</em> — filters,
+ * permissions, value sources, invocation handlers — and run during apply against the complete
+ * staged graph, before anything is published.
+ *
+ * @param <T> the expected Java class of the instance root, checked at plan time.
+ */
+public final class InstantiationRequest<T extends UaNode> {
+
+  private final Class<T> rootClass;
+  private final NodeId typeDefinitionId;
+  private final NodeId rootNodeId;
+  private final AttributeSnapshot rootAttributeOverrides;
+  private final @Nullable NodeId parentNodeId;
+  private final @Nullable NodeId parentReferenceTypeId;
+  private final NodeManager<UaNode> target;
+  private final Set<BrowsePath> includedPaths;
+  private final Set<BrowsePath> excludedPaths;
+  private final boolean includeAllOptionals;
+  private final @Nullable Predicate<InstanceDeclaration> includePredicate;
+  private final @Nullable Function<NodeIdContext, NodeId> nodeIdStrategy;
+  private final Map<BrowsePath, NodeId> assignedNodeIds;
+  private final boolean legacyPathStrings;
+  private final ConflictPolicy conflictPolicy;
+  private final MethodInstantiation methodInstantiation;
+  private final Map<BrowsePath, NodeId> concreteTypes;
+  private final InstantiationPurpose purpose;
+  private final ReferenceReplicationPolicy referenceReplication;
+  private final ClassResolution classResolution;
+  private final List<OnNode> onNodeHooks;
+  private final Map<BrowsePath, Consumer<UaMethodNode>> methodBinders;
+
+  private InstantiationRequest(Builder<T> builder) {
+    this.rootClass = builder.rootClass;
+    this.typeDefinitionId = builder.typeDefinitionId;
+    this.rootNodeId = requireNonNull(builder.rootNodeId, "nodeId");
+    this.rootAttributeOverrides = builder.rootAttributeOverrides.build();
+    this.parentNodeId = builder.parentNodeId;
+    this.parentReferenceTypeId = builder.parentReferenceTypeId;
+    this.target = requireNonNull(builder.target, "target");
+    this.includedPaths = Set.copyOf(builder.includedPaths);
+    this.excludedPaths = Set.copyOf(builder.excludedPaths);
+    this.includeAllOptionals = builder.includeAllOptionals;
+    this.includePredicate = builder.includePredicate;
+    this.nodeIdStrategy = builder.nodeIdStrategy;
+    this.assignedNodeIds = Map.copyOf(builder.assignedNodeIds);
+    this.legacyPathStrings = builder.legacyPathStrings;
+    this.conflictPolicy = builder.conflictPolicy;
+    this.methodInstantiation = builder.methodInstantiation;
+    this.concreteTypes = Map.copyOf(builder.concreteTypes);
+    this.purpose = builder.purpose;
+    this.referenceReplication = builder.referenceReplication;
+    this.classResolution = builder.classResolution;
+    this.onNodeHooks = List.copyOf(builder.onNodeHooks);
+    this.methodBinders = Map.copyOf(builder.methodBinders);
+  }
+
+  /**
+   * Start a request to instantiate the type identified by {@code typeDefinitionId} as an instance
+   * of {@code rootClass}.
+   *
+   * @param rootClass the expected Java class of the instance root; checked at plan time against the
+   *     registered (or nearest-registered-ancestor) class, failing with {@link
+   *     InstantiationDiagnostic.Code#INVALID_ROOT_CLASS} instead of a downstream cast.
+   * @param typeDefinitionId the {@link NodeId} of the ObjectType or VariableType to instantiate.
+   * @param <T> the expected root class.
+   * @return a new {@link Builder}.
+   */
+  public static <T extends UaNode> Builder<T> of(Class<T> rootClass, NodeId typeDefinitionId) {
+    return new Builder<>(rootClass, typeDefinitionId);
+  }
+
+  /**
+   * @return the expected Java class of the instance root.
+   */
+  public Class<T> rootClass() {
+    return rootClass;
+  }
+
+  /**
+   * @return the {@link NodeId} of the type to instantiate.
+   */
+  public NodeId typeDefinitionId() {
+    return typeDefinitionId;
+  }
+
+  /**
+   * @return the {@link NodeId} of the instance root.
+   */
+  public NodeId rootNodeId() {
+    return rootNodeId;
+  }
+
+  /**
+   * @return the request's root attribute overrides, applied over the type-derived defaults; absent
+   *     entries defer to the type, explicit-null entries override with null.
+   */
+  public AttributeSnapshot rootAttributeOverrides() {
+    return rootAttributeOverrides;
+  }
+
+  /**
+   * @return the parent the root is attached under, if placement was requested.
+   */
+  public Optional<NodeId> parentNodeId() {
+    return Optional.ofNullable(parentNodeId);
+  }
+
+  /**
+   * @return the hierarchical ReferenceType the root is attached with, if placement was requested.
+   */
+  public Optional<NodeId> parentReferenceTypeId() {
+    return Optional.ofNullable(parentReferenceTypeId);
+  }
+
+  /**
+   * @return the destination {@link NodeManager} nodes are committed into.
+   */
+  public NodeManager<UaNode> target() {
+    return target;
+  }
+
+  /**
+   * @return the explicitly included occurrence paths; including a nested path implies its
+   *     ancestors.
+   */
+  public Set<BrowsePath> includedPaths() {
+    return includedPaths;
+  }
+
+  /**
+   * @return the explicitly excluded occurrence paths; excluding a path prunes its whole subtree.
+   */
+  public Set<BrowsePath> excludedPaths() {
+    return excludedPaths;
+  }
+
+  /**
+   * @return {@code true} if every Optional declaration is selected.
+   */
+  public boolean includeAllOptionals() {
+    return includeAllOptionals;
+  }
+
+  /**
+   * @return the selection predicate escape hatch, if configured.
+   */
+  public Optional<Predicate<InstanceDeclaration>> includePredicate() {
+    return Optional.ofNullable(includePredicate);
+  }
+
+  /**
+   * @return the per-call NodeId strategy, if configured.
+   */
+  public Optional<Function<NodeIdContext, NodeId>> nodeIdStrategy() {
+    return Optional.ofNullable(nodeIdStrategy);
+  }
+
+  /**
+   * @return the per-path pinned NodeIds; pins win over the strategy and the defaults.
+   */
+  public Map<BrowsePath, NodeId> assignedNodeIds() {
+    return assignedNodeIds;
+  }
+
+  /**
+   * @return {@code true} if unpinned, non-strategy NodeIds use the legacy {@code NodeFactory}
+   *     formula ({@link NodeIdContext#legacyNodeId()}) instead of the escaped default.
+   */
+  public boolean legacyPathStrings() {
+    return legacyPathStrings;
+  }
+
+  /**
+   * @return the collision policy; {@link ConflictPolicy#FAIL} unless configured otherwise.
+   */
+  public ConflictPolicy conflictPolicy() {
+    return conflictPolicy;
+  }
+
+  /**
+   * @return the Method realization mode; {@link MethodInstantiation#COPY} unless configured
+   *     otherwise.
+   */
+  public MethodInstantiation methodInstantiation() {
+    return methodInstantiation;
+  }
+
+  /**
+   * @return the per-path concrete-subtype selections for abstract member types.
+   */
+  public Map<BrowsePath, NodeId> concreteTypes() {
+    return concreteTypes;
+  }
+
+  /**
+   * @return the instantiation purpose; {@link InstantiationPurpose#NORMAL_INSTANCE} unless
+   *     configured otherwise.
+   */
+  public InstantiationPurpose purpose() {
+    return purpose;
+  }
+
+  /**
+   * @return the reference replication policy; {@link ReferenceReplicationPolicy#DEFAULT} unless
+   *     configured otherwise.
+   */
+  public ReferenceReplicationPolicy referenceReplication() {
+    return referenceReplication;
+  }
+
+  /**
+   * @return how Java classes are resolved from the typed registries; {@link
+   *     ClassResolution#NEAREST_ANCESTOR} unless configured otherwise.
+   */
+  public ClassResolution classResolution() {
+    return classResolution;
+  }
+
+  /**
+   * @return the {@code onNode} hooks, in registration order.
+   */
+  public List<OnNode> onNodeHooks() {
+    return onNodeHooks;
+  }
+
+  /**
+   * @return the per-path Method binders.
+   */
+  public Map<BrowsePath, Consumer<UaMethodNode>> methodBinders() {
+    return methodBinders;
+  }
+
+  /**
+   * How the engine resolves the Java class (and constructor) for a type from the typed registries.
+   * This is a per-request knob; the legacy {@code NodeFactory} lookup keeps its exact-match
+   * semantics regardless.
+   */
+  public enum ClassResolution {
+
+    /**
+     * Walk the {@code HasSubtype} chain to the nearest registered ancestor before degrading to
+     * {@code UaObjectNode}/{@code UaVariableNode}, so unregistered subtypes get their closest
+     * registered ancestor's class. The default.
+     */
+    NEAREST_ANCESTOR,
+
+    /** Exact-match only: an unregistered type resolves directly to the base node class. */
+    EXACT
+  }
+
+  /**
+   * A per-node behavior hook, run during apply after the complete staged graph is constructed and
+   * before anything is committed or published: attach filters, permissions, value sources, and
+   * initial state here instead of mutating nodes after creation.
+   */
+  @FunctionalInterface
+  public interface OnNode {
+
+    /**
+     * Customize one staged node.
+     *
+     * @param declaration the declaration occurrence realized by {@code node}; {@code null} for the
+     *     instance root, which realizes the type itself rather than a declaration.
+     * @param node the staged, fully constructed node.
+     * @param parent the staged parent node; non-null for every non-root node, {@code null} for the
+     *     root.
+     * @param graph a read-only view of the complete staged graph, for cross-node wiring.
+     */
+    void accept(
+        @Nullable InstanceDeclaration declaration,
+        UaNode node,
+        @Nullable UaNode parent,
+        StagedGraph graph);
+  }
+
+  /** Builder for {@link InstantiationRequest}s. */
+  public static final class Builder<T extends UaNode> {
+
+    private final Class<T> rootClass;
+    private final NodeId typeDefinitionId;
+
+    private @Nullable NodeId rootNodeId;
+    private final AttributeSnapshot.Builder rootAttributeOverrides = AttributeSnapshot.builder();
+    private @Nullable NodeId parentNodeId;
+    private @Nullable NodeId parentReferenceTypeId;
+    private @Nullable NodeManager<UaNode> target;
+    private final Set<BrowsePath> includedPaths = new LinkedHashSet<>();
+    private final Set<BrowsePath> excludedPaths = new LinkedHashSet<>();
+    private boolean includeAllOptionals = false;
+    private @Nullable Predicate<InstanceDeclaration> includePredicate;
+    private @Nullable Function<NodeIdContext, NodeId> nodeIdStrategy;
+    private final Map<BrowsePath, NodeId> assignedNodeIds = new LinkedHashMap<>();
+    private boolean legacyPathStrings = false;
+    private ConflictPolicy conflictPolicy = ConflictPolicy.FAIL;
+    private MethodInstantiation methodInstantiation = MethodInstantiation.COPY;
+    private final Map<BrowsePath, NodeId> concreteTypes = new LinkedHashMap<>();
+    private InstantiationPurpose purpose = InstantiationPurpose.NORMAL_INSTANCE;
+    private ReferenceReplicationPolicy referenceReplication = ReferenceReplicationPolicy.DEFAULT;
+    private ClassResolution classResolution = ClassResolution.NEAREST_ANCESTOR;
+    private final List<OnNode> onNodeHooks = new ArrayList<>();
+    private final Map<BrowsePath, Consumer<UaMethodNode>> methodBinders = new LinkedHashMap<>();
+
+    private Builder(Class<T> rootClass, NodeId typeDefinitionId) {
+      this.rootClass = requireNonNull(rootClass, "rootClass");
+      this.typeDefinitionId = requireNonNull(typeDefinitionId, "typeDefinitionId");
+    }
+
+    /**
+     * Set the {@link NodeId} of the instance root. Required.
+     *
+     * @param nodeId the root {@link NodeId}.
+     * @return this builder.
+     */
+    public Builder<T> nodeId(NodeId nodeId) {
+      this.rootNodeId = requireNonNull(nodeId, "nodeId");
+      return this;
+    }
+
+    /**
+     * Set the root's BrowseName. Precedence when absent: the type's {@code
+     * DefaultInstanceBrowseName}, then the type's own BrowseName.
+     *
+     * @param browseName the root BrowseName.
+     * @return this builder.
+     */
+    public Builder<T> browseName(QualifiedName browseName) {
+      return rootAttribute(AttributeId.BrowseName, requireNonNull(browseName, "browseName"));
+    }
+
+    /**
+     * Set the root's DisplayName; the type's DisplayName is the default.
+     *
+     * @param displayName the root DisplayName.
+     * @return this builder.
+     */
+    public Builder<T> displayName(LocalizedText displayName) {
+      return rootAttribute(AttributeId.DisplayName, requireNonNull(displayName, "displayName"));
+    }
+
+    /**
+     * Set the root's Description.
+     *
+     * @param description the root Description.
+     * @return this builder.
+     */
+    public Builder<T> description(LocalizedText description) {
+      return rootAttribute(AttributeId.Description, description);
+    }
+
+    /**
+     * Set the root's Value (VariableType instantiation).
+     *
+     * @param value the root Value.
+     * @return this builder.
+     */
+    public Builder<T> value(DataValue value) {
+      return rootAttribute(AttributeId.Value, value);
+    }
+
+    /**
+     * Override any root attribute over the type-derived defaults. A {@code null} value records an
+     * explicit null (distinct from not overriding at all).
+     *
+     * @param attributeId the attribute to override.
+     * @param value the value, or {@code null} for explicit null.
+     * @return this builder.
+     */
+    public Builder<T> rootAttribute(AttributeId attributeId, @Nullable Object value) {
+      rootAttributeOverrides.put(attributeId, value);
+      return this;
+    }
+
+    /**
+     * Attach the root under {@code parentNodeId} via a forward {@code referenceTypeId} reference,
+     * committed atomically with the rest of the graph. Optional: transient or hidden destinations
+     * legitimately have no parent.
+     *
+     * @param parentNodeId the parent node.
+     * @param referenceTypeId the hierarchical ReferenceType to attach with.
+     * @return this builder.
+     */
+    public Builder<T> parent(NodeId parentNodeId, NodeId referenceTypeId) {
+      this.parentNodeId = requireNonNull(parentNodeId, "parentNodeId");
+      this.parentReferenceTypeId = requireNonNull(referenceTypeId, "referenceTypeId");
+      return this;
+    }
+
+    /**
+     * Set the destination {@link NodeManager} nodes are committed into. Required. The source of
+     * type information is always the server's address space; the destination is entirely the
+     * request's business.
+     *
+     * @param target the destination manager.
+     * @return this builder.
+     */
+    public Builder<T> target(NodeManager<UaNode> target) {
+      this.target = requireNonNull(target, "target");
+      return this;
+    }
+
+    /**
+     * Select the Optional (or vendor-rule) declaration at {@code path}. Selecting a nested path
+     * implies its ancestors.
+     *
+     * @param path the occurrence path to include.
+     * @return this builder.
+     */
+    public Builder<T> includeOptional(BrowsePath path) {
+      includedPaths.add(requireNonNull(path, "path"));
+      return this;
+    }
+
+    /**
+     * Exclude the declaration at {@code path}, pruning its whole subtree (descendants are skipped
+     * as {@link SkippedDeclaration.Reason#ANCESTOR_OMITTED}). Excluding a Mandatory declaration
+     * whose parent path exists is a plan error. Exclusion wins over every inclusion mechanism.
+     *
+     * @param path the occurrence path to exclude.
+     * @return this builder.
+     */
+    public Builder<T> excludeOptional(BrowsePath path) {
+      excludedPaths.add(requireNonNull(path, "path"));
+      return this;
+    }
+
+    /**
+     * Select every Optional declaration (vendor-rule declarations stay unselected).
+     *
+     * @return this builder.
+     */
+    public Builder<T> includeAllOptionals() {
+      this.includeAllOptionals = true;
+      return this;
+    }
+
+    /**
+     * Selection escape hatch: consulted for each Optional or vendor-rule declaration not decided by
+     * an explicit path; receives the full {@link InstanceDeclaration} occurrence.
+     *
+     * @param predicate returns {@code true} to select the declaration.
+     * @return this builder.
+     */
+    public Builder<T> includeOptionals(Predicate<InstanceDeclaration> predicate) {
+      this.includePredicate = requireNonNull(predicate, "predicate");
+      return this;
+    }
+
+    /**
+     * Set the NodeId derivation used for every planned node not pinned via {@link #assignNodeId}.
+     * The strategy receives full context and may return any identifier type; {@link
+     * NodeIdContext#defaultNodeId()} and {@link NodeIdContext#legacyNodeId()} are available as
+     * fallbacks.
+     *
+     * @param strategy the derivation function.
+     * @return this builder.
+     */
+    public Builder<T> nodeIdStrategy(Function<NodeIdContext, NodeId> strategy) {
+      this.nodeIdStrategy = requireNonNull(strategy, "strategy");
+      return this;
+    }
+
+    /**
+     * Pin the {@link NodeId} of the planned node at {@code path}; wins over the strategy and the
+     * defaults.
+     *
+     * @param path the occurrence path to pin.
+     * @param nodeId the pinned id.
+     * @return this builder.
+     */
+    public Builder<T> assignNodeId(BrowsePath path, NodeId nodeId) {
+      assignedNodeIds.put(requireNonNull(path, "path"), requireNonNull(nodeId, "nodeId"));
+      return this;
+    }
+
+    /**
+     * Derive unpinned, non-strategy NodeIds with the legacy {@code NodeFactory} formula ({@link
+     * NodeIdContext#legacyNodeId()}) so derived ids match existing deployments during migration.
+     *
+     * @return this builder.
+     */
+    public Builder<T> legacyPathStrings() {
+      this.legacyPathStrings = true;
+      return this;
+    }
+
+    /**
+     * Set the collision policy.
+     *
+     * @param conflictPolicy the policy.
+     * @return this builder.
+     */
+    public Builder<T> conflictPolicy(ConflictPolicy conflictPolicy) {
+      this.conflictPolicy = requireNonNull(conflictPolicy, "conflictPolicy");
+      return this;
+    }
+
+    /**
+     * Set the Method realization mode.
+     *
+     * @param methodInstantiation the mode.
+     * @return this builder.
+     */
+    public Builder<T> methodInstantiation(MethodInstantiation methodInstantiation) {
+      this.methodInstantiation = requireNonNull(methodInstantiation, "methodInstantiation");
+      return this;
+    }
+
+    /**
+     * Choose the concrete subtype instantiated for the (typically abstract-typed) member at {@code
+     * path}. Must be the declared member type or a subtype of it.
+     *
+     * @param path the member occurrence path.
+     * @param typeDefinitionId the concrete type to instantiate.
+     * @return this builder.
+     */
+    public Builder<T> concreteType(BrowsePath path, NodeId typeDefinitionId) {
+      concreteTypes.put(
+          requireNonNull(path, "path"), requireNonNull(typeDefinitionId, "typeDefinitionId"));
+      return this;
+    }
+
+    /**
+     * Set the instantiation purpose.
+     *
+     * @param purpose the purpose.
+     * @return this builder.
+     */
+    public Builder<T> purpose(InstantiationPurpose purpose) {
+      this.purpose = requireNonNull(purpose, "purpose");
+      return this;
+    }
+
+    /**
+     * Set the reference replication policy.
+     *
+     * @param policy the policy.
+     * @return this builder.
+     */
+    public Builder<T> referenceReplication(ReferenceReplicationPolicy policy) {
+      this.referenceReplication = requireNonNull(policy, "policy");
+      return this;
+    }
+
+    /**
+     * Set how Java classes are resolved from the typed registries.
+     *
+     * @param classResolution the resolution mode.
+     * @return this builder.
+     */
+    public Builder<T> classResolution(ClassResolution classResolution) {
+      this.classResolution = requireNonNull(classResolution, "classResolution");
+      return this;
+    }
+
+    /**
+     * Add a per-node behavior hook, run during apply against the complete staged graph. Hooks run
+     * in registration order; a hook exception aborts apply with full rollback.
+     *
+     * @param hook the hook.
+     * @return this builder.
+     */
+    public Builder<T> onNode(OnNode hook) {
+      onNodeHooks.add(requireNonNull(hook, "hook"));
+      return this;
+    }
+
+    /**
+     * Bind behavior to the Method realized at {@code path} (under either {@link
+     * MethodInstantiation} mode), at creation rather than post-hoc. A path matching no planned
+     * Method produces a plan warning.
+     *
+     * @param path the Method occurrence path.
+     * @param binder receives the realized {@link UaMethodNode}.
+     * @return this builder.
+     */
+    public Builder<T> bindMethod(BrowsePath path, Consumer<UaMethodNode> binder) {
+      methodBinders.put(requireNonNull(path, "path"), requireNonNull(binder, "binder"));
+      return this;
+    }
+
+    /**
+     * @return the immutable {@link InstantiationRequest}.
+     * @throws NullPointerException if {@code nodeId} or {@code target} was not set.
+     */
+    public InstantiationRequest<T> build() {
+      return new InstantiationRequest<>(this);
+    }
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/InstantiationRequest.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/InstantiationRequest.java
@@ -71,6 +71,7 @@ public final class InstantiationRequest<T extends UaNode> {
   private final ClassResolution classResolution;
   private final List<OnNode> onNodeHooks;
   private final Map<BrowsePath, Consumer<UaMethodNode>> methodBinders;
+  private final List<Consumer<InstantiationResult<T>>> afterCommitObservers;
 
   private InstantiationRequest(Builder<T> builder) {
     this.rootClass = builder.rootClass;
@@ -95,6 +96,7 @@ public final class InstantiationRequest<T extends UaNode> {
     this.classResolution = builder.classResolution;
     this.onNodeHooks = List.copyOf(builder.onNodeHooks);
     this.methodBinders = Map.copyOf(builder.methodBinders);
+    this.afterCommitObservers = List.copyOf(builder.afterCommitObservers);
   }
 
   /**
@@ -274,6 +276,13 @@ public final class InstantiationRequest<T extends UaNode> {
   }
 
   /**
+   * @return the after-commit observers, in registration order.
+   */
+  public List<Consumer<InstantiationResult<T>>> afterCommitObservers() {
+    return afterCommitObservers;
+  }
+
+  /**
    * How the engine resolves the Java class (and constructor) for a type from the typed registries.
    * This is a per-request knob; the legacy {@code NodeFactory} lookup keeps its exact-match
    * semantics regardless.
@@ -295,6 +304,13 @@ public final class InstantiationRequest<T extends UaNode> {
    * A per-node behavior hook, run during apply after the complete staged graph is constructed and
    * before anything is committed or published: attach filters, permissions, value sources, and
    * initial state here instead of mutating nodes after creation.
+   *
+   * <p>Configure node-local state only. Graph-mutating conveniences ({@link UaNode#addReference},
+   * {@code setProperty}, {@code addComponent}, …) write through the node's context straight into
+   * the live target NodeManager — outside the journaled batch, so they are never rolled back on
+   * failure, never removed by {@link InstantiationResult#deleteCreated()}, and they advance the
+   * target generation, forcing a commit retry. Structure belongs in the request (selection, {@code
+   * assignNodeId}, reference replication), not in a hook.
    */
   @FunctionalInterface
   public interface OnNode {
@@ -342,6 +358,7 @@ public final class InstantiationRequest<T extends UaNode> {
     private ClassResolution classResolution = ClassResolution.NEAREST_ANCESTOR;
     private final List<OnNode> onNodeHooks = new ArrayList<>();
     private final Map<BrowsePath, Consumer<UaMethodNode>> methodBinders = new LinkedHashMap<>();
+    private final List<Consumer<InstantiationResult<T>>> afterCommitObservers = new ArrayList<>();
 
     private Builder(Class<T> rootClass, NodeId typeDefinitionId) {
       this.rootClass = requireNonNull(rootClass, "rootClass");
@@ -609,8 +626,14 @@ public final class InstantiationRequest<T extends UaNode> {
 
     /**
      * Bind behavior to the Method realized at {@code path} (under either {@link
-     * MethodInstantiation} mode), at creation rather than post-hoc. A path matching no planned
-     * Method produces a plan warning.
+     * MethodInstantiation} mode), within the same apply rather than post-hoc. A path matching no
+     * planned Method produces a plan warning.
+     *
+     * <p>Binders run immediately after a successful commit — a binder may target a reused or shared
+     * Method the instantiation does not own, so binding earlier would leave mutations on published
+     * nodes if the commit failed. A binder exception aborts apply and rolls back the committed
+     * additions; a mutation an earlier binder made to a reused or shared node cannot be rolled
+     * back.
      *
      * @param path the Method occurrence path.
      * @param binder receives the realized {@link UaMethodNode}.
@@ -618,6 +641,20 @@ public final class InstantiationRequest<T extends UaNode> {
      */
     public Builder<T> bindMethod(BrowsePath path, Consumer<UaMethodNode> binder) {
       methodBinders.put(requireNonNull(path, "path"), requireNonNull(binder, "binder"));
+      return this;
+    }
+
+    /**
+     * Add an observer notified after a successful commit, with the completed {@link
+     * InstantiationResult}. Notification only: observers run after the graph is committed and
+     * published, and an observer exception is logged and swallowed — it cannot affect the
+     * instantiation's success. Initialization belongs in {@link #onNode} / {@link #bindMethod}.
+     *
+     * @param observer the observer.
+     * @return this builder.
+     */
+    public Builder<T> afterCommit(Consumer<InstantiationResult<T>> observer) {
+      afterCommitObservers.add(requireNonNull(observer, "observer"));
       return this;
     }
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/InstantiationResult.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/InstantiationResult.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.eclipse.milo.opcua.sdk.server.NodeManager;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * The outcome of one applied {@link InstantiationPlan}: the typed root, per-path lookups, the
+ * created/reused/shared index with provenance, the skipped index, the committed references, and
+ * ownership-safe cleanup — everything the caller needs, with no casts and no post-hoc mutation.
+ *
+ * <p>The result also reports the commit guarantee actually achieved ({@link #storageGuarantee()}):
+ * {@link NodeManager.StorageGuarantee#ATOMIC} when the target overrides the storage primitives,
+ * {@link NodeManager.StorageGuarantee#BEST_EFFORT} when the commit ran on the sequential emulations
+ * — a degraded apply proceeds but never silently claims atomicity.
+ *
+ * @param <T> the Java class of the instance root.
+ */
+public final class InstantiationResult<T extends UaNode> {
+
+  private final T root;
+  private final Map<BrowsePath, MaterializedNode> materializedByPath;
+  private final List<MaterializedNode> materializedNodes;
+  private final List<SkippedDeclaration> skippedDeclarations;
+  private final List<MaterializedReference> references;
+  private final List<InstantiationDiagnostic> diagnostics;
+  private final long modelRevision;
+  private final NodeManager.StorageGuarantee storageGuarantee;
+
+  private final NodeManager<UaNode> target;
+  private final AtomicBoolean deleted = new AtomicBoolean(false);
+
+  InstantiationResult(
+      T root,
+      List<MaterializedNode> materializedNodes,
+      List<SkippedDeclaration> skippedDeclarations,
+      List<MaterializedReference> references,
+      List<InstantiationDiagnostic> diagnostics,
+      long modelRevision,
+      NodeManager.StorageGuarantee storageGuarantee,
+      NodeManager<UaNode> target) {
+
+    this.root = root;
+    this.materializedNodes = List.copyOf(materializedNodes);
+    this.skippedDeclarations = List.copyOf(skippedDeclarations);
+    this.references = List.copyOf(references);
+    this.diagnostics = List.copyOf(diagnostics);
+    this.modelRevision = modelRevision;
+    this.storageGuarantee = storageGuarantee;
+    this.target = target;
+
+    var byPath = new LinkedHashMap<BrowsePath, MaterializedNode>();
+    for (MaterializedNode node : this.materializedNodes) {
+      byPath.put(node.browsePath(), node);
+    }
+    this.materializedByPath = byPath;
+  }
+
+  /**
+   * @return the instance root, already of the request's expected class — no cast.
+   */
+  public T root() {
+    return root;
+  }
+
+  /**
+   * @param path the occurrence path to look up.
+   * @return the node realized at {@code path}, if one was.
+   */
+  public Optional<UaNode> node(BrowsePath path) {
+    return Optional.ofNullable(materializedByPath.get(path)).map(MaterializedNode::node);
+  }
+
+  /**
+   * Get the node realized at {@code path}, checked against an expected class.
+   *
+   * @param path the occurrence path to look up.
+   * @param type the expected node class.
+   * @param <N> the expected node class.
+   * @return the node realized at {@code path}.
+   * @throws UaException if no node was realized at {@code path} ({@code Bad_NotFound}) or the
+   *     realized node is not a {@code type} ({@code Bad_TypeMismatch}).
+   */
+  public <N extends UaNode> N require(BrowsePath path, Class<N> type) throws UaException {
+    UaNode node =
+        node(path)
+            .orElseThrow(
+                () -> new UaException(StatusCodes.Bad_NotFound, "no node realized at " + path));
+
+    if (!type.isInstance(node)) {
+      throw new UaException(
+          StatusCodes.Bad_TypeMismatch,
+          "node at " + path + " is a " + node.getClass().getName() + ", not a " + type.getName());
+    }
+
+    return type.cast(node);
+  }
+
+  /**
+   * @return every realized node with provenance, browse-path ordered, the root first.
+   */
+  public List<MaterializedNode> materializedNodes() {
+    return materializedNodes;
+  }
+
+  /**
+   * @param path the occurrence path to look up.
+   * @return the realized entry at {@code path}, with provenance, if one exists.
+   */
+  public Optional<MaterializedNode> materializedNode(BrowsePath path) {
+    return Optional.ofNullable(materializedByPath.get(path));
+  }
+
+  /**
+   * @return every declaration occurrence the plan decided not to realize, with reasons.
+   */
+  public List<SkippedDeclaration> skippedDeclarations() {
+    return skippedDeclarations;
+  }
+
+  /**
+   * @return every reference row the commit touched — planned rows and their inverses — each marked
+   *     added or already-present.
+   */
+  public List<MaterializedReference> references() {
+    return references;
+  }
+
+  /**
+   * @return every finding carried by the plan; a returned result never contains errors. Apply-phase
+   *     failures are reported by {@link InstantiationException} instead of on a result.
+   */
+  public List<InstantiationDiagnostic> diagnostics() {
+    return diagnostics;
+  }
+
+  /**
+   * @return the model revision this instantiation was applied against.
+   */
+  public long modelRevision() {
+    return modelRevision;
+  }
+
+  /**
+   * @return the commit guarantee actually achieved, from the target's capability probe.
+   */
+  public NodeManager.StorageGuarantee storageGuarantee() {
+    return storageGuarantee;
+  }
+
+  /**
+   * Delete everything this instantiation created — the journaled node and reference additions —
+   * from the target {@link NodeManager}, and nothing else.
+   *
+   * <p>Idempotent; subsequent calls do nothing. Removal is by exact journal, never a recursive
+   * delete from the root: reused, shared, and pre-existing resources are untouched, including
+   * reference occurrences that already existed before the commit.
+   *
+   * <p>A removal failure does not abort the cleanup: every remaining journaled item is still
+   * attempted, and the first failure is rethrown afterwards with any others suppressed.
+   */
+  public void deleteCreated() {
+    if (!deleted.compareAndSet(false, true)) {
+      return;
+    }
+
+    RuntimeException failure = null;
+
+    for (MaterializedReference reference : references) {
+      if (!reference.added()) {
+        continue;
+      }
+      try {
+        target.removeReference(reference.reference());
+      } catch (RuntimeException e) {
+        failure = suppress(failure, e);
+      }
+    }
+
+    for (MaterializedNode node : materializedNodes) {
+      if (node.provenance() != MaterializedNode.Provenance.CREATED) {
+        continue;
+      }
+      try {
+        target.removeNode(node.nodeId());
+      } catch (RuntimeException e) {
+        failure = suppress(failure, e);
+      }
+    }
+
+    if (failure != null) {
+      throw failure;
+    }
+  }
+
+  private static RuntimeException suppress(
+      @Nullable RuntimeException failure, RuntimeException next) {
+    if (failure == null) {
+      return next;
+    }
+    failure.addSuppressed(next);
+    return failure;
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/MaterializedNode.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/MaterializedNode.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
+
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+
+/**
+ * One node an apply realized, with the provenance that makes cleanup ownership-safe: {@link
+ * InstantiationResult#deleteCreated()} removes {@link Provenance#CREATED} resources only — a node
+ * that was adopted or shared is never this instantiation's to delete.
+ *
+ * @param browsePath the occurrence path; {@link BrowsePath#root()} for the instance root.
+ * @param node the realized node.
+ * @param provenance how the node was realized.
+ */
+public record MaterializedNode(BrowsePath browsePath, UaNode node, Provenance provenance) {
+
+  /**
+   * @return the realized node's {@link NodeId}.
+   */
+  public NodeId nodeId() {
+    return node.getNodeId();
+  }
+
+  /** How a {@link MaterializedNode} was realized. */
+  public enum Provenance {
+
+    /** A new node was constructed and committed; owned by this instantiation. */
+    CREATED,
+
+    /**
+     * A compatible existing node in the target was adopted ({@link
+     * ConflictPolicy#REUSE_COMPATIBLE}); never modified, never deleted by cleanup.
+     */
+    REUSED,
+
+    /**
+     * The type's own Method node serves this instance ({@link MethodInstantiation#SHARE}); nothing
+     * was constructed and cleanup never touches it.
+     */
+    SHARED
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/MaterializedReference.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/MaterializedReference.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
+
+import org.eclipse.milo.opcua.sdk.core.Reference;
+
+/**
+ * One reference row an apply committed into the target, including the inverse rows added alongside
+ * each planned reference. Rows that were already logically present in the target were skipped by
+ * the commit's deduplication and report {@code added == false}; {@link
+ * InstantiationResult#deleteCreated()} removes only the added rows, so a pre-existing occurrence is
+ * never removed by cleanup.
+ *
+ * @param reference the committed reference row.
+ * @param added {@code true} if the commit physically added the row (it is part of the journal);
+ *     {@code false} if an equal row was already present.
+ */
+public record MaterializedReference(Reference reference, boolean added) {}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/MethodInstantiation.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/MethodInstantiation.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
+
+/**
+ * How Method declarations are realized on instances.
+ *
+ * <p>Sharing is limited to Methods: they are stateless invocation points, the one node kind the
+ * spec community commonly shares (Part 3 §6.4.3 permits it), and the only sharing with observed
+ * user demand. {@code bindMethod} works under either mode.
+ */
+public enum MethodInstantiation {
+
+  /**
+   * Each instance gets its own Method node (and argument Property copies). The default; naive
+   * per-instance handler binding works without surprises.
+   */
+  COPY,
+
+  /**
+   * Instances reference the type's Method node instead of copying it. The Method (and its argument
+   * Properties) are not constructed; the hierarchy reference targets the declaration node itself. A
+   * handler bound to a shared Method serves every instance.
+   */
+  SHARE
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/ModelCompilationException.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/ModelCompilationException.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
+
+import java.util.List;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+
+/**
+ * Thrown when a TypeDefinition's model cannot be compiled: the type graph admits no correct
+ * instantiation (unknown or remote types, cycles, missing hierarchy targets, duplicate sibling
+ * BrowseNames). No model — partial or otherwise — is produced; the full diagnostic list, including
+ * any warnings gathered before the failure, is carried on the exception.
+ */
+public class ModelCompilationException extends UaException {
+
+  private final NodeId typeDefinitionId;
+  private final List<ModelDiagnostic> diagnostics;
+
+  /**
+   * @param typeDefinitionId the type whose compilation failed.
+   * @param diagnostics the full diagnostic list; contains at least one error.
+   */
+  public ModelCompilationException(NodeId typeDefinitionId, List<ModelDiagnostic> diagnostics) {
+    super(StatusCodes.Bad_TypeDefinitionInvalid, buildMessage(typeDefinitionId, diagnostics));
+
+    this.typeDefinitionId = typeDefinitionId;
+    this.diagnostics = List.copyOf(diagnostics);
+  }
+
+  /**
+   * @return the type whose compilation failed.
+   */
+  public NodeId getTypeDefinitionId() {
+    return typeDefinitionId;
+  }
+
+  /**
+   * @return the full diagnostic list gathered during the failed compilation; contains at least one
+   *     {@link ModelDiagnostic.Severity#ERROR} entry.
+   */
+  public List<ModelDiagnostic> getDiagnostics() {
+    return diagnostics;
+  }
+
+  private static String buildMessage(NodeId typeDefinitionId, List<ModelDiagnostic> diagnostics) {
+    long errorCount = diagnostics.stream().filter(ModelDiagnostic::isError).count();
+
+    String firstError =
+        diagnostics.stream()
+            .filter(ModelDiagnostic::isError)
+            .findFirst()
+            .map(d -> d.code() + ": " + d.message())
+            .orElse("no error diagnostics");
+
+    return "model compilation failed for %s (%d error%s): %s"
+        .formatted(typeDefinitionId, errorCount, errorCount == 1 ? "" : "s", firstError);
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/ModelDiagnostic.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/ModelDiagnostic.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
+
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A structured finding produced while compiling a {@link TypeInstantiationModel}.
+ *
+ * <p>The severity dividing line is operational: a diagnostic is an {@link Severity#ERROR} only when
+ * the model admits no correct instantiation of the affected declaration (missing hierarchy targets,
+ * cycles, duplicate sibling BrowseNames, unresolvable types) — the compiler then rejects the whole
+ * compilation rather than returning a silently truncated hierarchy. Everything the walk can
+ * classify and carry — vendor rules, contested rule tightenings, abstract member types, narrowing
+ * violations — is a {@link Severity#WARNING} on a model that remains usable. {@link Severity#INFO}
+ * records traceable exclusions that are not defects (e.g. a rule-less node, which Part 3 §6.2.2
+ * assigns to the type node only).
+ *
+ * @param severity the finding's severity.
+ * @param code the machine-readable finding code.
+ * @param message a human-readable description.
+ * @param browsePath the affected declaration's path, if the finding is path-specific.
+ * @param nodeId the affected node, if identifiable.
+ */
+public record ModelDiagnostic(
+    Severity severity,
+    Code code,
+    String message,
+    @Nullable BrowsePath browsePath,
+    @Nullable NodeId nodeId) {
+
+  /** Severity of a {@link ModelDiagnostic}. */
+  public enum Severity {
+    /** A traceable exclusion or note; not a defect. */
+    INFO,
+    /** A malformed-but-usable finding; the model compiles with the declaration classified. */
+    WARNING,
+    /** The model admits no correct instantiation; compilation is rejected. */
+    ERROR
+  }
+
+  /** Machine-readable codes for {@link ModelDiagnostic}s. */
+  public enum Code {
+    /** The type definition node (root, supertype, or member type) was not found or is remote. */
+    TYPE_NOT_FOUND,
+    /** A node referenced as a type definition is not an ObjectType or VariableType node. */
+    TYPE_NODE_CLASS_INVALID,
+    /** The subtype chain or member-type recursion re-entered a type being compiled. */
+    TYPE_CYCLE,
+    /** A type has more than one resolvable supertype; single inheritance is required. */
+    MULTIPLE_SUPERTYPES,
+    /** A declaration walk re-entered a declaration node already on the current path. */
+    DECLARATION_CYCLE,
+    /** A forward hierarchical reference target could not be resolved. */
+    REFERENCE_TARGET_MISSING,
+    /** Two sibling declarations share a BrowseName (violates Part 3 §4.6.4 / §6.2.6). */
+    DUPLICATE_BROWSE_NAME,
+    /** An Object or Variable declaration has no HasTypeDefinition reference. */
+    TYPE_DEFINITION_MISSING,
+    /** An Object or Variable declaration has more than one HasTypeDefinition reference. */
+    MULTIPLE_TYPE_DEFINITIONS,
+    /**
+     * A NodeClass incompatibility: an override changes NodeClass (Part 3 §6.3.3.3), a declaration's
+     * TypeDefinition has the wrong NodeClass, or a supertype is in a different type family.
+     */
+    NODE_CLASS_MISMATCH,
+    /**
+     * An override's TypeDefinition is not the overridden declaration's type or a subtype (Part 3
+     * §6.3.3.3).
+     */
+    TYPE_INCOMPATIBLE,
+    /**
+     * An override's ModellingRule transition violates Part 3 §6.4.4.2 Table 21, or is the contested
+     * OptionalPlaceholder to MandatoryPlaceholder transition (a warning, not an error, because the
+     * spec does not settle it).
+     */
+    MODELLING_RULE_TIGHTENING,
+    /** An override violates the Variable narrowing rules of Part 3 §6.2.8. */
+    VARIABLE_NARROWING,
+    /** A Method override's argument lists are not compatible (Part 3 §6.3.3.3). */
+    METHOD_SIGNATURE_MISMATCH,
+    /**
+     * A non-placeholder member's TypeDefinition is abstract; instantiation requires a concrete
+     * subtype choice.
+     */
+    ABSTRACT_MEMBER_TYPE,
+    /** A declaration carries a non-standard ModellingRule, classified as {@code OTHER}. */
+    VENDOR_MODELLING_RULE,
+    /**
+     * An Object/Variable/Method under the type has no ModellingRule and is excluded (Part 3
+     * §6.2.2).
+     */
+    NOT_AN_INSTANCE_DECLARATION,
+    /** A declaration carries more than one HasModellingRule reference (Part 3 §7.12 allows one). */
+    MULTIPLE_MODELLING_RULES,
+    /**
+     * A HasModellingRule target is unresolvable, missing, or not a ModellingRuleType Object.
+     * Unresolvable-only targets reject the compile (the declaration cannot be classified); a
+     * missing or wrong-class target node is a warning on the classified declaration.
+     */
+    MODELLING_RULE_INVALID,
+    /** The type or declaration graph exceeds the compiler's depth bound; compilation rejects. */
+    DEPTH_LIMIT_EXCEEDED,
+    /** A reference target matches more than one declaration occurrence; the row stays absolute. */
+    AMBIGUOUS_REFERENCE_TARGET,
+    /** A mandatory interface member has no same-path declaration. */
+    INTERFACE_MEMBER_MISSING,
+    /** A same-path declaration is incompatible with a mandatory interface member. */
+    INTERFACE_MEMBER_INCOMPATIBLE,
+    /** A placeholder declaration's TypeDefinition could not be resolved. */
+    PLACEHOLDER_TYPE_MISSING
+  }
+
+  /**
+   * Create an {@link Severity#ERROR} diagnostic.
+   *
+   * @param code the finding code.
+   * @param message a human-readable description.
+   * @param browsePath the affected path, or {@code null}.
+   * @param nodeId the affected node, or {@code null}.
+   * @return the diagnostic.
+   */
+  public static ModelDiagnostic error(
+      Code code, String message, @Nullable BrowsePath browsePath, @Nullable NodeId nodeId) {
+    return new ModelDiagnostic(Severity.ERROR, code, message, browsePath, nodeId);
+  }
+
+  /**
+   * Create a {@link Severity#WARNING} diagnostic.
+   *
+   * @param code the finding code.
+   * @param message a human-readable description.
+   * @param browsePath the affected path, or {@code null}.
+   * @param nodeId the affected node, or {@code null}.
+   * @return the diagnostic.
+   */
+  public static ModelDiagnostic warning(
+      Code code, String message, @Nullable BrowsePath browsePath, @Nullable NodeId nodeId) {
+    return new ModelDiagnostic(Severity.WARNING, code, message, browsePath, nodeId);
+  }
+
+  /**
+   * Create an {@link Severity#INFO} diagnostic.
+   *
+   * @param code the finding code.
+   * @param message a human-readable description.
+   * @param browsePath the affected path, or {@code null}.
+   * @param nodeId the affected node, or {@code null}.
+   * @return the diagnostic.
+   */
+  public static ModelDiagnostic info(
+      Code code, String message, @Nullable BrowsePath browsePath, @Nullable NodeId nodeId) {
+    return new ModelDiagnostic(Severity.INFO, code, message, browsePath, nodeId);
+  }
+
+  /**
+   * @return {@code true} if this diagnostic's severity is {@link Severity#ERROR}.
+   */
+  public boolean isError() {
+    return severity == Severity.ERROR;
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/ModellingRule.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/ModellingRule.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
+
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+
+/**
+ * Classification of an InstanceDeclaration's ModellingRule (OPC UA Part 3 §6.4.4).
+ *
+ * <p>Every rule is admitted by classification rather than filtering: the five standard rules map to
+ * their own constants, and any other rule Object — vendor-defined rules are explicitly permitted by
+ * Part 3 §6.4.4.1 — classifies as {@link #OTHER} with the raw rule {@link NodeId} preserved on the
+ * {@link InstanceDeclaration}.
+ */
+public enum ModellingRule {
+
+  /** Mandatory ({@code i=78}): a similar node shall exist for each existing BrowsePath. */
+  MANDATORY,
+
+  /** Optional ({@code i=80}): a similar node may exist. */
+  OPTIONAL,
+
+  /**
+   * OptionalPlaceholder ({@code i=11508}): a documented extension point; never instantiated by
+   * default.
+   */
+  OPTIONAL_PLACEHOLDER,
+
+  /**
+   * MandatoryPlaceholder ({@code i=11510}): at least one conforming member shall exist; never
+   * instantiated by default.
+   */
+  MANDATORY_PLACEHOLDER,
+
+  /**
+   * ExposesItsArray ({@code i=83}): one member per array element of the exposing Variable; surfaced
+   * in the model but never materialized by default.
+   */
+  EXPOSES_ITS_ARRAY,
+
+  /**
+   * Any non-standard rule Object. The raw rule id is preserved on the declaration and a model
+   * diagnostic is emitted.
+   */
+  OTHER;
+
+  /**
+   * Classify a raw ModellingRule Object id.
+   *
+   * @param modellingRuleId the {@link NodeId} of the ModellingRule Object.
+   * @return the classification; {@link #OTHER} for any id that is not one of the five standard
+   *     rules.
+   */
+  public static ModellingRule of(NodeId modellingRuleId) {
+    if (NodeIds.ModellingRule_Mandatory.equals(modellingRuleId)) {
+      return MANDATORY;
+    } else if (NodeIds.ModellingRule_Optional.equals(modellingRuleId)) {
+      return OPTIONAL;
+    } else if (NodeIds.ModellingRule_OptionalPlaceholder.equals(modellingRuleId)) {
+      return OPTIONAL_PLACEHOLDER;
+    } else if (NodeIds.ModellingRule_MandatoryPlaceholder.equals(modellingRuleId)) {
+      return MANDATORY_PLACEHOLDER;
+    } else if (NodeIds.ModellingRule_ExposesItsArray.equals(modellingRuleId)) {
+      return EXPOSES_ITS_ARRAY;
+    } else {
+      return OTHER;
+    }
+  }
+
+  /**
+   * @return {@code true} for {@link #OPTIONAL_PLACEHOLDER} and {@link #MANDATORY_PLACEHOLDER}.
+   */
+  public boolean isPlaceholder() {
+    return this == OPTIONAL_PLACEHOLDER || this == MANDATORY_PLACEHOLDER;
+  }
+
+  /**
+   * @return {@code true} for rules recorded shallowly — placeholders and {@link #EXPOSES_ITS_ARRAY}
+   *     — whose declaration subtrees are neither walked nor instantiated by default (Part 3
+   *     §6.4.4.4.4–.5).
+   */
+  public boolean isShallow() {
+    return isPlaceholder() || this == EXPOSES_ITS_ARRAY;
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/NodeIdContext.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/NodeIdContext.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
+
+import java.util.UUID;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+
+/**
+ * The full context a request's {@code nodeIdStrategy} receives for one planned node: the instance
+ * root's {@link NodeId}, the occurrence's {@link BrowsePath}, and the {@link InstanceDeclaration}
+ * being realized. Any identifier type may be returned; every produced id is collision-checked
+ * against the target and the rest of the plan before anything is constructed.
+ *
+ * <p>{@link #defaultNodeId()} and {@link #legacyNodeId()} expose the built-in derivations so a
+ * strategy can special-case some paths and fall back for the rest.
+ *
+ * @param rootNodeId the {@link NodeId} of the instance root being planned.
+ * @param path the occurrence's {@link BrowsePath} relative to the root.
+ * @param declaration the declaration occurrence being realized.
+ */
+public record NodeIdContext(NodeId rootNodeId, BrowsePath path, InstanceDeclaration declaration) {
+
+  /**
+   * The default derivation: a String identifier in the root's namespace, the root identifier prefix
+   * followed by {@code /<namespaceIndex>:<name>} per path element, with {@code \}, {@code /}, and
+   * {@code :} escaped inside names ({@code \\}, {@code \/}, {@code \:}) and non-String root
+   * identifiers rendered with a type marker ({@code i=}, {@code g=}, {@code b=}).
+   *
+   * <p>Unlike the legacy formula this is collision-resistant: a member named {@code "A/1:B"} cannot
+   * collide with a nested member {@code A} containing {@code B}, and a numeric root {@code 7}
+   * cannot collide with a String root {@code "7"}.
+   *
+   * @return the default {@link NodeId} for this occurrence.
+   */
+  public NodeId defaultNodeId() {
+    Object rootIdentifier = rootNodeId.getIdentifier();
+
+    String prefix;
+    if (rootIdentifier instanceof String s) {
+      prefix = s;
+    } else if (rootIdentifier instanceof UInteger u) {
+      prefix = "i=" + u;
+    } else if (rootIdentifier instanceof UUID g) {
+      prefix = "g=" + g;
+    } else {
+      prefix = "b=" + rootIdentifier;
+    }
+
+    StringBuilder sb = new StringBuilder(prefix);
+    for (QualifiedName element : path.elements()) {
+      sb.append('/').append(element.namespaceIndex()).append(':').append(escape(element.name()));
+    }
+
+    return new NodeId(rootNodeId.getNamespaceIndex(), sb.toString());
+  }
+
+  /**
+   * The legacy {@code NodeFactory} derivation, verbatim: the root identifier's string form
+   * concatenated with {@code /<namespaceIndex>:<name>} per path element, unescaped, a String
+   * identifier in the root's namespace. Ambiguous by construction (that is D9); provided because
+   * derived ids are persisted identity for existing deployments migrating to this API.
+   *
+   * @return the legacy-formula {@link NodeId} for this occurrence.
+   */
+  public NodeId legacyNodeId() {
+    StringBuilder sb = new StringBuilder(String.valueOf(rootNodeId.getIdentifier()));
+    for (QualifiedName element : path.elements()) {
+      sb.append('/').append(element.namespaceIndex()).append(':').append(element.name());
+    }
+
+    return new NodeId(rootNodeId.getNamespaceIndex(), sb.toString());
+  }
+
+  private static String escape(String name) {
+    StringBuilder sb = new StringBuilder(name.length());
+    for (int i = 0; i < name.length(); i++) {
+      char c = name.charAt(i);
+      if (c == '\\' || c == '/' || c == ':') {
+        sb.append('\\');
+      }
+      sb.append(c);
+    }
+    return sb.toString();
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/NodeIdContext.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/NodeIdContext.java
@@ -14,6 +14,7 @@ import java.util.UUID;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.jspecify.annotations.Nullable;
 
 /**
  * The full context a request's {@code nodeIdStrategy} receives for one planned node: the instance
@@ -33,12 +34,15 @@ public record NodeIdContext(NodeId rootNodeId, BrowsePath path, InstanceDeclarat
   /**
    * The default derivation: a String identifier in the root's namespace, the root identifier prefix
    * followed by {@code /<namespaceIndex>:<name>} per path element, with {@code \}, {@code /}, and
-   * {@code :} escaped inside names ({@code \\}, {@code \/}, {@code \:}) and non-String root
-   * identifiers rendered with a type marker ({@code i=}, {@code g=}, {@code b=}).
+   * {@code :} escaped ({@code \\}, {@code \/}, {@code \:}) inside names and String root identifiers
+   * alike. Non-String root identifiers are rendered with a type marker ({@code i=}, {@code g=},
+   * {@code b=}); a String root that itself begins with a marker gets an {@code s=} marker so no
+   * rendered root can impersonate another.
    *
    * <p>Unlike the legacy formula this is collision-resistant: a member named {@code "A/1:B"} cannot
-   * collide with a nested member {@code A} containing {@code B}, and a numeric root {@code 7}
-   * cannot collide with a String root {@code "7"}.
+   * collide with a nested member {@code A} containing {@code B}, a numeric root {@code 7} cannot
+   * collide with a String root {@code "7"} or {@code "i=7"}, and a String root containing {@code /}
+   * or {@code :} cannot collide with another root's derived member.
    *
    * @return the default {@link NodeId} for this occurrence.
    */
@@ -47,7 +51,7 @@ public record NodeIdContext(NodeId rootNodeId, BrowsePath path, InstanceDeclarat
 
     String prefix;
     if (rootIdentifier instanceof String s) {
-      prefix = s;
+      prefix = mimicsTypeMarker(s) ? "s=" + escape(s) : escape(s);
     } else if (rootIdentifier instanceof UInteger u) {
       prefix = "i=" + u;
     } else if (rootIdentifier instanceof UUID g) {
@@ -67,8 +71,8 @@ public record NodeIdContext(NodeId rootNodeId, BrowsePath path, InstanceDeclarat
   /**
    * The legacy {@code NodeFactory} derivation, verbatim: the root identifier's string form
    * concatenated with {@code /<namespaceIndex>:<name>} per path element, unescaped, a String
-   * identifier in the root's namespace. Ambiguous by construction (that is D9); provided because
-   * derived ids are persisted identity for existing deployments migrating to this API.
+   * identifier in the root's namespace. Ambiguous by construction; provided anyway because derived
+   * ids are persisted identity for existing deployments migrating to this API.
    *
    * @return the legacy-formula {@link NodeId} for this occurrence.
    */
@@ -81,7 +85,25 @@ public record NodeIdContext(NodeId rootNodeId, BrowsePath path, InstanceDeclarat
     return new NodeId(rootNodeId.getNamespaceIndex(), sb.toString());
   }
 
-  private static String escape(String name) {
+  /**
+   * Whether {@code identifier} begins with one of the rendered root markers ({@code i=}, {@code
+   * g=}, {@code b=}, {@code s=}), in which case it needs an {@code s=} marker of its own to stay
+   * distinguishable from a rendered non-String root.
+   */
+  private static boolean mimicsTypeMarker(String identifier) {
+    if (identifier.length() < 2 || identifier.charAt(1) != '=') {
+      return false;
+    }
+    char c = identifier.charAt(0);
+    return c == 'i' || c == 'g' || c == 'b' || c == 's';
+  }
+
+  private static String escape(@Nullable String name) {
+    if (name == null) {
+      // A QualifiedName's name may be null; derive from the empty string rather than failing
+      // where the model layer tolerated the malformed BrowseName.
+      return "";
+    }
     StringBuilder sb = new StringBuilder(name.length());
     for (int i = 0; i < name.length(); i++) {
       char c = name.charAt(i);

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/NodeInstantiator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/NodeInstantiator.java
@@ -1,0 +1,1103 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import org.eclipse.milo.opcua.sdk.core.Reference;
+import org.eclipse.milo.opcua.sdk.core.ValueRanks;
+import org.eclipse.milo.opcua.sdk.server.NodeManager;
+import org.eclipse.milo.opcua.sdk.server.ObjectTypeManager;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.sdk.server.VariableTypeManager;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaMethodNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableNode;
+import org.eclipse.milo.opcua.stack.core.AttributeId;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * The server-scoped instantiation facade: {@link #describe} exposes a type's compiled {@link
+ * TypeInstantiationModel} (through the server's {@link TypeModelCache}), and {@link #plan} joins a
+ * model with an {@link InstantiationRequest} into a pure-data {@link InstantiationPlan} — no nodes
+ * created, nothing mutated.
+ *
+ * <p>Source type information always comes from the server's address space; the destination is
+ * entirely the request's business (its target {@link NodeManager}) — plan only ever <em>reads</em>
+ * the target, for collision preflight.
+ */
+public final class NodeInstantiator {
+
+  private final OpcUaServer server;
+
+  /**
+   * Create an instantiator scoped to {@code server}.
+   *
+   * @param server the server whose address space, model cache, and typed registries are used.
+   */
+  public NodeInstantiator(OpcUaServer server) {
+    this.server = server;
+  }
+
+  /**
+   * Get the compiled instantiation model of the type identified by {@code typeDefinitionId},
+   * through the server's {@link TypeModelCache}.
+   *
+   * @param typeDefinitionId the {@link NodeId} of an ObjectType or VariableType node.
+   * @return the compiled, validated {@link TypeInstantiationModel}.
+   * @throws UaException if the type graph admits no correct instantiation (see {@link
+   *     ModelCompilationException}).
+   */
+  public TypeInstantiationModel describe(NodeId typeDefinitionId) throws UaException {
+    return server.getTypeModelCache().getOrCompile(typeDefinitionId);
+  }
+
+  /**
+   * Compute the plan joining {@code request} with its type's model: every declaration accounted
+   * for, all NodeIds allocated and collision-checked, every reference resolved to instance ids.
+   *
+   * <p>Pure computation: nothing is constructed and nothing — source or target — is mutated.
+   * Request-level findings (collisions, invalid classes, omitted Mandatories, …) are returned
+   * <em>on</em> the plan as {@link InstantiationDiagnostic}s rather than thrown; a plan carrying
+   * errors is inspectable but refused by apply.
+   *
+   * @param request the request to plan.
+   * @param <T> the expected root class.
+   * @return the computed {@link InstantiationPlan}.
+   * @throws UaException if the type's model cannot be compiled.
+   */
+  public <T extends UaNode> InstantiationPlan<T> plan(InstantiationRequest<T> request)
+      throws UaException {
+
+    TypeInstantiationModel model = describe(request.typeDefinitionId());
+
+    return new PlanComputation<>(this, request, model).compute();
+  }
+
+  /**
+   * One plan computation: selection, class and attribute resolution, NodeId allocation, collision
+   * preflight, and reference resolution over a single model snapshot.
+   */
+  private static final class PlanComputation<T extends UaNode> {
+
+    private final NodeInstantiator instantiator;
+    private final OpcUaServer server;
+    private final InstantiationRequest<T> request;
+    private final TypeInstantiationModel model;
+
+    private final Map<BrowsePath, Working> planned = new LinkedHashMap<>();
+    private final Map<BrowsePath, SkippedDeclaration> skipped = new LinkedHashMap<>();
+    private final List<InstantiationDiagnostic> diagnostics = new ArrayList<>();
+    private final Map<NodeId, TypeInstantiationModel> memberModels = new HashMap<>();
+
+    private PlanComputation(
+        NodeInstantiator instantiator,
+        InstantiationRequest<T> request,
+        TypeInstantiationModel model) {
+
+      this.instantiator = instantiator;
+      this.server = instantiator.server;
+      this.request = request;
+      this.model = model;
+    }
+
+    InstantiationPlan<T> compute() throws UaException {
+      planRoot();
+
+      for (InstanceDeclaration declaration : model.declarations()) {
+        classify(declaration);
+      }
+
+      allocateNodeIds();
+      preflightCollisions();
+
+      List<Reference> references = resolveReferences();
+
+      warnUnmatchedPaths();
+
+      List<PlannedNode> plannedNodes =
+          planned.values().stream().map(Working::toPlannedNode).toList();
+
+      return new InstantiationPlan<>(
+          request, model, plannedNodes, List.copyOf(skipped.values()), references, diagnostics);
+    }
+
+    // region Root
+
+    private void planRoot() {
+      AttributeSnapshot typeAttributes = model.rootAttributes();
+
+      NodeClass typeNodeClass = (NodeClass) typeAttributes.getOrNull(AttributeId.NodeClass);
+      NodeClass instanceNodeClass =
+          typeNodeClass == NodeClass.VariableType ? NodeClass.Variable : NodeClass.Object;
+
+      if (Boolean.TRUE.equals(typeAttributes.getOrNull(AttributeId.IsAbstract))) {
+        diagnostics.add(
+            InstantiationDiagnostic.planError(
+                InstantiationDiagnostic.Code.ABSTRACT_TYPE,
+                "type " + model.typeDefinitionId() + " is abstract; request a concrete subtype",
+                BrowsePath.root(),
+                model.typeDefinitionId()));
+      }
+
+      ResolvedClass resolved = resolveJavaClass(model.typeDefinitionId(), instanceNodeClass);
+
+      if (!request.rootClass().isAssignableFrom(resolved.javaClass())) {
+        diagnostics.add(
+            InstantiationDiagnostic.planError(
+                InstantiationDiagnostic.Code.INVALID_ROOT_CLASS,
+                "type "
+                    + model.typeDefinitionId()
+                    + " resolves to "
+                    + resolved.javaClass().getName()
+                    + ", not assignable to expected root class "
+                    + request.rootClass().getName(),
+                BrowsePath.root(),
+                model.typeDefinitionId()));
+      }
+
+      AttributeSnapshot effective = rootEffectiveAttributes(typeAttributes, instanceNodeClass);
+
+      if (instanceNodeClass == NodeClass.Variable) {
+        validateRootNarrowing(effective, typeAttributes);
+      }
+
+      Working root =
+          new Working(
+              BrowsePath.root(),
+              null,
+              instanceNodeClass,
+              model.typeDefinitionId(),
+              resolved.javaClass(),
+              resolved.constructorTypeId(),
+              effective);
+      root.nodeId = request.rootNodeId();
+
+      planned.put(BrowsePath.root(), root);
+    }
+
+    /**
+     * Root attributes come from the type per Part 3 §6.4.2 (minus type-only attributes), then the
+     * request's overrides; BrowseName precedence is request over {@code DefaultInstanceBrowseName}
+     * over the type's own BrowseName.
+     */
+    private AttributeSnapshot rootEffectiveAttributes(
+        AttributeSnapshot typeAttributes, NodeClass instanceNodeClass) {
+
+      AttributeSnapshot.Builder b = AttributeSnapshot.builder();
+
+      for (AttributeId id : typeAttributes.attributeIds()) {
+        if (id == AttributeId.IsAbstract || id == AttributeId.NodeClass) {
+          continue;
+        }
+        b.put(id, typeAttributes.isNull(id) ? null : typeAttributes.getOrNull(id));
+      }
+
+      b.put(AttributeId.NodeClass, instanceNodeClass);
+
+      AttributeSnapshot overrides = request.rootAttributeOverrides();
+
+      if (!overrides.contains(AttributeId.BrowseName)) {
+        model
+            .defaultInstanceBrowseName()
+            .ifPresent(defaultName -> b.put(AttributeId.BrowseName, defaultName));
+      }
+
+      for (AttributeId id : overrides.attributeIds()) {
+        b.put(id, overrides.isNull(id) ? null : overrides.getOrNull(id));
+      }
+
+      return b.build();
+    }
+
+    private void validateRootNarrowing(AttributeSnapshot effective, AttributeSnapshot base) {
+      AttributeSnapshot overrides = request.rootAttributeOverrides();
+
+      NodeId effectiveDataType = effective.dataType();
+      NodeId baseDataType = base.dataType();
+      if (overrides.contains(AttributeId.DataType)
+          && effectiveDataType != null
+          && baseDataType != null
+          && !isTypeSubtypeOfOrEqual(effectiveDataType, baseDataType)) {
+        diagnostics.add(
+            InstantiationDiagnostic.planError(
+                InstantiationDiagnostic.Code.VARIABLE_NARROWING,
+                "requested DataType "
+                    + effectiveDataType
+                    + " is not "
+                    + baseDataType
+                    + " or a subtype (Part 3 §6.2.8)",
+                BrowsePath.root(),
+                model.typeDefinitionId()));
+      }
+
+      Integer effectiveRank = effective.valueRank();
+      Integer baseRank = base.valueRank();
+      if (overrides.contains(AttributeId.ValueRank)
+          && effectiveRank != null
+          && baseRank != null
+          && !isValueRankRestriction(baseRank, effectiveRank)) {
+        diagnostics.add(
+            InstantiationDiagnostic.planError(
+                InstantiationDiagnostic.Code.VARIABLE_NARROWING,
+                "requested ValueRank "
+                    + effectiveRank
+                    + " is not a valid restriction of "
+                    + baseRank
+                    + " (Part 3 §6.2.8)",
+                BrowsePath.root(),
+                model.typeDefinitionId()));
+      }
+
+      UInteger[] effectiveDimensions = effective.arrayDimensions();
+      UInteger[] baseDimensions = base.arrayDimensions();
+      if (overrides.contains(AttributeId.ArrayDimensions)
+          && effectiveDimensions != null
+          && baseDimensions != null
+          && !isArrayDimensionsRestriction(baseDimensions, effectiveDimensions)) {
+        diagnostics.add(
+            InstantiationDiagnostic.planError(
+                InstantiationDiagnostic.Code.VARIABLE_NARROWING,
+                "requested ArrayDimensions are not a valid restriction (Part 3 §6.2.8)",
+                BrowsePath.root(),
+                model.typeDefinitionId()));
+      }
+    }
+
+    // endregion
+
+    // region Selection
+
+    private void classify(InstanceDeclaration declaration) throws UaException {
+      BrowsePath path = declaration.browsePath();
+      BrowsePath parentPath = path.parent();
+
+      if (skipped.containsKey(parentPath)) {
+        skip(declaration, SkippedDeclaration.Reason.ANCESTOR_OMITTED);
+        return;
+      }
+
+      Working parent = planned.get(parentPath);
+      if (parent == null) {
+        // Defensive: paths are ordered parents-first, so an unaccounted parent cannot happen.
+        skip(declaration, SkippedDeclaration.Reason.ANCESTOR_OMITTED);
+        return;
+      }
+
+      if (parent.materialization == PlannedNode.Materialization.SHARE) {
+        skip(declaration, SkippedDeclaration.Reason.METHOD_SHARED);
+        return;
+      }
+
+      if (request.excludedPaths().contains(path)) {
+        if (declaration.rule() == ModellingRule.MANDATORY) {
+          diagnostics.add(
+              InstantiationDiagnostic.planError(
+                  InstantiationDiagnostic.Code.MANDATORY_OMITTED,
+                  "Mandatory declaration at "
+                      + path
+                      + " was excluded but its parent path exists (Part 3 §6.4.4.4.2)",
+                  path,
+                  declaration.declarationNodeId()));
+        }
+        skip(declaration, SkippedDeclaration.Reason.EXCLUDED);
+        return;
+      }
+
+      switch (declaration.rule()) {
+        case MANDATORY -> plan(declaration);
+        case OPTIONAL -> {
+          if (isSelected(declaration, true)) {
+            plan(declaration);
+          } else {
+            skip(declaration, SkippedDeclaration.Reason.OPTIONAL_NOT_SELECTED);
+          }
+        }
+        case OTHER -> {
+          if (isSelected(declaration, false)) {
+            plan(declaration);
+          } else {
+            skip(declaration, SkippedDeclaration.Reason.VENDOR_RULE);
+          }
+        }
+        case OPTIONAL_PLACEHOLDER -> skip(declaration, SkippedDeclaration.Reason.PLACEHOLDER);
+        case MANDATORY_PLACEHOLDER -> {
+          skip(declaration, SkippedDeclaration.Reason.PLACEHOLDER);
+          // Placeholder expansion does not exist yet; the ≥1-realization obligation becomes an
+          // error once a request can satisfy it.
+          diagnostics.add(
+              InstantiationDiagnostic.planWarning(
+                  InstantiationDiagnostic.Code.MANDATORY_PLACEHOLDER_UNSATISFIED,
+                  "MandatoryPlaceholder at "
+                      + path
+                      + " requires at least one realization; none is bound by this request",
+                  path,
+                  declaration.declarationNodeId()));
+        }
+        case EXPOSES_ITS_ARRAY -> {
+          skip(declaration, SkippedDeclaration.Reason.EXPOSES_ITS_ARRAY);
+          diagnostics.add(
+              InstantiationDiagnostic.planWarning(
+                  InstantiationDiagnostic.Code.EXPOSES_ITS_ARRAY_NOT_MATERIALIZED,
+                  "ExposesItsArray declaration at " + path + " is not materialized",
+                  path,
+                  declaration.declarationNodeId()));
+        }
+      }
+    }
+
+    private boolean isSelected(InstanceDeclaration declaration, boolean isOptional) {
+      BrowsePath path = declaration.browsePath();
+
+      for (BrowsePath included : request.includedPaths()) {
+        // Selecting a nested path implies its ancestors.
+        if (included.startsWith(path)) {
+          return true;
+        }
+      }
+
+      if (isOptional && request.includeAllOptionals()) {
+        return true;
+      }
+
+      return request.includePredicate().map(p -> p.test(declaration)).orElse(false);
+    }
+
+    private void skip(InstanceDeclaration declaration, SkippedDeclaration.Reason reason) {
+      skipped.put(declaration.browsePath(), new SkippedDeclaration(declaration, reason));
+    }
+
+    // endregion
+
+    // region Member resolution
+
+    private void plan(InstanceDeclaration declaration) throws UaException {
+      BrowsePath path = declaration.browsePath();
+
+      if (declaration.nodeClass() == NodeClass.Method) {
+        planMethod(declaration);
+        return;
+      }
+
+      NodeId declaredTypeId =
+          Objects.requireNonNull(declaration.typeDefinitionId(), "typeDefinitionId");
+      NodeId effectiveTypeId = declaredTypeId;
+
+      NodeId concreteTypeId = request.concreteTypes().get(path);
+      if (concreteTypeId != null && !concreteTypeId.equals(declaredTypeId)) {
+        if (isTypeSubtypeOfOrEqual(concreteTypeId, declaredTypeId)) {
+          effectiveTypeId = concreteTypeId;
+        } else {
+          diagnostics.add(
+              InstantiationDiagnostic.planError(
+                  InstantiationDiagnostic.Code.CONCRETE_TYPE_INVALID,
+                  "concreteType "
+                      + concreteTypeId
+                      + " for "
+                      + path
+                      + " is not declared type "
+                      + declaredTypeId
+                      + " or a subtype",
+                  path,
+                  concreteTypeId));
+        }
+      }
+
+      TypeInstantiationModel memberModel = memberModel(effectiveTypeId, path);
+
+      if (memberModel != null) {
+        validateMemberType(declaration, memberModel, effectiveTypeId);
+      }
+
+      AttributeSnapshot effective = memberEffectiveAttributes(declaration, memberModel);
+
+      ResolvedClass resolved = resolveJavaClass(effectiveTypeId, declaration.nodeClass());
+
+      planned.put(
+          path,
+          new Working(
+              path,
+              declaration,
+              declaration.nodeClass(),
+              effectiveTypeId,
+              resolved.javaClass(),
+              resolved.constructorTypeId(),
+              effective));
+    }
+
+    private void planMethod(InstanceDeclaration declaration) {
+      BrowsePath path = declaration.browsePath();
+
+      // A Method signature finding on the declaration's own path is worth surfacing per request.
+      model.diagnostics().stream()
+          .filter(d -> d.code() == ModelDiagnostic.Code.METHOD_SIGNATURE_MISMATCH)
+          .filter(d -> path.equals(d.browsePath()))
+          .findFirst()
+          .ifPresent(
+              d ->
+                  diagnostics.add(
+                      InstantiationDiagnostic.planWarning(
+                          InstantiationDiagnostic.Code.METHOD_SIGNATURE_MISMATCH,
+                          d.message(),
+                          path,
+                          declaration.declarationNodeId())));
+
+      Working working =
+          new Working(
+              path,
+              declaration,
+              NodeClass.Method,
+              null,
+              UaMethodNode.class,
+              null,
+              declaration.attributes());
+
+      if (request.methodInstantiation() == MethodInstantiation.SHARE) {
+        working.materialization = PlannedNode.Materialization.SHARE;
+        working.nodeId = declaration.declarationNodeId();
+      }
+
+      planned.put(path, working);
+    }
+
+    private void validateMemberType(
+        InstanceDeclaration declaration,
+        TypeInstantiationModel memberModel,
+        NodeId effectiveTypeId) {
+
+      BrowsePath path = declaration.browsePath();
+      boolean isConcreteOverride = !effectiveTypeId.equals(declaration.typeDefinitionId());
+
+      AttributeSnapshot memberTypeAttributes = memberModel.rootAttributes();
+
+      NodeClass memberTypeNodeClass =
+          (NodeClass) memberTypeAttributes.getOrNull(AttributeId.NodeClass);
+      boolean classCompatible =
+          (declaration.nodeClass() == NodeClass.Object
+                  && memberTypeNodeClass == NodeClass.ObjectType)
+              || (declaration.nodeClass() == NodeClass.Variable
+                  && memberTypeNodeClass == NodeClass.VariableType);
+      if (isConcreteOverride && !classCompatible) {
+        diagnostics.add(
+            InstantiationDiagnostic.planError(
+                InstantiationDiagnostic.Code.CONCRETE_TYPE_INVALID,
+                "concreteType "
+                    + effectiveTypeId
+                    + " for "
+                    + path
+                    + " has NodeClass "
+                    + memberTypeNodeClass,
+                path,
+                effectiveTypeId));
+      }
+
+      if (Boolean.TRUE.equals(memberTypeAttributes.getOrNull(AttributeId.IsAbstract))) {
+        if (isConcreteOverride) {
+          diagnostics.add(
+              InstantiationDiagnostic.planError(
+                  InstantiationDiagnostic.Code.CONCRETE_TYPE_INVALID,
+                  "concreteType " + effectiveTypeId + " for " + path + " is itself abstract",
+                  path,
+                  effectiveTypeId));
+        } else {
+          diagnostics.add(
+              InstantiationDiagnostic.planError(
+                  InstantiationDiagnostic.Code.ABSTRACT_MEMBER_TYPE,
+                  "member type "
+                      + effectiveTypeId
+                      + " at "
+                      + path
+                      + " is abstract; select a concrete subtype via concreteType(path, typeId)",
+                  path,
+                  effectiveTypeId));
+        }
+      }
+
+      if (isConcreteOverride) {
+        // The plan realizes the *declared* type's members; a concrete subtype's additional
+        // members are not expanded in this release. Say so instead of silently omitting them.
+        boolean hasUnmodeledMembers =
+            memberModel.declarations().stream()
+                .map(md -> path.concat(md.browsePath()))
+                .anyMatch(p -> model.get(p).isEmpty());
+        if (hasUnmodeledMembers) {
+          diagnostics.add(
+              InstantiationDiagnostic.planWarning(
+                  InstantiationDiagnostic.Code.CONCRETE_TYPE_NOT_EXPANDED,
+                  "concreteType "
+                      + effectiveTypeId
+                      + " for "
+                      + path
+                      + " declares members beyond "
+                      + declaration.typeDefinitionId()
+                      + "; they are not expanded",
+                  path,
+                  effectiveTypeId));
+        }
+      }
+    }
+
+    /**
+     * Member-type attribute defaults per the attribute policy: a Variable declaration's absent (or
+     * explicitly unset Value) attributes fall back to its (concrete-resolved) VariableType's,
+     * before class defaults apply at construction.
+     */
+    private AttributeSnapshot memberEffectiveAttributes(
+        InstanceDeclaration declaration, @Nullable TypeInstantiationModel memberModel) {
+
+      AttributeSnapshot declared = declaration.attributes();
+
+      if (declaration.nodeClass() != NodeClass.Variable || memberModel == null) {
+        return declared;
+      }
+
+      AttributeSnapshot typeAttributes = memberModel.rootAttributes();
+
+      AttributeSnapshot.Builder b = AttributeSnapshot.builder();
+      for (AttributeId id : declared.attributeIds()) {
+        b.put(id, declared.isNull(id) ? null : declared.getOrNull(id));
+      }
+
+      for (AttributeId id :
+          List.of(
+              AttributeId.Value,
+              AttributeId.DataType,
+              AttributeId.ValueRank,
+              AttributeId.ArrayDimensions)) {
+        boolean declaredProvides;
+        if (id == AttributeId.Value) {
+          // A Variable's Value attribute always exists; "no value declared" is a DataValue
+          // carrying a null Variant (the Bad_NoValue convention), not an absent attribute.
+          DataValue declaredValue = declared.value();
+          declaredProvides = declaredValue != null && declaredValue.getValue().getValue() != null;
+        } else {
+          declaredProvides = declared.contains(id) && !declared.isNull(id);
+        }
+        if (!declaredProvides && typeAttributes.contains(id) && !typeAttributes.isNull(id)) {
+          b.put(id, typeAttributes.getOrNull(id));
+        }
+      }
+
+      return b.build();
+    }
+
+    private @Nullable TypeInstantiationModel memberModel(NodeId typeId, BrowsePath path)
+        throws UaException {
+
+      if (memberModels.containsKey(typeId)) {
+        return memberModels.get(typeId);
+      }
+
+      TypeInstantiationModel memberModel;
+      try {
+        memberModel = instantiator.describe(typeId);
+      } catch (ModelCompilationException e) {
+        // The main model compiled, so a failing member compile means a concrete-type selection
+        // that does not itself compile.
+        diagnostics.add(
+            InstantiationDiagnostic.planError(
+                InstantiationDiagnostic.Code.CONCRETE_TYPE_INVALID,
+                "type " + typeId + " for " + path + " does not compile: " + e.getMessage(),
+                path,
+                typeId));
+        memberModel = null;
+      }
+
+      memberModels.put(typeId, memberModel);
+      return memberModel;
+    }
+
+    // endregion
+
+    // region NodeId allocation and collision preflight
+
+    private void allocateNodeIds() {
+      for (Working working : planned.values()) {
+        if (working.nodeId != null) {
+          // The root and shared Methods are already resolved.
+          continue;
+        }
+
+        NodeId pinned = request.assignedNodeIds().get(working.path);
+        if (pinned != null) {
+          working.nodeId = pinned;
+          continue;
+        }
+
+        NodeIdContext context =
+            new NodeIdContext(
+                request.rootNodeId(),
+                working.path,
+                Objects.requireNonNull(working.declaration, "declaration"));
+
+        working.nodeId =
+            request
+                .nodeIdStrategy()
+                .map(strategy -> strategy.apply(context))
+                .orElseGet(
+                    () ->
+                        request.legacyPathStrings()
+                            ? context.legacyNodeId()
+                            : context.defaultNodeId());
+      }
+    }
+
+    private void preflightCollisions() {
+      Map<NodeId, BrowsePath> intraPlan = new HashMap<>();
+
+      for (Working working : planned.values()) {
+        if (working.materialization == PlannedNode.Materialization.SHARE) {
+          continue;
+        }
+
+        NodeId nodeId = Objects.requireNonNull(working.nodeId);
+
+        BrowsePath previous = intraPlan.putIfAbsent(nodeId, working.path);
+        if (previous != null) {
+          diagnostics.add(
+              InstantiationDiagnostic.planError(
+                  InstantiationDiagnostic.Code.NODE_ID_COLLISION,
+                  "planned NodeId "
+                      + nodeId
+                      + " at "
+                      + working.path
+                      + " collides with the node planned at "
+                      + previous,
+                  working.path,
+                  nodeId));
+          continue;
+        }
+
+        if (!request.target().containsNode(nodeId)) {
+          continue;
+        }
+
+        if (request.conflictPolicy() == ConflictPolicy.FAIL) {
+          diagnostics.add(
+              InstantiationDiagnostic.planError(
+                  InstantiationDiagnostic.Code.NODE_ID_COLLISION,
+                  "planned NodeId "
+                      + nodeId
+                      + " at "
+                      + working.path
+                      + " already exists in the target NodeManager",
+                  working.path,
+                  nodeId));
+        } else {
+          UaNode existing = request.target().getNode(nodeId).orElse(null);
+          String incompatibility = reuseIncompatibility(existing, working);
+          if (incompatibility == null) {
+            working.materialization = PlannedNode.Materialization.REUSE;
+          } else {
+            diagnostics.add(
+                InstantiationDiagnostic.planError(
+                    InstantiationDiagnostic.Code.INCOMPATIBLE_REUSE,
+                    "existing node at "
+                        + nodeId
+                        + " cannot be reused for "
+                        + working.path
+                        + ": "
+                        + incompatibility,
+                    working.path,
+                    nodeId));
+          }
+        }
+      }
+    }
+
+    /**
+     * Validate reuse compatibility: namespace-qualified BrowseName, NodeClass, TypeDefinition (the
+     * planned type or a subtype), and — for the root — the expected Java class the typed result
+     * promises.
+     *
+     * @return {@code null} if compatible, otherwise a description of the incompatibility.
+     */
+    private @Nullable String reuseIncompatibility(@Nullable UaNode existing, Working working) {
+      if (existing == null) {
+        return "the node disappeared between preflight checks";
+      }
+
+      QualifiedName plannedBrowseName =
+          (QualifiedName) working.effectiveAttributes.getOrNull(AttributeId.BrowseName);
+      if (!Objects.equals(existing.getBrowseName(), plannedBrowseName)) {
+        return "BrowseName "
+            + existing.getBrowseName()
+            + " does not match planned "
+            + plannedBrowseName;
+      }
+
+      if (existing.getNodeClass() != working.nodeClass) {
+        return "NodeClass " + existing.getNodeClass() + " does not match " + working.nodeClass;
+      }
+
+      if (working.isRoot() && !request.rootClass().isInstance(existing)) {
+        return "existing node is not a " + request.rootClass().getName();
+      }
+
+      if (working.typeDefinitionId != null) {
+        NodeId existingTypeId =
+            request.target().getReferences(working.nodeId).stream()
+                .filter(Reference.HAS_TYPE_DEFINITION_PREDICATE)
+                .map(r -> r.getTargetNodeId().toNodeId(server.getNamespaceTable()).orElse(null))
+                .filter(Objects::nonNull)
+                .findFirst()
+                .orElse(null);
+
+        if (existingTypeId == null
+            || !isTypeSubtypeOfOrEqual(existingTypeId, working.typeDefinitionId)) {
+          return "TypeDefinition "
+              + existingTypeId
+              + " is not "
+              + working.typeDefinitionId
+              + " or a subtype";
+        }
+      }
+
+      return null;
+    }
+
+    // endregion
+
+    // region References
+
+    private List<Reference> resolveReferences() {
+      List<Reference> references = new ArrayList<>();
+
+      NodeId rootNodeId = request.rootNodeId();
+
+      Working root = planned.get(BrowsePath.root());
+      if (root != null && root.materialization == PlannedNode.Materialization.CREATE) {
+        references.add(
+            new Reference(
+                rootNodeId, NodeIds.HasTypeDefinition, model.typeDefinitionId().expanded(), true));
+      }
+
+      if (request.parentNodeId().isPresent() && request.parentReferenceTypeId().isPresent()) {
+        references.add(
+            new Reference(
+                request.parentNodeId().get(),
+                request.parentReferenceTypeId().get(),
+                rootNodeId.expanded(),
+                true));
+      }
+
+      for (DeclarationEdge edge : model.hierarchy()) {
+        Working parent = planned.get(edge.parentPath());
+        Working child = planned.get(edge.childPath());
+        if (parent == null || child == null) {
+          continue;
+        }
+        references.add(
+            new Reference(
+                Objects.requireNonNull(parent.nodeId),
+                edge.referenceTypeId(),
+                Objects.requireNonNull(child.nodeId).expanded(),
+                true));
+      }
+
+      ReferenceReplicationPolicy policy = request.referenceReplication();
+
+      for (ReferenceRow row : model.references()) {
+        Working source = planned.get(row.sourcePath());
+        if (source == null || source.materialization != PlannedNode.Materialization.CREATE) {
+          // Skipped sources have no instance; reused and shared nodes already carry their own
+          // non-hierarchy references.
+          continue;
+        }
+
+        NodeId sourceNodeId = Objects.requireNonNull(source.nodeId);
+        NodeId referenceTypeId = row.referenceTypeId();
+
+        if (isReferenceSubtypeOfOrEqual(referenceTypeId, NodeIds.HasTypeDefinition)) {
+          // Substituted rather than copied: a concreteType selection redirects the instance's
+          // type; every created instance gets exactly its effective type.
+          references.add(
+              new Reference(
+                  sourceNodeId,
+                  referenceTypeId,
+                  Objects.requireNonNull(source.typeDefinitionId).expanded(),
+                  true));
+          continue;
+        }
+
+        if (isReferenceSubtypeOfOrEqual(referenceTypeId, NodeIds.HasModellingRule)) {
+          if (request.purpose() == InstantiationPurpose.INSTANCE_DECLARATION) {
+            references.add(
+                new Reference(
+                    sourceNodeId,
+                    referenceTypeId,
+                    Objects.requireNonNull(row.targetNodeId()),
+                    row.direction() == Reference.Direction.FORWARD));
+          }
+          continue;
+        }
+
+        if (row.isRelative()) {
+          if (policy.internal() == ReferenceReplicationPolicy.InternalReferences.OMIT) {
+            continue;
+          }
+          Working target = planned.get(row.targetPath());
+          if (target == null) {
+            // No planned edge to an omitted target.
+            continue;
+          }
+          references.add(
+              new Reference(
+                  sourceNodeId,
+                  referenceTypeId,
+                  Objects.requireNonNull(target.nodeId).expanded(),
+                  true));
+        } else {
+          if (policy.external() == ReferenceReplicationPolicy.ExternalReferences.COPY) {
+            references.add(
+                new Reference(
+                    sourceNodeId,
+                    referenceTypeId,
+                    Objects.requireNonNull(row.targetNodeId()),
+                    row.direction() == Reference.Direction.FORWARD));
+          }
+        }
+      }
+
+      return references;
+    }
+
+    // endregion
+
+    // region Unmatched request paths
+
+    private void warnUnmatchedPaths() {
+      for (BrowsePath path : sorted(request.includedPaths())) {
+        if (model.get(path).isEmpty()) {
+          warnUnmatched("includeOptional", path);
+        } else if (model.get(path).map(InstanceDeclaration::isPlaceholder).orElse(false)) {
+          diagnostics.add(
+              InstantiationDiagnostic.planWarning(
+                  InstantiationDiagnostic.Code.UNMATCHED_PATH,
+                  "includeOptional path "
+                      + path
+                      + " names a placeholder; placeholders are realized by expansion, not"
+                      + " selection",
+                  path,
+                  null));
+        }
+      }
+
+      for (BrowsePath path : sorted(request.excludedPaths())) {
+        if (model.get(path).isEmpty()) {
+          warnUnmatched("excludeOptional", path);
+        }
+      }
+
+      for (BrowsePath path : sorted(request.assignedNodeIds().keySet())) {
+        Working working = planned.get(path);
+        if (working == null || working.materialization == PlannedNode.Materialization.SHARE) {
+          warnUnmatched("assignNodeId", path);
+        }
+      }
+
+      for (BrowsePath path : sorted(request.concreteTypes().keySet())) {
+        if (!planned.containsKey(path)) {
+          warnUnmatched("concreteType", path);
+        }
+      }
+
+      for (BrowsePath path : sorted(request.methodBinders().keySet())) {
+        Working working = planned.get(path);
+        if (working == null || working.nodeClass != NodeClass.Method) {
+          warnUnmatched("bindMethod", path);
+        }
+      }
+    }
+
+    private void warnUnmatched(String axis, BrowsePath path) {
+      diagnostics.add(
+          InstantiationDiagnostic.planWarning(
+              InstantiationDiagnostic.Code.UNMATCHED_PATH,
+              axis + " path " + path + " matches nothing this plan can affect",
+              path,
+              null));
+    }
+
+    private static List<BrowsePath> sorted(Set<BrowsePath> paths) {
+      return paths.stream().sorted().toList();
+    }
+
+    // endregion
+
+    // region Type space helpers
+
+    private ResolvedClass resolveJavaClass(NodeId typeId, NodeClass instanceNodeClass) {
+      if (instanceNodeClass == NodeClass.Object) {
+        ObjectTypeManager typeManager = server.getObjectTypeManager();
+
+        NodeId current = typeId;
+        Set<NodeId> visited = new HashSet<>();
+        while (current != null && visited.add(current)) {
+          ObjectTypeManager.RegisteredObjectType registered =
+              typeManager.getRegisteredType(current).orElse(null);
+          if (registered != null) {
+            return new ResolvedClass(registered.nodeClass(), current);
+          }
+          if (request.classResolution() == InstantiationRequest.ClassResolution.EXACT) {
+            break;
+          }
+          current = immediateSupertype(current);
+        }
+
+        return new ResolvedClass(UaObjectNode.class, null);
+      } else {
+        VariableTypeManager typeManager = server.getVariableTypeManager();
+
+        NodeId current = typeId;
+        Set<NodeId> visited = new HashSet<>();
+        while (current != null && visited.add(current)) {
+          VariableTypeManager.RegisteredVariableType registered =
+              typeManager.getRegisteredType(current).orElse(null);
+          if (registered != null) {
+            return new ResolvedClass(registered.nodeClass(), current);
+          }
+          if (request.classResolution() == InstantiationRequest.ClassResolution.EXACT) {
+            break;
+          }
+          current = immediateSupertype(current);
+        }
+
+        return new ResolvedClass(UaVariableNode.class, null);
+      }
+    }
+
+    private boolean isTypeSubtypeOfOrEqual(NodeId typeId, NodeId supertypeId) {
+      if (typeId.equals(supertypeId)) {
+        return true;
+      }
+      Set<NodeId> visited = new HashSet<>();
+      NodeId current = typeId;
+      while (current != null && visited.add(current)) {
+        NodeId parent = immediateSupertype(current);
+        if (supertypeId.equals(parent)) {
+          return true;
+        }
+        current = parent;
+      }
+      return false;
+    }
+
+    private @Nullable NodeId immediateSupertype(NodeId typeId) {
+      return server.getAddressSpaceManager().getManagedReferences(typeId).stream()
+          .filter(Reference.SUBTYPE_OF)
+          .map(r -> r.getTargetNodeId().toNodeId(server.getNamespaceTable()).orElse(null))
+          .filter(Objects::nonNull)
+          .min(Comparator.comparing(NodeId::toParseableString))
+          .orElse(null);
+    }
+
+    private boolean isReferenceSubtypeOfOrEqual(NodeId referenceTypeId, NodeId supertypeId) {
+      return referenceTypeId.equals(supertypeId)
+          || server.getReferenceTypeTree().isSubtypeOf(referenceTypeId, supertypeId);
+    }
+
+    private static boolean isValueRankRestriction(int base, int restricted) {
+      if (base == restricted || base == ValueRanks.Any) {
+        return true;
+      }
+      if (base == ValueRanks.ScalarOrOneDimension) {
+        return restricted == ValueRanks.Scalar || restricted == 1;
+      }
+      if (base == ValueRanks.OneOrMoreDimensions) {
+        return restricted >= 1;
+      }
+      return false;
+    }
+
+    private static boolean isArrayDimensionsRestriction(UInteger[] base, UInteger[] restricted) {
+      if (restricted.length != base.length) {
+        return false;
+      }
+      for (int i = 0; i < base.length; i++) {
+        if (base[i].longValue() != 0 && !base[i].equals(restricted[i])) {
+          return false;
+        }
+      }
+      return true;
+    }
+
+    // endregion
+
+    private record ResolvedClass(
+        Class<? extends UaNode> javaClass, @Nullable NodeId constructorTypeId) {}
+
+    /** Mutable per-node working state, finalized into a {@link PlannedNode}. */
+    private static final class Working {
+
+      final BrowsePath path;
+      final @Nullable InstanceDeclaration declaration;
+      final NodeClass nodeClass;
+      final @Nullable NodeId typeDefinitionId;
+      final Class<? extends UaNode> javaClass;
+      final @Nullable NodeId constructorTypeId;
+      final AttributeSnapshot effectiveAttributes;
+
+      @Nullable NodeId nodeId;
+      PlannedNode.Materialization materialization = PlannedNode.Materialization.CREATE;
+
+      Working(
+          BrowsePath path,
+          @Nullable InstanceDeclaration declaration,
+          NodeClass nodeClass,
+          @Nullable NodeId typeDefinitionId,
+          Class<? extends UaNode> javaClass,
+          @Nullable NodeId constructorTypeId,
+          AttributeSnapshot effectiveAttributes) {
+
+        this.path = path;
+        this.declaration = declaration;
+        this.nodeClass = nodeClass;
+        this.typeDefinitionId = typeDefinitionId;
+        this.javaClass = javaClass;
+        this.constructorTypeId = constructorTypeId;
+        this.effectiveAttributes = effectiveAttributes;
+      }
+
+      boolean isRoot() {
+        return path.isRoot();
+      }
+
+      PlannedNode toPlannedNode() {
+        return new PlannedNode(
+            path,
+            declaration,
+            Objects.requireNonNull(nodeId),
+            nodeClass,
+            typeDefinitionId,
+            javaClass,
+            constructorTypeId,
+            effectiveAttributes,
+            materialization);
+      }
+    }
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/NodeInstantiator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/NodeInstantiator.java
@@ -11,7 +11,6 @@
 package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
 
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -20,7 +19,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import org.eclipse.milo.opcua.sdk.core.Reference;
-import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.sdk.server.NodeManager;
 import org.eclipse.milo.opcua.sdk.server.ObjectTypeManager;
 import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
@@ -112,6 +110,8 @@ public final class NodeInstantiator {
     private final Map<BrowsePath, SkippedDeclaration> skipped = new LinkedHashMap<>();
     private final List<InstantiationDiagnostic> diagnostics = new ArrayList<>();
     private final Map<NodeId, TypeInstantiationModel> memberModels = new HashMap<>();
+
+    private @Nullable Set<BrowsePath> effectiveIncludedPaths;
 
     private PlanComputation(
         NodeInstantiator instantiator,
@@ -372,8 +372,10 @@ public final class NodeInstantiator {
     private boolean isSelected(InstanceDeclaration declaration, boolean isOptional) {
       BrowsePath path = declaration.browsePath();
 
-      for (BrowsePath included : request.includedPaths()) {
-        // Selecting a nested path implies its ancestors.
+      for (BrowsePath included : effectiveIncludedPaths()) {
+        // Selecting a nested path implies its ancestors — but only a path that resolves in the
+        // model implies anything; a mistyped include must not materialize its ancestors (it is
+        // reported by the UNMATCHED_PATH warning instead).
         if (included.startsWith(path)) {
           return true;
         }
@@ -384,6 +386,20 @@ public final class NodeInstantiator {
       }
 
       return request.includePredicate().map(p -> p.test(declaration)).orElse(false);
+    }
+
+    /** The request's included paths that resolve to a declaration in the model. */
+    private Set<BrowsePath> effectiveIncludedPaths() {
+      if (effectiveIncludedPaths == null) {
+        Set<BrowsePath> resolved = new HashSet<>();
+        for (BrowsePath included : request.includedPaths()) {
+          if (model.get(included).isPresent()) {
+            resolved.add(included);
+          }
+        }
+        effectiveIncludedPaths = resolved;
+      }
+      return effectiveIncludedPaths;
     }
 
     private void skip(InstanceDeclaration declaration, SkippedDeclaration.Reason reason) {
@@ -796,12 +812,34 @@ public final class NodeInstantiator {
       }
 
       if (request.parentNodeId().isPresent() && request.parentReferenceTypeId().isPresent()) {
-        references.add(
-            new Reference(
-                request.parentNodeId().get(),
-                request.parentReferenceTypeId().get(),
-                rootNodeId.expanded(),
-                true));
+        NodeId parentNodeId = request.parentNodeId().get();
+        NodeId parentReferenceTypeId = request.parentReferenceTypeId().get();
+
+        if (!isReferenceSubtypeOfOrEqual(parentReferenceTypeId, NodeIds.HierarchicalReferences)) {
+          diagnostics.add(
+              InstantiationDiagnostic.planError(
+                  InstantiationDiagnostic.Code.INVALID_PARENT,
+                  "parent reference type "
+                      + parentReferenceTypeId
+                      + " is not a hierarchical ReferenceType",
+                  BrowsePath.root(),
+                  parentNodeId));
+        } else {
+          // The parent may live in any NodeManager, so resolution is server-wide with a target
+          // fallback; a missing parent is advisory only — commit is where a dangling attachment
+          // actually fails.
+          if (server.getAddressSpaceManager().getManagedNode(parentNodeId).isEmpty()
+              && !request.target().containsNode(parentNodeId)) {
+            diagnostics.add(
+                InstantiationDiagnostic.planWarning(
+                    InstantiationDiagnostic.Code.INVALID_PARENT,
+                    "parent node " + parentNodeId + " does not resolve in this server at plan time",
+                    BrowsePath.root(),
+                    parentNodeId));
+          }
+          references.add(
+              new Reference(parentNodeId, parentReferenceTypeId, rootNodeId.expanded(), true));
+        }
       }
 
       for (DeclarationEdge edge : model.hierarchy()) {
@@ -991,58 +1029,31 @@ public final class NodeInstantiator {
     }
 
     private boolean isTypeSubtypeOfOrEqual(NodeId typeId, NodeId supertypeId) {
-      if (typeId.equals(supertypeId)) {
-        return true;
-      }
-      Set<NodeId> visited = new HashSet<>();
-      NodeId current = typeId;
-      while (current != null && visited.add(current)) {
-        NodeId parent = immediateSupertype(current);
-        if (supertypeId.equals(parent)) {
-          return true;
-        }
-        current = parent;
-      }
-      return false;
+      return TypeSpaceRules.isTypeSubtypeOfOrEqual(
+          typeId,
+          supertypeId,
+          id -> server.getAddressSpaceManager().getManagedReferences(id),
+          server.getNamespaceTable());
     }
 
     private @Nullable NodeId immediateSupertype(NodeId typeId) {
-      return server.getAddressSpaceManager().getManagedReferences(typeId).stream()
-          .filter(Reference.SUBTYPE_OF)
-          .map(r -> r.getTargetNodeId().toNodeId(server.getNamespaceTable()).orElse(null))
-          .filter(Objects::nonNull)
-          .min(Comparator.comparing(NodeId::toParseableString))
-          .orElse(null);
+      return TypeSpaceRules.immediateSupertype(
+          typeId,
+          id -> server.getAddressSpaceManager().getManagedReferences(id),
+          server.getNamespaceTable());
     }
 
     private boolean isReferenceSubtypeOfOrEqual(NodeId referenceTypeId, NodeId supertypeId) {
-      return referenceTypeId.equals(supertypeId)
-          || server.getReferenceTypeTree().isSubtypeOf(referenceTypeId, supertypeId);
+      return TypeSpaceRules.isReferenceSubtypeOfOrEqual(
+          server.getReferenceTypeTree(), referenceTypeId, supertypeId);
     }
 
     private static boolean isValueRankRestriction(int base, int restricted) {
-      if (base == restricted || base == ValueRanks.Any) {
-        return true;
-      }
-      if (base == ValueRanks.ScalarOrOneDimension) {
-        return restricted == ValueRanks.Scalar || restricted == 1;
-      }
-      if (base == ValueRanks.OneOrMoreDimensions) {
-        return restricted >= 1;
-      }
-      return false;
+      return TypeSpaceRules.isValueRankRestriction(base, restricted);
     }
 
     private static boolean isArrayDimensionsRestriction(UInteger[] base, UInteger[] restricted) {
-      if (restricted.length != base.length) {
-        return false;
-      }
-      for (int i = 0; i < base.length; i++) {
-        if (base[i].longValue() != 0 && !base[i].equals(restricted[i])) {
-          return false;
-        }
-      }
-      return true;
+      return TypeSpaceRules.isArrayDimensionsRestriction(base, restricted);
     }
 
     // endregion

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/NodeInstantiator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/NodeInstantiator.java
@@ -10,44 +10,66 @@
 
 package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
 
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ubyte;
+
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
+import java.util.function.Consumer;
 import org.eclipse.milo.opcua.sdk.core.Reference;
 import org.eclipse.milo.opcua.sdk.server.NodeManager;
+import org.eclipse.milo.opcua.sdk.server.NodeManagerBatch;
+import org.eclipse.milo.opcua.sdk.server.NodeManagerBatchException;
 import org.eclipse.milo.opcua.sdk.server.ObjectTypeManager;
 import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
 import org.eclipse.milo.opcua.sdk.server.VariableTypeManager;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaMethodNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNodeContext;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableNode;
 import org.eclipse.milo.opcua.stack.core.AttributeId;
+import org.eclipse.milo.opcua.stack.core.NamespaceTable;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
+import org.eclipse.milo.opcua.stack.core.types.structured.AccessRestrictionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.RolePermissionType;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The server-scoped instantiation facade: {@link #describe} exposes a type's compiled {@link
- * TypeInstantiationModel} (through the server's {@link TypeModelCache}), and {@link #plan} joins a
+ * TypeInstantiationModel} (through the server's {@link TypeModelCache}), {@link #plan} joins a
  * model with an {@link InstantiationRequest} into a pure-data {@link InstantiationPlan} — no nodes
- * created, nothing mutated.
+ * created, nothing mutated — and {@link #apply} materializes a plan into the request's target as a
+ * staged, journaled unit. {@link #instantiate} is the one-call convenience wrapping plan and apply.
  *
  * <p>Source type information always comes from the server's address space; the destination is
  * entirely the request's business (its target {@link NodeManager}) — plan only ever <em>reads</em>
- * the target, for collision preflight.
+ * the target, for collision preflight, and apply writes to nothing else.
  */
 public final class NodeInstantiator {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(NodeInstantiator.class);
 
   private final OpcUaServer server;
 
@@ -96,6 +118,63 @@ public final class NodeInstantiator {
   }
 
   /**
+   * Materialize {@code plan} into its request's target {@link NodeManager} as a staged, journaled
+   * unit.
+   *
+   * <p>Six stages: (1) revalidate the model fingerprints — a type changed since planning fails with
+   * {@link InstantiationDiagnostic.Code#MODEL_CHANGED} before anything is constructed; (2) recheck
+   * collisions, reused-node compatibility, and the parent attachment against the target; (3)
+   * construct every planned node, unpublished; (4) run the request's {@code onNode} hooks against
+   * the complete staged graph; (5) commit nodes and references as one journaled batch through the
+   * target's storage primitives, then run the request's {@code bindMethod} binders against the
+   * committed graph; (6) on failure, roll back exactly the journaled additions — never a recursive
+   * delete from the root.
+   *
+   * <p>If the target does not override the storage primitives, the commit runs on the sequential
+   * emulations and the result reports {@link NodeManager.StorageGuarantee#BEST_EFFORT} instead of
+   * atomic — degraded, and said so, never silent.
+   *
+   * <p>A commit rejected because the target's generation advanced is rechecked and retried a small,
+   * bounded number of times. Under sustained concurrent mutation of the same target — even by
+   * non-conflicting writers — the retries can be exhausted, failing with {@link
+   * InstantiationDiagnostic.Code#COMMIT_FAILED} and {@code Bad_InvalidState}; such a failure is
+   * safe to retry by re-applying the plan.
+   *
+   * @param plan the plan to materialize.
+   * @param <T> the expected root class.
+   * @return the {@link InstantiationResult}.
+   * @throws InstantiationException if {@code plan} carries errors, or an apply stage fails; apart
+   *     from a failed rollback ({@link InstantiationDiagnostic.Code#ROLLBACK_FAILED}, reported
+   *     loudly), a failed apply leaves no residue in the target.
+   * @throws UaException if the model revalidation cannot read the type.
+   */
+  public <T extends UaNode> InstantiationResult<T> apply(InstantiationPlan<T> plan)
+      throws UaException {
+
+    if (plan.hasErrors()) {
+      throw new InstantiationException(
+          StatusCodes.Bad_InvalidArgument, InstantiationDiagnostic.Phase.PLAN, plan.errors(), null);
+    }
+
+    return new ApplyExecution<>(this, plan).execute();
+  }
+
+  /**
+   * Plan and apply {@code request} in one call — the 90% case.
+   *
+   * @param request the request to instantiate.
+   * @param <T> the expected root class.
+   * @return the {@link InstantiationResult}.
+   * @throws InstantiationException if the plan carries errors or apply fails.
+   * @throws UaException if the type's model cannot be compiled.
+   */
+  public <T extends UaNode> InstantiationResult<T> instantiate(InstantiationRequest<T> request)
+      throws UaException {
+
+    return apply(plan(request));
+  }
+
+  /**
    * One plan computation: selection, class and attribute resolution, NodeId allocation, collision
    * preflight, and reference resolution over a single model snapshot.
    */
@@ -109,7 +188,7 @@ public final class NodeInstantiator {
     private final Map<BrowsePath, Working> planned = new LinkedHashMap<>();
     private final Map<BrowsePath, SkippedDeclaration> skipped = new LinkedHashMap<>();
     private final List<InstantiationDiagnostic> diagnostics = new ArrayList<>();
-    private final Map<NodeId, TypeInstantiationModel> memberModels = new HashMap<>();
+    private final Map<NodeId, @Nullable TypeInstantiationModel> memberModels = new HashMap<>();
 
     private @Nullable Set<BrowsePath> effectiveIncludedPaths;
 
@@ -141,8 +220,23 @@ public final class NodeInstantiator {
       List<PlannedNode> plannedNodes =
           planned.values().stream().map(Working::toPlannedNode).toList();
 
+      Map<NodeId, Long> consultedModelRevisions = new HashMap<>();
+      consultedModelRevisions.put(model.typeDefinitionId(), model.modelRevision());
+      memberModels.forEach(
+          (typeId, memberModel) -> {
+            if (memberModel != null) {
+              consultedModelRevisions.put(typeId, memberModel.modelRevision());
+            }
+          });
+
       return new InstantiationPlan<>(
-          request, model, plannedNodes, List.copyOf(skipped.values()), references, diagnostics);
+          request,
+          model,
+          plannedNodes,
+          List.copyOf(skipped.values()),
+          references,
+          diagnostics,
+          consultedModelRevisions);
     }
 
     // region Root
@@ -180,6 +274,8 @@ public final class NodeInstantiator {
       }
 
       AttributeSnapshot effective = rootEffectiveAttributes(typeAttributes, instanceNodeClass);
+
+      validateRootOverrideNulls(instanceNodeClass);
 
       if (instanceNodeClass == NodeClass.Variable) {
         validateRootNarrowing(effective, typeAttributes);
@@ -231,6 +327,58 @@ public final class NodeInstantiator {
       }
 
       return b.build();
+    }
+
+    /** Attributes every Object instance must carry; an explicit-null override cannot stand. */
+    private static final Set<AttributeId> MANDATORY_OBJECT_ATTRIBUTES =
+        EnumSet.of(
+            AttributeId.NodeClass,
+            AttributeId.BrowseName,
+            AttributeId.DisplayName,
+            AttributeId.EventNotifier);
+
+    /**
+     * Attributes every Variable instance must carry; an explicit-null override cannot stand. Value
+     * is exempt: a null Value follows the Bad_NoValue convention rather than being invalid.
+     */
+    private static final Set<AttributeId> MANDATORY_VARIABLE_ATTRIBUTES =
+        EnumSet.of(
+            AttributeId.NodeClass,
+            AttributeId.BrowseName,
+            AttributeId.DisplayName,
+            AttributeId.DataType,
+            AttributeId.ValueRank,
+            AttributeId.AccessLevel,
+            AttributeId.UserAccessLevel,
+            AttributeId.Historizing);
+
+    /**
+     * An explicit-null override of a mandatory attribute would survive construction defaults (the
+     * overlay preserves explicit nulls by design) and commit a node no client can read correctly,
+     * so it is rejected here; explicit nulls remain valid for optional attributes.
+     */
+    private void validateRootOverrideNulls(NodeClass instanceNodeClass) {
+      Set<AttributeId> mandatory =
+          instanceNodeClass == NodeClass.Variable
+              ? MANDATORY_VARIABLE_ATTRIBUTES
+              : MANDATORY_OBJECT_ATTRIBUTES;
+
+      AttributeSnapshot overrides = request.rootAttributeOverrides();
+      for (AttributeId id : overrides.attributeIds()) {
+        if (overrides.isNull(id) && mandatory.contains(id)) {
+          diagnostics.add(
+              InstantiationDiagnostic.planError(
+                  InstantiationDiagnostic.Code.INVALID_ATTRIBUTE,
+                  "attribute override "
+                      + id
+                      + " is an explicit null, but "
+                      + id
+                      + " is mandatory for NodeClass "
+                      + instanceNodeClass,
+                  BrowsePath.root(),
+                  model.typeDefinitionId()));
+        }
+      }
     }
 
     private void validateRootNarrowing(AttributeSnapshot effective, AttributeSnapshot base) {
@@ -744,55 +892,16 @@ public final class NodeInstantiator {
       }
     }
 
-    /**
-     * Validate reuse compatibility: namespace-qualified BrowseName, NodeClass, TypeDefinition (the
-     * planned type or a subtype), and — for the root — the expected Java class the typed result
-     * promises.
-     *
-     * @return {@code null} if compatible, otherwise a description of the incompatibility.
-     */
     private @Nullable String reuseIncompatibility(@Nullable UaNode existing, Working working) {
-      if (existing == null) {
-        return "the node disappeared between preflight checks";
-      }
-
-      QualifiedName plannedBrowseName =
-          (QualifiedName) working.effectiveAttributes.getOrNull(AttributeId.BrowseName);
-      if (!Objects.equals(existing.getBrowseName(), plannedBrowseName)) {
-        return "BrowseName "
-            + existing.getBrowseName()
-            + " does not match planned "
-            + plannedBrowseName;
-      }
-
-      if (existing.getNodeClass() != working.nodeClass) {
-        return "NodeClass " + existing.getNodeClass() + " does not match " + working.nodeClass;
-      }
-
-      if (working.isRoot() && !request.rootClass().isInstance(existing)) {
-        return "existing node is not a " + request.rootClass().getName();
-      }
-
-      if (working.typeDefinitionId != null) {
-        NodeId existingTypeId =
-            request.target().getReferences(working.nodeId).stream()
-                .filter(Reference.HAS_TYPE_DEFINITION_PREDICATE)
-                .map(r -> r.getTargetNodeId().toNodeId(server.getNamespaceTable()).orElse(null))
-                .filter(Objects::nonNull)
-                .findFirst()
-                .orElse(null);
-
-        if (existingTypeId == null
-            || !isTypeSubtypeOfOrEqual(existingTypeId, working.typeDefinitionId)) {
-          return "TypeDefinition "
-              + existingTypeId
-              + " is not "
-              + working.typeDefinitionId
-              + " or a subtype";
-        }
-      }
-
-      return null;
+      return instantiator.reuseIncompatibility(
+          existing,
+          (QualifiedName) working.effectiveAttributes.getOrNull(AttributeId.BrowseName),
+          working.nodeClass,
+          working.isRoot(),
+          request.rootClass(),
+          working.typeDefinitionId,
+          Objects.requireNonNull(working.nodeId),
+          request.target());
     }
 
     // endregion
@@ -826,8 +935,8 @@ public final class NodeInstantiator {
                   parentNodeId));
         } else {
           // The parent may live in any NodeManager, so resolution is server-wide with a target
-          // fallback; a missing parent is advisory only — commit is where a dangling attachment
-          // actually fails.
+          // fallback; a missing parent is advisory at plan time — the apply-stage recheck fails
+          // if it is still missing, so no dangling attachment is committed.
           if (server.getAddressSpaceManager().getManagedNode(parentNodeId).isEmpty()
               && !request.target().containsNode(parentNodeId)) {
             diagnostics.add(
@@ -1029,11 +1138,7 @@ public final class NodeInstantiator {
     }
 
     private boolean isTypeSubtypeOfOrEqual(NodeId typeId, NodeId supertypeId) {
-      return TypeSpaceRules.isTypeSubtypeOfOrEqual(
-          typeId,
-          supertypeId,
-          id -> server.getAddressSpaceManager().getManagedReferences(id),
-          server.getNamespaceTable());
+      return instantiator.isTypeSubtypeOfOrEqual(typeId, supertypeId);
     }
 
     private @Nullable NodeId immediateSupertype(NodeId typeId) {
@@ -1109,6 +1214,864 @@ public final class NodeInstantiator {
             effectiveAttributes,
             materialization);
       }
+    }
+  }
+
+  private boolean isTypeSubtypeOfOrEqual(NodeId typeId, NodeId supertypeId) {
+    return TypeSpaceRules.isTypeSubtypeOfOrEqual(
+        typeId,
+        supertypeId,
+        id -> server.getAddressSpaceManager().getManagedReferences(id),
+        server.getNamespaceTable());
+  }
+
+  /**
+   * Validate reuse compatibility, shared by plan preflight and apply recheck: namespace-qualified
+   * BrowseName, NodeClass, TypeDefinition (the planned type or a subtype, read from the target's
+   * reference rows), and — for the root — the expected Java class the typed result promises.
+   *
+   * @return {@code null} if compatible, otherwise a description of the incompatibility.
+   */
+  private @Nullable String reuseIncompatibility(
+      @Nullable UaNode existing,
+      @Nullable QualifiedName plannedBrowseName,
+      NodeClass plannedNodeClass,
+      boolean isRoot,
+      Class<? extends UaNode> rootClass,
+      @Nullable NodeId plannedTypeDefinitionId,
+      NodeId nodeId,
+      NodeManager<UaNode> target) {
+
+    if (existing == null) {
+      return "the node disappeared between preflight checks";
+    }
+
+    if (!Objects.equals(existing.getBrowseName(), plannedBrowseName)) {
+      return "BrowseName "
+          + existing.getBrowseName()
+          + " does not match planned "
+          + plannedBrowseName;
+    }
+
+    if (existing.getNodeClass() != plannedNodeClass) {
+      return "NodeClass " + existing.getNodeClass() + " does not match " + plannedNodeClass;
+    }
+
+    if (isRoot && !rootClass.isInstance(existing)) {
+      return "existing node is not a " + rootClass.getName();
+    }
+
+    if (plannedTypeDefinitionId != null) {
+      NamespaceTable namespaceTable = server.getNamespaceTable();
+      NodeId existingTypeId =
+          target.getReferences(nodeId, Reference.HAS_TYPE_DEFINITION_PREDICATE).stream()
+              .map(r -> r.getTargetNodeId().toNodeId(namespaceTable).orElse(null))
+              .filter(Objects::nonNull)
+              .findFirst()
+              .orElse(null);
+
+      if (existingTypeId == null
+          || !isTypeSubtypeOfOrEqual(existingTypeId, plannedTypeDefinitionId)) {
+        return "TypeDefinition "
+            + existingTypeId
+            + " is not "
+            + plannedTypeDefinitionId
+            + " or a subtype";
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * One apply: model revalidation, target recheck, unpublished staging, hooks, journaled commit
+   * with rollback — the six stages over a single error-free plan.
+   */
+  private static final class ApplyExecution<T extends UaNode> {
+
+    /**
+     * A stale-generation commit means the target advanced between the stage-2 recheck and the
+     * commit; the recheck is re-run and the commit retried, bounded so a busy target degrades to a
+     * clean failure rather than livelock.
+     */
+    private static final int MAX_COMMIT_ATTEMPTS = 3;
+
+    /** Attributes consumed by every node constructor form's common prefix. */
+    private static final Set<AttributeId> COMMON_CONSTRUCTED =
+        EnumSet.of(
+            AttributeId.NodeClass,
+            AttributeId.BrowseName,
+            AttributeId.DisplayName,
+            AttributeId.Description,
+            AttributeId.WriteMask,
+            AttributeId.UserWriteMask,
+            AttributeId.RolePermissions,
+            AttributeId.UserRolePermissions,
+            AttributeId.AccessRestrictions);
+
+    /** Attributes consumed by the Variable tuple constructor beyond the common prefix. */
+    private static final Set<AttributeId> VARIABLE_CONSTRUCTED = variableConstructed();
+
+    private static Set<AttributeId> variableConstructed() {
+      EnumSet<AttributeId> set = EnumSet.copyOf(COMMON_CONSTRUCTED);
+      set.addAll(
+          EnumSet.of(
+              AttributeId.Value,
+              AttributeId.DataType,
+              AttributeId.ValueRank,
+              AttributeId.ArrayDimensions));
+      return set;
+    }
+
+    /** Attributes consumed by the Method constructor (security attributes are overlaid). */
+    private static final Set<AttributeId> METHOD_CONSTRUCTED =
+        EnumSet.of(
+            AttributeId.NodeClass,
+            AttributeId.BrowseName,
+            AttributeId.DisplayName,
+            AttributeId.Description,
+            AttributeId.WriteMask,
+            AttributeId.UserWriteMask,
+            AttributeId.Executable,
+            AttributeId.UserExecutable);
+
+    private final NodeInstantiator instantiator;
+    private final OpcUaServer server;
+    private final InstantiationPlan<T> plan;
+    private final InstantiationRequest<T> request;
+    private final NodeManager<UaNode> target;
+
+    /** Constructed-but-unpublished nodes, by path; CREATE entries only. */
+    private final Map<BrowsePath, UaNode> staged = new LinkedHashMap<>();
+
+    /** Existing nodes serving REUSE and SHARE entries, resolved by the recheck. */
+    private final Map<BrowsePath, UaNode> adopted = new HashMap<>();
+
+    private ApplyExecution(NodeInstantiator instantiator, InstantiationPlan<T> plan) {
+      this.instantiator = instantiator;
+      this.server = instantiator.server;
+      this.plan = plan;
+      this.request = plan.request();
+      this.target = request.target();
+    }
+
+    InstantiationResult<T> execute() throws UaException {
+      revalidateModel();
+
+      long generation = recheckTarget();
+
+      stageNodes();
+      runHooks();
+
+      InstantiationResult<T> result = commitAndBuildResult(generation);
+
+      notifyObservers(result);
+
+      return result;
+    }
+
+    // region Stage 1: model revalidation
+
+    /**
+     * Every model the plan consulted is revalidated, not just the root's: a {@code concreteType}
+     * selection outside the root model's dependency closure has its own cache entry, and a stale
+     * one would silently commit outdated attribute defaults or an instance of a now-abstract type.
+     */
+    private void revalidateModel() throws InstantiationException {
+      for (Map.Entry<NodeId, Long> consulted : plan.consultedModelRevisions().entrySet()) {
+        NodeId typeDefinitionId = consulted.getKey();
+
+        TypeInstantiationModel current;
+        try {
+          current = instantiator.describe(typeDefinitionId);
+        } catch (UaException e) {
+          throw failure(
+              StatusCodes.Bad_InvalidState,
+              InstantiationDiagnostic.applyError(
+                  InstantiationDiagnostic.Code.MODEL_CHANGED,
+                  "type " + typeDefinitionId + " no longer compiles: " + e.getMessage(),
+                  BrowsePath.root(),
+                  typeDefinitionId),
+              e);
+        }
+
+        if (current.modelRevision() != consulted.getValue()) {
+          throw failure(
+              StatusCodes.Bad_InvalidState,
+              InstantiationDiagnostic.applyError(
+                  InstantiationDiagnostic.Code.MODEL_CHANGED,
+                  "type "
+                      + typeDefinitionId
+                      + " changed since this plan was computed (model revision "
+                      + consulted.getValue()
+                      + " -> "
+                      + current.modelRevision()
+                      + "); re-plan against the current model",
+                  BrowsePath.root(),
+                  typeDefinitionId),
+              null);
+        }
+      }
+    }
+
+    // endregion
+
+    // region Stage 2: target recheck
+
+    /**
+     * Recheck the plan's target assumptions and capture the generation the commit will expect, so
+     * recheck-and-commit is atomic on targets whose primitives track generations.
+     *
+     * @return the target generation captured before the recheck reads.
+     */
+    private long recheckTarget() throws InstantiationException {
+      long generation = target.getGeneration().value();
+
+      for (PlannedNode planned : plan.plannedNodes()) {
+        switch (planned.materialization()) {
+          case CREATE -> {
+            if (target.containsNode(planned.nodeId())) {
+              throw failure(
+                  StatusCodes.Bad_NodeIdExists,
+                  InstantiationDiagnostic.applyError(
+                      InstantiationDiagnostic.Code.NODE_ID_COLLISION,
+                      "planned NodeId "
+                          + planned.nodeId()
+                          + " at "
+                          + planned.browsePath()
+                          + " appeared in the target since the plan was computed; re-plan"
+                          + " (adoption is a plan-time decision)",
+                      planned.browsePath(),
+                      planned.nodeId()),
+                  null);
+            }
+          }
+          case REUSE -> {
+            UaNode existing = target.getNode(planned.nodeId()).orElse(null);
+
+            String incompatibility =
+                instantiator.reuseIncompatibility(
+                    existing,
+                    (QualifiedName) planned.effectiveAttributes().getOrNull(AttributeId.BrowseName),
+                    planned.nodeClass(),
+                    planned.isRoot(),
+                    request.rootClass(),
+                    planned.typeDefinitionId(),
+                    planned.nodeId(),
+                    target);
+
+            if (incompatibility != null) {
+              throw failure(
+                  StatusCodes.Bad_NodeIdExists,
+                  InstantiationDiagnostic.applyError(
+                      InstantiationDiagnostic.Code.INCOMPATIBLE_REUSE,
+                      "existing node at "
+                          + planned.nodeId()
+                          + " can no longer be reused for "
+                          + planned.browsePath()
+                          + ": "
+                          + incompatibility,
+                      planned.browsePath(),
+                      planned.nodeId()),
+                  null);
+            }
+
+            adopted.put(planned.browsePath(), existing);
+          }
+          case SHARE -> {
+            UaNode shared =
+                server.getAddressSpaceManager().getManagedNode(planned.nodeId()).orElse(null);
+
+            if (!(shared instanceof UaMethodNode)) {
+              throw failure(
+                  StatusCodes.Bad_InvalidState,
+                  InstantiationDiagnostic.applyError(
+                      InstantiationDiagnostic.Code.MODEL_CHANGED,
+                      "shared Method declaration "
+                          + planned.nodeId()
+                          + " at "
+                          + planned.browsePath()
+                          + " no longer resolves to a Method node",
+                      planned.browsePath(),
+                      planned.nodeId()),
+                  null);
+            }
+
+            adopted.put(planned.browsePath(), shared);
+          }
+        }
+      }
+
+      // The commit validates only the batch's own nodes, so a parent that disappeared since plan
+      // time would otherwise commit as a reference row sourced at a nonexistent NodeId — and a
+      // node later created at that id would silently acquire a phantom child.
+      if (request.parentNodeId().isPresent() && request.parentReferenceTypeId().isPresent()) {
+        NodeId parentNodeId = request.parentNodeId().get();
+        if (server.getAddressSpaceManager().getManagedNode(parentNodeId).isEmpty()
+            && !target.containsNode(parentNodeId)) {
+          throw failure(
+              StatusCodes.Bad_ParentNodeIdInvalid,
+              InstantiationDiagnostic.applyError(
+                  InstantiationDiagnostic.Code.INVALID_PARENT,
+                  "parent node "
+                      + parentNodeId
+                      + " does not resolve in this server; the planned parent attachment would"
+                      + " dangle",
+                  BrowsePath.root(),
+                  parentNodeId),
+              null);
+        }
+      }
+
+      return generation;
+    }
+
+    // endregion
+
+    // region Stage 3: staging
+
+    private void stageNodes() throws InstantiationException {
+      // Staged nodes see the *destination* as their context: post-commit, node-level navigation
+      // (typed getters, getComponent, property lookups) resolves against the target's references.
+      UaNodeContext context =
+          new UaNodeContext() {
+            @Override
+            public OpcUaServer getServer() {
+              return server;
+            }
+
+            @Override
+            public NodeManager<UaNode> getNodeManager() {
+              return target;
+            }
+          };
+
+      for (PlannedNode planned : plan.plannedNodes()) {
+        if (planned.materialization() != PlannedNode.Materialization.CREATE) {
+          continue;
+        }
+
+        UaNode node;
+        try {
+          node = construct(context, planned);
+        } catch (Exception e) {
+          throw failure(
+              StatusCodes.Bad_InternalError,
+              InstantiationDiagnostic.applyError(
+                  InstantiationDiagnostic.Code.CONSTRUCTOR_FAILED,
+                  "constructor failed at " + planned.browsePath() + ": " + e,
+                  planned.browsePath(),
+                  planned.nodeId()),
+              e);
+        }
+
+        if (!planned.javaClass().isInstance(node)) {
+          throw failure(
+              StatusCodes.Bad_InternalError,
+              InstantiationDiagnostic.applyError(
+                  InstantiationDiagnostic.Code.CONSTRUCTOR_FAILED,
+                  "constructor for "
+                      + planned.constructorTypeId()
+                      + " returned a "
+                      + node.getClass().getName()
+                      + ", expected "
+                      + planned.javaClass().getName(),
+                  planned.browsePath(),
+                  planned.nodeId()),
+              null);
+        }
+
+        staged.put(planned.browsePath(), node);
+      }
+    }
+
+    private UaNode construct(UaNodeContext context, PlannedNode planned) {
+      AttributeSnapshot attributes = planned.effectiveAttributes();
+
+      return switch (planned.nodeClass()) {
+        case Object -> constructObject(context, planned, attributes);
+        case Variable -> constructVariable(context, planned, attributes);
+        case Method -> constructMethod(context, planned, attributes);
+        default ->
+            throw new IllegalStateException("unexpected instance NodeClass " + planned.nodeClass());
+      };
+    }
+
+    private UaObjectNode constructObject(
+        UaNodeContext context, PlannedNode planned, AttributeSnapshot attributes) {
+
+      ObjectTypeManager.RegisteredObjectType registered =
+          planned.constructorTypeId() != null
+              ? server
+                  .getObjectTypeManager()
+                  .getRegisteredType(planned.constructorTypeId())
+                  .orElse(null)
+              : null;
+
+      if (registered != null && registered.snapshotConstructor() != null) {
+        return registered.snapshotConstructor().apply(context, planned.nodeId(), attributes);
+      }
+
+      UaObjectNode node;
+      if (registered != null && registered.nodeConstructor() != null) {
+        node =
+            registered
+                .nodeConstructor()
+                .apply(
+                    context,
+                    planned.nodeId(),
+                    (QualifiedName) attributes.getOrNull(AttributeId.BrowseName),
+                    (LocalizedText) attributes.getOrNull(AttributeId.DisplayName),
+                    (LocalizedText) attributes.getOrNull(AttributeId.Description),
+                    (UInteger) attributes.getOrNull(AttributeId.WriteMask),
+                    (UInteger) attributes.getOrNull(AttributeId.UserWriteMask),
+                    (RolePermissionType[]) attributes.getOrNull(AttributeId.RolePermissions),
+                    (RolePermissionType[]) attributes.getOrNull(AttributeId.UserRolePermissions),
+                    (AccessRestrictionType) attributes.getOrNull(AttributeId.AccessRestrictions));
+      } else {
+        UByte eventNotifier = (UByte) attributes.getOrNull(AttributeId.EventNotifier);
+        node =
+            new UaObjectNode(
+                context,
+                planned.nodeId(),
+                (QualifiedName) attributes.getOrNull(AttributeId.BrowseName),
+                (LocalizedText) attributes.getOrNull(AttributeId.DisplayName),
+                (LocalizedText) attributes.getOrNull(AttributeId.Description),
+                (UInteger) attributes.getOrNull(AttributeId.WriteMask),
+                (UInteger) attributes.getOrNull(AttributeId.UserWriteMask),
+                (RolePermissionType[]) attributes.getOrNull(AttributeId.RolePermissions),
+                (RolePermissionType[]) attributes.getOrNull(AttributeId.UserRolePermissions),
+                (AccessRestrictionType) attributes.getOrNull(AttributeId.AccessRestrictions),
+                eventNotifier != null ? eventNotifier : ubyte(0));
+      }
+
+      // The remaining planned attributes (EventNotifier for the tuple form) — the R4 adaptation
+      // overlay that lets tuple-signature registrations receive newly modeled attributes.
+      overlay(node, attributes, COMMON_CONSTRUCTED);
+
+      return node;
+    }
+
+    private UaVariableNode constructVariable(
+        UaNodeContext context, PlannedNode planned, AttributeSnapshot attributes) {
+
+      VariableTypeManager.RegisteredVariableType registered =
+          planned.constructorTypeId() != null
+              ? server
+                  .getVariableTypeManager()
+                  .getRegisteredType(planned.constructorTypeId())
+                  .orElse(null)
+              : null;
+
+      // Committed Variables never share the declaration's DataValue instance: values are re-issued
+      // with a fresh source timestamp, and an unset value follows the Bad_NoValue convention.
+      DataValue freshValue = freshValue(attributes.value());
+
+      UaVariableNode node;
+      if (registered != null && registered.snapshotConstructor() != null) {
+        node = registered.snapshotConstructor().apply(context, planned.nodeId(), attributes);
+      } else if (registered != null && registered.nodeConstructor() != null) {
+        node =
+            registered
+                .nodeConstructor()
+                .apply(
+                    context,
+                    planned.nodeId(),
+                    (QualifiedName) attributes.getOrNull(AttributeId.BrowseName),
+                    (LocalizedText) attributes.getOrNull(AttributeId.DisplayName),
+                    (LocalizedText) attributes.getOrNull(AttributeId.Description),
+                    (UInteger) attributes.getOrNull(AttributeId.WriteMask),
+                    (UInteger) attributes.getOrNull(AttributeId.UserWriteMask),
+                    (RolePermissionType[]) attributes.getOrNull(AttributeId.RolePermissions),
+                    (RolePermissionType[]) attributes.getOrNull(AttributeId.UserRolePermissions),
+                    (AccessRestrictionType) attributes.getOrNull(AttributeId.AccessRestrictions),
+                    freshValue,
+                    attributes.dataType(),
+                    attributes.valueRank(),
+                    attributes.arrayDimensions());
+        overlay(node, attributes, VARIABLE_CONSTRUCTED);
+      } else {
+        node =
+            new UaVariableNode(
+                context,
+                planned.nodeId(),
+                (QualifiedName) attributes.getOrNull(AttributeId.BrowseName),
+                (LocalizedText) attributes.getOrNull(AttributeId.DisplayName),
+                (LocalizedText) attributes.getOrNull(AttributeId.Description),
+                (UInteger) attributes.getOrNull(AttributeId.WriteMask),
+                (UInteger) attributes.getOrNull(AttributeId.UserWriteMask),
+                (RolePermissionType[]) attributes.getOrNull(AttributeId.RolePermissions),
+                (RolePermissionType[]) attributes.getOrNull(AttributeId.UserRolePermissions),
+                (AccessRestrictionType) attributes.getOrNull(AttributeId.AccessRestrictions),
+                freshValue,
+                attributes.dataType(),
+                attributes.valueRank(),
+                attributes.arrayDimensions());
+        overlay(node, attributes, VARIABLE_CONSTRUCTED);
+      }
+
+      // Uniform value policy across all constructor forms (a snapshot constructor received the
+      // snapshot's normalized value, not the freshened one).
+      node.setAttribute(AttributeId.Value, freshValue);
+
+      return node;
+    }
+
+    private UaMethodNode constructMethod(
+        UaNodeContext context, PlannedNode planned, AttributeSnapshot attributes) {
+
+      Boolean executable = (Boolean) attributes.getOrNull(AttributeId.Executable);
+      Boolean userExecutable = (Boolean) attributes.getOrNull(AttributeId.UserExecutable);
+
+      UaMethodNode node =
+          new UaMethodNode(
+              context,
+              planned.nodeId(),
+              (QualifiedName) attributes.getOrNull(AttributeId.BrowseName),
+              (LocalizedText) attributes.getOrNull(AttributeId.DisplayName),
+              (LocalizedText) attributes.getOrNull(AttributeId.Description),
+              (UInteger) attributes.getOrNull(AttributeId.WriteMask),
+              (UInteger) attributes.getOrNull(AttributeId.UserWriteMask),
+              executable != null ? executable : Boolean.TRUE,
+              userExecutable != null ? userExecutable : Boolean.TRUE);
+
+      overlay(node, attributes, METHOD_CONSTRUCTED);
+
+      return node;
+    }
+
+    /**
+     * Apply every planned attribute the constructor did not consume, preserving explicit nulls.
+     * Direct field writes ({@link UaNode#setAttribute}), bypassing any filters a constructor may
+     * have installed — this is construction, not runtime mutation.
+     */
+    private static void overlay(
+        UaNode node, AttributeSnapshot attributes, Set<AttributeId> consumed) {
+      for (AttributeId attributeId : attributes.attributeIds()) {
+        if (consumed.contains(attributeId)) {
+          continue;
+        }
+        node.setAttribute(
+            attributeId, attributes.isNull(attributeId) ? null : attributes.getOrNull(attributeId));
+      }
+    }
+
+    private static DataValue freshValue(@Nullable DataValue declared) {
+      if (declared == null || declared.getValue().getValue() == null) {
+        return new DataValue(
+            Variant.NULL_VALUE, new StatusCode(StatusCodes.Bad_NoValue), DateTime.now());
+      }
+
+      return new DataValue(declared.getValue(), declared.getStatusCode(), DateTime.now());
+    }
+
+    // endregion
+
+    // region Stage 4: hooks
+
+    private void runHooks() throws InstantiationException {
+      if (request.onNodeHooks().isEmpty()) {
+        return;
+      }
+
+      StagedGraph graph = new StagedGraphView(realizedInOrder());
+
+      for (PlannedNode planned : plan.plannedNodes()) {
+        UaNode node = staged.get(planned.browsePath());
+        if (node == null) {
+          // Hooks customize what this apply constructs; adopted and shared nodes are not modified.
+          continue;
+        }
+
+        UaNode parent = planned.isRoot() ? null : realizedAt(planned.browsePath().parent());
+
+        for (InstantiationRequest.OnNode hook : request.onNodeHooks()) {
+          try {
+            hook.accept(planned.declaration(), node, parent, graph);
+          } catch (Exception e) {
+            throw failure(
+                StatusCodes.Bad_InternalError,
+                InstantiationDiagnostic.applyError(
+                    InstantiationDiagnostic.Code.CUSTOMIZATION_FAILED,
+                    "onNode hook failed at " + planned.browsePath() + ": " + e,
+                    planned.browsePath(),
+                    planned.nodeId()),
+                e);
+          }
+        }
+      }
+    }
+
+    /**
+     * Binders run only after a successful commit: they may target reused or shared nodes the
+     * instantiation does not own, so binding earlier would leave mutations on published nodes if
+     * the commit failed, and a stale-generation retry can re-adopt a different instance — binding
+     * pre-commit would customize an instance the committed graph no longer contains.
+     */
+    private void bindMethods() throws InstantiationException {
+      for (BrowsePath path : request.methodBinders().keySet().stream().sorted().toList()) {
+        UaNode node = realizedAt(path);
+        if (node instanceof UaMethodNode method) {
+          try {
+            request.methodBinders().get(path).accept(method);
+          } catch (Exception e) {
+            throw failure(
+                StatusCodes.Bad_InternalError,
+                InstantiationDiagnostic.applyError(
+                    InstantiationDiagnostic.Code.CUSTOMIZATION_FAILED,
+                    "bindMethod binder failed at " + path + ": " + e,
+                    path,
+                    node.getNodeId()),
+                e);
+          }
+        }
+        // A path matching no realized Method was already warned about at plan time.
+      }
+    }
+
+    private @Nullable UaNode realizedAt(BrowsePath path) {
+      UaNode node = staged.get(path);
+      return node != null ? node : adopted.get(path);
+    }
+
+    private Map<BrowsePath, UaNode> realizedInOrder() {
+      Map<BrowsePath, UaNode> ordered = new LinkedHashMap<>();
+      for (PlannedNode planned : plan.plannedNodes()) {
+        UaNode node = realizedAt(planned.browsePath());
+        if (node != null) {
+          ordered.put(planned.browsePath(), node);
+        }
+      }
+      return ordered;
+    }
+
+    // endregion
+
+    // region Stages 5 and 6: commit, rollback, result
+
+    private InstantiationResult<T> commitAndBuildResult(long generation) throws UaException {
+      for (int attempt = 1; ; attempt++) {
+        NodeManagerBatch<UaNode> batch = buildBatch(generation);
+
+        NodeManager.CommitResult journal;
+        try {
+          journal = target.commit(batch);
+        } catch (NodeManagerBatchException e) {
+          List<InstantiationDiagnostic> rollbackFindings = rollBack(e.getApplied());
+
+          // The typed signal, not the status code: implementations may throw Bad_InvalidState for
+          // unrelated failures, which must not be retried as if the target had merely advanced.
+          boolean staleGeneration = e.isStaleGeneration() && rollbackFindings.isEmpty();
+
+          if (staleGeneration && attempt < MAX_COMMIT_ATTEMPTS) {
+            // The target advanced between recheck and commit (nothing was applied); revalidate the
+            // plan's target assumptions against the new state and try again.
+            generation = recheckTarget();
+            continue;
+          }
+
+          List<InstantiationDiagnostic> diagnostics = new ArrayList<>();
+          diagnostics.add(
+              InstantiationDiagnostic.applyError(
+                  InstantiationDiagnostic.Code.COMMIT_FAILED,
+                  "batch commit into the target NodeManager failed: " + e.getMessage(),
+                  null,
+                  null));
+          diagnostics.addAll(rollbackFindings);
+
+          throw new InstantiationException(
+              e.getStatusCode().getValue(), InstantiationDiagnostic.Phase.APPLY, diagnostics, e);
+        } catch (RuntimeException e) {
+          // An unchecked failure crossing the commit seam. AbstractNodeManager's atomic commit
+          // wraps these itself (rolled back, empty journal); a third-party emulation may not, and
+          // without a journal nothing can be removed deterministically — on a best-effort target
+          // the residue is unknown.
+          throw failure(
+              StatusCodes.Bad_InternalError,
+              InstantiationDiagnostic.applyError(
+                  InstantiationDiagnostic.Code.COMMIT_FAILED,
+                  "batch commit into the target NodeManager failed unchecked ("
+                      + e
+                      + "); no journal is available, residue on a best-effort target is unknown",
+                  null,
+                  null),
+              e);
+        }
+
+        try {
+          bindMethods();
+        } catch (InstantiationException bindFailure) {
+          // The commit succeeded but a binder failed; remove the journaled additions so the
+          // no-residue contract holds for everything this apply created. A mutation an earlier
+          // binder made to a reused or shared node cannot be undone and remains.
+          List<InstantiationDiagnostic> rollbackFindings = rollBack(journal);
+          if (rollbackFindings.isEmpty()) {
+            throw bindFailure;
+          }
+
+          List<InstantiationDiagnostic> diagnostics = new ArrayList<>(bindFailure.getDiagnostics());
+          diagnostics.addAll(rollbackFindings);
+
+          throw new InstantiationException(
+              bindFailure.getStatusCode().getValue(),
+              InstantiationDiagnostic.Phase.APPLY,
+              diagnostics,
+              bindFailure);
+        }
+
+        return buildResult(batch, journal);
+      }
+    }
+
+    private NodeManagerBatch<UaNode> buildBatch(long generation) {
+      NodeManagerBatch.Builder<UaNode> batch = NodeManagerBatch.builder();
+
+      batch.expectGeneration(generation);
+
+      for (UaNode node : staged.values()) {
+        batch.addNode(node);
+      }
+
+      for (PlannedNode planned : plan.plannedNodes()) {
+        if (planned.materialization() == PlannedNode.Materialization.REUSE) {
+          batch.reuseNode(planned.nodeId());
+        }
+      }
+
+      NamespaceTable namespaceTable = server.getNamespaceTable();
+      for (Reference reference : plan.references()) {
+        batch.addReference(reference);
+        reference.invert(namespaceTable).ifPresent(batch::addReference);
+      }
+
+      return batch.build();
+    }
+
+    /**
+     * Remove exactly the additions in {@code applied} — journal removal only, never a recursive
+     * delete from the root, which would follow HasChild into reused or shared nodes. Empty on the
+     * atomic path (a failed atomic commit applied nothing); the partial journal of a failed
+     * best-effort commit otherwise.
+     *
+     * @return findings for anything that could not be removed; empty on full success.
+     */
+    private List<InstantiationDiagnostic> rollBack(NodeManager.CommitResult applied) {
+      List<InstantiationDiagnostic> findings = new ArrayList<>();
+
+      for (Reference reference : applied.addedReferences()) {
+        try {
+          target.removeReference(reference);
+        } catch (Exception e) {
+          findings.add(
+              InstantiationDiagnostic.applyError(
+                  InstantiationDiagnostic.Code.ROLLBACK_FAILED,
+                  "rollback could not remove reference " + reference + ": " + e,
+                  null,
+                  reference.getSourceNodeId()));
+        }
+      }
+
+      for (NodeId nodeId : applied.addedNodes()) {
+        try {
+          target.removeNode(nodeId);
+        } catch (Exception e) {
+          findings.add(
+              InstantiationDiagnostic.applyError(
+                  InstantiationDiagnostic.Code.ROLLBACK_FAILED,
+                  "rollback could not remove node " + nodeId + ": " + e,
+                  null,
+                  nodeId));
+        }
+      }
+
+      return findings;
+    }
+
+    private InstantiationResult<T> buildResult(
+        NodeManagerBatch<UaNode> batch, NodeManager.CommitResult journal) {
+
+      List<MaterializedNode> materializedNodes = new ArrayList<>();
+      for (PlannedNode planned : plan.plannedNodes()) {
+        UaNode node = Objects.requireNonNull(realizedAt(planned.browsePath()));
+
+        MaterializedNode.Provenance provenance =
+            switch (planned.materialization()) {
+              case CREATE -> MaterializedNode.Provenance.CREATED;
+              case REUSE -> MaterializedNode.Provenance.REUSED;
+              case SHARE -> MaterializedNode.Provenance.SHARED;
+            };
+
+        materializedNodes.add(new MaterializedNode(planned.browsePath(), node, provenance));
+      }
+
+      Set<Reference> added = new HashSet<>(journal.addedReferences());
+      List<MaterializedReference> references =
+          batch.getReferenceAdditions().stream()
+              .map(r -> new MaterializedReference(r, added.contains(r)))
+              .toList();
+
+      T root = request.rootClass().cast(Objects.requireNonNull(realizedAt(BrowsePath.root())));
+
+      return new InstantiationResult<>(
+          root,
+          materializedNodes,
+          plan.skippedDeclarations(),
+          references,
+          plan.diagnostics(),
+          plan.modelRevision(),
+          target.getStorageGuarantee(),
+          target);
+    }
+
+    private void notifyObservers(InstantiationResult<T> result) {
+      for (Consumer<InstantiationResult<T>> observer : request.afterCommitObservers()) {
+        try {
+          observer.accept(result);
+        } catch (Exception e) {
+          LOGGER.warn(
+              "after-commit observer failed for instantiation of {}: {}",
+              plan.model().typeDefinitionId(),
+              e,
+              e);
+        }
+      }
+    }
+
+    // endregion
+
+    private static InstantiationException failure(
+        long statusCode, InstantiationDiagnostic diagnostic, @Nullable Throwable cause) {
+      return new InstantiationException(
+          statusCode, InstantiationDiagnostic.Phase.APPLY, List.of(diagnostic), cause);
+    }
+  }
+
+  /** The read-only staged-graph view handed to {@code onNode} hooks. */
+  private static final class StagedGraphView implements StagedGraph {
+
+    private final Map<BrowsePath, UaNode> nodes;
+    private final List<UaNode> nodeList;
+
+    private StagedGraphView(Map<BrowsePath, UaNode> nodes) {
+      this.nodes = nodes;
+      // The backing map is complete before the view is constructed, so one immutable copy serves
+      // every nodes() call.
+      this.nodeList = List.copyOf(nodes.values());
+    }
+
+    @Override
+    public UaNode root() {
+      return Objects.requireNonNull(nodes.get(BrowsePath.root()));
+    }
+
+    @Override
+    public Optional<UaNode> node(BrowsePath path) {
+      return Optional.ofNullable(nodes.get(path));
+    }
+
+    @Override
+    public List<UaNode> nodes() {
+      return nodeList;
     }
   }
 }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/NodeInstantiator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/NodeInstantiator.java
@@ -23,6 +23,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
 import org.eclipse.milo.opcua.sdk.core.Reference;
 import org.eclipse.milo.opcua.sdk.server.NodeManager;
 import org.eclipse.milo.opcua.sdk.server.NodeManagerBatch;
@@ -112,7 +113,13 @@ public final class NodeInstantiator {
   public <T extends UaNode> InstantiationPlan<T> plan(InstantiationRequest<T> request)
       throws UaException {
 
-    TypeInstantiationModel model = describe(request.typeDefinitionId());
+    // A concreteType selection at the root path substitutes the instantiated type wholesale —
+    // how a forPlaceholder request selects a concrete subtype of an abstract declared type;
+    // validated against the declared type when the root is planned.
+    NodeId rootTypeId =
+        request.concreteTypes().getOrDefault(BrowsePath.root(), request.typeDefinitionId());
+
+    TypeInstantiationModel model = describe(rootTypeId);
 
     return new PlanComputation<>(this, request, model).compute();
   }
@@ -190,7 +197,17 @@ public final class NodeInstantiator {
     private final List<InstantiationDiagnostic> diagnostics = new ArrayList<>();
     private final Map<NodeId, @Nullable TypeInstantiationModel> memberModels = new HashMap<>();
 
-    private @Nullable Set<BrowsePath> effectiveIncludedPaths;
+    /** Expanded placeholder subtrees: realization path -> the member-type model grafted there. */
+    private final Map<BrowsePath, TypeInstantiationModel> graftedModels = new LinkedHashMap<>();
+
+    /** Hierarchy edges added by placeholder expansion, absolute-path keyed like the model's. */
+    private final List<DeclarationEdge> graftedEdges = new ArrayList<>();
+
+    /** Reference rows added by placeholder expansion, relocated to realized paths. */
+    private final List<ReferenceRow> graftedRows = new ArrayList<>();
+
+    /** Expansion paths that reached an expandable placeholder; any others are plan errors. */
+    private final Set<BrowsePath> consumedExpansions = new HashSet<>();
 
     private PlanComputation(
         NodeInstantiator instantiator,
@@ -209,6 +226,8 @@ public final class NodeInstantiator {
       for (InstanceDeclaration declaration : model.declarations()) {
         classify(declaration);
       }
+
+      validateExpansions();
 
       allocateNodeIds();
       preflightCollisions();
@@ -242,6 +261,21 @@ public final class NodeInstantiator {
     // region Root
 
     private void planRoot() {
+      NodeId declaredTypeId = request.typeDefinitionId();
+      if (!model.typeDefinitionId().equals(declaredTypeId)
+          && !isTypeSubtypeOfOrEqual(model.typeDefinitionId(), declaredTypeId)) {
+        diagnostics.add(
+            InstantiationDiagnostic.planError(
+                InstantiationDiagnostic.Code.CONCRETE_TYPE_INVALID,
+                "concreteType "
+                    + model.typeDefinitionId()
+                    + " for the instance root is not declared type "
+                    + declaredTypeId
+                    + " or a subtype",
+                BrowsePath.root(),
+                model.typeDefinitionId()));
+      }
+
       AttributeSnapshot typeAttributes = model.rootAttributes();
 
       NodeClass typeNodeClass = (NodeClass) typeAttributes.getOrNull(AttributeId.NodeClass);
@@ -471,6 +505,17 @@ public final class NodeInstantiator {
                   path,
                   declaration.declarationNodeId()));
         }
+        if (declaration.rule() == ModellingRule.MANDATORY_PLACEHOLDER) {
+          diagnostics.add(
+              InstantiationDiagnostic.planError(
+                  InstantiationDiagnostic.Code.MANDATORY_PLACEHOLDER_UNSATISFIED,
+                  "MandatoryPlaceholder at "
+                      + path
+                      + " was excluded, but it requires at least one realization while its parent"
+                      + " path exists (Part 3 §6.4.4.4.5)",
+                  path,
+                  declaration.declarationNodeId()));
+        }
         skip(declaration, SkippedDeclaration.Reason.EXCLUDED);
         return;
       }
@@ -491,19 +536,28 @@ public final class NodeInstantiator {
             skip(declaration, SkippedDeclaration.Reason.VENDOR_RULE);
           }
         }
-        case OPTIONAL_PLACEHOLDER -> skip(declaration, SkippedDeclaration.Reason.PLACEHOLDER);
-        case MANDATORY_PLACEHOLDER -> {
+        case OPTIONAL_PLACEHOLDER, MANDATORY_PLACEHOLDER -> {
+          // The placeholder occurrence itself is never materialized; its realizations are planned
+          // as sibling paths by expansion.
           skip(declaration, SkippedDeclaration.Reason.PLACEHOLDER);
-          // Placeholder expansion does not exist yet; the ≥1-realization obligation becomes an
-          // error once a request can satisfy it.
-          diagnostics.add(
-              InstantiationDiagnostic.planWarning(
-                  InstantiationDiagnostic.Code.MANDATORY_PLACEHOLDER_UNSATISFIED,
-                  "MandatoryPlaceholder at "
-                      + path
-                      + " requires at least one realization; none is bound by this request",
-                  path,
-                  declaration.declarationNodeId()));
+
+          List<PlaceholderRealization> realizations =
+              request.placeholderExpansions().getOrDefault(path, List.of());
+
+          if (!realizations.isEmpty()) {
+            consumedExpansions.add(path);
+            expandPlaceholder(declaration, realizations);
+          } else if (declaration.rule() == ModellingRule.MANDATORY_PLACEHOLDER) {
+            diagnostics.add(
+                InstantiationDiagnostic.planError(
+                    InstantiationDiagnostic.Code.MANDATORY_PLACEHOLDER_UNSATISFIED,
+                    "MandatoryPlaceholder at "
+                        + path
+                        + " requires at least one realization; none is bound by this request"
+                        + " (Part 3 §6.4.4.4.5)",
+                    path,
+                    declaration.declarationNodeId()));
+          }
         }
         case EXPOSES_ITS_ARRAY -> {
           skip(declaration, SkippedDeclaration.Reason.EXPOSES_ITS_ARRAY);
@@ -520,11 +574,19 @@ public final class NodeInstantiator {
     private boolean isSelected(InstanceDeclaration declaration, boolean isOptional) {
       BrowsePath path = declaration.browsePath();
 
-      for (BrowsePath included : effectiveIncludedPaths()) {
-        // Selecting a nested path implies its ancestors — but only a path that resolves in the
-        // model implies anything; a mistyped include must not materialize its ancestors (it is
-        // reported by the UNMATCHED_PATH warning instead).
-        if (included.startsWith(path)) {
+      // Selecting a nested path implies its ancestors — but only a path that resolves (in the
+      // model or in an expanded placeholder's grafted subtree) implies anything; a mistyped
+      // include must not materialize its ancestors (it is reported by the UNMATCHED_PATH warning
+      // instead).
+      for (BrowsePath included : request.includedPaths()) {
+        if (included.startsWith(path) && resolvesInPlan(included)) {
+          return true;
+        }
+      }
+
+      // Binding realizations to a nested placeholder implies its ancestors the same way.
+      for (BrowsePath expansion : request.placeholderExpansions().keySet()) {
+        if (expansion.startsWith(path) && resolvesInPlan(expansion)) {
           return true;
         }
       }
@@ -536,18 +598,36 @@ public final class NodeInstantiator {
       return request.includePredicate().map(p -> p.test(declaration)).orElse(false);
     }
 
-    /** The request's included paths that resolve to a declaration in the model. */
-    private Set<BrowsePath> effectiveIncludedPaths() {
-      if (effectiveIncludedPaths == null) {
-        Set<BrowsePath> resolved = new HashSet<>();
-        for (BrowsePath included : request.includedPaths()) {
-          if (model.get(included).isPresent()) {
-            resolved.add(included);
+    /**
+     * Resolve the declaration occurrence a request path names: a declaration of the root model, or
+     * — inside an expanded placeholder's realized subtree — a declaration of the grafted
+     * member-type model. A grafted declaration is returned as the member model holds it, with its
+     * BrowsePath relative to the realization.
+     */
+    private Optional<InstanceDeclaration> declarationAt(BrowsePath path) {
+      Optional<InstanceDeclaration> declaration = model.get(path);
+      if (declaration.isPresent()) {
+        return declaration;
+      }
+
+      for (Map.Entry<BrowsePath, TypeInstantiationModel> graft : graftedModels.entrySet()) {
+        BrowsePath realizedPath = graft.getKey();
+        if (path.startsWith(realizedPath) && path.depth() > realizedPath.depth()) {
+          BrowsePath relative =
+              BrowsePath.of(path.elements().subList(realizedPath.depth(), path.depth()));
+          Optional<InstanceDeclaration> grafted = graft.getValue().get(relative);
+          if (grafted.isPresent()) {
+            return grafted;
           }
         }
-        effectiveIncludedPaths = resolved;
       }
-      return effectiveIncludedPaths;
+
+      return Optional.empty();
+    }
+
+    /** Whether a request path names a declaration this plan can reach. */
+    private boolean resolvesInPlan(BrowsePath path) {
+      return declarationAt(path).isPresent();
     }
 
     private void skip(InstanceDeclaration declaration, SkippedDeclaration.Reason reason) {
@@ -556,21 +636,224 @@ public final class NodeInstantiator {
 
     // endregion
 
+    // region Placeholder expansion
+
+    /**
+     * Realize the request's bindings for one placeholder. Each realization is planned as a sibling
+     * of the placeholder path, carrying the placeholder declaration's attributes over its
+     * (concrete-resolved) type's, attached by the same edges that attached the placeholder — and
+     * the effective type's full member hierarchy is grafted beneath it, relocated under the
+     * realized path and classified through the ordinary machinery. Grafting happens here, per
+     * realization, because placeholders are recorded shallowly in the model (Part 3 §6.4.4.4.4–.5).
+     */
+    private void expandPlaceholder(
+        InstanceDeclaration placeholder, List<PlaceholderRealization> realizations)
+        throws UaException {
+
+      BrowsePath placeholderPath = placeholder.browsePath();
+      BrowsePath parentPath = placeholderPath.parent();
+
+      // Every edge that attaches the placeholder attaches each realization: several references
+      // between one declaration pair map onto the same realized pair (Part 3 §6.4.3).
+      List<DeclarationEdge> attachingEdges =
+          Stream.concat(model.hierarchy().stream(), graftedEdges.stream())
+              .filter(edge -> edge.childPath().equals(placeholderPath))
+              .toList();
+
+      // Rows recorded from the placeholder declaration (HasTypeDefinition included) re-source at
+      // each realization; the HasTypeDefinition substitution then targets the effective type.
+      List<ReferenceRow> placeholderRows =
+          Stream.concat(model.references().stream(), graftedRows.stream())
+              .filter(row -> row.sourcePath().equals(placeholderPath))
+              .toList();
+
+      for (PlaceholderRealization realization : realizations) {
+        BrowsePath realizedPath = parentPath.append(realization.browseName());
+
+        if (planned.containsKey(realizedPath)
+            || skipped.containsKey(realizedPath)
+            || resolvesInPlan(realizedPath)) {
+          diagnostics.add(
+              InstantiationDiagnostic.planError(
+                  InstantiationDiagnostic.Code.PLACEHOLDER_EXPANSION_INVALID,
+                  "realization "
+                      + realization.browseName()
+                      + " of placeholder "
+                      + placeholderPath
+                      + " collides with the declaration or realization at "
+                      + realizedPath,
+                  realizedPath,
+                  realization.nodeId()));
+          continue;
+        }
+
+        InstanceDeclaration realized =
+            new InstanceDeclaration(
+                realizedPath,
+                realization.browseName(),
+                placeholder.nodeClass(),
+                placeholder.declarationNodeId(),
+                placeholder.declaringTypeId(),
+                placeholder.overriddenDeclarations(),
+                placeholder.modellingRuleId(),
+                placeholder.rule(),
+                placeholder.typeDefinitionId(),
+                realizationAttributes(placeholder, realization));
+
+        NodeId concreteTypeId =
+            realization.typeDefinitionId() != null
+                ? realization.typeDefinitionId()
+                : request.concreteTypes().get(realizedPath);
+
+        NodeId effectiveTypeId = planMember(realized, concreteTypeId, true);
+
+        Working working = planned.get(realizedPath);
+        if (working != null && working.nodeId == null && realization.nodeId() != null) {
+          working.nodeId = realization.nodeId();
+        }
+
+        for (DeclarationEdge edge : attachingEdges) {
+          graftedEdges.add(
+              new DeclarationEdge(edge.parentPath(), edge.referenceTypeId(), realizedPath));
+        }
+
+        for (ReferenceRow row : placeholderRows) {
+          graftedRows.add(relocateSource(row, realizedPath));
+        }
+
+        if (effectiveTypeId == null) {
+          // A Method placeholder realization has no member model to graft.
+          continue;
+        }
+
+        TypeInstantiationModel memberModel = memberModel(effectiveTypeId, realizedPath);
+        if (memberModel == null) {
+          // The effective type does not compile; the error is already on the plan.
+          continue;
+        }
+
+        // Registered before the subtree is classified so nested includes, nested expansion
+        // bindings, and collision checks resolve against this graft.
+        graftedModels.put(realizedPath, memberModel);
+
+        for (DeclarationEdge edge : memberModel.hierarchy()) {
+          graftedEdges.add(
+              new DeclarationEdge(
+                  realizedPath.concat(edge.parentPath()),
+                  edge.referenceTypeId(),
+                  realizedPath.concat(edge.childPath())));
+        }
+
+        for (ReferenceRow row : memberModel.references()) {
+          graftedRows.add(relocate(row, realizedPath));
+        }
+
+        for (InstanceDeclaration member : memberModel.declarations()) {
+          classify(member.withBrowsePath(realizedPath.concat(member.browsePath())));
+        }
+      }
+    }
+
+    /**
+     * The realization's attributes are the placeholder declaration's — the attribute policy's
+     * "declaration wins" tier — with BrowseName and DisplayName replaced by the realization's name:
+     * a placeholder's own names are markers like {@code <ChannelName>}, not instance names.
+     */
+    private static AttributeSnapshot realizationAttributes(
+        InstanceDeclaration placeholder, PlaceholderRealization realization) {
+
+      AttributeSnapshot declared = placeholder.attributes();
+
+      AttributeSnapshot.Builder b = AttributeSnapshot.builder();
+      for (AttributeId id : declared.attributeIds()) {
+        b.put(id, declared.isNull(id) ? null : declared.getOrNull(id));
+      }
+      b.put(AttributeId.BrowseName, realization.browseName());
+      b.put(AttributeId.DisplayName, new LocalizedText(realization.browseName().name()));
+      return b.build();
+    }
+
+    /**
+     * Relocate a member-model row under a realization: relative rows move both ends; absolute rows
+     * keep their verbatim target.
+     */
+    private static ReferenceRow relocate(ReferenceRow row, BrowsePath realizedPath) {
+      if (row.isRelative()) {
+        return ReferenceRow.relative(
+            realizedPath.concat(row.sourcePath()),
+            row.referenceTypeId(),
+            realizedPath.concat(Objects.requireNonNull(row.targetPath())));
+      }
+      return ReferenceRow.absolute(
+          realizedPath.concat(row.sourcePath()),
+          row.referenceTypeId(),
+          row.direction(),
+          Objects.requireNonNull(row.targetNodeId()));
+    }
+
+    /** Re-source a placeholder-declaration row at the realization's path. */
+    private static ReferenceRow relocateSource(ReferenceRow row, BrowsePath realizedPath) {
+      if (row.isRelative()) {
+        return ReferenceRow.relative(
+            realizedPath, row.referenceTypeId(), Objects.requireNonNull(row.targetPath()));
+      }
+      return ReferenceRow.absolute(
+          realizedPath,
+          row.referenceTypeId(),
+          row.direction(),
+          Objects.requireNonNull(row.targetNodeId()));
+    }
+
+    /**
+     * Expansion is a directive to create, so any binding that never reached an expandable
+     * placeholder — mistyped, excluded, or under an omitted ancestor — is an error, not a silent
+     * drop.
+     */
+    private void validateExpansions() {
+      for (BrowsePath path : sorted(request.placeholderExpansions().keySet())) {
+        if (!consumedExpansions.contains(path)) {
+          diagnostics.add(
+              InstantiationDiagnostic.planError(
+                  InstantiationDiagnostic.Code.PLACEHOLDER_EXPANSION_INVALID,
+                  "expandPlaceholder path "
+                      + path
+                      + " does not name an expandable placeholder in this plan",
+                  path,
+                  null));
+        }
+      }
+    }
+
+    // endregion
+
     // region Member resolution
 
     private void plan(InstanceDeclaration declaration) throws UaException {
+      planMember(declaration, request.concreteTypes().get(declaration.browsePath()), false);
+    }
+
+    /**
+     * Plan one member occurrence. {@code expandsSubtree} marks a placeholder realization, whose
+     * effective type's full member hierarchy is grafted beneath it — suppressing the
+     * CONCRETE_TYPE_NOT_EXPANDED warning that applies to ordinary members.
+     *
+     * @return the effective (concrete-resolved) member type; {@code null} for Methods.
+     */
+    private @Nullable NodeId planMember(
+        InstanceDeclaration declaration, @Nullable NodeId concreteTypeId, boolean expandsSubtree)
+        throws UaException {
+
       BrowsePath path = declaration.browsePath();
 
       if (declaration.nodeClass() == NodeClass.Method) {
         planMethod(declaration);
-        return;
+        return null;
       }
 
       NodeId declaredTypeId =
           Objects.requireNonNull(declaration.typeDefinitionId(), "typeDefinitionId");
       NodeId effectiveTypeId = declaredTypeId;
 
-      NodeId concreteTypeId = request.concreteTypes().get(path);
       if (concreteTypeId != null && !concreteTypeId.equals(declaredTypeId)) {
         if (isTypeSubtypeOfOrEqual(concreteTypeId, declaredTypeId)) {
           effectiveTypeId = concreteTypeId;
@@ -593,7 +876,7 @@ public final class NodeInstantiator {
       TypeInstantiationModel memberModel = memberModel(effectiveTypeId, path);
 
       if (memberModel != null) {
-        validateMemberType(declaration, memberModel, effectiveTypeId);
+        validateMemberType(declaration, memberModel, effectiveTypeId, expandsSubtree);
       }
 
       AttributeSnapshot effective = memberEffectiveAttributes(declaration, memberModel);
@@ -610,6 +893,8 @@ public final class NodeInstantiator {
               resolved.javaClass(),
               resolved.constructorTypeId(),
               effective));
+
+      return effectiveTypeId;
     }
 
     private void planMethod(InstanceDeclaration declaration) {
@@ -650,7 +935,8 @@ public final class NodeInstantiator {
     private void validateMemberType(
         InstanceDeclaration declaration,
         TypeInstantiationModel memberModel,
-        NodeId effectiveTypeId) {
+        NodeId effectiveTypeId,
+        boolean expandsSubtree) {
 
       BrowsePath path = declaration.browsePath();
       boolean isConcreteOverride = !effectiveTypeId.equals(declaration.typeDefinitionId());
@@ -700,9 +986,10 @@ public final class NodeInstantiator {
         }
       }
 
-      if (isConcreteOverride) {
+      if (isConcreteOverride && !expandsSubtree) {
         // The plan realizes the *declared* type's members; a concrete subtype's additional
         // members are not expanded in this release. Say so instead of silently omitting them.
+        // (A placeholder realization is exempt: its effective type's full hierarchy IS grafted.)
         boolean hasUnmodeledMembers =
             memberModel.declarations().stream()
                 .map(md -> path.concat(md.browsePath()))
@@ -920,11 +1207,17 @@ public final class NodeInstantiator {
                 rootNodeId, NodeIds.HasTypeDefinition, model.typeDefinitionId().expanded(), true));
       }
 
-      if (request.parentNodeId().isPresent() && request.parentReferenceTypeId().isPresent()) {
+      if (request.parentNodeId().isPresent()) {
         NodeId parentNodeId = request.parentNodeId().get();
-        NodeId parentReferenceTypeId = request.parentReferenceTypeId().get();
+        NodeId parentReferenceTypeId =
+            request.parentReferenceTypeId().orElseGet(this::placeholderParentReferenceTypeId);
 
-        if (!isReferenceSubtypeOfOrEqual(parentReferenceTypeId, NodeIds.HierarchicalReferences)) {
+        //noinspection StatementWithEmptyBody
+        if (parentReferenceTypeId == null) {
+          // A forPlaceholder request whose declaration attachment could not be read back; the
+          // error diagnostic is already recorded.
+        } else if (!isReferenceSubtypeOfOrEqual(
+            parentReferenceTypeId, NodeIds.HierarchicalReferences)) {
           diagnostics.add(
               InstantiationDiagnostic.planError(
                   InstantiationDiagnostic.Code.INVALID_PARENT,
@@ -952,84 +1245,140 @@ public final class NodeInstantiator {
       }
 
       for (DeclarationEdge edge : model.hierarchy()) {
-        Working parent = planned.get(edge.parentPath());
-        Working child = planned.get(edge.childPath());
-        if (parent == null || child == null) {
-          continue;
-        }
-        references.add(
-            new Reference(
-                Objects.requireNonNull(parent.nodeId),
-                edge.referenceTypeId(),
-                Objects.requireNonNull(child.nodeId).expanded(),
-                true));
+        resolveEdge(edge, references);
+      }
+      for (DeclarationEdge edge : graftedEdges) {
+        resolveEdge(edge, references);
       }
 
       ReferenceReplicationPolicy policy = request.referenceReplication();
 
       for (ReferenceRow row : model.references()) {
-        Working source = planned.get(row.sourcePath());
-        if (source == null || source.materialization != PlannedNode.Materialization.CREATE) {
-          // Skipped sources have no instance; reused and shared nodes already carry their own
-          // non-hierarchy references.
-          continue;
-        }
-
-        NodeId sourceNodeId = Objects.requireNonNull(source.nodeId);
-        NodeId referenceTypeId = row.referenceTypeId();
-
-        if (isReferenceSubtypeOfOrEqual(referenceTypeId, NodeIds.HasTypeDefinition)) {
-          // Substituted rather than copied: a concreteType selection redirects the instance's
-          // type; every created instance gets exactly its effective type.
-          references.add(
-              new Reference(
-                  sourceNodeId,
-                  referenceTypeId,
-                  Objects.requireNonNull(source.typeDefinitionId).expanded(),
-                  true));
-          continue;
-        }
-
-        if (isReferenceSubtypeOfOrEqual(referenceTypeId, NodeIds.HasModellingRule)) {
-          if (request.purpose() == InstantiationPurpose.INSTANCE_DECLARATION) {
-            references.add(
-                new Reference(
-                    sourceNodeId,
-                    referenceTypeId,
-                    Objects.requireNonNull(row.targetNodeId()),
-                    row.direction() == Reference.Direction.FORWARD));
-          }
-          continue;
-        }
-
-        if (row.isRelative()) {
-          if (policy.internal() == ReferenceReplicationPolicy.InternalReferences.OMIT) {
-            continue;
-          }
-          Working target = planned.get(row.targetPath());
-          if (target == null) {
-            // No planned edge to an omitted target.
-            continue;
-          }
-          references.add(
-              new Reference(
-                  sourceNodeId,
-                  referenceTypeId,
-                  Objects.requireNonNull(target.nodeId).expanded(),
-                  true));
-        } else {
-          if (policy.external() == ReferenceReplicationPolicy.ExternalReferences.COPY) {
-            references.add(
-                new Reference(
-                    sourceNodeId,
-                    referenceTypeId,
-                    Objects.requireNonNull(row.targetNodeId()),
-                    row.direction() == Reference.Direction.FORWARD));
-          }
-        }
+        resolveRow(row, policy, references);
+      }
+      for (ReferenceRow row : graftedRows) {
+        resolveRow(row, policy, references);
       }
 
       return references;
+    }
+
+    private void resolveEdge(DeclarationEdge edge, List<Reference> references) {
+      Working parent = planned.get(edge.parentPath());
+      Working child = planned.get(edge.childPath());
+      if (parent == null || child == null) {
+        return;
+      }
+      references.add(
+          new Reference(
+              Objects.requireNonNull(parent.nodeId),
+              edge.referenceTypeId(),
+              Objects.requireNonNull(child.nodeId).expanded(),
+              true));
+    }
+
+    private void resolveRow(
+        ReferenceRow row, ReferenceReplicationPolicy policy, List<Reference> references) {
+
+      Working source = planned.get(row.sourcePath());
+      if (source == null || source.materialization != PlannedNode.Materialization.CREATE) {
+        // Skipped sources have no instance; reused and shared nodes already carry their own
+        // non-hierarchy references.
+        return;
+      }
+
+      NodeId sourceNodeId = Objects.requireNonNull(source.nodeId);
+      NodeId referenceTypeId = row.referenceTypeId();
+
+      if (isReferenceSubtypeOfOrEqual(referenceTypeId, NodeIds.HasTypeDefinition)) {
+        // Substituted rather than copied: a concreteType selection redirects the instance's
+        // type; every created instance gets exactly its effective type.
+        references.add(
+            new Reference(
+                sourceNodeId,
+                referenceTypeId,
+                Objects.requireNonNull(source.typeDefinitionId).expanded(),
+                true));
+        return;
+      }
+
+      if (isReferenceSubtypeOfOrEqual(referenceTypeId, NodeIds.HasModellingRule)) {
+        if (request.purpose() == InstantiationPurpose.INSTANCE_DECLARATION) {
+          references.add(
+              new Reference(
+                  sourceNodeId,
+                  referenceTypeId,
+                  Objects.requireNonNull(row.targetNodeId()),
+                  row.direction() == Reference.Direction.FORWARD));
+        }
+        return;
+      }
+
+      if (row.isRelative()) {
+        if (policy.internal() == ReferenceReplicationPolicy.InternalReferences.OMIT) {
+          return;
+        }
+        Working target = planned.get(row.targetPath());
+        if (target == null) {
+          // No planned edge to an omitted target.
+          return;
+        }
+        references.add(
+            new Reference(
+                sourceNodeId,
+                referenceTypeId,
+                Objects.requireNonNull(target.nodeId).expanded(),
+                true));
+      } else {
+        if (policy.external() == ReferenceReplicationPolicy.ExternalReferences.COPY) {
+          references.add(
+              new Reference(
+                  sourceNodeId,
+                  referenceTypeId,
+                  Objects.requireNonNull(row.targetNodeId()),
+                  row.direction() == Reference.Direction.FORWARD));
+        }
+      }
+    }
+
+    /**
+     * A forPlaceholder request that did not set the parent ReferenceType explicitly attaches its
+     * realization with the ReferenceType connecting the placeholder declaration to its own parent,
+     * read back from the declaration node's inverse hierarchical references (deterministically the
+     * smallest ReferenceType NodeId if several parents attach it). Unresolvable — the declaration
+     * node is gone or carries no inverse hierarchical reference — is a plan error naming the fix.
+     */
+    private @Nullable NodeId placeholderParentReferenceTypeId() {
+      InstantiationRequest.PlaceholderOrigin origin = request.placeholderOrigin().orElse(null);
+      if (origin == null) {
+        // Unreachable via the builder: parent() requires both values, so a missing reference type
+        // implies a forPlaceholder request. Guard with the common default anyway.
+        return NodeIds.HasComponent;
+      }
+
+      NodeId declarationNodeId = origin.declaration().declarationNodeId();
+
+      Optional<NodeId> referenceTypeId =
+          server.getAddressSpaceManager().getManagedReferences(declarationNodeId).stream()
+              .filter(r -> !r.isForward())
+              .map(Reference::getReferenceTypeId)
+              .filter(typeId -> isReferenceSubtypeOfOrEqual(typeId, NodeIds.HierarchicalReferences))
+              .min(TypeSpaceRules.NODE_ID_ORDER);
+
+      if (referenceTypeId.isEmpty()) {
+        diagnostics.add(
+            InstantiationDiagnostic.planError(
+                InstantiationDiagnostic.Code.INVALID_PARENT,
+                "the ReferenceType attaching placeholder declaration "
+                    + declarationNodeId
+                    + " to its parent cannot be resolved; set parent(parentNodeId, referenceTypeId)"
+                    + " explicitly",
+                BrowsePath.root(),
+                declarationNodeId));
+        return null;
+      }
+
+      return referenceTypeId.get();
     }
 
     // endregion
@@ -1038,9 +1387,10 @@ public final class NodeInstantiator {
 
     private void warnUnmatchedPaths() {
       for (BrowsePath path : sorted(request.includedPaths())) {
-        if (model.get(path).isEmpty()) {
+        Optional<InstanceDeclaration> declaration = declarationAt(path);
+        if (declaration.isEmpty()) {
           warnUnmatched("includeOptional", path);
-        } else if (model.get(path).map(InstanceDeclaration::isPlaceholder).orElse(false)) {
+        } else if (declaration.get().isPlaceholder()) {
           diagnostics.add(
               InstantiationDiagnostic.planWarning(
                   InstantiationDiagnostic.Code.UNMATCHED_PATH,
@@ -1054,7 +1404,7 @@ public final class NodeInstantiator {
       }
 
       for (BrowsePath path : sorted(request.excludedPaths())) {
-        if (model.get(path).isEmpty()) {
+        if (!resolvesInPlan(path)) {
           warnUnmatched("excludeOptional", path);
         }
       }
@@ -1504,8 +1854,10 @@ public final class NodeInstantiator {
 
       // The commit validates only the batch's own nodes, so a parent that disappeared since plan
       // time would otherwise commit as a reference row sourced at a nonexistent NodeId — and a
-      // node later created at that id would silently acquire a phantom child.
-      if (request.parentNodeId().isPresent() && request.parentReferenceTypeId().isPresent()) {
+      // node later created at that id would silently acquire a phantom child. This covers a
+      // forPlaceholder request too, whose parent attachment resolves its ReferenceType lazily and
+      // so leaves parentReferenceTypeId absent even though a parent attachment is planned.
+      if (request.parentNodeId().isPresent()) {
         NodeId parentNodeId = request.parentNodeId().get();
         if (server.getAddressSpaceManager().getManagedNode(parentNodeId).isEmpty()
             && !target.containsNode(parentNodeId)) {

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/NodeInstantiator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/NodeInstantiator.java
@@ -282,7 +282,8 @@ public final class NodeInstantiator {
       NodeClass instanceNodeClass =
           typeNodeClass == NodeClass.VariableType ? NodeClass.Variable : NodeClass.Object;
 
-      if (Boolean.TRUE.equals(typeAttributes.getOrNull(AttributeId.IsAbstract))) {
+      if (Boolean.TRUE.equals(typeAttributes.getOrNull(AttributeId.IsAbstract))
+          && !request.allowAbstractType()) {
         diagnostics.add(
             InstantiationDiagnostic.planError(
                 InstantiationDiagnostic.Code.ABSTRACT_TYPE,

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/PlaceholderRealization.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/PlaceholderRealization.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
+
+import static java.util.Objects.requireNonNull;
+
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * One member realized from a placeholder declaration by {@link
+ * InstantiationRequest.Builder#expandPlaceholder}: the BrowseName the realization gets, an optional
+ * pinned {@link NodeId}, and an optional concrete subtype of the placeholder's declared type.
+ *
+ * <p>A realization is planned as a sibling of the placeholder path — the placeholder's path with
+ * its last element replaced by {@link #browseName()} — carrying the placeholder declaration's
+ * attributes over its (concrete-resolved) type's, with the full member hierarchy of that type
+ * realized beneath it through the same selection, allocation, and reference machinery as every
+ * other planned node.
+ *
+ * @param browseName the BrowseName of the realized member; also its default DisplayName.
+ * @param nodeId the pinned {@link NodeId} of the realized member, or {@code null} to derive one
+ *     like any other planned node (request pins at the realized path are superseded by this one).
+ * @param typeDefinitionId the concrete type to instantiate — the placeholder's declared type or a
+ *     subtype of it — or {@code null} for the declared type itself.
+ */
+public record PlaceholderRealization(
+    QualifiedName browseName, @Nullable NodeId nodeId, @Nullable NodeId typeDefinitionId) {
+
+  public PlaceholderRealization {
+    requireNonNull(browseName, "browseName");
+  }
+
+  /**
+   * Create a realization named {@code browseName}, its NodeId derived like any other planned node
+   * and its type the placeholder's declared type.
+   *
+   * @param browseName the BrowseName of the realized member.
+   * @return the realization.
+   */
+  public static PlaceholderRealization of(QualifiedName browseName) {
+    return new PlaceholderRealization(browseName, null, null);
+  }
+
+  /**
+   * @param nodeId the {@link NodeId} to pin the realized member to.
+   * @return a copy of this realization with its {@link #nodeId()} pinned.
+   */
+  public PlaceholderRealization withNodeId(NodeId nodeId) {
+    return new PlaceholderRealization(
+        browseName, requireNonNull(nodeId, "nodeId"), typeDefinitionId);
+  }
+
+  /**
+   * @param typeDefinitionId the concrete type to instantiate; must be the placeholder's declared
+   *     type or a subtype of it, validated at plan time.
+   * @return a copy of this realization with its {@link #typeDefinitionId()} set.
+   */
+  public PlaceholderRealization withConcreteType(NodeId typeDefinitionId) {
+    return new PlaceholderRealization(
+        browseName, nodeId, requireNonNull(typeDefinitionId, "typeDefinitionId"));
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/PlannedNode.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/PlannedNode.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
+
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * One node an {@link InstantiationPlan} decided to realize: identity resolved, Java class and
+ * constructor chosen, effective attributes computed — everything apply needs, decided before
+ * anything is constructed.
+ *
+ * @param browsePath the occurrence path; {@link BrowsePath#root()} for the instance root.
+ * @param declaration the declaration occurrence realized; {@code null} for the instance root, which
+ *     realizes the type itself.
+ * @param nodeId the resolved instance {@link NodeId} (for {@link Materialization#SHARE}, the shared
+ *     declaration node's id).
+ * @param nodeClass the instance NodeClass.
+ * @param typeDefinitionId the instance's TypeDefinition — the declared member type, or the
+ *     request's {@code concreteType} selection; {@code null} for Methods.
+ * @param javaClass the Java class the node is constructed as (or expected to be, for {@link
+ *     Materialization#REUSE}).
+ * @param constructorTypeId the registry key the constructor was resolved from — the type itself, or
+ *     the nearest registered ancestor under {@link
+ *     InstantiationRequest.ClassResolution#NEAREST_ANCESTOR}; {@code null} if no registration
+ *     applies (default construction).
+ * @param effectiveAttributes the effective attributes: declaration over member type, absent /
+ *     explicit-null distinction preserved (for the root: type attributes per Part 3 §6.4.2, then
+ *     request overrides).
+ * @param materialization how the node is realized at apply time.
+ */
+public record PlannedNode(
+    BrowsePath browsePath,
+    @Nullable InstanceDeclaration declaration,
+    NodeId nodeId,
+    NodeClass nodeClass,
+    @Nullable NodeId typeDefinitionId,
+    Class<? extends UaNode> javaClass,
+    @Nullable NodeId constructorTypeId,
+    AttributeSnapshot effectiveAttributes,
+    Materialization materialization) {
+
+  /**
+   * @return {@code true} if this is the instance root.
+   */
+  public boolean isRoot() {
+    return browsePath.isRoot();
+  }
+
+  /** How a {@link PlannedNode} is realized at apply time. */
+  public enum Materialization {
+
+    /** A new node is constructed and committed. */
+    CREATE,
+
+    /**
+     * A compatible existing node in the target is adopted ({@link
+     * ConflictPolicy#REUSE_COMPATIBLE}); it is never modified and never deleted by cleanup.
+     */
+    REUSE,
+
+    /**
+     * The type's own Method node is referenced instead of copied ({@link
+     * MethodInstantiation#SHARE}); nothing is constructed.
+     */
+    SHARE
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/ReferenceReplicationPolicy.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/ReferenceReplicationPolicy.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
+
+/**
+ * How declaration reference rows ({@link ReferenceRow}) are replicated onto instances. The spec
+ * makes non-hierarchical replication server-specific (Part 3 §6.4.4.2), so both defaults are
+ * overridable as a named policy.
+ *
+ * <p>The policy governs only the model's non-hierarchy rows. Hierarchy edges ({@link
+ * DeclarationEdge}) and each instance's {@code HasTypeDefinition} reference are structural and
+ * always materialized; {@code HasModellingRule} replication is governed by {@link
+ * InstantiationPurpose}, not by this policy.
+ *
+ * @param internal how rows whose both ends are declarations of the model are treated.
+ * @param external how rows targeting nodes outside the model are treated.
+ */
+public record ReferenceReplicationPolicy(InternalReferences internal, ExternalReferences external) {
+
+  /**
+   * The default policy: internal rows re-mapped onto the corresponding instances ({@link
+   * InternalReferences#REMAP}), external rows copied verbatim ({@link ExternalReferences#COPY}).
+   */
+  public static final ReferenceReplicationPolicy DEFAULT =
+      new ReferenceReplicationPolicy(InternalReferences.REMAP, ExternalReferences.COPY);
+
+  /** Treatment of rows whose source and target are both declarations of the model. */
+  public enum InternalReferences {
+
+    /**
+     * Rewrite the row onto the corresponding instance pair, exactly once, preserving the
+     * ReferenceType and direction — direct-connection consistency per Part 3 §6.4.3 (the
+     * state-machine {@code HasCause}/{@code HasEffect} workload).
+     */
+    REMAP,
+
+    /** Do not replicate internal non-hierarchical rows (spec-legal per Part 3 §6.4.4.2). */
+    OMIT
+  }
+
+  /** Treatment of rows targeting nodes outside the model. */
+  public enum ExternalReferences {
+
+    /** Copy the row verbatim: same ReferenceType, direction, and absolute target. */
+    COPY,
+
+    /** Do not replicate external rows. */
+    OMIT
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/ReferenceRow.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/ReferenceRow.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
+
+import static java.util.Objects.requireNonNull;
+
+import org.eclipse.milo.opcua.sdk.core.Reference;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * One non-hierarchy reference row of a {@link TypeInstantiationModel}, recorded from a declaration
+ * node. Rows cover everything the walk's {@link DeclarationEdge}s do not: non-hierarchical
+ * references in both directions, including {@code HasTypeDefinition} and {@code HasModellingRule}
+ * (retention of the latter on instances is a purpose-dependent planning decision, not a model one).
+ *
+ * <p>A row is either <b>relative</b> — both ends are declarations of the model, the target
+ * identified by {@link #targetPath}, canonicalized to forward direction — or <b>absolute</b> — the
+ * target is outside the model, kept verbatim as {@link #targetNodeId} with the recorded direction.
+ * Relative rows are the precondition for re-mapping declaration-internal references onto instances;
+ * absolute rows are copied or dropped per the reference replication policy at plan time.
+ *
+ * @param sourcePath the path of the declaration the row was recorded from (relative rows: the
+ *     forward source).
+ * @param referenceTypeId the ReferenceType of the row.
+ * @param direction the row's direction; always {@link Reference.Direction#FORWARD} for relative
+ *     rows.
+ * @param targetPath the target declaration's path; non-null iff the row is relative.
+ * @param targetNodeId the absolute target; non-null iff the row is absolute.
+ */
+public record ReferenceRow(
+    BrowsePath sourcePath,
+    NodeId referenceTypeId,
+    Reference.Direction direction,
+    @Nullable BrowsePath targetPath,
+    @Nullable ExpandedNodeId targetNodeId) {
+
+  public ReferenceRow {
+    if ((targetPath == null) == (targetNodeId == null)) {
+      throw new IllegalArgumentException("exactly one of targetPath / targetNodeId must be set");
+    }
+  }
+
+  /**
+   * Create a relative row: both ends are declarations of the model; direction is canonicalized to
+   * forward.
+   *
+   * @param sourcePath the forward source declaration's path.
+   * @param referenceTypeId the ReferenceType.
+   * @param targetPath the forward target declaration's path.
+   * @return a relative {@link ReferenceRow}.
+   */
+  public static ReferenceRow relative(
+      BrowsePath sourcePath, NodeId referenceTypeId, BrowsePath targetPath) {
+
+    return new ReferenceRow(
+        sourcePath, referenceTypeId, Reference.Direction.FORWARD, targetPath, null);
+  }
+
+  /**
+   * Create an absolute row: the target is outside the model and kept verbatim.
+   *
+   * @param sourcePath the declaration's path the row was recorded from.
+   * @param referenceTypeId the ReferenceType.
+   * @param direction the recorded direction.
+   * @param targetNodeId the absolute target.
+   * @return an absolute {@link ReferenceRow}.
+   */
+  public static ReferenceRow absolute(
+      BrowsePath sourcePath,
+      NodeId referenceTypeId,
+      Reference.Direction direction,
+      ExpandedNodeId targetNodeId) {
+
+    return new ReferenceRow(sourcePath, referenceTypeId, direction, null, targetNodeId);
+  }
+
+  /**
+   * @return {@code true} if both ends of this row are declarations of the model.
+   */
+  public boolean isRelative() {
+    return targetPath != null;
+  }
+
+  /**
+   * @return a stable string identifying this row's target — the target {@link BrowsePath} for a
+   *     relative row, the parseable target {@link ExpandedNodeId} for an absolute one — for
+   *     deterministic ordering and fingerprinting.
+   */
+  String targetKey() {
+    return targetPath != null
+        ? targetPath.toString()
+        : requireNonNull(targetNodeId).toParseableString();
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/SkippedDeclaration.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/SkippedDeclaration.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
+
+/**
+ * One declaration occurrence a plan decided not to realize, with a machine-readable reason — "why
+ * isn't my node there?" is answerable from the plan, without a debugger.
+ *
+ * @param declaration the skipped occurrence.
+ * @param reason why it was skipped.
+ */
+public record SkippedDeclaration(InstanceDeclaration declaration, Reason reason) {
+
+  /** Why a declaration occurrence was not realized. */
+  public enum Reason {
+
+    /** An Optional declaration the request did not select. */
+    OPTIONAL_NOT_SELECTED,
+
+    /** The declaration was explicitly excluded by the request. */
+    EXCLUDED,
+
+    /**
+     * An ancestor occurrence was omitted, so this occurrence's BrowsePath does not exist — the
+     * valid exception to "Mandatory shall exist" (Part 3 §6.4.4.4.2). Never an orphan: nothing
+     * beneath an omitted ancestor is created.
+     */
+    ANCESTOR_OMITTED,
+
+    /**
+     * A placeholder extension point ({@code OptionalPlaceholder} / {@code MandatoryPlaceholder});
+     * never auto-instantiated — creation goes through placeholder expansion.
+     */
+    PLACEHOLDER,
+
+    /** An {@code ExposesItsArray} declaration; surfaced but never materialized. */
+    EXPOSES_ITS_ARRAY,
+
+    /** A vendor-rule declaration the request did not explicitly select. */
+    VENDOR_RULE,
+
+    /**
+     * A descendant of a Method realized as {@link PlannedNode.Materialization#SHARE}: the shared
+     * Method's existing children serve every instance.
+     */
+    METHOD_SHARED
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/StagedGraph.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/StagedGraph.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
+
+import java.util.List;
+import java.util.Optional;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
+
+/**
+ * A read-only view of the complete constructed-but-unpublished node graph, passed to {@code onNode}
+ * hooks during apply so cross-node wiring sees fully-built neighbors before anything is committed
+ * or browsable.
+ *
+ * <p>The interface is part of the request surface (hooks are request data); the apply engine
+ * provides the implementation.
+ */
+public interface StagedGraph {
+
+  /**
+   * @return the staged root node.
+   */
+  UaNode root();
+
+  /**
+   * @param path the occurrence path to look up.
+   * @return the staged node realized at {@code path}, if one was planned and staged.
+   */
+  Optional<UaNode> node(BrowsePath path);
+
+  /**
+   * @return every staged node, browse-path ordered, root first.
+   */
+  List<UaNode> nodes();
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/TypeInstantiationModel.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/TypeInstantiationModel.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+
+/**
+ * The immutable, validated instantiation model of one TypeDefinition: its fully-inherited
+ * InstanceDeclarationHierarchy per OPC UA Part 3 §6.3.3.2, computed at every nesting depth, with
+ * every ModellingRule classified and every exclusion traceable through {@link #diagnostics()}.
+ *
+ * <p>Models are structural only — they contain no request state (no callbacks, root ids,
+ * selections, or destinations) — and are safe to share and cache. {@link #modelRevision()} is a
+ * content fingerprint: an unchanged type recompiles to an equal revision, and any change to a node
+ * in {@link #dependencies()} produces a different one, which is what apply-time revalidation and
+ * cache invalidation consume.
+ */
+public interface TypeInstantiationModel {
+
+  /**
+   * @return the {@link NodeId} of the TypeDefinition this model describes.
+   */
+  NodeId typeDefinitionId();
+
+  /**
+   * @return the content fingerprint of this model, for revalidation and cache invalidation.
+   */
+  long modelRevision();
+
+  /**
+   * @return the {@link NodeId} of every node this model was built from (the type, its supertype
+   *     chain, declarations, member types, and interface types).
+   */
+  Set<NodeId> dependencies();
+
+  /**
+   * @return every declaration occurrence, browse-path ordered; deterministic across compilations.
+   */
+  List<InstanceDeclaration> declarations();
+
+  /**
+   * @param path the occurrence path to look up.
+   * @return the declaration at {@code path}, if present.
+   */
+  Optional<InstanceDeclaration> get(BrowsePath path);
+
+  /**
+   * @return the placeholder extension points (OptionalPlaceholder / MandatoryPlaceholder
+   *     declarations), browse-path ordered.
+   */
+  List<InstanceDeclaration> placeholders();
+
+  /**
+   * @return the hierarchical edges connecting declarations (and the type root), as a canonical
+   *     logical set.
+   */
+  List<DeclarationEdge> hierarchy();
+
+  /**
+   * @return the non-hierarchy reference rows recorded from declarations, relative where both ends
+   *     are in the model and absolute otherwise.
+   */
+  List<ReferenceRow> references();
+
+  /**
+   * @return the compile-time findings for this model; never contains {@link
+   *     ModelDiagnostic.Severity#ERROR} entries (errors reject compilation instead).
+   */
+  List<ModelDiagnostic> diagnostics();
+
+  /**
+   * @return the attribute snapshot of the TypeDefinition node itself, the source of a new root
+   *     instance's initial attributes per Part 3 §6.4.2.
+   */
+  AttributeSnapshot rootAttributes();
+
+  /**
+   * @return the type's {@code DefaultInstanceBrowseName} property value, from this type or the
+   *     nearest supertype providing one; participates in root BrowseName precedence (request &gt;
+   *     DefaultInstanceBrowseName &gt; type BrowseName).
+   */
+  Optional<QualifiedName> defaultInstanceBrowseName();
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/TypeModelCache.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/TypeModelCache.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Supplier;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+
+/**
+ * A per-server cache of compiled {@link TypeInstantiationModel}s with dependency-aware transitive
+ * invalidation.
+ *
+ * <p>Entries are keyed by TypeDefinition NodeId <em>within one server</em>: each server owns its
+ * own instance (see {@link OpcUaServer#getTypeModelCache()}), so two servers in one JVM whose
+ * address spaces use identical NodeIds for different types never share models. Each type's model is
+ * cached individually — a supertype's model keeps its own entry rather than living only inside its
+ * subtypes' entries.
+ *
+ * <p>Invalidation is driven by each cached model's {@link TypeInstantiationModel#dependencies()},
+ * which already contains every node the model was compiled from at every depth (the type, its
+ * supertype chain, declarations, member types and their closures). {@link #invalidate(NodeId)}
+ * therefore drops every dependent model transitively: editing a supertype invalidates all cached
+ * subtype models, and editing a member type invalidates every model whose dependency closure
+ * contains it.
+ *
+ * <p>The invalidation contract: explicit {@link #invalidate(NodeId)} is how type changes reach this
+ * cache. Server-internal mutation paths clear conservatively (registering or unregistering a {@code
+ * NodeManager} clears the whole cache); address spaces that mutate type definitions out-of-band
+ * must call {@link #invalidate(NodeId)} with the changed node's id themselves.
+ *
+ * <p>The cache is an optimization with correctness obligations, not a correctness mechanism:
+ * entries may be dropped at any time (the next {@link #getOrCompile(NodeId)} simply recompiles),
+ * and a plan raced by a concurrent type mutation is caught by apply-time {@link
+ * TypeInstantiationModel#modelRevision()} revalidation, not by this cache.
+ */
+public class TypeModelCache {
+
+  private final Cache<NodeId, TypeInstantiationModel> models = CacheBuilder.newBuilder().build();
+
+  private final Supplier<TypeModelCompiler> compilerFactory;
+
+  /**
+   * Create a cache compiling from {@code server}'s address space.
+   *
+   * @param server the server whose types this cache holds models of.
+   */
+  public TypeModelCache(OpcUaServer server) {
+    // A compiler snapshots the server's ReferenceTypeTree, which is lazily built from the address
+    // space, so one is created per compilation rather than at cache construction.
+    this(() -> new TypeModelCompiler(server));
+  }
+
+  /**
+   * Create a cache obtaining a compiler from {@code compilerFactory}.
+   *
+   * @param compilerFactory supplies the compiler used when a requested model is absent; invoked
+   *     once per compilation, so it may return a fresh compiler reflecting current server state.
+   */
+  TypeModelCache(Supplier<TypeModelCompiler> compilerFactory) {
+    this.compilerFactory = compilerFactory;
+  }
+
+  /**
+   * Get the cached model of the type identified by {@code typeDefinitionId}, compiling and caching
+   * it if absent.
+   *
+   * <p>Concurrent calls for the same type share a single compilation and observe the same model
+   * instance. Failed compilations are not cached; a subsequent call compiles again.
+   *
+   * @param typeDefinitionId the NodeId of an ObjectType or VariableType node.
+   * @return the cached or freshly compiled model.
+   * @throws ModelCompilationException if the type graph admits no correct instantiation (see {@link
+   *     TypeModelCompiler#compile(NodeId)}).
+   */
+  public TypeInstantiationModel getOrCompile(NodeId typeDefinitionId)
+      throws ModelCompilationException {
+
+    try {
+      return models.get(typeDefinitionId, () -> compilerFactory.get().compile(typeDefinitionId));
+    } catch (ExecutionException e) {
+      // compile(...)'s only checked exception; Guava wraps it here.
+      throw (ModelCompilationException) e.getCause();
+    } catch (UncheckedExecutionException e) {
+      // An unchecked failure during compilation; unwrap to surface the original exception.
+      throw (RuntimeException) e.getCause();
+    }
+  }
+
+  /**
+   * Get the cached model of the type identified by {@code typeDefinitionId}, if one is currently
+   * cached; never compiles.
+   *
+   * @param typeDefinitionId the NodeId of an ObjectType or VariableType node.
+   * @return the cached model, or empty if the type is absent or was invalidated.
+   */
+  public Optional<TypeInstantiationModel> getIfPresent(NodeId typeDefinitionId) {
+    return Optional.ofNullable(models.getIfPresent(typeDefinitionId));
+  }
+
+  /**
+   * Invalidate every cached model built from the node identified by {@code nodeId}, transitively:
+   * any model whose {@link TypeInstantiationModel#dependencies()} contain the node is dropped, in
+   * addition to the model of the type itself.
+   *
+   * <p>Call this after mutating a type definition node or any node reachable from one (supertypes,
+   * instance declarations, member types) through a path this cache cannot observe.
+   *
+   * @param nodeId the {@link NodeId} of the changed node.
+   */
+  public void invalidate(NodeId nodeId) {
+    models
+        .asMap()
+        .entrySet()
+        .removeIf(e -> e.getKey().equals(nodeId) || e.getValue().dependencies().contains(nodeId));
+  }
+
+  /** Invalidate every cached model. */
+  public void invalidateAll() {
+    models.invalidateAll();
+  }
+
+  /**
+   * @return the number of models currently cached.
+   */
+  public int size() {
+    return (int) models.size();
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/TypeModelCompiler.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/TypeModelCompiler.java
@@ -1,0 +1,1844 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import org.eclipse.milo.opcua.sdk.core.Reference;
+import org.eclipse.milo.opcua.sdk.core.ValueRanks;
+import org.eclipse.milo.opcua.sdk.core.typetree.ReferenceTypeTree;
+import org.eclipse.milo.opcua.sdk.server.AddressSpaceManager;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaDataTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableTypeNode;
+import org.eclipse.milo.opcua.stack.core.AttributeId;
+import org.eclipse.milo.opcua.stack.core.NamespaceTable;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
+import org.eclipse.milo.opcua.stack.core.types.structured.Argument;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Compiles the {@link TypeInstantiationModel} of a TypeDefinition from live address-space state.
+ *
+ * <p>Given a type NodeId, the compiler produces either a validated, immutable, fully-inherited
+ * model or a {@link ModelCompilationException} carrying structured diagnostics — never a silently
+ * truncated hierarchy. It implements, per OPC UA Part 3:
+ *
+ * <ul>
+ *   <li>the §6.3.3.2 fully-inherited table merge, folding the supertype chain in with the subtype's
+ *       entry winning at an already-present BrowsePath (§6.3.3.3);
+ *   <li>recursion through <em>model compilation</em> for member TypeDefinitions, so nested types
+ *       are fully inherited at every depth, with explicit on-declaration children overriding
+ *       same-path member-type defaults;
+ *   <li>classification (not filtering) of every ModellingRule, placeholders recorded shallowly per
+ *       §6.4.4.4.4–.5 and vendor rules preserved as {@link ModellingRule#OTHER};
+ *   <li>browse-path extension along forward hierarchical references only, with explicit rejection
+ *       of subtype cycles and declaration loops;
+ *   <li>non-hierarchy reference rows with direction, relative targets whenever both ends are in the
+ *       model, and validation of what the legacy walk silently tolerated (missing targets,
+ *       duplicate sibling BrowseNames, NodeClass/type incompatibility, Variable narrowing, Method
+ *       signatures, modelling-rule tightening, abstract member types, {@code HasInterface}
+ *       compatibility).
+ * </ul>
+ *
+ * <p>Address-space state is read exclusively through {@link
+ * AddressSpaceManager#getManagedNode(NodeId)} and {@link
+ * AddressSpaceManager#getManagedReferences(NodeId)}. Every node read this way is recorded in the
+ * model's {@link TypeInstantiationModel#dependencies()}.
+ *
+ * <p>The compiler is uncached: every {@link #compile(NodeId)} call is a fresh read of the address
+ * space (types compiled more than once within a single call — shared supertypes, repeated member
+ * types — are memoized for that call only). Model output is deterministic: declarations, edges, and
+ * rows are browse-path ordered, and an unchanged type recompiles to an equal {@link
+ * TypeInstantiationModel#modelRevision()}.
+ *
+ * <p>Graph depth (supertype/member-type recursion and declaration hierarchy alike) is bounded by
+ * {@link #MAX_DEPTH}: a deeper graph rejects with a structured {@code DEPTH_LIMIT_EXCEEDED}
+ * diagnostic rather than a {@link StackOverflowError}.
+ */
+public class TypeModelCompiler {
+
+  /** The maximum type-recursion and declaration-hierarchy depth compiled before rejecting. */
+  static final int MAX_DEPTH = 512;
+
+  private static final QualifiedName DEFAULT_INSTANCE_BROWSE_NAME =
+      new QualifiedName(0, "DefaultInstanceBrowseName");
+
+  private static final QualifiedName INPUT_ARGUMENTS = new QualifiedName(0, "InputArguments");
+  private static final QualifiedName OUTPUT_ARGUMENTS = new QualifiedName(0, "OutputArguments");
+
+  private static final Comparator<NodeId> NODE_ID_ORDER =
+      Comparator.comparing(NodeId::toParseableString);
+
+  private final AddressSpaceManager addressSpaceManager;
+  private final NamespaceTable namespaceTable;
+  private final ReferenceTypeTree referenceTypeTree;
+
+  /**
+   * Create a compiler reading through {@code server}'s {@link AddressSpaceManager}, using its
+   * namespace table and ReferenceType tree.
+   *
+   * @param server the server whose address space is compiled from.
+   */
+  public TypeModelCompiler(OpcUaServer server) {
+    this(
+        server.getAddressSpaceManager(), server.getNamespaceTable(), server.getReferenceTypeTree());
+  }
+
+  /**
+   * Create a compiler from its collaborators.
+   *
+   * @param addressSpaceManager the read surface for nodes and references.
+   * @param namespaceTable the table used to resolve {@link ExpandedNodeId} targets.
+   * @param referenceTypeTree the ReferenceType hierarchy, used to classify hierarchical references.
+   */
+  public TypeModelCompiler(
+      AddressSpaceManager addressSpaceManager,
+      NamespaceTable namespaceTable,
+      ReferenceTypeTree referenceTypeTree) {
+
+    this.addressSpaceManager = addressSpaceManager;
+    this.namespaceTable = namespaceTable;
+    this.referenceTypeTree = referenceTypeTree;
+  }
+
+  /**
+   * Compile the instantiation model of the type identified by {@code typeDefinitionId}.
+   *
+   * @param typeDefinitionId the NodeId of an ObjectType or VariableType node.
+   * @return the validated model; its diagnostics contain warnings and infos only.
+   * @throws ModelCompilationException if the type graph admits no correct instantiation; the
+   *     exception carries the full diagnostic list and no partial model is produced.
+   */
+  public TypeInstantiationModel compile(NodeId typeDefinitionId) throws ModelCompilationException {
+    CompileContext ctx = new CompileContext();
+
+    CompiledType compiled = compileType(typeDefinitionId, ctx);
+
+    if (compiled == null || ctx.hasErrors) {
+      throw new ModelCompilationException(typeDefinitionId, dedupe(ctx.diagnostics));
+    }
+
+    List<InstanceDeclaration> declarations =
+        compiled.declarations.values().stream()
+            .sorted(Comparator.comparing(InstanceDeclaration::browsePath))
+            .toList();
+
+    List<DeclarationEdge> hierarchy =
+        compiled.edges.stream()
+            .sorted(
+                Comparator.comparing(DeclarationEdge::parentPath)
+                    .thenComparing(DeclarationEdge::childPath)
+                    .thenComparing(e -> e.referenceTypeId().toParseableString()))
+            .toList();
+
+    List<ReferenceRow> references =
+        compiled.rows.stream()
+            .map(Row::row)
+            .sorted(
+                Comparator.comparing(ReferenceRow::sourcePath)
+                    .thenComparing(r -> r.referenceTypeId().toParseableString())
+                    .thenComparing(r -> r.direction().ordinal())
+                    .thenComparing(ReferenceRow::targetKey))
+            .distinct()
+            .toList();
+
+    List<ModelDiagnostic> diagnostics = dedupe(ctx.diagnostics);
+
+    long revision =
+        fingerprint(
+            typeDefinitionId,
+            compiled.rootAttributes,
+            compiled.defaultInstanceBrowseName,
+            declarations,
+            hierarchy,
+            references,
+            diagnostics);
+
+    return new CompiledModel(
+        typeDefinitionId,
+        revision,
+        Set.copyOf(ctx.dependencies),
+        declarations,
+        hierarchy,
+        references,
+        diagnostics,
+        compiled.rootAttributes,
+        compiled.defaultInstanceBrowseName);
+  }
+
+  // region Type compilation
+
+  private @Nullable CompiledType compileType(NodeId typeId, CompileContext ctx) {
+    CompiledType memoized = ctx.memo.get(typeId);
+    if (memoized != null) {
+      return memoized;
+    }
+
+    if (ctx.inProgress.size() >= MAX_DEPTH) {
+      ctx.add(
+          ModelDiagnostic.error(
+              ModelDiagnostic.Code.DEPTH_LIMIT_EXCEEDED,
+              "type recursion depth exceeds " + MAX_DEPTH + " at " + typeId,
+              null,
+              typeId));
+      return null;
+    }
+
+    if (!ctx.inProgress.add(typeId)) {
+      ctx.add(
+          ModelDiagnostic.error(
+              ModelDiagnostic.Code.TYPE_CYCLE,
+              "type " + typeId + " re-entered while compiling (subtype or member-type cycle)",
+              null,
+              typeId));
+      return null;
+    }
+
+    try {
+      UaNode typeNode = getNode(typeId, ctx);
+      if (typeNode == null) {
+        ctx.add(
+            ModelDiagnostic.error(
+                ModelDiagnostic.Code.TYPE_NOT_FOUND,
+                "type " + typeId + " not found",
+                null,
+                typeId));
+        return null;
+      }
+      if (!(typeNode instanceof UaObjectTypeNode) && !(typeNode instanceof UaVariableTypeNode)) {
+        ctx.add(
+            ModelDiagnostic.error(
+                ModelDiagnostic.Code.TYPE_NODE_CLASS_INVALID,
+                "node "
+                    + typeId
+                    + " is a "
+                    + typeNode.getNodeClass()
+                    + ", not an ObjectType or VariableType",
+                null,
+                typeId));
+        return null;
+      }
+
+      List<Reference> typeRefs = getReferences(typeId, ctx);
+
+      // Malformed supertype ancestry rejects rather than compiling a silently truncated model:
+      // an unresolvable (remote) supertype must not demote the type to a root, and multiple
+      // supertypes have no defined merge order (single inheritance, Part 3 §6.3.1).
+      List<ExpandedNodeId> supertypeTargets =
+          typeRefs.stream()
+              .filter(Reference.SUBTYPE_OF)
+              .map(Reference::getTargetNodeId)
+              .distinct()
+              .toList();
+
+      List<ExpandedNodeId> unresolvable =
+          supertypeTargets.stream().filter(x -> x.toNodeId(namespaceTable).isEmpty()).toList();
+      if (!unresolvable.isEmpty()) {
+        ctx.add(
+            ModelDiagnostic.error(
+                ModelDiagnostic.Code.TYPE_NOT_FOUND,
+                "supertype "
+                    + unresolvable.get(0)
+                    + " of type "
+                    + typeId
+                    + " is not resolvable in this server",
+                null,
+                typeId));
+        return null;
+      }
+
+      List<NodeId> supertypeIds =
+          supertypeTargets.stream()
+              .map(x -> x.toNodeId(namespaceTable).orElseThrow())
+              .distinct()
+              .sorted(NODE_ID_ORDER)
+              .toList();
+      if (supertypeIds.size() > 1) {
+        ctx.add(
+            ModelDiagnostic.error(
+                ModelDiagnostic.Code.MULTIPLE_SUPERTYPES,
+                "type "
+                    + typeId
+                    + " has "
+                    + supertypeIds.size()
+                    + " supertypes "
+                    + supertypeIds
+                    + "; single inheritance is required",
+                null,
+                typeId));
+        return null;
+      }
+
+      NodeId supertypeId = supertypeIds.isEmpty() ? null : supertypeIds.get(0);
+      CompiledType supertype = supertypeId != null ? compileType(supertypeId, ctx) : null;
+
+      if (supertype != null) {
+        NodeClass supertypeClass =
+            (NodeClass) supertype.rootAttributes.getOrNull(AttributeId.NodeClass);
+        if (typeNode.getNodeClass() != supertypeClass) {
+          ctx.add(
+              ModelDiagnostic.error(
+                  ModelDiagnostic.Code.NODE_CLASS_MISMATCH,
+                  "type "
+                      + typeId
+                      + " is a "
+                      + typeNode.getNodeClass()
+                      + " but its supertype "
+                      + supertypeId
+                      + " is a "
+                      + supertypeClass,
+                  null,
+                  typeId));
+          return null;
+        }
+      }
+
+      CompiledType result =
+          new CompiledType(
+              typeId,
+              AttributeSnapshot.of(typeNode),
+              findDefaultInstanceBrowseName(typeRefs, ctx, supertype));
+
+      Set<NodeId> pathNodeIds = new HashSet<>();
+      pathNodeIds.add(typeId);
+      walkChildren(typeId, BrowsePath.root(), typeId, result, ctx, pathNodeIds);
+
+      if (supertype != null) {
+        foldInto(result, supertype, BrowsePath.root(), ctx);
+      }
+
+      resolveRows(result, ctx);
+
+      validateInterfaces(typeId, typeRefs, result, ctx);
+
+      ctx.memo.put(typeId, result);
+      return result;
+    } finally {
+      ctx.inProgress.remove(typeId);
+    }
+  }
+
+  private void walkChildren(
+      NodeId sourceNodeId,
+      BrowsePath parentPath,
+      NodeId declaringTypeId,
+      CompiledType table,
+      CompileContext ctx,
+      Set<NodeId> pathNodeIds) {
+
+    List<Reference> refs = getReferences(sourceNodeId, ctx);
+
+    record Child(Reference reference, NodeId targetId, UaNode node) {}
+    List<Child> children = new ArrayList<>();
+
+    for (Reference r : refs) {
+      if (!r.isForward()) {
+        continue;
+      }
+      NodeId refTypeId = r.getReferenceTypeId();
+      // HasSubtype targets are types, never InstanceDeclarations; skipping before the fetch
+      // keeps every subtype of a base type out of the walk and the dependency set.
+      if (NodeIds.HasSubtype.equals(refTypeId) || !isHierarchical(refTypeId)) {
+        continue;
+      }
+
+      NodeId targetId = r.getTargetNodeId().toNodeId(namespaceTable).orElse(null);
+      if (targetId == null) {
+        ctx.add(
+            ModelDiagnostic.error(
+                ModelDiagnostic.Code.REFERENCE_TARGET_MISSING,
+                "hierarchical reference target "
+                    + r.getTargetNodeId()
+                    + " from "
+                    + sourceNodeId
+                    + " is not resolvable in this server",
+                parentPath,
+                sourceNodeId));
+        continue;
+      }
+
+      UaNode target = getNode(targetId, ctx);
+      if (target == null) {
+        ctx.add(
+            ModelDiagnostic.error(
+                ModelDiagnostic.Code.REFERENCE_TARGET_MISSING,
+                "hierarchical reference target "
+                    + targetId
+                    + " from "
+                    + sourceNodeId
+                    + " not found",
+                parentPath,
+                sourceNodeId));
+        continue;
+      }
+
+      NodeClass nodeClass = target.getNodeClass();
+      if (nodeClass != NodeClass.Object
+          && nodeClass != NodeClass.Variable
+          && nodeClass != NodeClass.Method) {
+        // Structurally never an InstanceDeclaration (Part 3 §6.2.1); not an exclusion worth noting.
+        continue;
+      }
+
+      children.add(new Child(r, targetId, target));
+    }
+
+    children.sort(
+        Comparator.comparing((Child c) -> c.node.getBrowseName().namespaceIndex().intValue())
+            .thenComparing(c -> Objects.requireNonNullElse(c.node.getBrowseName().name(), ""))
+            .thenComparing(c -> c.reference.getReferenceTypeId().toParseableString())
+            .thenComparing(c -> c.targetId.toParseableString()));
+
+    for (Child child : children) {
+      processChild(
+          child.reference,
+          child.targetId,
+          child.node,
+          parentPath,
+          declaringTypeId,
+          table,
+          ctx,
+          pathNodeIds);
+    }
+  }
+
+  private void processChild(
+      Reference reference,
+      NodeId targetId,
+      UaNode node,
+      BrowsePath parentPath,
+      NodeId declaringTypeId,
+      CompiledType table,
+      CompileContext ctx,
+      Set<NodeId> pathNodeIds) {
+
+    QualifiedName browseName = node.getBrowseName();
+    NodeClass nodeClass = node.getNodeClass();
+    BrowsePath path = parentPath.append(browseName);
+
+    // Sibling BrowseName uniqueness (Part 3 §4.6.4 / §6.2.6) covers every walked child, rule-less
+    // ones included, so validity is not identifier-order dependent.
+    NodeId occupant = table.pathOccupants.get(path);
+    if (occupant != null) {
+      if (occupant.equals(targetId)) {
+        if (table.declarations.containsKey(path)) {
+          // The same declaration pair connected by another reference (Part 3 §6.4.3): one more
+          // logical edge onto the same occurrence, nothing else changes.
+          table.edges.add(new DeclarationEdge(parentPath, reference.getReferenceTypeId(), path));
+        }
+      } else {
+        ctx.add(
+            ModelDiagnostic.error(
+                ModelDiagnostic.Code.DUPLICATE_BROWSE_NAME,
+                "two sibling declarations under "
+                    + parentPath
+                    + " share BrowseName "
+                    + browseName
+                    + " ("
+                    + occupant
+                    + " and "
+                    + targetId
+                    + ")",
+                path,
+                targetId));
+      }
+      return;
+    }
+    table.pathOccupants.put(path, targetId);
+
+    List<Reference> nodeRefs = getReferences(targetId, ctx);
+
+    List<Reference> ruleRefs =
+        nodeRefs.stream().filter(Reference.HAS_MODELLING_RULE_PREDICATE).toList();
+
+    List<NodeId> ruleIds =
+        ruleRefs.stream()
+            .map(r -> r.getTargetNodeId().toNodeId(namespaceTable).orElse(null))
+            .filter(Objects::nonNull)
+            .sorted(NODE_ID_ORDER)
+            .toList();
+
+    if (ruleRefs.isEmpty()) {
+      // Belongs to the type node only (Part 3 §6.2.2); excluded, traceably. The type's own
+      // DefaultInstanceBrowseName property is consumed by the model instead of noted.
+      if (!DEFAULT_INSTANCE_BROWSE_NAME.equals(browseName)) {
+        ctx.add(
+            ModelDiagnostic.info(
+                ModelDiagnostic.Code.NOT_AN_INSTANCE_DECLARATION,
+                "node "
+                    + targetId
+                    + " at "
+                    + path
+                    + " has no ModellingRule and is not instantiated",
+                path,
+                targetId));
+      }
+      return;
+    }
+
+    if (ruleIds.isEmpty()) {
+      // A rule reference exists but no target resolves: the declaration cannot be classified,
+      // and excluding it would silently truncate the hierarchy.
+      ctx.add(
+          ModelDiagnostic.error(
+              ModelDiagnostic.Code.MODELLING_RULE_INVALID,
+              "declaration "
+                  + targetId
+                  + " at "
+                  + path
+                  + " has no resolvable HasModellingRule target ("
+                  + ruleRefs.get(0).getTargetNodeId()
+                  + ")",
+              path,
+              targetId));
+      return;
+    }
+
+    if (ruleRefs.size() > 1) {
+      ctx.add(
+          ModelDiagnostic.warning(
+              ModelDiagnostic.Code.MULTIPLE_MODELLING_RULES,
+              "declaration "
+                  + targetId
+                  + " at "
+                  + path
+                  + " has "
+                  + ruleRefs.size()
+                  + " HasModellingRule references; using "
+                  + ruleIds.get(0),
+              path,
+              targetId));
+    }
+
+    NodeId modellingRuleId = ruleIds.get(0);
+    ModellingRule rule = ModellingRule.of(modellingRuleId);
+
+    if (rule == ModellingRule.OTHER) {
+      ctx.add(
+          ModelDiagnostic.warning(
+              ModelDiagnostic.Code.VENDOR_MODELLING_RULE,
+              "declaration at " + path + " uses non-standard ModellingRule " + modellingRuleId,
+              path,
+              targetId));
+    }
+
+    validateModellingRuleTarget(modellingRuleId, path, targetId, ctx);
+
+    NodeId memberTypeId = null;
+    if (nodeClass != NodeClass.Method) {
+      List<ExpandedNodeId> memberTypeXnis =
+          nodeRefs.stream()
+              .filter(Reference.HAS_TYPE_DEFINITION_PREDICATE)
+              .map(Reference::getTargetNodeId)
+              .distinct()
+              .toList();
+
+      if (memberTypeXnis.isEmpty()) {
+        ctx.add(
+            ModelDiagnostic.error(
+                ModelDiagnostic.Code.TYPE_DEFINITION_MISSING,
+                nodeClass + " declaration at " + path + " has no HasTypeDefinition reference",
+                path,
+                targetId));
+        return;
+      }
+
+      if (memberTypeXnis.size() > 1) {
+        // Objects and Variables have exactly one TypeDefinition; picking one silently would let
+        // expansion and validation use a type other copies of the reference contradict.
+        ctx.add(
+            ModelDiagnostic.error(
+                ModelDiagnostic.Code.MULTIPLE_TYPE_DEFINITIONS,
+                "declaration at "
+                    + path
+                    + " has "
+                    + memberTypeXnis.size()
+                    + " HasTypeDefinition references "
+                    + memberTypeXnis
+                    + "; exactly one is required",
+                path,
+                targetId));
+        return;
+      }
+
+      ExpandedNodeId memberTypeXni = memberTypeXnis.get(0);
+      memberTypeId = memberTypeXni.toNodeId(namespaceTable).orElse(null);
+      if (memberTypeId == null) {
+        ctx.add(
+            ModelDiagnostic.error(
+                ModelDiagnostic.Code.TYPE_NOT_FOUND,
+                "member type "
+                    + memberTypeXni
+                    + " of declaration at "
+                    + path
+                    + " is not resolvable in this server",
+                path,
+                targetId));
+        return;
+      }
+    }
+
+    InstanceDeclaration declaration =
+        new InstanceDeclaration(
+            path,
+            browseName,
+            nodeClass,
+            targetId,
+            declaringTypeId,
+            List.of(),
+            modellingRuleId,
+            rule,
+            memberTypeId,
+            AttributeSnapshot.of(node));
+
+    table.declarations.put(path, declaration);
+    table.edges.add(new DeclarationEdge(parentPath, reference.getReferenceTypeId(), path));
+
+    recordRows(path, nodeRefs, table);
+
+    if (rule.isShallow()) {
+      // Recorded shallowly: complex structures beneath placeholders are not further considered
+      // for instantiating (Part 3 §6.4.4.4.4–.5); ExposesItsArray is model-visibility only (KD10).
+      // Shallow recording skips subtree expansion, not validation of the recorded type metadata.
+      if (memberTypeId != null) {
+        UaNode memberTypeNode = getNode(memberTypeId, ctx);
+        if (memberTypeNode == null) {
+          ctx.add(
+              ModelDiagnostic.warning(
+                  ModelDiagnostic.Code.PLACEHOLDER_TYPE_MISSING,
+                  "type " + memberTypeId + " of placeholder at " + path + " not found",
+                  path,
+                  targetId));
+        } else {
+          boolean classCompatible =
+              (nodeClass == NodeClass.Object && memberTypeNode instanceof UaObjectTypeNode)
+                  || (nodeClass == NodeClass.Variable
+                      && memberTypeNode instanceof UaVariableTypeNode);
+          if (!classCompatible) {
+            ctx.add(
+                ModelDiagnostic.warning(
+                    ModelDiagnostic.Code.NODE_CLASS_MISMATCH,
+                    nodeClass
+                        + " declaration at "
+                        + path
+                        + " has TypeDefinition "
+                        + memberTypeId
+                        + " of NodeClass "
+                        + memberTypeNode.getNodeClass(),
+                    path,
+                    targetId));
+          }
+        }
+      }
+      return;
+    }
+
+    if (path.depth() >= MAX_DEPTH) {
+      ctx.add(
+          ModelDiagnostic.error(
+              ModelDiagnostic.Code.DEPTH_LIMIT_EXCEEDED,
+              "declaration hierarchy exceeds depth " + MAX_DEPTH + " at " + path,
+              path,
+              targetId));
+      return;
+    }
+
+    if (!pathNodeIds.add(targetId)) {
+      ctx.add(
+          ModelDiagnostic.error(
+              ModelDiagnostic.Code.DECLARATION_CYCLE,
+              "declaration " + targetId + " reached again along its own path at " + path,
+              path,
+              targetId));
+      return;
+    }
+
+    try {
+      // Explicit on-declaration children first: they win over same-path member-type defaults
+      // (Part 3 §6.3.3.3).
+      walkChildren(targetId, path, declaringTypeId, table, ctx, pathNodeIds);
+    } finally {
+      pathNodeIds.remove(targetId);
+    }
+
+    if (memberTypeId != null) {
+      expandMemberType(declaration, memberTypeId, path, targetId, table, ctx);
+    }
+  }
+
+  /**
+   * Validate that a resolved HasModellingRule target actually exists and is an Object of {@code
+   * ModellingRuleType} (or a subtype). The declaration stays classified either way — these are
+   * warnings on a usable model.
+   */
+  private void validateModellingRuleTarget(
+      NodeId modellingRuleId, BrowsePath path, NodeId declarationId, CompileContext ctx) {
+
+    UaNode ruleNode = getNode(modellingRuleId, ctx);
+    if (ruleNode == null) {
+      ctx.add(
+          ModelDiagnostic.warning(
+              ModelDiagnostic.Code.MODELLING_RULE_INVALID,
+              "ModellingRule " + modellingRuleId + " of declaration at " + path + " not found",
+              path,
+              declarationId));
+      return;
+    }
+
+    if (!(ruleNode instanceof UaObjectNode)) {
+      ctx.add(
+          ModelDiagnostic.warning(
+              ModelDiagnostic.Code.MODELLING_RULE_INVALID,
+              "ModellingRule "
+                  + modellingRuleId
+                  + " of declaration at "
+                  + path
+                  + " is a "
+                  + ruleNode.getNodeClass()
+                  + ", not an Object",
+              path,
+              declarationId));
+      return;
+    }
+
+    NodeId ruleTypeId =
+        getReferences(modellingRuleId, ctx).stream()
+            .filter(Reference.HAS_TYPE_DEFINITION_PREDICATE)
+            .map(r -> r.getTargetNodeId().toNodeId(namespaceTable).orElse(null))
+            .filter(Objects::nonNull)
+            .findFirst()
+            .orElse(null);
+    if (ruleTypeId == null || !isTypeSubtypeOfOrEqual(ruleTypeId, NodeIds.ModellingRuleType, ctx)) {
+      ctx.add(
+          ModelDiagnostic.warning(
+              ModelDiagnostic.Code.MODELLING_RULE_INVALID,
+              "ModellingRule "
+                  + modellingRuleId
+                  + " of declaration at "
+                  + path
+                  + " is not a ModellingRuleType Object",
+              path,
+              declarationId));
+    }
+  }
+
+  private void expandMemberType(
+      InstanceDeclaration declaration,
+      NodeId memberTypeId,
+      BrowsePath path,
+      NodeId targetId,
+      CompiledType table,
+      CompileContext ctx) {
+
+    CompiledType memberModel = compileType(memberTypeId, ctx);
+    if (memberModel == null) {
+      // The failure (TYPE_NOT_FOUND, TYPE_CYCLE, …) is already recorded; compile() will reject.
+      return;
+    }
+
+    NodeClass typeNodeClass =
+        (NodeClass) memberModel.rootAttributes.getOrNull(AttributeId.NodeClass);
+    boolean classCompatible =
+        (declaration.nodeClass() == NodeClass.Object && typeNodeClass == NodeClass.ObjectType)
+            || (declaration.nodeClass() == NodeClass.Variable
+                && typeNodeClass == NodeClass.VariableType);
+    if (!classCompatible) {
+      ctx.add(
+          ModelDiagnostic.error(
+              ModelDiagnostic.Code.NODE_CLASS_MISMATCH,
+              declaration.nodeClass()
+                  + " declaration at "
+                  + path
+                  + " has TypeDefinition "
+                  + memberTypeId
+                  + " of NodeClass "
+                  + typeNodeClass,
+              path,
+              targetId));
+      return;
+    }
+
+    if (memberModel.isAbstract()) {
+      ctx.add(
+          ModelDiagnostic.warning(
+              ModelDiagnostic.Code.ABSTRACT_MEMBER_TYPE,
+              "declaration at "
+                  + path
+                  + " is typed by abstract type "
+                  + memberTypeId
+                  + "; instantiation requires an explicit concrete subtype",
+              path,
+              targetId));
+    }
+
+    if (declaration.nodeClass() == NodeClass.Variable) {
+      validateNarrowing(declaration.attributes(), memberModel.rootAttributes, path, targetId, ctx);
+    }
+
+    // Graft the member type's fully-inherited model beneath this declaration (the D2 fix).
+    // Explicit on-declaration entries were walked first and win per path (the D5 fix).
+    foldInto(table, memberModel, path, ctx);
+  }
+
+  /**
+   * Fold {@code source}'s fully-inherited tables into {@code target}, relocated beneath {@code
+   * prefix} — the root path for a supertype merge (Part 3 §6.3.3.2), a declaration's path for a
+   * member-type graft. An entry already present in {@code target} at a path wins (the subtype's own
+   * entry, or an explicit on-declaration child), with its override chain appended and the
+   * transition validated by {@code override}.
+   *
+   * <p>Inherited references at an overridden path are suppressed only where Part 3 §6.3.3.3
+   * replaces them: a hierarchy edge is replaced when the winner connects the same parent/child pair
+   * with the same ReferenceType or a subtype; of the non-hierarchical rows only the singular
+   * HasTypeDefinition / HasModellingRule references are replaced by the winner's own. All other
+   * inherited edges and rows describe distinct relationships and remain in the merged model.
+   */
+  private void foldInto(
+      CompiledType target, CompiledType source, BrowsePath prefix, CompileContext ctx) {
+
+    Set<BrowsePath> overriddenPaths = new HashSet<>();
+
+    for (InstanceDeclaration d : source.declarations.values()) {
+      BrowsePath path = prefix.concat(d.browsePath());
+      InstanceDeclaration incoming = prefix.isRoot() ? d : d.withBrowsePath(path);
+
+      InstanceDeclaration existing = target.declarations.get(path);
+      if (existing == null) {
+        target.declarations.put(path, incoming);
+      } else {
+        overriddenPaths.add(path);
+        override(existing, incoming, target, ctx);
+      }
+    }
+
+    for (DeclarationEdge e : source.edges) {
+      BrowsePath parentPath = prefix.concat(e.parentPath());
+      BrowsePath childPath = prefix.concat(e.childPath());
+      if (overriddenPaths.contains(childPath)) {
+        boolean replaced =
+            target.edges.stream()
+                .anyMatch(
+                    w ->
+                        w.parentPath().equals(parentPath)
+                            && w.childPath().equals(childPath)
+                            && isReferenceSubtypeOfOrEqual(
+                                w.referenceTypeId(), e.referenceTypeId()));
+        if (replaced) {
+          continue;
+        }
+      }
+      target.edges.add(new DeclarationEdge(parentPath, e.referenceTypeId(), childPath));
+    }
+
+    for (Row r : source.rows) {
+      if (overriddenPaths.contains(prefix.concat(r.row().sourcePath()))
+          && isSingularReference(r.row().referenceTypeId())) {
+        continue;
+      }
+      target.rows.add(new Row(reroot(r.row(), prefix), r.frozen()));
+    }
+  }
+
+  /**
+   * ReferenceTypes that permit one reference per source node; the winner's replaces on override.
+   */
+  private boolean isSingularReference(NodeId referenceTypeId) {
+    return isReferenceSubtypeOfOrEqual(referenceTypeId, NodeIds.HasTypeDefinition)
+        || isReferenceSubtypeOfOrEqual(referenceTypeId, NodeIds.HasModellingRule);
+  }
+
+  private boolean isReferenceSubtypeOfOrEqual(NodeId referenceTypeId, NodeId supertypeId) {
+    return referenceTypeId.equals(supertypeId)
+        || referenceTypeTree.isSubtypeOf(referenceTypeId, supertypeId);
+  }
+
+  /**
+   * Record {@code winner} as overriding {@code overridden} at the same BrowsePath, appending the
+   * override chain and validating the transition per Part 3 §6.3.3.3 / §6.4.4.2.
+   */
+  private void override(
+      InstanceDeclaration winner,
+      InstanceDeclaration overridden,
+      CompiledType table,
+      CompileContext ctx) {
+
+    BrowsePath path = winner.browsePath();
+
+    List<NodeId> chain = new ArrayList<>(winner.overriddenDeclarations());
+    chain.add(overridden.declarationNodeId());
+    chain.addAll(overridden.overriddenDeclarations());
+
+    table.declarations.put(path, winner.withOverridden(chain));
+
+    // No instance can conform to both the inherited and the overriding declaration when the
+    // override changes NodeClass or replaces the TypeDefinition with an unrelated type (Part 3
+    // §6.3.3.3) — these reject the compile rather than escaping as usable warnings.
+    if (winner.nodeClass() != overridden.nodeClass()) {
+      ctx.add(
+          ModelDiagnostic.error(
+              ModelDiagnostic.Code.NODE_CLASS_MISMATCH,
+              "override at "
+                  + path
+                  + " changes NodeClass from "
+                  + overridden.nodeClass()
+                  + " to "
+                  + winner.nodeClass(),
+              path,
+              winner.declarationNodeId()));
+    }
+
+    validateRuleTransition(overridden, winner, ctx);
+
+    if (winner.typeDefinitionId() != null
+        && overridden.typeDefinitionId() != null
+        && !isTypeSubtypeOfOrEqual(winner.typeDefinitionId(), overridden.typeDefinitionId(), ctx)) {
+      ctx.add(
+          ModelDiagnostic.error(
+              ModelDiagnostic.Code.TYPE_INCOMPATIBLE,
+              "override at "
+                  + path
+                  + " has TypeDefinition "
+                  + winner.typeDefinitionId()
+                  + ", not "
+                  + overridden.typeDefinitionId()
+                  + " or a subtype",
+              path,
+              winner.declarationNodeId()));
+    }
+
+    if (winner.nodeClass() == NodeClass.Variable && overridden.nodeClass() == NodeClass.Variable) {
+      validateNarrowing(
+          winner.attributes(), overridden.attributes(), path, winner.declarationNodeId(), ctx);
+    }
+
+    if (winner.nodeClass() == NodeClass.Method && overridden.nodeClass() == NodeClass.Method) {
+      validateMethodSignature(winner, overridden, path, ctx);
+    }
+  }
+
+  private void validateRuleTransition(
+      InstanceDeclaration overridden, InstanceDeclaration winner, CompileContext ctx) {
+
+    boolean isMethod =
+        winner.nodeClass() == NodeClass.Method && overridden.nodeClass() == NodeClass.Method;
+
+    if (!isMethod && Objects.equals(overridden.modellingRuleId(), winner.modellingRuleId())) {
+      return;
+    }
+
+    ModellingRule from = overridden.rule();
+    ModellingRule to = winner.rule();
+
+    if (from == ModellingRule.OTHER
+        || to == ModellingRule.OTHER
+        || from == ModellingRule.EXPOSES_ITS_ARRAY
+        || to == ModellingRule.EXPOSES_ITS_ARRAY) {
+      // No normative tightening table covers vendor rules or ExposesItsArray.
+      return;
+    }
+
+    if (isMethod) {
+      // Methods have their own transition rules: a placeholder Method only defines the BrowseName,
+      // and an overriding subtype shall change OptionalPlaceholder to Optional or Mandatory and
+      // MandatoryPlaceholder to Mandatory (Part 3 §6.4.4.4.4–.5).
+      boolean allowed =
+          switch (from) {
+            case MANDATORY, MANDATORY_PLACEHOLDER -> to == ModellingRule.MANDATORY;
+            case OPTIONAL, OPTIONAL_PLACEHOLDER ->
+                to == ModellingRule.OPTIONAL || to == ModellingRule.MANDATORY;
+            default -> true;
+          };
+      if (!allowed) {
+        String requirement =
+            switch (from) {
+              case MANDATORY_PLACEHOLDER ->
+                  "a MandatoryPlaceholder Method override shall change to Mandatory (§6.4.4.4.5)";
+              case OPTIONAL_PLACEHOLDER ->
+                  "an OptionalPlaceholder Method override shall change to Optional or Mandatory"
+                      + " (§6.4.4.4.4)";
+              default -> "not a valid tightening per Part 3 Table 21";
+            };
+        ctx.add(
+            ModelDiagnostic.warning(
+                ModelDiagnostic.Code.MODELLING_RULE_TIGHTENING,
+                "Method override at "
+                    + winner.browsePath()
+                    + " keeps or changes ModellingRule from "
+                    + from
+                    + " to "
+                    + to
+                    + "; "
+                    + requirement,
+                winner.browsePath(),
+                winner.declarationNodeId()));
+      }
+      return;
+    }
+
+    if (from == ModellingRule.OPTIONAL_PLACEHOLDER && to == ModellingRule.MANDATORY_PLACEHOLDER) {
+      // Q4: Table 21 permits this transition but §6.4.4.4.4 contests it; warn, don't error.
+      ctx.add(
+          ModelDiagnostic.warning(
+              ModelDiagnostic.Code.MODELLING_RULE_TIGHTENING,
+              "override at "
+                  + winner.browsePath()
+                  + " tightens OptionalPlaceholder to MandatoryPlaceholder (contested between"
+                  + " Part 3 Table 21 and §6.4.4.4.4)",
+              winner.browsePath(),
+              winner.declarationNodeId()));
+      return;
+    }
+
+    boolean allowed =
+        switch (from) {
+          case MANDATORY -> to == ModellingRule.MANDATORY;
+          case OPTIONAL -> to == ModellingRule.MANDATORY || to == ModellingRule.OPTIONAL;
+          case MANDATORY_PLACEHOLDER -> to == ModellingRule.MANDATORY_PLACEHOLDER;
+          case OPTIONAL_PLACEHOLDER -> to == ModellingRule.OPTIONAL_PLACEHOLDER;
+          default -> true;
+        };
+
+    if (!allowed) {
+      ctx.add(
+          ModelDiagnostic.warning(
+              ModelDiagnostic.Code.MODELLING_RULE_TIGHTENING,
+              "override at "
+                  + winner.browsePath()
+                  + " changes ModellingRule from "
+                  + from
+                  + " to "
+                  + to
+                  + ", not a valid tightening per Part 3 Table 21",
+              winner.browsePath(),
+              winner.declarationNodeId()));
+    }
+  }
+
+  private void validateNarrowing(
+      AttributeSnapshot narrowed,
+      AttributeSnapshot base,
+      BrowsePath path,
+      NodeId nodeId,
+      CompileContext ctx) {
+
+    NodeId narrowedDataType = narrowed.dataType();
+    NodeId baseDataType = base.dataType();
+    if (narrowedDataType != null
+        && baseDataType != null
+        && !isTypeSubtypeOfOrEqual(narrowedDataType, baseDataType, ctx)) {
+      ctx.add(
+          ModelDiagnostic.warning(
+              ModelDiagnostic.Code.VARIABLE_NARROWING,
+              "DataType "
+                  + narrowedDataType
+                  + " at "
+                  + path
+                  + " is not "
+                  + baseDataType
+                  + " or a subtype (Part 3 §6.2.8)",
+              path,
+              nodeId));
+    }
+
+    Integer narrowedRank = narrowed.valueRank();
+    Integer baseRank = base.valueRank();
+    if (narrowedRank != null
+        && baseRank != null
+        && !isValueRankRestriction(baseRank, narrowedRank)) {
+      ctx.add(
+          ModelDiagnostic.warning(
+              ModelDiagnostic.Code.VARIABLE_NARROWING,
+              "ValueRank "
+                  + narrowedRank
+                  + " at "
+                  + path
+                  + " is not a valid restriction of "
+                  + baseRank
+                  + " (Part 3 §6.2.8)",
+              path,
+              nodeId));
+    }
+
+    UInteger[] narrowedDimensions = narrowed.arrayDimensions();
+    UInteger[] baseDimensions = base.arrayDimensions();
+    if (narrowedDimensions != null
+        && baseDimensions != null
+        && !isArrayDimensionsRestriction(baseDimensions, narrowedDimensions)) {
+      ctx.add(
+          ModelDiagnostic.warning(
+              ModelDiagnostic.Code.VARIABLE_NARROWING,
+              "ArrayDimensions "
+                  + Arrays.toString(narrowedDimensions)
+                  + " at "
+                  + path
+                  + " is not a valid restriction of "
+                  + Arrays.toString(baseDimensions)
+                  + " (Part 3 §6.2.8)",
+              path,
+              nodeId));
+    }
+  }
+
+  private static boolean isValueRankRestriction(int base, int restricted) {
+    if (base == restricted || base == ValueRanks.Any) {
+      return true;
+    }
+    if (base == ValueRanks.ScalarOrOneDimension) {
+      return restricted == ValueRanks.Scalar || restricted == 1;
+    }
+    if (base == ValueRanks.OneOrMoreDimensions) {
+      return restricted >= 1;
+    }
+    return false;
+  }
+
+  private static boolean isArrayDimensionsRestriction(UInteger[] base, UInteger[] restricted) {
+    if (restricted.length != base.length) {
+      return false;
+    }
+    for (int i = 0; i < base.length; i++) {
+      if (base[i].longValue() != 0 && !base[i].equals(restricted[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private void validateMethodSignature(
+      InstanceDeclaration winner,
+      InstanceDeclaration overridden,
+      BrowsePath path,
+      CompileContext ctx) {
+
+    for (QualifiedName property : List.of(INPUT_ARGUMENTS, OUTPUT_ARGUMENTS)) {
+      Object winnerRaw =
+          readPropertyValue(getReferences(winner.declarationNodeId(), ctx), property, ctx);
+      Object overriddenRaw =
+          readPropertyValue(getReferences(overridden.declarationNodeId(), ctx), property, ctx);
+
+      if (overriddenRaw != null && winnerRaw == null) {
+        ctx.add(
+            ModelDiagnostic.warning(
+                ModelDiagnostic.Code.METHOD_SIGNATURE_MISMATCH,
+                "Method override at "
+                    + path
+                    + " removes the "
+                    + property.name()
+                    + " property (Part 3 §6.3.3.3 forbids removing arguments)",
+                path,
+                winner.declarationNodeId()));
+        continue;
+      }
+
+      // Encoded argument lists (ExtensionObject[]) are not decodable without an encoding context;
+      // signature validation is skipped for them (raw is not an Argument[]) in this release.
+      if (!(winnerRaw instanceof Argument[] winnerArguments)
+          || !(overriddenRaw instanceof Argument[] overriddenArguments)) {
+        continue;
+      }
+
+      if (winnerArguments.length < overriddenArguments.length) {
+        ctx.add(
+            ModelDiagnostic.warning(
+                ModelDiagnostic.Code.METHOD_SIGNATURE_MISMATCH,
+                "Method override at "
+                    + path
+                    + " removes "
+                    + property.name()
+                    + " entries ("
+                    + overriddenArguments.length
+                    + " -> "
+                    + winnerArguments.length
+                    + "; Part 3 §6.3.3.3 permits appending only)",
+                path,
+                winner.declarationNodeId()));
+        continue;
+      }
+
+      for (int i = 0; i < overriddenArguments.length; i++) {
+        if (!Objects.equals(overriddenArguments[i].getName(), winnerArguments[i].getName())) {
+          ctx.add(
+              ModelDiagnostic.warning(
+                  ModelDiagnostic.Code.METHOD_SIGNATURE_MISMATCH,
+                  "Method override at "
+                      + path
+                      + " renames "
+                      + property.name()
+                      + "["
+                      + i
+                      + "] from "
+                      + overriddenArguments[i].getName()
+                      + " to "
+                      + winnerArguments[i].getName(),
+                  path,
+                  winner.declarationNodeId()));
+          continue;
+        }
+
+        validateArgumentCompatibility(
+            overriddenArguments[i], winnerArguments[i], property, i, path, winner, ctx);
+      }
+    }
+  }
+
+  /**
+   * Validate one overriding argument against the overridden one: a concrete DataType shall not
+   * change, an abstract DataType may only be specialized to a subtype, and rank/dimensions may only
+   * be restricted (Part 3 §6.3.3.3).
+   */
+  private void validateArgumentCompatibility(
+      Argument base,
+      Argument override,
+      QualifiedName property,
+      int index,
+      BrowsePath path,
+      InstanceDeclaration winner,
+      CompileContext ctx) {
+
+    NodeId baseDataType = base.getDataType();
+    NodeId overrideDataType = override.getDataType();
+    if (!Objects.equals(baseDataType, overrideDataType)) {
+      boolean specialization =
+          baseDataType != null
+              && overrideDataType != null
+              && isAbstractDataType(baseDataType, ctx)
+              && isTypeSubtypeOfOrEqual(overrideDataType, baseDataType, ctx);
+      if (!specialization) {
+        ctx.add(
+            ModelDiagnostic.warning(
+                ModelDiagnostic.Code.METHOD_SIGNATURE_MISMATCH,
+                "Method override at "
+                    + path
+                    + " changes "
+                    + property.name()
+                    + "["
+                    + index
+                    + "] DataType from "
+                    + baseDataType
+                    + " to "
+                    + overrideDataType
+                    + " (Part 3 §6.3.3.3 permits specializing abstract DataTypes only)",
+                path,
+                winner.declarationNodeId()));
+      }
+    }
+
+    Integer baseRank = base.getValueRank();
+    Integer overrideRank = override.getValueRank();
+    if (baseRank != null
+        && overrideRank != null
+        && !isValueRankRestriction(baseRank, overrideRank)) {
+      ctx.add(
+          ModelDiagnostic.warning(
+              ModelDiagnostic.Code.METHOD_SIGNATURE_MISMATCH,
+              "Method override at "
+                  + path
+                  + " changes "
+                  + property.name()
+                  + "["
+                  + index
+                  + "] ValueRank from "
+                  + baseRank
+                  + " to "
+                  + overrideRank,
+              path,
+              winner.declarationNodeId()));
+    }
+
+    UInteger[] baseDimensions = base.getArrayDimensions();
+    UInteger[] overrideDimensions = override.getArrayDimensions();
+    if (baseDimensions != null
+        && overrideDimensions != null
+        && !isArrayDimensionsRestriction(baseDimensions, overrideDimensions)) {
+      ctx.add(
+          ModelDiagnostic.warning(
+              ModelDiagnostic.Code.METHOD_SIGNATURE_MISMATCH,
+              "Method override at "
+                  + path
+                  + " changes "
+                  + property.name()
+                  + "["
+                  + index
+                  + "] ArrayDimensions from "
+                  + Arrays.toString(baseDimensions)
+                  + " to "
+                  + Arrays.toString(overrideDimensions),
+              path,
+              winner.declarationNodeId()));
+    }
+  }
+
+  private boolean isAbstractDataType(NodeId dataTypeId, CompileContext ctx) {
+    return getNode(dataTypeId, ctx) instanceof UaDataTypeNode dataTypeNode
+        && Boolean.TRUE.equals(dataTypeNode.getIsAbstract());
+  }
+
+  /**
+   * Read the Value of the forward {@code HasProperty} child in {@code refs} whose BrowseName is
+   * {@code propertyName}, routing the node read through the dependency-tracking {@link #getNode}.
+   *
+   * @return the matched property's raw value, or {@code null} if no such property exists.
+   */
+  private @Nullable Object readPropertyValue(
+      List<Reference> refs, QualifiedName propertyName, CompileContext ctx) {
+
+    for (Reference r : refs) {
+      if (!Reference.HAS_PROPERTY_PREDICATE.test(r)) {
+        continue;
+      }
+      NodeId targetId = r.getTargetNodeId().toNodeId(namespaceTable).orElse(null);
+      if (targetId == null) {
+        continue;
+      }
+      UaNode target = getNode(targetId, ctx);
+      if (target instanceof UaVariableNode variable
+          && propertyName.equals(variable.getBrowseName())) {
+        return ((DataValue) variable.getAttribute(AttributeId.Value)).getValue().getValue();
+      }
+    }
+    return null;
+  }
+
+  private void validateInterfaces(
+      NodeId typeId, List<Reference> typeRefs, CompiledType merged, CompileContext ctx) {
+
+    List<NodeId> interfaceIds =
+        typeRefs.stream()
+            .filter(
+                r ->
+                    r.isForward()
+                        && (NodeIds.HasInterface.equals(r.getReferenceTypeId())
+                            || referenceTypeTree.isSubtypeOf(
+                                r.getReferenceTypeId(), NodeIds.HasInterface)))
+            .map(r -> r.getTargetNodeId().toNodeId(namespaceTable).orElse(null))
+            .filter(Objects::nonNull)
+            .sorted(NODE_ID_ORDER)
+            .toList();
+
+    for (NodeId interfaceId : interfaceIds) {
+      CompiledType interfaceModel = compileType(interfaceId, ctx);
+      if (interfaceModel == null) {
+        continue;
+      }
+
+      for (InstanceDeclaration member : interfaceModel.declarations.values()) {
+        boolean mandatory = member.rule() == ModellingRule.MANDATORY;
+
+        InstanceDeclaration local = merged.declarations.get(member.browsePath());
+        if (local == null) {
+          if (mandatory) {
+            ctx.add(
+                ModelDiagnostic.warning(
+                    ModelDiagnostic.Code.INTERFACE_MEMBER_MISSING,
+                    "mandatory member "
+                        + member.browsePath()
+                        + " of interface "
+                        + interfaceId
+                        + " has no matching declaration on "
+                        + typeId,
+                    member.browsePath(),
+                    typeId));
+          }
+          continue;
+        }
+
+        // Every same-path collision is validated (KD11), not only the mandatory members: a local
+        // declaration colliding with any interface member's BrowsePath must be similar to it.
+        boolean compatible =
+            local.nodeClass() == member.nodeClass()
+                && (member.typeDefinitionId() == null
+                    || (local.typeDefinitionId() != null
+                        && isTypeSubtypeOfOrEqual(
+                            local.typeDefinitionId(), member.typeDefinitionId(), ctx)));
+        if (!compatible) {
+          ctx.add(
+              ModelDiagnostic.warning(
+                  ModelDiagnostic.Code.INTERFACE_MEMBER_INCOMPATIBLE,
+                  "declaration at "
+                      + member.browsePath()
+                      + " is not compatible with the member of interface "
+                      + interfaceId,
+                  member.browsePath(),
+                  typeId));
+          continue;
+        }
+
+        // A mandatory interface member must be represented as a mandatory declaration (Part 3
+        // §4.10.2); an Optional local representation would let instances omit it.
+        if (mandatory && local.rule() != ModellingRule.MANDATORY) {
+          ctx.add(
+              ModelDiagnostic.warning(
+                  ModelDiagnostic.Code.INTERFACE_MEMBER_INCOMPATIBLE,
+                  "mandatory member "
+                      + member.browsePath()
+                      + " of interface "
+                      + interfaceId
+                      + " is represented by a declaration with ModellingRule "
+                      + local.rule()
+                      + "; it shall be Mandatory",
+                  member.browsePath(),
+                  typeId));
+        }
+      }
+    }
+  }
+
+  // endregion
+
+  // region Reference rows
+
+  private void recordRows(BrowsePath path, List<Reference> nodeRefs, CompiledType table) {
+    for (Reference r : nodeRefs) {
+      if (isHierarchical(r.getReferenceTypeId())) {
+        // Forward hierarchical rows are the walk's domain (edges or traceable exclusions);
+        // inverse hierarchical rows are their back-links.
+        continue;
+      }
+      table.rows.add(
+          new Row(
+              ReferenceRow.absolute(
+                  path, r.getReferenceTypeId(), r.getDirection(), r.getTargetNodeId()),
+              false));
+    }
+  }
+
+  /**
+   * Resolve absolute rows whose targets are declarations of {@code table} into relative rows,
+   * canonicalized to forward direction. A target matching more than one occurrence resolves through
+   * the source's occurrence context when that disambiguates (the candidate sharing the longest
+   * browse-path prefix with the source, if unique — a self-reference resolves to its own
+   * occurrence); otherwise the row stays absolute (frozen) with a warning. A target matching
+   * nothing stays absolute and may still resolve in an enclosing scope after grafting.
+   */
+  private void resolveRows(CompiledType table, CompileContext ctx) {
+    Map<NodeId, List<BrowsePath>> pathsByDeclarationId = new HashMap<>();
+    for (InstanceDeclaration d : table.declarations.values()) {
+      pathsByDeclarationId
+          .computeIfAbsent(d.declarationNodeId(), k -> new ArrayList<>())
+          .add(d.browsePath());
+    }
+
+    List<Row> resolved = new ArrayList<>(table.rows.size());
+    for (Row row : table.rows) {
+      ReferenceRow ref = row.row();
+      if (ref.isRelative() || row.frozen()) {
+        resolved.add(row);
+        continue;
+      }
+
+      ExpandedNodeId targetNodeId = requireNonNull(ref.targetNodeId());
+      NodeId targetId = targetNodeId.toNodeId(namespaceTable).orElse(null);
+      List<BrowsePath> targetPaths =
+          targetId != null ? pathsByDeclarationId.getOrDefault(targetId, List.of()) : List.of();
+
+      BrowsePath targetPath;
+      if (targetPaths.isEmpty()) {
+        resolved.add(row);
+        continue;
+      } else if (targetPaths.size() == 1) {
+        targetPath = targetPaths.get(0);
+      } else {
+        targetPath = occurrenceContextTarget(ref.sourcePath(), targetPaths);
+        if (targetPath == null) {
+          ctx.add(
+              ModelDiagnostic.warning(
+                  ModelDiagnostic.Code.AMBIGUOUS_REFERENCE_TARGET,
+                  "reference target "
+                      + targetId
+                      + " from "
+                      + ref.sourcePath()
+                      + " matches "
+                      + targetPaths.size()
+                      + " declaration occurrences; row kept absolute",
+                  ref.sourcePath(),
+                  targetId));
+          resolved.add(new Row(ref, true));
+          continue;
+        }
+      }
+
+      ReferenceRow relative =
+          ref.direction() == Reference.Direction.FORWARD
+              ? ReferenceRow.relative(ref.sourcePath(), ref.referenceTypeId(), targetPath)
+              : ReferenceRow.relative(targetPath, ref.referenceTypeId(), ref.sourcePath());
+      resolved.add(new Row(relative, false));
+    }
+
+    table.rows.clear();
+    table.rows.addAll(resolved);
+  }
+
+  /**
+   * Pick the occurrence of a multi-occurrence target that the source's own occurrence context
+   * identifies: the candidate sharing the longest non-empty browse-path prefix with the source
+   * path, when that maximum is unique. Returns {@code null} when no candidate shares context or
+   * several share equally (genuinely ambiguous).
+   */
+  private static @Nullable BrowsePath occurrenceContextTarget(
+      BrowsePath sourcePath, List<BrowsePath> candidates) {
+
+    BrowsePath best = null;
+    int bestLength = 0;
+    boolean unique = false;
+    for (BrowsePath candidate : candidates) {
+      int length = commonPrefixLength(sourcePath, candidate);
+      if (length > bestLength) {
+        bestLength = length;
+        best = candidate;
+        unique = true;
+      } else if (length == bestLength) {
+        unique = false;
+      }
+    }
+    return unique ? best : null;
+  }
+
+  private static int commonPrefixLength(BrowsePath a, BrowsePath b) {
+    List<QualifiedName> aElements = a.elements();
+    List<QualifiedName> bElements = b.elements();
+    int max = Math.min(aElements.size(), bElements.size());
+    int i = 0;
+    while (i < max && aElements.get(i).equals(bElements.get(i))) {
+      i++;
+    }
+    return i;
+  }
+
+  private static ReferenceRow reroot(ReferenceRow row, BrowsePath prefix) {
+    if (prefix.isRoot()) {
+      return row;
+    }
+    BrowsePath targetPath = row.targetPath();
+    if (targetPath != null) {
+      return ReferenceRow.relative(
+          prefix.concat(row.sourcePath()), row.referenceTypeId(), prefix.concat(targetPath));
+    } else {
+      return ReferenceRow.absolute(
+          prefix.concat(row.sourcePath()),
+          row.referenceTypeId(),
+          row.direction(),
+          requireNonNull(row.targetNodeId()));
+    }
+  }
+
+  // endregion
+
+  // region Address-space access
+
+  private @Nullable UaNode getNode(NodeId nodeId, CompileContext ctx) {
+    ctx.dependencies.add(nodeId);
+    return ctx.nodes.computeIfAbsent(nodeId, addressSpaceManager::getManagedNode).orElse(null);
+  }
+
+  private List<Reference> getReferences(NodeId nodeId, CompileContext ctx) {
+    ctx.dependencies.add(nodeId);
+    return ctx.references.computeIfAbsent(nodeId, addressSpaceManager::getManagedReferences);
+  }
+
+  private boolean isHierarchical(NodeId referenceTypeId) {
+    return NodeIds.HierarchicalReferences.equals(referenceTypeId)
+        || referenceTypeTree.isSubtypeOf(referenceTypeId, NodeIds.HierarchicalReferences);
+  }
+
+  /**
+   * Walk the inverse HasSubtype chain through the {@link AddressSpaceManager} to decide whether
+   * {@code typeId} is {@code supertypeId} or one of its subtypes. Used for TypeDefinition and
+   * DataType compatibility, which the ReferenceType tree does not cover.
+   */
+  private boolean isTypeSubtypeOfOrEqual(NodeId typeId, NodeId supertypeId, CompileContext ctx) {
+    if (typeId.equals(supertypeId)) {
+      return true;
+    }
+    Set<NodeId> visited = new HashSet<>();
+    NodeId current = typeId;
+    while (current != null && visited.add(current)) {
+      NodeId parent = immediateSupertype(current, ctx);
+      if (supertypeId.equals(parent)) {
+        return true;
+      }
+      current = parent;
+    }
+    return false;
+  }
+
+  /**
+   * @return the immediate supertype of {@code typeId} — the lowest-ordered target of an inverse
+   *     {@code HasSubtype} reference — or {@code null} if the type has none.
+   */
+  private @Nullable NodeId immediateSupertype(NodeId typeId, CompileContext ctx) {
+    return getReferences(typeId, ctx).stream()
+        .filter(Reference.SUBTYPE_OF)
+        .map(r -> r.getTargetNodeId().toNodeId(namespaceTable).orElse(null))
+        .filter(Objects::nonNull)
+        .min(NODE_ID_ORDER)
+        .orElse(null);
+  }
+
+  private @Nullable QualifiedName findDefaultInstanceBrowseName(
+      List<Reference> typeRefs, CompileContext ctx, @Nullable CompiledType supertype) {
+
+    Object raw = readPropertyValue(typeRefs, DEFAULT_INSTANCE_BROWSE_NAME, ctx);
+    if (raw instanceof QualifiedName qualifiedName) {
+      return qualifiedName;
+    }
+
+    return supertype != null ? supertype.defaultInstanceBrowseName : null;
+  }
+
+  // endregion
+
+  // region Fingerprint
+
+  private static long fingerprint(
+      NodeId typeId,
+      AttributeSnapshot rootAttributes,
+      @Nullable QualifiedName defaultInstanceBrowseName,
+      List<InstanceDeclaration> declarations,
+      List<DeclarationEdge> hierarchy,
+      List<ReferenceRow> references,
+      List<ModelDiagnostic> diagnostics) {
+
+    long h = 0xcbf29ce484222325L; // FNV-1a 64 offset basis
+
+    h = mix(h, typeId.toParseableString());
+    h = mix(h, rootAttributes.contentHash());
+    h = mix(h, String.valueOf(defaultInstanceBrowseName));
+
+    for (InstanceDeclaration d : declarations) {
+      h = mix(h, d.browsePath().toString());
+      h = mix(h, String.valueOf(d.browseName()));
+      h = mix(h, d.nodeClass().name());
+      h = mix(h, d.declarationNodeId().toParseableString());
+      h = mix(h, d.declaringTypeId().toParseableString());
+      h = mix(h, d.overriddenDeclarations().toString());
+      h = mix(h, d.modellingRuleId().toParseableString());
+      h = mix(h, d.rule().name());
+      h = mix(h, String.valueOf(d.typeDefinitionId()));
+      h = mix(h, d.attributes().contentHash());
+    }
+
+    for (DeclarationEdge e : hierarchy) {
+      h = mix(h, e.parentPath().toString());
+      h = mix(h, e.referenceTypeId().toParseableString());
+      h = mix(h, e.childPath().toString());
+    }
+
+    for (ReferenceRow r : references) {
+      h = mix(h, r.sourcePath().toString());
+      h = mix(h, r.referenceTypeId().toParseableString());
+      h = mix(h, r.direction().name());
+      h = mix(h, r.targetKey());
+    }
+
+    // Diagnostics capture validation-relevant state the tables alone do not — e.g. a nested
+    // member type turning abstract changes the plan-time concrete-type requirement but no
+    // declaration row — so semantic edits cannot leave the revision unchanged.
+    for (ModelDiagnostic d : diagnostics) {
+      h = mix(h, d.severity().name());
+      h = mix(h, d.code().name());
+      h = mix(h, String.valueOf(d.browsePath()));
+      h = mix(h, String.valueOf(d.nodeId()));
+      h = mix(h, d.message());
+    }
+
+    return h;
+  }
+
+  private static long mix(long h, String s) {
+    for (int i = 0; i < s.length(); i++) {
+      h ^= s.charAt(i);
+      h *= 0x100000001b3L; // FNV-1a 64 prime
+    }
+    h ^= ' ';
+    h *= 0x100000001b3L;
+    return h;
+  }
+
+  // endregion
+
+  // region Support types
+
+  private static List<ModelDiagnostic> dedupe(List<ModelDiagnostic> diagnostics) {
+    return List.copyOf(new LinkedHashSet<>(diagnostics));
+  }
+
+  private static final class CompileContext {
+    final Map<NodeId, CompiledType> memo = new HashMap<>();
+    final Set<NodeId> inProgress = new HashSet<>();
+    final List<ModelDiagnostic> diagnostics = new ArrayList<>();
+    final Set<NodeId> dependencies = new HashSet<>();
+
+    // Address-space reads are cached for the lifetime of one compile() call: nodes and references
+    // are read at least twice each (the type/declaration walk re-reads its own references, and the
+    // subtype-chain walk revisits types), and the compiled model is a single point-in-time
+    // snapshot.
+    final Map<NodeId, Optional<UaNode>> nodes = new HashMap<>();
+    final Map<NodeId, List<Reference>> references = new HashMap<>();
+
+    boolean hasErrors;
+
+    void add(ModelDiagnostic diagnostic) {
+      diagnostics.add(diagnostic);
+      hasErrors |= diagnostic.isError();
+    }
+  }
+
+  /** A reference row plus its resolution state; frozen rows stay absolute (ambiguous target). */
+  private record Row(ReferenceRow row, boolean frozen) {}
+
+  /** One type's fully-inherited tables; memoized per compile call and grafted into parents. */
+  private static final class CompiledType {
+    final NodeId typeId;
+    final AttributeSnapshot rootAttributes;
+    final @Nullable QualifiedName defaultInstanceBrowseName;
+    final LinkedHashMap<BrowsePath, InstanceDeclaration> declarations = new LinkedHashMap<>();
+    final LinkedHashSet<DeclarationEdge> edges = new LinkedHashSet<>();
+    final List<Row> rows = new ArrayList<>();
+
+    // Every walked child by path, rule-less exclusions included, so sibling BrowseName
+    // uniqueness (Part 3 §4.6.4) is validated independent of NodeId order.
+    final Map<BrowsePath, NodeId> pathOccupants = new HashMap<>();
+
+    CompiledType(
+        NodeId typeId,
+        AttributeSnapshot rootAttributes,
+        @Nullable QualifiedName defaultInstanceBrowseName) {
+      this.typeId = typeId;
+      this.rootAttributes = rootAttributes;
+      this.defaultInstanceBrowseName = defaultInstanceBrowseName;
+    }
+
+    boolean isAbstract() {
+      return Boolean.TRUE.equals(rootAttributes.getOrNull(AttributeId.IsAbstract));
+    }
+  }
+
+  private static final class CompiledModel implements TypeInstantiationModel {
+    private final NodeId typeDefinitionId;
+    private final long modelRevision;
+    private final Set<NodeId> dependencies;
+    private final List<InstanceDeclaration> declarations;
+    private final Map<BrowsePath, InstanceDeclaration> declarationsByPath;
+    private final List<InstanceDeclaration> placeholders;
+    private final List<DeclarationEdge> hierarchy;
+    private final List<ReferenceRow> references;
+    private final List<ModelDiagnostic> diagnostics;
+    private final AttributeSnapshot rootAttributes;
+    private final @Nullable QualifiedName defaultInstanceBrowseName;
+
+    CompiledModel(
+        NodeId typeDefinitionId,
+        long modelRevision,
+        Set<NodeId> dependencies,
+        List<InstanceDeclaration> declarations,
+        List<DeclarationEdge> hierarchy,
+        List<ReferenceRow> references,
+        List<ModelDiagnostic> diagnostics,
+        AttributeSnapshot rootAttributes,
+        @Nullable QualifiedName defaultInstanceBrowseName) {
+
+      this.typeDefinitionId = typeDefinitionId;
+      this.modelRevision = modelRevision;
+      this.dependencies = dependencies;
+      this.declarations = declarations;
+      this.hierarchy = hierarchy;
+      this.references = references;
+      this.diagnostics = diagnostics;
+      this.rootAttributes = rootAttributes;
+      this.defaultInstanceBrowseName = defaultInstanceBrowseName;
+
+      this.declarationsByPath = new HashMap<>();
+      declarations.forEach(d -> declarationsByPath.put(d.browsePath(), d));
+
+      this.placeholders = declarations.stream().filter(InstanceDeclaration::isPlaceholder).toList();
+    }
+
+    @Override
+    public NodeId typeDefinitionId() {
+      return typeDefinitionId;
+    }
+
+    @Override
+    public long modelRevision() {
+      return modelRevision;
+    }
+
+    @Override
+    public Set<NodeId> dependencies() {
+      return dependencies;
+    }
+
+    @Override
+    public List<InstanceDeclaration> declarations() {
+      return declarations;
+    }
+
+    @Override
+    public Optional<InstanceDeclaration> get(BrowsePath path) {
+      return Optional.ofNullable(declarationsByPath.get(path));
+    }
+
+    @Override
+    public List<InstanceDeclaration> placeholders() {
+      return placeholders;
+    }
+
+    @Override
+    public List<DeclarationEdge> hierarchy() {
+      return hierarchy;
+    }
+
+    @Override
+    public List<ReferenceRow> references() {
+      return references;
+    }
+
+    @Override
+    public List<ModelDiagnostic> diagnostics() {
+      return diagnostics;
+    }
+
+    @Override
+    public AttributeSnapshot rootAttributes() {
+      return rootAttributes;
+    }
+
+    @Override
+    public Optional<QualifiedName> defaultInstanceBrowseName() {
+      return Optional.ofNullable(defaultInstanceBrowseName);
+    }
+  }
+
+  // endregion
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/TypeModelCompiler.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/TypeModelCompiler.java
@@ -25,7 +25,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import org.eclipse.milo.opcua.sdk.core.Reference;
-import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.sdk.core.typetree.ReferenceTypeTree;
 import org.eclipse.milo.opcua.sdk.server.AddressSpaceManager;
 import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
@@ -97,8 +96,7 @@ public class TypeModelCompiler {
   private static final QualifiedName INPUT_ARGUMENTS = new QualifiedName(0, "InputArguments");
   private static final QualifiedName OUTPUT_ARGUMENTS = new QualifiedName(0, "OutputArguments");
 
-  private static final Comparator<NodeId> NODE_ID_ORDER =
-      Comparator.comparing(NodeId::toParseableString);
+  private static final Comparator<NodeId> NODE_ID_ORDER = TypeSpaceRules.NODE_ID_ORDER;
 
   private final AddressSpaceManager addressSpaceManager;
   private final NamespaceTable namespaceTable;
@@ -629,8 +627,9 @@ public class TypeModelCompiler {
 
     if (rule.isShallow()) {
       // Recorded shallowly: complex structures beneath placeholders are not further considered
-      // for instantiating (Part 3 §6.4.4.4.4–.5); ExposesItsArray is model-visibility only (KD10).
-      // Shallow recording skips subtree expansion, not validation of the recorded type metadata.
+      // for instantiating (Part 3 §6.4.4.4.4–.5), and ExposesItsArray is visible in the model but
+      // never materialized. Shallow recording skips subtree expansion, not validation of the
+      // recorded type metadata.
       if (memberTypeId != null) {
         UaNode memberTypeNode = getNode(memberTypeId, ctx);
         if (memberTypeNode == null) {
@@ -806,8 +805,9 @@ public class TypeModelCompiler {
       validateNarrowing(declaration.attributes(), memberModel.rootAttributes, path, targetId, ctx);
     }
 
-    // Graft the member type's fully-inherited model beneath this declaration (the D2 fix).
-    // Explicit on-declaration entries were walked first and win per path (the D5 fix).
+    // Graft the member type's fully-inherited model beneath this declaration, so nested types are
+    // expanded at every depth. Explicit on-declaration entries were walked first and win per path
+    // (Part 3 §6.3.3.3).
     foldInto(table, memberModel, path, ctx);
   }
 
@@ -816,7 +816,11 @@ public class TypeModelCompiler {
    * prefix} — the root path for a supertype merge (Part 3 §6.3.3.2), a declaration's path for a
    * member-type graft. An entry already present in {@code target} at a path wins (the subtype's own
    * entry, or an explicit on-declaration child), with its override chain appended and the
-   * transition validated by {@code override}.
+   * transition validated by {@code override} — unless the folded entry already overrode the present
+   * one in its own model. That provenance identifies a supertype's explicit specialization arriving
+   * at a path currently occupied by a member-type default the subtype re-grafted without
+   * re-declaring the child: the specialization is the more derived declaration and wins, with the
+   * override validated in the matching direction.
    *
    * <p>Inherited references at an overridden path are suppressed only where Part 3 §6.3.3.3
    * replaces them: a hierarchy edge is replaced when the winner connects the same parent/child pair
@@ -828,6 +832,7 @@ public class TypeModelCompiler {
       CompiledType target, CompiledType source, BrowsePath prefix, CompileContext ctx) {
 
     Set<BrowsePath> overriddenPaths = new HashSet<>();
+    Set<BrowsePath> incomingWins = new HashSet<>();
 
     for (InstanceDeclaration d : source.declarations.values()) {
       BrowsePath path = prefix.concat(d.browsePath());
@@ -836,18 +841,33 @@ public class TypeModelCompiler {
       InstanceDeclaration existing = target.declarations.get(path);
       if (existing == null) {
         target.declarations.put(path, incoming);
+      } else if (incoming.overriddenDeclarations().contains(existing.declarationNodeId())) {
+        overriddenPaths.add(path);
+        incomingWins.add(path);
+        override(incoming, existing, target, ctx);
       } else {
         overriddenPaths.add(path);
         override(existing, incoming, target, ctx);
       }
     }
 
+    // Only edges present before this fold can replace an inherited edge; two edges folded by the
+    // same loop describe distinct relationships and must not suppress each other.
+    List<DeclarationEdge> preexistingEdges = List.copyOf(target.edges);
+
     for (DeclarationEdge e : source.edges) {
       BrowsePath parentPath = prefix.concat(e.parentPath());
       BrowsePath childPath = prefix.concat(e.childPath());
-      if (overriddenPaths.contains(childPath)) {
+      if (incomingWins.contains(childPath)) {
+        // The folded declaration won at this path, so its edge replaces the loser's.
+        target.edges.removeIf(
+            w ->
+                w.parentPath().equals(parentPath)
+                    && w.childPath().equals(childPath)
+                    && isReferenceSubtypeOfOrEqual(e.referenceTypeId(), w.referenceTypeId()));
+      } else if (overriddenPaths.contains(childPath)) {
         boolean replaced =
-            target.edges.stream()
+            preexistingEdges.stream()
                 .anyMatch(
                     w ->
                         w.parentPath().equals(parentPath)
@@ -862,9 +882,17 @@ public class TypeModelCompiler {
     }
 
     for (Row r : source.rows) {
-      if (overriddenPaths.contains(prefix.concat(r.row().sourcePath()))
-          && isSingularReference(r.row().referenceTypeId())) {
-        continue;
+      BrowsePath rowPath = prefix.concat(r.row().sourcePath());
+      if (overriddenPaths.contains(rowPath) && isSingularReference(r.row().referenceTypeId())) {
+        if (incomingWins.contains(rowPath)) {
+          // The folded declaration won at this path, so its singular rows replace the loser's.
+          target.rows.removeIf(
+              t ->
+                  t.row().sourcePath().equals(rowPath)
+                      && sameSingularFamily(t.row().referenceTypeId(), r.row().referenceTypeId()));
+        } else {
+          continue;
+        }
       }
       target.rows.add(new Row(reroot(r.row(), prefix), r.frozen()));
     }
@@ -878,9 +906,17 @@ public class TypeModelCompiler {
         || isReferenceSubtypeOfOrEqual(referenceTypeId, NodeIds.HasModellingRule);
   }
 
+  /** Whether {@code a} and {@code b} are singular references of the same family. */
+  private boolean sameSingularFamily(NodeId a, NodeId b) {
+    return (isReferenceSubtypeOfOrEqual(a, NodeIds.HasTypeDefinition)
+            && isReferenceSubtypeOfOrEqual(b, NodeIds.HasTypeDefinition))
+        || (isReferenceSubtypeOfOrEqual(a, NodeIds.HasModellingRule)
+            && isReferenceSubtypeOfOrEqual(b, NodeIds.HasModellingRule));
+  }
+
   private boolean isReferenceSubtypeOfOrEqual(NodeId referenceTypeId, NodeId supertypeId) {
-    return referenceTypeId.equals(supertypeId)
-        || referenceTypeTree.isSubtypeOf(referenceTypeId, supertypeId);
+    return TypeSpaceRules.isReferenceSubtypeOfOrEqual(
+        referenceTypeTree, referenceTypeId, supertypeId);
   }
 
   /**
@@ -895,11 +931,13 @@ public class TypeModelCompiler {
 
     BrowsePath path = winner.browsePath();
 
-    List<NodeId> chain = new ArrayList<>(winner.overriddenDeclarations());
+    // A LinkedHashSet because the winner's chain may already contain the overridden declaration
+    // (a supertype specialization beating a re-grafted member-type default it overrode before).
+    LinkedHashSet<NodeId> chain = new LinkedHashSet<>(winner.overriddenDeclarations());
     chain.add(overridden.declarationNodeId());
     chain.addAll(overridden.overriddenDeclarations());
 
-    table.declarations.put(path, winner.withOverridden(chain));
+    table.declarations.put(path, winner.withOverridden(List.copyOf(chain)));
 
     // No instance can conform to both the inherited and the overriding declaration when the
     // override changes NodeClass or replaces the TypeDefinition with an unrelated type (Part 3
@@ -1007,7 +1045,7 @@ public class TypeModelCompiler {
     }
 
     if (from == ModellingRule.OPTIONAL_PLACEHOLDER && to == ModellingRule.MANDATORY_PLACEHOLDER) {
-      // Q4: Table 21 permits this transition but §6.4.4.4.4 contests it; warn, don't error.
+      // Table 21 permits this transition but §6.4.4.4.4 contests it; warn, don't error.
       ctx.add(
           ModelDiagnostic.warning(
               ModelDiagnostic.Code.MODELLING_RULE_TIGHTENING,
@@ -1111,28 +1149,11 @@ public class TypeModelCompiler {
   }
 
   private static boolean isValueRankRestriction(int base, int restricted) {
-    if (base == restricted || base == ValueRanks.Any) {
-      return true;
-    }
-    if (base == ValueRanks.ScalarOrOneDimension) {
-      return restricted == ValueRanks.Scalar || restricted == 1;
-    }
-    if (base == ValueRanks.OneOrMoreDimensions) {
-      return restricted >= 1;
-    }
-    return false;
+    return TypeSpaceRules.isValueRankRestriction(base, restricted);
   }
 
   private static boolean isArrayDimensionsRestriction(UInteger[] base, UInteger[] restricted) {
-    if (restricted.length != base.length) {
-      return false;
-    }
-    for (int i = 0; i < base.length; i++) {
-      if (base[i].longValue() != 0 && !base[i].equals(restricted[i])) {
-        return false;
-      }
-    }
-    return true;
+    return TypeSpaceRules.isArrayDimensionsRestriction(base, restricted);
   }
 
   private void validateMethodSignature(
@@ -1338,9 +1359,8 @@ public class TypeModelCompiler {
             .filter(
                 r ->
                     r.isForward()
-                        && (NodeIds.HasInterface.equals(r.getReferenceTypeId())
-                            || referenceTypeTree.isSubtypeOf(
-                                r.getReferenceTypeId(), NodeIds.HasInterface)))
+                        && isReferenceSubtypeOfOrEqual(
+                            r.getReferenceTypeId(), NodeIds.HasInterface))
             .map(r -> r.getTargetNodeId().toNodeId(namespaceTable).orElse(null))
             .filter(Objects::nonNull)
             .sorted(NODE_ID_ORDER)
@@ -1373,7 +1393,7 @@ public class TypeModelCompiler {
           continue;
         }
 
-        // Every same-path collision is validated (KD11), not only the mandatory members: a local
+        // Every same-path collision is validated, not only the mandatory members: a local
         // declaration colliding with any interface member's BrowsePath must be similar to it.
         boolean compatible =
             local.nodeClass() == member.nodeClass()
@@ -1567,29 +1587,17 @@ public class TypeModelCompiler {
   }
 
   private boolean isHierarchical(NodeId referenceTypeId) {
-    return NodeIds.HierarchicalReferences.equals(referenceTypeId)
-        || referenceTypeTree.isSubtypeOf(referenceTypeId, NodeIds.HierarchicalReferences);
+    return isReferenceSubtypeOfOrEqual(referenceTypeId, NodeIds.HierarchicalReferences);
   }
 
   /**
-   * Walk the inverse HasSubtype chain through the {@link AddressSpaceManager} to decide whether
-   * {@code typeId} is {@code supertypeId} or one of its subtypes. Used for TypeDefinition and
-   * DataType compatibility, which the ReferenceType tree does not cover.
+   * Walk the inverse HasSubtype chain, reading through the dependency-tracking context, to decide
+   * whether {@code typeId} is {@code supertypeId} or one of its subtypes. Used for TypeDefinition
+   * and DataType compatibility, which the ReferenceType tree does not cover.
    */
   private boolean isTypeSubtypeOfOrEqual(NodeId typeId, NodeId supertypeId, CompileContext ctx) {
-    if (typeId.equals(supertypeId)) {
-      return true;
-    }
-    Set<NodeId> visited = new HashSet<>();
-    NodeId current = typeId;
-    while (current != null && visited.add(current)) {
-      NodeId parent = immediateSupertype(current, ctx);
-      if (supertypeId.equals(parent)) {
-        return true;
-      }
-      current = parent;
-    }
-    return false;
+    return TypeSpaceRules.isTypeSubtypeOfOrEqual(
+        typeId, supertypeId, id -> getReferences(id, ctx), namespaceTable);
   }
 
   /**
@@ -1597,12 +1605,7 @@ public class TypeModelCompiler {
    *     {@code HasSubtype} reference — or {@code null} if the type has none.
    */
   private @Nullable NodeId immediateSupertype(NodeId typeId, CompileContext ctx) {
-    return getReferences(typeId, ctx).stream()
-        .filter(Reference.SUBTYPE_OF)
-        .map(r -> r.getTargetNodeId().toNodeId(namespaceTable).orElse(null))
-        .filter(Objects::nonNull)
-        .min(NODE_ID_ORDER)
-        .orElse(null);
+    return TypeSpaceRules.immediateSupertype(typeId, id -> getReferences(id, ctx), namespaceTable);
   }
 
   private @Nullable QualifiedName findDefaultInstanceBrowseName(

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/TypeSpaceRules.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/TypeSpaceRules.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
+
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import org.eclipse.milo.opcua.sdk.core.Reference;
+import org.eclipse.milo.opcua.sdk.core.ValueRanks;
+import org.eclipse.milo.opcua.sdk.core.typetree.ReferenceTypeTree;
+import org.eclipse.milo.opcua.stack.core.NamespaceTable;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * The type-space rules shared by compile-time validation ({@link TypeModelCompiler}) and plan-time
+ * validation ({@link NodeInstantiator}): supertype-chain walks over live address-space reads and
+ * the Part 3 §6.2.8 Variable narrowing predicates. One definition keeps the two phases from
+ * disagreeing about what is a valid type or restriction.
+ *
+ * <p>The supertype walks read references through a caller-supplied function so the compiler can
+ * route reads through its dependency-tracking, memoizing context while the instantiator reads the
+ * live {@link org.eclipse.milo.opcua.sdk.server.AddressSpaceManager} directly.
+ */
+final class TypeSpaceRules {
+
+  /** Deterministic {@link NodeId} ordering used for sorts and the multi-supertype tiebreak. */
+  static final Comparator<NodeId> NODE_ID_ORDER = Comparator.comparing(NodeId::toParseableString);
+
+  private TypeSpaceRules() {}
+
+  /** Whether {@code referenceTypeId} is {@code supertypeId} or one of its subtypes. */
+  static boolean isReferenceSubtypeOfOrEqual(
+      ReferenceTypeTree referenceTypeTree, NodeId referenceTypeId, NodeId supertypeId) {
+    return referenceTypeId.equals(supertypeId)
+        || referenceTypeTree.isSubtypeOf(referenceTypeId, supertypeId);
+  }
+
+  /**
+   * Walk the inverse HasSubtype chain to decide whether {@code typeId} is {@code supertypeId} or
+   * one of its subtypes. Used for TypeDefinition and DataType compatibility, which the
+   * ReferenceType tree does not cover.
+   */
+  static boolean isTypeSubtypeOfOrEqual(
+      NodeId typeId,
+      NodeId supertypeId,
+      Function<NodeId, List<Reference>> references,
+      NamespaceTable namespaceTable) {
+
+    if (typeId.equals(supertypeId)) {
+      return true;
+    }
+    Set<NodeId> visited = new HashSet<>();
+    NodeId current = typeId;
+    while (current != null && visited.add(current)) {
+      NodeId parent = immediateSupertype(current, references, namespaceTable);
+      if (supertypeId.equals(parent)) {
+        return true;
+      }
+      current = parent;
+    }
+    return false;
+  }
+
+  /**
+   * @return the immediate supertype of {@code typeId} — the lowest-ordered target of an inverse
+   *     {@code HasSubtype} reference — or {@code null} if the type has none.
+   */
+  static @Nullable NodeId immediateSupertype(
+      NodeId typeId, Function<NodeId, List<Reference>> references, NamespaceTable namespaceTable) {
+
+    return references.apply(typeId).stream()
+        .filter(Reference.SUBTYPE_OF)
+        .map(r -> r.getTargetNodeId().toNodeId(namespaceTable).orElse(null))
+        .filter(Objects::nonNull)
+        .min(NODE_ID_ORDER)
+        .orElse(null);
+  }
+
+  /**
+   * Whether {@code restricted} is a valid ValueRank restriction of {@code base} (Part 3 §6.2.8).
+   */
+  static boolean isValueRankRestriction(int base, int restricted) {
+    if (base == restricted || base == ValueRanks.Any) {
+      return true;
+    }
+    if (base == ValueRanks.ScalarOrOneDimension) {
+      return restricted == ValueRanks.Scalar || restricted == 1;
+    }
+    if (base == ValueRanks.OneOrMoreDimensions) {
+      return restricted >= 1;
+    }
+    return false;
+  }
+
+  /**
+   * Whether {@code restricted} is a valid ArrayDimensions restriction of {@code base} (Part 3
+   * §6.2.8): same length, and every fixed (non-zero) base dimension preserved.
+   */
+  static boolean isArrayDimensionsRestriction(UInteger[] base, UInteger[] restricted) {
+    if (restricted.length != base.length) {
+      return false;
+    }
+    for (int i = 0; i < base.length; i++) {
+      if (base[i].longValue() != 0 && !base[i].equals(restricted[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/package-info.java
@@ -20,6 +20,13 @@
  * a silently truncated hierarchy. Models are structural snapshots keyed by {@link
  * org.eclipse.milo.opcua.sdk.server.nodes.instantiation.BrowsePath}, with every ModellingRule
  * classified and provenance preserved for diagnostics.
+ *
+ * <p><strong>Experimental:</strong> this package is new API, subject to adjustment for one minor
+ * release based on experience from Milo's in-tree migrations and validation of the placeholder
+ * surface against real companion-specification workloads, after which it freezes. The legacy {@code
+ * org.eclipse.milo.opcua.sdk.server.nodes.factories} subsystem remains available, with unchanged
+ * behavior, for the whole deprecation period; see {@code
+ * docs/features/node-instantiation-migration.md} for the legacy-to-new mapping.
  */
 @NullMarked
 package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/**
+ * Type-model-driven node instantiation: compiles a TypeDefinition's fully-inherited
+ * InstanceDeclarationHierarchy (OPC UA Part 3 §6.3.3) into an immutable, cacheable {@link
+ * org.eclipse.milo.opcua.sdk.server.nodes.instantiation.TypeInstantiationModel}.
+ *
+ * <p>{@link org.eclipse.milo.opcua.sdk.server.nodes.instantiation.TypeModelCompiler} reads live
+ * address-space state and either produces a validated model or fails with a {@link
+ * org.eclipse.milo.opcua.sdk.server.nodes.instantiation.ModelCompilationException} carrying
+ * structured {@link org.eclipse.milo.opcua.sdk.server.nodes.instantiation.ModelDiagnostic}s — never
+ * a silently truncated hierarchy. Models are structural snapshots keyed by {@link
+ * org.eclipse.milo.opcua.sdk.server.nodes.instantiation.BrowsePath}, with every ModellingRule
+ * classified and provenance preserved for diagnostics.
+ */
+@NullMarked
+package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
+
+import org.jspecify.annotations.NullMarked;

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/NodeManagerPrimitivesTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/NodeManagerPrimitivesTest.java
@@ -1,0 +1,604 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import org.eclipse.milo.opcua.sdk.core.Reference;
+import org.eclipse.milo.opcua.sdk.core.nodes.Node;
+import org.eclipse.milo.opcua.sdk.server.NodeManager.CommitResult;
+import org.eclipse.milo.opcua.sdk.server.NodeManager.Generation;
+import org.eclipse.milo.opcua.sdk.server.NodeManager.StorageGuarantee;
+import org.eclipse.milo.opcua.stack.core.NamespaceTable;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for the {@link NodeManager} storage primitives: conditional add, batch commit, generation
+ * handle, and the capability probe.
+ *
+ * <p>The atomic overrides in {@link AbstractNodeManager} are the guarantee node-instantiation
+ * rollback rests on; the default emulations are the documented single-writer boundary for
+ * third-party managers that override nothing new.
+ */
+public class NodeManagerPrimitivesTest {
+
+  private static Node node(NodeId nodeId) {
+    Node node = mock(Node.class);
+    when(node.getNodeId()).thenReturn(nodeId);
+    return node;
+  }
+
+  private static Reference reference(NodeId sourceNodeId, NodeId targetNodeId) {
+    return new Reference(sourceNodeId, NodeIds.HasComponent, targetNodeId.expanded(), true);
+  }
+
+  private static long occurrencesOf(NodeManager<Node> manager, Reference reference) {
+    return manager.getReferences(reference.getSourceNodeId()).stream()
+        .filter(reference::equals)
+        .count();
+  }
+
+  @Nested
+  class ConditionalAdd {
+
+    private final AbstractNodeManager<Node> manager = new AbstractNodeManager<>();
+
+    @Test
+    void addNodeIfAbsentAddsWhenAbsent() {
+      Node node = node(new NodeId(1, "a"));
+
+      assertTrue(manager.addNodeIfAbsent(node));
+      assertSame(node, manager.get(new NodeId(1, "a")));
+    }
+
+    // Fail-on-collision conflict policies are impossible to implement race-free on top of an
+    // unconditional replacing add; the conditional add must never replace.
+    @Test
+    void addNodeIfAbsentRefusesToReplace() {
+      Node original = node(new NodeId(1, "a"));
+      Node replacement = node(new NodeId(1, "a"));
+
+      manager.addNode(original);
+
+      assertFalse(manager.addNodeIfAbsent(replacement));
+      assertSame(original, manager.get(new NodeId(1, "a")), "existing Node must be retained");
+    }
+
+    // Pins that the pre-existing API contract is unchanged: addNode replaces.
+    @Test
+    void plainAddNodeStillReplaces() {
+      Node original = node(new NodeId(1, "a"));
+      Node replacement = node(new NodeId(1, "a"));
+
+      manager.addNode(original);
+      Optional<Node> previous = manager.addNode(replacement);
+
+      assertSame(original, previous.orElse(null));
+      assertSame(replacement, manager.get(new NodeId(1, "a")));
+    }
+
+    // The default emulation must provide the same observable semantics as the atomic override.
+    @Test
+    void defaultEmulationRefusesToReplace() {
+      ThirdPartyNodeManager thirdParty = new ThirdPartyNodeManager();
+      Node original = node(new NodeId(1, "a"));
+
+      assertTrue(thirdParty.addNodeIfAbsent(original));
+      assertFalse(thirdParty.addNodeIfAbsent(node(new NodeId(1, "a"))));
+      assertSame(original, thirdParty.get(new NodeId(1, "a")));
+    }
+  }
+
+  @Nested
+  class AtomicCommit {
+
+    private final AbstractNodeManager<Node> manager = new AbstractNodeManager<>();
+
+    private final NodeId aId = new NodeId(1, "a");
+    private final NodeId bId = new NodeId(1, "b");
+
+    @Test
+    void commitAppliesNodesAndReferencesAsOneUnit() throws Exception {
+      Node existing = node(new NodeId(1, "existing"));
+      manager.addNode(existing);
+
+      Node a = node(aId);
+      Node b = node(bId);
+      Reference aToB = reference(aId, bId);
+
+      CommitResult result =
+          manager.commit(
+              NodeManagerBatch.<Node>builder()
+                  .addNode(a)
+                  .addNode(b)
+                  .reuseNode(existing.getNodeId())
+                  .addReference(aToB)
+                  .build());
+
+      assertSame(a, manager.get(aId));
+      assertSame(b, manager.get(bId));
+      assertEquals(1, occurrencesOf(manager, aToB));
+      assertSame(existing, manager.get(existing.getNodeId()), "reused Node must not be touched");
+      assertEquals(List.of(aId, bId), result.addedNodes());
+      assertEquals(List.of(aToB), result.addedReferences());
+    }
+
+    // References are stored as a multiset, so the commit must skip References that already
+    // logically exist — a duplicate occurrence could never be safely attributed to its owner
+    // again. The journal must exclude the skipped Reference so rollback won't remove the
+    // pre-existing occurrence.
+    @Test
+    void commitSkipsLogicallyPresentReferencesAndJournalsOnlyNewOnes() throws Exception {
+      manager.addNode(node(aId));
+      manager.addNode(node(bId));
+
+      Reference alreadyPresent = reference(aId, bId);
+      manager.addReference(alreadyPresent);
+
+      Reference newReference = reference(bId, aId);
+
+      CommitResult result =
+          manager.commit(
+              NodeManagerBatch.<Node>builder()
+                  .addReference(alreadyPresent)
+                  .addReference(newReference)
+                  .build());
+
+      assertEquals(1, occurrencesOf(manager, alreadyPresent), "no duplicate occurrence");
+      assertEquals(1, occurrencesOf(manager, newReference), "control: new Reference added");
+      assertEquals(List.of(newReference), result.addedReferences());
+    }
+
+    @Test
+    void builderCollapsesEqualReferencesWithinOneBatch() throws Exception {
+      Reference reference = reference(aId, bId);
+
+      CommitResult result =
+          manager.commit(
+              NodeManagerBatch.<Node>builder()
+                  .addReference(reference)
+                  .addReference(reference(aId, bId))
+                  .build());
+
+      assertEquals(1, occurrencesOf(manager, reference));
+      assertEquals(List.of(reference), result.addedReferences());
+    }
+
+    // The all-or-nothing guarantee: a collision anywhere in the batch means *nothing* is
+    // applied — earlier additions in the same batch must not remain.
+    @Test
+    void collisionFailureLeavesNoResidue() {
+      Node existing = node(bId);
+      manager.addNode(existing);
+
+      NodeManagerBatch<Node> batch =
+          NodeManagerBatch.<Node>builder()
+              .addNode(node(aId))
+              .addNode(node(bId))
+              .addReference(reference(aId, bId))
+              .build();
+
+      NodeManagerBatchException e =
+          assertThrows(NodeManagerBatchException.class, () -> manager.commit(batch));
+
+      assertEquals(StatusCodes.Bad_NodeIdExists, e.getStatusCode().getValue());
+      assertTrue(e.getApplied().addedNodes().isEmpty(), "atomic commit applied nothing");
+      assertTrue(e.getApplied().addedReferences().isEmpty(), "atomic commit applied nothing");
+      assertFalse(manager.containsNode(aId), "earlier batch addition must not remain");
+      assertTrue(manager.getReferences(aId).isEmpty(), "no Reference residue");
+      assertSame(existing, manager.get(bId), "colliding Node must be untouched");
+      assertEquals(List.of(bId), manager.getNodeIds());
+    }
+
+    // A batch that reuses an existing Node depends on it being there; committing against a
+    // manager where it vanished would materialize a dangling subtree.
+    @Test
+    void missingReusedNodeFailsWithNoResidue() {
+      NodeManagerBatch<Node> batch =
+          NodeManagerBatch.<Node>builder()
+              .addNode(node(aId))
+              .reuseNode(new NodeId(1, "missing"))
+              .build();
+
+      NodeManagerBatchException e =
+          assertThrows(NodeManagerBatchException.class, () -> manager.commit(batch));
+
+      assertEquals(StatusCodes.Bad_NodeIdUnknown, e.getStatusCode().getValue());
+      assertFalse(manager.containsNode(aId));
+      assertTrue(manager.getNodeIds().isEmpty());
+    }
+
+    // Staleness detection: a generation captured before a concurrent direct write must fail the
+    // commit before anything is applied — this closes the plan-then-commit race window.
+    @Test
+    void staleExpectedGenerationFailsWithNoResidue() {
+      long expected = manager.getGeneration().value();
+
+      manager.addNode(node(new NodeId(1, "concurrent"))); // a direct write in between
+
+      NodeManagerBatch<Node> batch =
+          NodeManagerBatch.<Node>builder().addNode(node(aId)).expectGeneration(expected).build();
+
+      NodeManagerBatchException e =
+          assertThrows(NodeManagerBatchException.class, () -> manager.commit(batch));
+
+      assertEquals(StatusCodes.Bad_InvalidState, e.getStatusCode().getValue());
+      assertFalse(manager.containsNode(aId));
+    }
+
+    // Control for staleness detection: an up-to-date expected generation commits normally.
+    @Test
+    void matchingExpectedGenerationCommits() throws Exception {
+      long expected = manager.getGeneration().value();
+
+      manager.commit(
+          NodeManagerBatch.<Node>builder().addNode(node(aId)).expectGeneration(expected).build());
+
+      assertTrue(manager.containsNode(aId));
+    }
+
+    @Test
+    void probeReportsAtomic() {
+      assertEquals(StorageGuarantee.ATOMIC, manager.getStorageGuarantee());
+    }
+  }
+
+  @Nested
+  class EmulatedCommit {
+
+    private final ThirdPartyNodeManager manager = new ThirdPartyNodeManager();
+
+    private final NodeId aId = new NodeId(1, "a");
+    private final NodeId bId = new NodeId(1, "b");
+    private final NodeId cId = new NodeId(1, "c");
+
+    // The default commit is a sequential composition of the pre-existing methods; in the
+    // single-writer case it must produce the same end state and journal as the atomic override.
+    @Test
+    void emulatedCommitAppliesSequentially() throws Exception {
+      Reference alreadyPresent = reference(aId, bId);
+      manager.addReference(alreadyPresent);
+
+      Reference newReference = reference(bId, aId);
+
+      CommitResult result =
+          manager.commit(
+              NodeManagerBatch.<Node>builder()
+                  .addNode(node(aId))
+                  .addNode(node(bId))
+                  .addReference(alreadyPresent)
+                  .addReference(newReference)
+                  .build());
+
+      assertTrue(manager.containsNode(aId));
+      assertTrue(manager.containsNode(bId));
+      assertEquals(1, occurrencesOf(manager, alreadyPresent), "logical dedup applies here too");
+      assertEquals(1, occurrencesOf(manager, newReference));
+      assertEquals(List.of(aId, bId), result.addedNodes());
+      assertEquals(List.of(newReference), result.addedReferences());
+    }
+
+    // The documented emulation boundary: failure mid-batch leaves the additions applied so far
+    // in place, and the exception journals them so a caller can attempt best-effort removal.
+    @Test
+    void emulatedCommitFailureLeavesPartialResidueAndReportsIt() {
+      manager.addNode(node(bId)); // will collide
+
+      NodeManagerBatch<Node> batch =
+          NodeManagerBatch.<Node>builder()
+              .addNode(node(aId))
+              .addNode(node(bId))
+              .addNode(node(cId))
+              .build();
+
+      NodeManagerBatchException e =
+          assertThrows(NodeManagerBatchException.class, () -> manager.commit(batch));
+
+      assertEquals(StatusCodes.Bad_NodeIdExists, e.getStatusCode().getValue());
+      assertTrue(manager.containsNode(aId), "sequential emulation leaves earlier additions");
+      assertFalse(manager.containsNode(cId), "additions after the failure are not applied");
+      assertEquals(List.of(aId), e.getApplied().addedNodes(), "partial journal reported");
+    }
+
+    // Callers must be able to tell they are on the emulated path so they can report a
+    // best-effort guarantee instead of silently claiming atomicity.
+    @Test
+    void probeReportsBestEffort() {
+      assertEquals(StorageGuarantee.BEST_EFFORT, manager.getStorageGuarantee());
+    }
+
+    // Documents the boundary rather than a feature: the default generation handle performs no
+    // tracking, so it cannot detect concurrent mutation. Callers see this via the probe.
+    @Test
+    void emulatedGenerationCannotDetectMutations() {
+      Generation generation = manager.getGeneration();
+
+      manager.addNode(node(aId));
+
+      assertEquals(0L, generation.value());
+      assertTrue(generation.isCurrent(), "no tracking: emulated handle never reports stale");
+    }
+  }
+
+  @Nested
+  class GenerationAndExclusion {
+
+    private final AbstractNodeManager<Node> manager = new AbstractNodeManager<>();
+
+    private final NodeId aId = new NodeId(1, "a");
+    private final NodeId bId = new NodeId(1, "b");
+
+    // Staleness detection is only trustworthy if every mutation path bumps the generation.
+    @Test
+    void everyMutationKindBumpsTheGeneration() throws Exception {
+      Generation g0 = manager.getGeneration();
+      manager.addNode(node(aId));
+      assertFalse(g0.isCurrent(), "addNode must bump the generation");
+
+      Generation g1 = manager.getGeneration();
+      manager.addNodeIfAbsent(node(bId));
+      assertFalse(g1.isCurrent(), "addNodeIfAbsent must bump the generation");
+
+      Reference reference = reference(aId, bId);
+      Generation g2 = manager.getGeneration();
+      manager.addReference(reference);
+      assertFalse(g2.isCurrent(), "addReference must bump the generation");
+
+      Generation g3 = manager.getGeneration();
+      manager.removeReference(reference);
+      assertFalse(g3.isCurrent(), "removeReference must bump the generation");
+
+      Generation g4 = manager.getGeneration();
+      manager.removeNode(bId);
+      assertFalse(g4.isCurrent(), "removeNode must bump the generation");
+
+      Generation g5 = manager.getGeneration();
+      manager.commit(NodeManagerBatch.<Node>builder().addNode(node(bId)).build());
+      assertFalse(g5.isCurrent(), "commit must bump the generation");
+    }
+
+    // Control: a handle must not go stale spuriously, or staleness-checked commits would fail
+    // for callers that only read.
+    @Test
+    void readsAndNoOpMutationsKeepTheGenerationCurrent() {
+      manager.addNode(node(aId));
+
+      Generation generation = manager.getGeneration();
+
+      manager.containsNode(aId);
+      manager.getNode(aId);
+      manager.getReferences(aId);
+      manager.removeNode(new NodeId(1, "missing"));
+      manager.removeReference(reference(aId, bId));
+      assertFalse(manager.addNodeIfAbsent(node(aId)), "refused add is a no-op");
+
+      assertTrue(generation.isCurrent(), "reads and no-op mutations must not bump");
+    }
+
+    // A commit that changes nothing must behave like any other no-op mutation and leave
+    // outstanding handles current, or it would spuriously fail other callers' staleness-checked
+    // commits.
+    @Test
+    void noOpCommitKeepsTheGenerationCurrent() throws Exception {
+      manager.addNode(node(aId));
+      Reference alreadyPresent = reference(aId, bId);
+      manager.addReference(alreadyPresent);
+
+      Generation generation = manager.getGeneration();
+
+      // Reuse-only plus a Reference that is already logically present: nothing is applied.
+      CommitResult result =
+          manager.commit(
+              NodeManagerBatch.<Node>builder().reuseNode(aId).addReference(alreadyPresent).build());
+
+      assertTrue(result.addedNodes().isEmpty());
+      assertTrue(result.addedReferences().isEmpty());
+      assertTrue(generation.isCurrent(), "a no-op commit must not bump the generation");
+    }
+
+    // The atomic commit shares the instance monitor with the pre-existing synchronized mutation
+    // methods; a commit must not interleave with them.
+    @Test
+    void commitIsExclusiveWithTheInstanceMonitor() throws Exception {
+      CountDownLatch monitorHeld = new CountDownLatch(1);
+      CountDownLatch releaseMonitor = new CountDownLatch(1);
+
+      Thread holder =
+          new Thread(
+              () -> {
+                synchronized (manager) {
+                  monitorHeld.countDown();
+                  try {
+                    releaseMonitor.await();
+                  } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                  }
+                }
+              });
+      holder.start();
+      assertTrue(monitorHeld.await(5, TimeUnit.SECONDS));
+
+      NodeManagerBatch<Node> batch = NodeManagerBatch.<Node>builder().addNode(node(aId)).build();
+      CompletableFuture<CommitResult> committed = new CompletableFuture<>();
+      Thread committer =
+          new Thread(
+              () -> {
+                try {
+                  committed.complete(manager.commit(batch));
+                } catch (Exception e) {
+                  committed.completeExceptionally(e);
+                }
+              });
+      committer.start();
+
+      // The committer must park on the monitor; wait deterministically for BLOCKED.
+      long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+      while (committer.getState() != Thread.State.BLOCKED && System.nanoTime() < deadline) {
+        Thread.onSpinWait();
+      }
+      assertEquals(Thread.State.BLOCKED, committer.getState(), "commit must wait for the monitor");
+      assertFalse(manager.containsNode(aId), "nothing applied while the monitor is held");
+
+      releaseMonitor.countDown();
+      committed.get(5, TimeUnit.SECONDS);
+      assertTrue(manager.containsNode(aId));
+
+      holder.join(5_000);
+      committer.join(5_000);
+    }
+  }
+
+  @Nested
+  class CompileCompatibility {
+
+    // Third-party NodeManager implementations must keep compiling unchanged: every method added
+    // by the storage primitives work must be a default method. This pins the full abstract
+    // method set so any future abstract addition fails loudly.
+    @Test
+    void interfaceGainedNoAbstractMethods() {
+      Set<String> abstractMethods =
+          Arrays.stream(NodeManager.class.getMethods())
+              .filter(m -> Modifier.isAbstract(m.getModifiers()))
+              .map(
+                  m ->
+                      m.getName()
+                          + Arrays.stream(m.getParameterTypes())
+                              .map(Class::getSimpleName)
+                              .collect(Collectors.joining(",", "(", ")")))
+              .collect(Collectors.toSet());
+
+      Set<String> preExisting =
+          Set.of(
+              "containsNode(NodeId)",
+              "containsNode(ExpandedNodeId,NamespaceTable)",
+              "addNode(Node)",
+              "getNode(NodeId)",
+              "getNode(ExpandedNodeId,NamespaceTable)",
+              "removeNode(NodeId)",
+              "removeNode(ExpandedNodeId,NamespaceTable)",
+              "addReference(Reference)",
+              "addReferences(Reference,NamespaceTable)",
+              "removeReference(Reference)",
+              "removeReferences(Reference,NamespaceTable)",
+              "getReferences(NodeId)",
+              "getReferences(NodeId,Predicate)");
+
+      assertEquals(preExisting, abstractMethods);
+    }
+  }
+
+  /**
+   * A third-party-style {@link NodeManager} implementing only the method set that existed before
+   * the storage primitives were added, overriding none of the new default methods.
+   *
+   * <p>That this class compiles at all is the source-compatibility proof; it also exercises the
+   * sequential default emulations of the primitives.
+   */
+  private static class ThirdPartyNodeManager implements NodeManager<Node> {
+
+    private final Map<NodeId, Node> nodes = new HashMap<>();
+    private final List<Reference> references = new ArrayList<>();
+
+    @Override
+    public boolean containsNode(NodeId nodeId) {
+      return nodes.containsKey(nodeId);
+    }
+
+    @Override
+    public boolean containsNode(ExpandedNodeId nodeId, NamespaceTable namespaceTable) {
+      return nodeId.toNodeId(namespaceTable).map(this::containsNode).orElse(false);
+    }
+
+    @Override
+    public Optional<Node> addNode(Node node) {
+      return Optional.ofNullable(nodes.put(node.getNodeId(), node));
+    }
+
+    @Override
+    public Optional<Node> getNode(NodeId nodeId) {
+      return Optional.ofNullable(nodes.get(nodeId));
+    }
+
+    @Override
+    public Optional<Node> getNode(ExpandedNodeId nodeId, NamespaceTable namespaceTable) {
+      return nodeId.toNodeId(namespaceTable).flatMap(this::getNode);
+    }
+
+    @Override
+    public Optional<Node> removeNode(NodeId nodeId) {
+      return Optional.ofNullable(nodes.remove(nodeId));
+    }
+
+    @Override
+    public Optional<Node> removeNode(ExpandedNodeId nodeId, NamespaceTable namespaceTable) {
+      return nodeId.toNodeId(namespaceTable).flatMap(this::removeNode);
+    }
+
+    @Override
+    public void addReference(Reference reference) {
+      references.add(reference);
+    }
+
+    @Override
+    public void addReferences(Reference reference, NamespaceTable namespaceTable) {
+      addReference(reference);
+      reference.invert(namespaceTable).ifPresent(this::addReference);
+    }
+
+    @Override
+    public void removeReference(Reference reference) {
+      references.remove(reference);
+    }
+
+    @Override
+    public void removeReferences(Reference reference, NamespaceTable namespaceTable) {
+      removeReference(reference);
+      reference.invert(namespaceTable).ifPresent(this::removeReference);
+    }
+
+    @Override
+    public List<Reference> getReferences(NodeId nodeId) {
+      return references.stream().filter(r -> r.getSourceNodeId().equals(nodeId)).toList();
+    }
+
+    @Override
+    public List<Reference> getReferences(NodeId nodeId, Predicate<Reference> filter) {
+      return references.stream()
+          .filter(r -> r.getSourceNodeId().equals(nodeId))
+          .filter(filter)
+          .toList();
+    }
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/TypeManagerRegistrationTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/TypeManagerRegistrationTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableNode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for the WP5 registry evolution of {@link ObjectTypeManager} and {@link
+ * VariableTypeManager}: the additive snapshot-constructor registration overload and the
+ * class-exposing {@code getRegisteredType} lookup, with the pre-existing tuple and {@code Legacy*}
+ * surfaces byte-for-byte untouched (R4).
+ */
+public class TypeManagerRegistrationTest {
+
+  private final NodeId typeId = new NodeId(1, "TestType");
+
+  @Test
+  void objectSnapshotRegistrationExposesClassAndSnapshotConstructor() {
+    ObjectTypeManager manager = new ObjectTypeManager();
+
+    ObjectTypeManager.SnapshotConstructor snapshotConstructor =
+        (context, nodeId, attributes) -> {
+          throw new UnsupportedOperationException("never invoked here");
+        };
+
+    manager.registerObjectType(typeId, UaObjectNode.class, snapshotConstructor);
+
+    ObjectTypeManager.RegisteredObjectType registered =
+        manager.getRegisteredType(typeId).orElseThrow();
+    assertEquals(UaObjectNode.class, registered.nodeClass());
+    assertSame(snapshotConstructor, registered.snapshotConstructor());
+    assertNull(registered.nodeConstructor());
+
+    // The legacy NodeFactory lookup path does not see snapshot registrations; it falls back to
+    // its default construction exactly as it does for an unregistered type.
+    assertTrue(manager.getNodeConstructor(typeId).isEmpty());
+  }
+
+  @Test
+  void objectTupleRegistrationExposesClassAndTupleConstructor() {
+    ObjectTypeManager manager = new ObjectTypeManager();
+
+    ObjectTypeManager.ObjectNodeConstructor tupleConstructor =
+        (context,
+            nodeId,
+            browseName,
+            displayName,
+            description,
+            writeMask,
+            userWriteMask,
+            rolePermissions,
+            userRolePermissions,
+            accessRestrictions) -> {
+          throw new UnsupportedOperationException("never invoked here");
+        };
+
+    manager.registerObjectType(typeId, UaObjectNode.class, tupleConstructor);
+
+    // The pre-existing lookup is unchanged (the legacy engine resolves this registration)...
+    assertSame(tupleConstructor, manager.getNodeConstructor(typeId).orElseThrow());
+
+    // ...and the new engine sees the same registration through the class-exposing accessor (R4).
+    ObjectTypeManager.RegisteredObjectType registered =
+        manager.getRegisteredType(typeId).orElseThrow();
+    assertEquals(UaObjectNode.class, registered.nodeClass());
+    assertSame(tupleConstructor, registered.nodeConstructor());
+    assertNull(registered.snapshotConstructor());
+  }
+
+  @Test
+  void objectLegacyRegistrationStillAdaptsAndIsVisibleToBothLookups() {
+    ObjectTypeManager manager = new ObjectTypeManager();
+
+    ObjectTypeManager.LegacyObjectNodeConstructor legacyConstructor =
+        (context, nodeId, browseName, displayName, description, writeMask, userWriteMask) -> {
+          throw new UnsupportedOperationException("never invoked here");
+        };
+
+    manager.registerObjectType(typeId, UaObjectNode.class, legacyConstructor);
+
+    assertTrue(manager.getNodeConstructor(typeId).isPresent(), "legacy lookup unchanged");
+
+    ObjectTypeManager.RegisteredObjectType registered =
+        manager.getRegisteredType(typeId).orElseThrow();
+    assertNotNull(registered.nodeConstructor(), "adapted constructor visible to the new engine");
+    assertNull(registered.snapshotConstructor());
+  }
+
+  @Test
+  void variableSnapshotRegistrationExposesClassAndSnapshotConstructor() {
+    VariableTypeManager manager = new VariableTypeManager();
+
+    VariableTypeManager.SnapshotConstructor snapshotConstructor =
+        (context, nodeId, attributes) -> {
+          throw new UnsupportedOperationException("never invoked here");
+        };
+
+    manager.registerVariableType(typeId, UaVariableNode.class, snapshotConstructor);
+
+    VariableTypeManager.RegisteredVariableType registered =
+        manager.getRegisteredType(typeId).orElseThrow();
+    assertEquals(UaVariableNode.class, registered.nodeClass());
+    assertSame(snapshotConstructor, registered.snapshotConstructor());
+    assertNull(registered.nodeConstructor());
+
+    assertTrue(manager.getNodeConstructor(typeId).isEmpty());
+  }
+
+  @Test
+  void variableTupleRegistrationExposesClassAndTupleConstructor() {
+    VariableTypeManager manager = new VariableTypeManager();
+
+    VariableTypeManager.VariableNodeConstructor tupleConstructor =
+        (context,
+            nodeId,
+            browseName,
+            displayName,
+            description,
+            writeMask,
+            userWriteMask,
+            rolePermissions,
+            userRolePermissions,
+            accessRestrictions,
+            value,
+            dataType,
+            valueRank,
+            arrayDimensions) -> {
+          throw new UnsupportedOperationException("never invoked here");
+        };
+
+    manager.registerVariableType(typeId, UaVariableNode.class, tupleConstructor);
+
+    assertSame(tupleConstructor, manager.getNodeConstructor(typeId).orElseThrow());
+
+    VariableTypeManager.RegisteredVariableType registered =
+        manager.getRegisteredType(typeId).orElseThrow();
+    assertEquals(UaVariableNode.class, registered.nodeClass());
+    assertSame(tupleConstructor, registered.nodeConstructor());
+    assertNull(registered.snapshotConstructor());
+  }
+
+  @Test
+  void variableLegacyRegistrationStillAdaptsAndIsVisibleToBothLookups() {
+    VariableTypeManager manager = new VariableTypeManager();
+
+    VariableTypeManager.LegacyVariableNodeConstructor legacyConstructor =
+        (context, nodeId, browseName, displayName, description, writeMask, userWriteMask) -> {
+          throw new UnsupportedOperationException("never invoked here");
+        };
+
+    manager.registerVariableType(typeId, UaVariableNode.class, legacyConstructor);
+
+    assertTrue(manager.getNodeConstructor(typeId).isPresent(), "legacy lookup unchanged");
+
+    VariableTypeManager.RegisteredVariableType registered =
+        manager.getRegisteredType(typeId).orElseThrow();
+    assertNotNull(registered.nodeConstructor(), "adapted constructor visible to the new engine");
+    assertNull(registered.snapshotConstructor());
+  }
+
+  @Test
+  void unregisteredTypeResolvesToNothingInBothLookups() {
+    ObjectTypeManager objectTypeManager = new ObjectTypeManager();
+    assertTrue(objectTypeManager.getNodeConstructor(typeId).isEmpty());
+    assertTrue(objectTypeManager.getRegisteredType(typeId).isEmpty());
+
+    VariableTypeManager variableTypeManager = new VariableTypeManager();
+    assertTrue(variableTypeManager.getNodeConstructor(typeId).isEmpty());
+    assertTrue(variableTypeManager.getRegisteredType(typeId).isEmpty());
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/TypeManagerRegistrationTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/TypeManagerRegistrationTest.java
@@ -22,10 +22,9 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests for the WP5 registry evolution of {@link ObjectTypeManager} and {@link
- * VariableTypeManager}: the additive snapshot-constructor registration overload and the
- * class-exposing {@code getRegisteredType} lookup, with the pre-existing tuple and {@code Legacy*}
- * surfaces byte-for-byte untouched (R4).
+ * Tests for the registry evolution of {@link ObjectTypeManager} and {@link VariableTypeManager}:
+ * the additive snapshot-constructor registration overload and the class-exposing {@code
+ * getRegisteredType} lookup, with the pre-existing tuple and {@code Legacy*} surfaces untouched.
  */
 public class TypeManagerRegistrationTest {
 
@@ -76,7 +75,7 @@ public class TypeManagerRegistrationTest {
     // The pre-existing lookup is unchanged (the legacy engine resolves this registration)...
     assertSame(tupleConstructor, manager.getNodeConstructor(typeId).orElseThrow());
 
-    // ...and the new engine sees the same registration through the class-exposing accessor (R4).
+    // ...and the new engine sees the same registration through the class-exposing accessor.
     ObjectTypeManager.RegisteredObjectType registered =
         manager.getRegisteredType(typeId).orElseThrow();
     assertEquals(UaObjectNode.class, registered.nodeClass());
@@ -173,6 +172,76 @@ public class TypeManagerRegistrationTest {
         manager.getRegisteredType(typeId).orElseThrow();
     assertNotNull(registered.nodeConstructor(), "adapted constructor visible to the new engine");
     assertNull(registered.snapshotConstructor());
+  }
+
+  @Test
+  void objectSnapshotRegistrationPreservesExistingTupleRegistration() {
+    ObjectTypeManager manager = new ObjectTypeManager();
+
+    ObjectTypeManager.ObjectNodeConstructor tupleConstructor =
+        (context,
+            nodeId,
+            browseName,
+            displayName,
+            description,
+            writeMask,
+            userWriteMask,
+            rolePermissions,
+            userRolePermissions,
+            accessRestrictions) -> {
+          throw new UnsupportedOperationException("never invoked here");
+        };
+    ObjectTypeManager.SnapshotConstructor snapshotConstructor =
+        (context, nodeId, attributes) -> {
+          throw new UnsupportedOperationException("never invoked here");
+        };
+
+    // Registering the snapshot form after the tuple form must not disconnect the legacy
+    // NodeFactory/EventFactory lookup from its typed constructor, and vice versa.
+    manager.registerObjectType(typeId, UaObjectNode.class, tupleConstructor);
+    manager.registerObjectType(typeId, UaObjectNode.class, snapshotConstructor);
+
+    assertSame(tupleConstructor, manager.getNodeConstructor(typeId).orElseThrow());
+    ObjectTypeManager.RegisteredObjectType registered =
+        manager.getRegisteredType(typeId).orElseThrow();
+    assertSame(tupleConstructor, registered.nodeConstructor());
+    assertSame(snapshotConstructor, registered.snapshotConstructor());
+  }
+
+  @Test
+  void variableTupleRegistrationPreservesExistingSnapshotRegistration() {
+    VariableTypeManager manager = new VariableTypeManager();
+
+    VariableTypeManager.VariableNodeConstructor tupleConstructor =
+        (context,
+            nodeId,
+            browseName,
+            displayName,
+            description,
+            writeMask,
+            userWriteMask,
+            rolePermissions,
+            userRolePermissions,
+            accessRestrictions,
+            value,
+            dataType,
+            valueRank,
+            arrayDimensions) -> {
+          throw new UnsupportedOperationException("never invoked here");
+        };
+    VariableTypeManager.SnapshotConstructor snapshotConstructor =
+        (context, nodeId, attributes) -> {
+          throw new UnsupportedOperationException("never invoked here");
+        };
+
+    manager.registerVariableType(typeId, UaVariableNode.class, snapshotConstructor);
+    manager.registerVariableType(typeId, UaVariableNode.class, tupleConstructor);
+
+    assertSame(tupleConstructor, manager.getNodeConstructor(typeId).orElseThrow());
+    VariableTypeManager.RegisteredVariableType registered =
+        manager.getRegisteredType(typeId).orElseThrow();
+    assertSame(tupleConstructor, registered.nodeConstructor());
+    assertSame(snapshotConstructor, registered.snapshotConstructor());
   }
 
   @Test

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/diagnostics/objects/SessionsDiagnosticsSummaryObjectTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/diagnostics/objects/SessionsDiagnosticsSummaryObjectTest.java
@@ -23,7 +23,9 @@ import org.eclipse.milo.opcua.sdk.server.model.variables.SessionDiagnosticsVaria
 import org.eclipse.milo.opcua.sdk.server.model.variables.SessionSecurityDiagnosticsArrayTypeNode;
 import org.eclipse.milo.opcua.sdk.server.model.variables.SessionSecurityDiagnosticsTypeNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableNode;
-import org.eclipse.milo.opcua.sdk.server.nodes.factories.NodeFactory;
+import org.eclipse.milo.opcua.sdk.server.nodes.instantiation.InstanceDeclaration;
+import org.eclipse.milo.opcua.sdk.server.nodes.instantiation.InstantiationRequest;
+import org.eclipse.milo.opcua.sdk.server.nodes.instantiation.StagedGraph;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
 import org.eclipse.milo.opcua.stack.core.types.structured.AccessRestrictionType;
@@ -50,6 +52,12 @@ class SessionsDiagnosticsSummaryObjectTest {
     assertDoesNotThrow(() -> new QualifiedName(1, browseName));
   }
 
+  /**
+   * The staged-graph hook must converge with the legacy post-hoc patch: security diagnostics
+   * Variables and their fields carry the standard security array's RolePermissions,
+   * UserRolePermissions, and AccessRestrictions, while ordinary SessionDiagnostics Variables retain
+   * their separate standard permissions.
+   */
   @Test
   void securityDiagnosticsAccessControlProtectsOnlySecurityDiagnosticsSubtree() {
     var summaryNode = mock(SessionsDiagnosticsSummaryTypeNode.class);
@@ -58,6 +66,7 @@ class SessionsDiagnosticsSummaryObjectTest {
     var securityField = mock(UaVariableNode.class);
     var ordinaryDiagnostics = mock(SessionDiagnosticsVariableTypeNode.class);
     var ordinaryField = mock(UaVariableNode.class);
+    var graph = mock(StagedGraph.class);
     var rolePermissions =
         new RolePermissionType[] {
           new RolePermissionType(
@@ -73,13 +82,13 @@ class SessionsDiagnosticsSummaryObjectTest {
     when(securityArray.getRolePermissions()).thenReturn(rolePermissions);
     when(securityArray.getAccessRestrictions()).thenReturn(accessRestrictions);
 
-    NodeFactory.InstantiationCallback callback =
+    InstantiationRequest.OnNode hook =
         SessionsDiagnosticsSummaryObject.securityDiagnosticsAccessControl(summaryNode);
 
-    callback.onVariableAdded(null, securityDiagnostics, NodeIds.SessionSecurityDiagnosticsType);
-    callback.onVariableAdded(securityDiagnostics, securityField, NodeIds.BaseDataVariableType);
-    callback.onVariableAdded(null, ordinaryDiagnostics, NodeIds.SessionDiagnosticsVariableType);
-    callback.onVariableAdded(ordinaryDiagnostics, ordinaryField, NodeIds.BaseDataVariableType);
+    hook.accept(mock(InstanceDeclaration.class), securityDiagnostics, null, graph);
+    hook.accept(mock(InstanceDeclaration.class), securityField, securityDiagnostics, graph);
+    hook.accept(mock(InstanceDeclaration.class), ordinaryDiagnostics, null, graph);
+    hook.accept(mock(InstanceDeclaration.class), ordinaryField, ordinaryDiagnostics, graph);
 
     verify(securityDiagnostics).setRolePermissions(rolePermissions);
     verify(securityDiagnostics).setUserRolePermissions(null);

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/SessionSecurityDiagnosticsVariableArrayTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/SessionSecurityDiagnosticsVariableArrayTest.java
@@ -12,11 +12,15 @@ package org.eclipse.milo.opcua.sdk.server.diagnostics.variables;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import org.eclipse.milo.opcua.sdk.server.model.variables.SessionSecurityDiagnosticsArrayTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableNode;
-import org.eclipse.milo.opcua.sdk.server.nodes.factories.NodeFactory;
+import org.eclipse.milo.opcua.sdk.server.nodes.instantiation.InstanceDeclaration;
+import org.eclipse.milo.opcua.sdk.server.nodes.instantiation.InstantiationRequest;
+import org.eclipse.milo.opcua.sdk.server.nodes.instantiation.StagedGraph;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
 import org.eclipse.milo.opcua.stack.core.types.structured.AccessRestrictionType;
 import org.eclipse.milo.opcua.stack.core.types.structured.PermissionType;
@@ -25,11 +29,19 @@ import org.junit.jupiter.api.Test;
 
 class SessionSecurityDiagnosticsVariableArrayTest {
 
+  /**
+   * The staged-graph hook must converge with the legacy post-hoc patch: every instantiated Variable
+   * — the element root (a root realizes the type itself, so its declaration is null) and its fields
+   * — carries the standard array instance's RolePermissions, UserRolePermissions, and
+   * AccessRestrictions, while non-Variable nodes are untouched.
+   */
   @Test
   void securityAccessControlAppliesArrayMetadataToElementAndFieldNodes() {
     var arrayNode = mock(SessionSecurityDiagnosticsArrayTypeNode.class);
     var elementNode = mock(UaVariableNode.class);
     var fieldNode = mock(UaVariableNode.class);
+    var objectNode = mock(UaObjectNode.class);
+    var graph = mock(StagedGraph.class);
     var rolePermissions =
         new RolePermissionType[] {
           new RolePermissionType(
@@ -44,11 +56,12 @@ class SessionSecurityDiagnosticsVariableArrayTest {
     when(arrayNode.getRolePermissions()).thenReturn(rolePermissions);
     when(arrayNode.getAccessRestrictions()).thenReturn(accessRestrictions);
 
-    NodeFactory.InstantiationCallback callback =
+    InstantiationRequest.OnNode hook =
         SessionSecurityDiagnosticsVariableArray.securityAccessControl(arrayNode);
 
-    callback.onVariableAdded(null, elementNode, NodeIds.SessionSecurityDiagnosticsType);
-    callback.onVariableAdded(elementNode, fieldNode, NodeIds.BaseDataVariableType);
+    hook.accept(null, elementNode, null, graph);
+    hook.accept(mock(InstanceDeclaration.class), fieldNode, elementNode, graph);
+    hook.accept(mock(InstanceDeclaration.class), objectNode, elementNode, graph);
 
     verify(elementNode).setRolePermissions(rolePermissions);
     verify(elementNode).setUserRolePermissions(null);
@@ -56,5 +69,6 @@ class SessionSecurityDiagnosticsVariableArrayTest {
     verify(fieldNode).setRolePermissions(rolePermissions);
     verify(fieldNode).setUserRolePermissions(null);
     verify(fieldNode).setAccessRestrictions(accessRestrictions);
+    verifyNoInteractions(objectNode);
   }
 }

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/UaNodeTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/UaNodeTest.java
@@ -21,6 +21,7 @@ import org.eclipse.milo.opcua.sdk.server.ObjectTypeManager;
 import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
 import org.eclipse.milo.opcua.sdk.server.UaNodeManager;
 import org.eclipse.milo.opcua.sdk.server.VariableTypeManager;
+import org.eclipse.milo.opcua.sdk.server.nodes.instantiation.TypeModelCache;
 import org.eclipse.milo.opcua.stack.core.NamespaceTable;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
 import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
@@ -52,6 +53,7 @@ public class UaNodeTest {
     Mockito.when(server.getVariableTypeManager()).thenReturn(variableTypeManager);
     Mockito.when(server.getStaticEncodingContext()).thenReturn(DefaultEncodingContext.INSTANCE);
     Mockito.when(server.getEncodingManager()).thenReturn(OpcUaEncodingManager.getInstance());
+    Mockito.when(server.getTypeModelCache()).thenReturn(new TypeModelCache(server));
 
     nodeManager = new UaNodeManager();
     addressSpaceManager.register(nodeManager);

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/factories/EventFactoryCharacterizationTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/factories/EventFactoryCharacterizationTest.java
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.nodes.factories;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.eclipse.milo.opcua.sdk.core.Reference;
+import org.eclipse.milo.opcua.sdk.core.typetree.ReferenceTypeTree;
+import org.eclipse.milo.opcua.sdk.server.AddressSpaceManager;
+import org.eclipse.milo.opcua.sdk.server.NodeManager;
+import org.eclipse.milo.opcua.sdk.server.ObjectTypeManager;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.sdk.server.UaNodeManager;
+import org.eclipse.milo.opcua.sdk.server.VariableTypeManager;
+import org.eclipse.milo.opcua.sdk.server.model.ObjectTypeInitializer;
+import org.eclipse.milo.opcua.sdk.server.model.VariableTypeInitializer;
+import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
+import org.eclipse.milo.opcua.sdk.server.namespaces.loader.NodeLoader;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNodeContext;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectTypeNode;
+import org.eclipse.milo.opcua.sdk.server.typetree.ReferenceTypeTreeBuilder;
+import org.eclipse.milo.opcua.stack.core.NamespaceTable;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
+import org.eclipse.milo.opcua.stack.core.encoding.OpcUaEncodingManager;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
+
+/**
+ * Characterization tests pinning the observable behavior of {@link EventFactory} exactly as
+ * shipped, before the replacement node-instantiation engine lands (design goal G7). This fixture is
+ * the assertion source for the event-path replacement: {@code createEvent} forces all optional
+ * members on, casts the result to {@link BaseEventTypeNode} (so a custom, unregistered event type
+ * throws {@link ClassCastException} — the D15 hazard, pinned as-is), applies {@code setEventType},
+ * and stores the created nodes in the factory's private, AddressSpaceManager-registered {@link
+ * UaNodeManager} rather than in any caller-visible NodeManager.
+ *
+ * <p>A test failure here means legacy behavior drifted; a deliberate, reviewed legacy fix must
+ * update this fixture in the same commit. See {@link NodeFactoryCharacterizationTest} for the
+ * shared nondeterminism (R3) and static-IDH-cache isolation notes; synthetic type NodeIds here are
+ * likewise unique per test method.
+ */
+public class EventFactoryCharacterizationTest {
+
+  private static final AtomicInteger TEST_COUNTER = new AtomicInteger();
+
+  private static final String TEST_NAMESPACE_URI = "urn:eclipse:milo:test:characterization:events";
+
+  /** Unique per test method; prefixes every synthetic NodeId to defeat the static IDH cache. */
+  private String testPrefix;
+
+  private OpcUaServer server;
+  private NamespaceTable namespaceTable;
+  private UaNodeManager nodeManager;
+  private UaNodeContext context;
+  private EventFactory eventFactory;
+
+  /** The private NodeManager EventFactory registered with the AddressSpaceManager on startup. */
+  private NodeManager<UaNode> privateNodeManager;
+
+  @BeforeEach
+  public void setup() throws Exception {
+    testPrefix = "EventFactoryCharacterization" + TEST_COUNTER.incrementAndGet();
+
+    server = Mockito.mock(OpcUaServer.class);
+
+    namespaceTable = new NamespaceTable();
+    namespaceTable.add(TEST_NAMESPACE_URI);
+    Mockito.when(server.getNamespaceTable()).thenReturn(namespaceTable);
+
+    nodeManager = new UaNodeManager();
+
+    AddressSpaceManager addressSpaceManager = Mockito.mock(AddressSpaceManager.class);
+
+    // EventFactory registers a private NodeManager with the AddressSpaceManager; lookups must
+    // aggregate the ns0 manager and everything registered, like the real composite does.
+    List<NodeManager<UaNode>> managers = new java.util.concurrent.CopyOnWriteArrayList<>();
+    managers.add(nodeManager);
+
+    Mockito.when(addressSpaceManager.getManagedNode(Mockito.any(NodeId.class)))
+        .then(
+            (Answer<Optional<UaNode>>)
+                invocation -> {
+                  NodeId nodeId = invocation.getArgument(0);
+                  return managers.stream().flatMap(m -> m.getNode(nodeId).stream()).findFirst();
+                });
+
+    Mockito.when(addressSpaceManager.getManagedNode(Mockito.any(ExpandedNodeId.class)))
+        .then(
+            (Answer<Optional<UaNode>>)
+                invocation -> {
+                  ExpandedNodeId nodeId = invocation.getArgument(0);
+                  return managers.stream()
+                      .flatMap(m -> m.getNode(nodeId, namespaceTable).stream())
+                      .findFirst();
+                });
+
+    Mockito.when(addressSpaceManager.getManagedReferences(Mockito.any(NodeId.class)))
+        .then(
+            (Answer<List<Reference>>)
+                invocation -> {
+                  NodeId nodeId = invocation.getArgument(0);
+                  return managers.stream().flatMap(m -> m.getReferences(nodeId).stream()).toList();
+                });
+
+    Mockito.when(addressSpaceManager.getManagedReferences(Mockito.any(NodeId.class), Mockito.any()))
+        .then(
+            (Answer<List<Reference>>)
+                invocation -> {
+                  NodeId nodeId = invocation.getArgument(0);
+                  java.util.function.Predicate<Reference> filter = invocation.getArgument(1);
+                  return managers.stream()
+                      .flatMap(m -> m.getReferences(nodeId, filter).stream())
+                      .toList();
+                });
+
+    Mockito.when(server.getAddressSpaceManager()).thenReturn(addressSpaceManager);
+    Mockito.when(server.getStaticEncodingContext()).thenReturn(DefaultEncodingContext.INSTANCE);
+    Mockito.when(server.getEncodingManager()).thenReturn(OpcUaEncodingManager.getInstance());
+
+    context =
+        new UaNodeContext() {
+          @Override
+          public OpcUaServer getServer() {
+            return server;
+          }
+
+          @Override
+          public NodeManager<UaNode> getNodeManager() {
+            return nodeManager;
+          }
+        };
+
+    new NodeLoader(context, nodeManager).loadNodes();
+
+    // Built outside the when() call because building the tree interacts with the same mock.
+    ReferenceTypeTree referenceTypeTree = ReferenceTypeTreeBuilder.build(server);
+    Mockito.when(server.getReferenceTypeTree()).thenReturn(referenceTypeTree);
+
+    ObjectTypeManager objectTypeManager = new ObjectTypeManager();
+    ObjectTypeInitializer.initialize(namespaceTable, objectTypeManager);
+
+    VariableTypeManager variableTypeManager = new VariableTypeManager();
+    VariableTypeInitializer.initialize(namespaceTable, variableTypeManager);
+
+    eventFactory = new EventFactory(server, objectTypeManager, variableTypeManager);
+    eventFactory.startup();
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<NodeManager<UaNode>> captor = ArgumentCaptor.forClass(NodeManager.class);
+    Mockito.verify(addressSpaceManager).register(captor.capture());
+    privateNodeManager = captor.getValue();
+    managers.add(privateNodeManager);
+  }
+
+  /**
+   * {@code createEvent}'s happy-path contract, pinned as shipped: all optional members are forced
+   * on (BaseEventType's Optional {@code LocalTime} property is instantiated), the result is a
+   * {@link BaseEventTypeNode} from the registered constructor, {@code setEventType} is applied, and
+   * every created node lands in the factory's private, ASM-registered NodeManager — not in any
+   * other NodeManager.
+   */
+  @Test
+  public void createEventForcesOptionalsAppliesEventTypeAndUsesPrivateNodeManager()
+      throws Exception {
+    assertNotSame(nodeManager, privateNodeManager, "EventFactory registered its own NodeManager");
+
+    NodeId eventNodeId = new NodeId(1, testPrefix + ":TestEvent");
+
+    BaseEventTypeNode event = eventFactory.createEvent(eventNodeId, NodeIds.BaseEventType);
+
+    assertNotNull(event);
+    assertEquals(eventNodeId, event.getNodeId());
+
+    // setEventType was applied.
+    assertEquals(NodeIds.BaseEventType, event.getEventType());
+
+    // Mandatory member present, with the child-id formula over the ns0 browse name.
+    NodeId eventIdPropertyId = new NodeId(1, testPrefix + ":TestEvent/0:EventId");
+    assertTrue(privateNodeManager.containsNode(eventIdPropertyId));
+
+    // Optional member (LocalTime, ModellingRule Optional in ns0) forced on.
+    NodeId localTimePropertyId = new NodeId(1, testPrefix + ":TestEvent/0:LocalTime");
+    assertTrue(
+        privateNodeManager.containsNode(localTimePropertyId),
+        "optional members are unconditionally included by createEvent");
+
+    // Nodes land in the private manager only.
+    assertTrue(privateNodeManager.containsNode(eventNodeId));
+    assertFalse(nodeManager.containsNode(eventNodeId));
+    assertFalse(nodeManager.containsNode(eventIdPropertyId));
+  }
+
+  /**
+   * The D15 hazard, pinned as shipped: an event type with no registered constructor falls back to a
+   * plain {@link UaObjectNode}, and {@code createEvent}'s cast throws {@link ClassCastException}
+   * instead of a {@code UaException}. The instantiated nodes have already been stored in the
+   * private NodeManager by the time the cast fails, and are left behind.
+   */
+  @Test
+  public void createEventWithUnregisteredCustomTypeThrowsClassCastException() {
+    NodeId customTypeId = new NodeId(1, testPrefix + ":CustomEventType");
+
+    UaObjectTypeNode customEventType =
+        new UaObjectTypeNode(
+            context,
+            customTypeId,
+            new QualifiedName(1, "CustomEventType"),
+            LocalizedText.english("CustomEventType"),
+            LocalizedText.NULL_VALUE,
+            UInteger.MIN,
+            UInteger.MIN,
+            false);
+    customEventType.addReference(
+        new Reference(customTypeId, NodeIds.HasSubtype, NodeIds.BaseEventType.expanded(), false));
+    nodeManager.addNode(customEventType);
+
+    NodeId eventNodeId = new NodeId(1, testPrefix + ":CustomEvent");
+
+    assertThrows(
+        ClassCastException.class, () -> eventFactory.createEvent(eventNodeId, customTypeId));
+
+    // Residue: the root instance (a plain UaObjectNode) and its members were stored before the
+    // cast failed, and remain in the private NodeManager.
+    UaNode residue = privateNodeManager.getNode(eventNodeId).orElse(null);
+    assertNotNull(residue, "nodes created before the failed cast are left behind");
+    assertInstanceOf(UaObjectNode.class, residue);
+    assertFalse(residue instanceof BaseEventTypeNode);
+    assertTrue(
+        privateNodeManager.containsNode(new NodeId(1, testPrefix + ":CustomEvent/0:Message")),
+        "inherited BaseEventType members were created and left behind too");
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/factories/EventFactoryCharacterizationTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/factories/EventFactoryCharacterizationTest.java
@@ -55,16 +55,16 @@ import org.mockito.stubbing.Answer;
 
 /**
  * Characterization tests pinning the observable behavior of {@link EventFactory} exactly as
- * shipped, before the replacement node-instantiation engine lands (design goal G7). This fixture is
- * the assertion source for the event-path replacement: {@code createEvent} forces all optional
- * members on, casts the result to {@link BaseEventTypeNode} (so a custom, unregistered event type
- * throws {@link ClassCastException} — the D15 hazard, pinned as-is), applies {@code setEventType},
- * and stores the created nodes in the factory's private, AddressSpaceManager-registered {@link
- * UaNodeManager} rather than in any caller-visible NodeManager.
+ * shipped, before the replacement node-instantiation engine lands. This fixture is the assertion
+ * source for the event-path replacement: {@code createEvent} forces all optional members on, casts
+ * the result to {@link BaseEventTypeNode} (so a custom, unregistered event type throws {@link
+ * ClassCastException} — a hazard pinned as-is), applies {@code setEventType}, and stores the
+ * created nodes in the factory's private, AddressSpaceManager-registered {@link UaNodeManager}
+ * rather than in any caller-visible NodeManager.
  *
  * <p>A test failure here means legacy behavior drifted; a deliberate, reviewed legacy fix must
  * update this fixture in the same commit. See {@link NodeFactoryCharacterizationTest} for the
- * shared nondeterminism (R3) and static-IDH-cache isolation notes; synthetic type NodeIds here are
+ * shared nondeterminism and static-IDH-cache isolation notes; synthetic type NodeIds here are
  * likewise unique per test method.
  */
 public class EventFactoryCharacterizationTest {
@@ -219,10 +219,10 @@ public class EventFactoryCharacterizationTest {
   }
 
   /**
-   * The D15 hazard, pinned as shipped: an event type with no registered constructor falls back to a
-   * plain {@link UaObjectNode}, and {@code createEvent}'s cast throws {@link ClassCastException}
-   * instead of a {@code UaException}. The instantiated nodes have already been stored in the
-   * private NodeManager by the time the cast fails, and are left behind.
+   * Pinned as shipped: an event type with no registered constructor falls back to a plain {@link
+   * UaObjectNode}, and {@code createEvent}'s cast throws {@link ClassCastException} instead of a
+   * {@code UaException}. The instantiated nodes have already been stored in the private NodeManager
+   * by the time the cast fails, and are left behind.
    */
   @Test
   public void createEventWithUnregisteredCustomTypeThrowsClassCastException() {

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/factories/NodeFactoryCharacterizationTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/factories/NodeFactoryCharacterizationTest.java
@@ -71,24 +71,25 @@ import org.mockito.stubbing.Answer;
  * InstanceDeclarationHierarchy} exactly as shipped, before the replacement node-instantiation
  * engine lands.
  *
- * <p>These tests are the fixture required by the replacement design's G7 ("legacy untouched"): they
- * assert what the legacy code <em>actually does today</em>, including behavior the design catalogs
- * as defective (D1, D2, D5, D6, silent collision replacement, the child NodeId formula's
- * ambiguities). A test failure here means legacy behavior drifted. Any deliberate, reviewed legacy
- * fix must update this fixture in the same commit — that is the audit trail G7 requires. Do not
- * "fix" a failing assertion by changing it to the spec-correct expectation.
+ * <p>These tests are the fixture required by the replacement design's "legacy untouched" guarantee:
+ * they assert what the legacy code <em>actually does today</em>, including behavior the design
+ * catalogs as defective (orphaned mandatory descendants of excluded optionals, shallow nested-type
+ * expansion, backwards declaration-vs-type precedence, unconditional optional Methods, silent
+ * collision replacement, the child NodeId formula's ambiguities). A test failure here means legacy
+ * behavior drifted. Any deliberate, reviewed legacy fix must update this fixture in the same commit
+ * — that is the audit trail the replacement design requires. Do not "fix" a failing assertion by
+ * changing it to the spec-correct expectation.
  *
- * <p><b>Nondeterminism (design risk R3):</b> node publication order — the order nodes are added to
- * the {@link NodeManager} — follows {@code HashMap} iteration order in {@code
- * NodeFactory.createNodeTree} and is not deterministic. Callback iteration follows the browse-path
- * tree. No test here asserts publication or callback <em>ordering</em>; assertions are on set
- * membership and per-node state only. G7 verification is therefore narrowed to this deterministic
- * subset, with ordering documented as unspecified.
+ * <p><b>Nondeterminism:</b> node publication order — the order nodes are added to the {@link
+ * NodeManager} — follows {@code HashMap} iteration order in {@code NodeFactory.createNodeTree} and
+ * is not deterministic. Callback iteration follows the browse-path tree. No test here asserts
+ * publication or callback <em>ordering</em>; assertions are on set membership and per-node state
+ * only. Drift verification is therefore narrowed to this deterministic subset, with ordering
+ * documented as unspecified.
  *
  * <p><b>Isolation note:</b> {@code NodeFactory} keeps a static JVM-global IDH cache keyed by type
- * NodeId alone (the D8 hazard). Every synthetic type in these tests gets a NodeId unique across the
- * whole test run ({@link #testPrefix}) so a cached hierarchy from one test can never be observed by
- * another.
+ * NodeId alone. Every synthetic type in these tests gets a NodeId unique across the whole test run
+ * ({@link #testPrefix}) so a cached hierarchy from one test can never be observed by another.
  */
 public class NodeFactoryCharacterizationTest {
 
@@ -174,8 +175,6 @@ public class NodeFactoryCharacterizationTest {
 
     nodeFactory = new NodeFactory(context, objectTypeManager, variableTypeManager);
   }
-
-  // region Child NodeId formula
 
   /**
    * Child NodeIds are the root identifier string-concatenated with the joined browse path
@@ -278,10 +277,6 @@ public class NodeFactoryCharacterizationTest {
     assertNotSame(nested, slash, "distinct logical members collide on one NodeId");
   }
 
-  // endregion
-
-  // region Callback timing and contract
-
   /**
    * Callbacks fire after <em>every</em> node of the tree has been stored in the NodeManager; the
    * root fires with {@code parent == null}; {@code includeOptionalNode} receives the
@@ -344,7 +339,7 @@ public class NodeFactoryCharacterizationTest {
         recorder.variableEvents.stream()
             .anyMatch(e -> e.parent() == root && nameOf(e.instance()).equals("OptVar")));
 
-    // Contract pin (the D7 mismatch, as shipped): includeOptionalNode received the *member's*
+    // Contract pin, as shipped: includeOptionalNode received the *member's*
     // type definition id, not the id of the type being instantiated.
     assertEquals(1, recorder.includeCalls.size(), "one optional member consulted once");
     RecordingCallback.IncludeCall call = recorder.includeCalls.get(0);
@@ -352,18 +347,14 @@ public class NodeFactoryCharacterizationTest {
     assertEquals(NodeIds.BaseDataVariableType, call.typeDefinitionId());
   }
 
-  // endregion
-
-  // region D1: excluded optional orphans its mandatory descendants
-
   /**
-   * D1, pinned as shipped: excluding an Optional member prevents only that node's creation. Its
+   * Pinned as shipped: excluding an Optional member prevents only that node's creation. Its
    * Mandatory descendants are still created and stored — unreachable, with no hierarchical
    * reference connecting them to anything — and their callbacks fire with {@code parent == null},
    * indistinguishable from the root signal.
    */
   @Test
-  public void d1ExcludedOptionalStillCreatesMandatoryDescendants() throws Exception {
+  public void excludedOptionalStillCreatesMandatoryDescendants() throws Exception {
     UaObjectTypeNode typeNode = addObjectType("D1Type", NodeIds.BaseObjectType);
     UaObjectNode optObj =
         addObjectDeclaration(
@@ -382,7 +373,7 @@ public class NodeFactoryCharacterizationTest {
     assertFalse(nodeManager.containsNode(optObjId), "excluded optional itself is not created");
     assertTrue(
         nodeManager.containsNode(orphanId),
-        "the excluded optional's mandatory descendant IS created and stored (D1)");
+        "the excluded optional's mandatory descendant IS created and stored");
 
     // The orphan has no hierarchical reference linking it to a parent: only its
     // HasTypeDefinition reference was wired (HasModellingRule is skipped, and the
@@ -408,18 +399,14 @@ public class NodeFactoryCharacterizationTest {
         recorder.objectEvents.stream().anyMatch(e -> e.parent() == null && e.instance() == root));
   }
 
-  // endregion
-
-  // region D2: nested member types are only shallowly expanded (A1 evidence)
-
   /**
-   * D2, pinned as shipped (A1 runtime evidence): a member whose type definition is a
-   * <em>subtype</em> is expanded without the subtype's supertype-declared members — the nested
-   * type-definition recursion does not build the member type's fully-inherited hierarchy. A member
-   * typed directly as the declaring supertype gets the member (control case).
+   * Pinned as shipped (confirmed at runtime): a member whose type definition is a <em>subtype</em>
+   * is expanded without the subtype's supertype-declared members — the nested type-definition
+   * recursion does not build the member type's fully-inherited hierarchy. A member typed directly
+   * as the declaring supertype gets the member (control case).
    */
   @Test
-  public void d2NestedMemberTypeMissingSupertypeMembers() throws Exception {
+  public void nestedMemberTypeMissingSupertypeMembers() throws Exception {
     // BaseSMType declares a Mandatory CurrentState; DerivedSMType subtypes it, adding nothing.
     UaObjectTypeNode baseSmType = addObjectType("BaseSMType", NodeIds.BaseObjectType);
     addVariableDeclaration(
@@ -437,25 +424,21 @@ public class NodeFactoryCharacterizationTest {
     assertTrue(nodeManager.containsNode(new NodeId(1, testPrefix + ":D2Root/1:SM")));
     assertFalse(
         nodeManager.containsNode(new NodeId(1, testPrefix + ":D2Root/1:SM/1:CurrentState")),
-        "member typed as a subtype is MISSING its supertype-declared mandatory member (D2)");
+        "member typed as a subtype is MISSING its supertype-declared mandatory member");
 
     assertTrue(
         nodeManager.containsNode(new NodeId(1, testPrefix + ":D2Root/1:SM2/1:CurrentState")),
         "control: member typed directly as the declaring type gets the member");
   }
 
-  // endregion
-
-  // region D5: type-declared entry wins over on-declaration override (A1 evidence)
-
   /**
-   * D5, pinned as shipped (A1 runtime evidence): for a member with both an on-declaration child and
-   * a same-named child declared by the member's type definition, the <em>type's</em> entry
-   * overwrites the on-declaration override (backwards relative to Part 3 §6.3.3.3), and the
-   * duplicate hierarchical rows produced by the two walks are both wired onto the instance.
+   * Pinned as shipped (confirmed at runtime): for a member with both an on-declaration child and a
+   * same-named child declared by the member's type definition, the <em>type's</em> entry overwrites
+   * the on-declaration override (backwards relative to Part 3 §6.3.3.3), and the duplicate
+   * hierarchical rows produced by the two walks are both wired onto the instance.
    */
   @Test
-  public void d5TypeDeclaredChildShadowsOnDeclarationOverride() throws Exception {
+  public void typeDeclaredChildShadowsOnDeclarationOverride() throws Exception {
     UaObjectTypeNode memberType = addObjectType("D5MemberType", NodeIds.BaseObjectType);
     UaVariableNode typeChild =
         addVariableDeclaration(
@@ -483,7 +466,7 @@ public class NodeFactoryCharacterizationTest {
     assertEquals(
         NodeIds.String,
         childInstance.getDataType(),
-        "the type-declared child won; the on-declaration override was silently discarded (D5)");
+        "the type-declared child won; the on-declaration override was silently discarded");
     assertEquals(new Variant("fromType"), childInstance.getValue().getValue());
 
     // Both walks appended a hierarchical row for the same parent/child pair; the factory wires
@@ -497,21 +480,17 @@ public class NodeFactoryCharacterizationTest {
                         && NodeIds.HasComponent.equals(r.getReferenceTypeId())
                         && r.getTargetNodeId().equals(childInstanceId.expanded()))
             .count();
-    assertEquals(2, duplicateRows, "duplicate hierarchical rows are wired verbatim (D5)");
+    assertEquals(2, duplicateRows, "duplicate hierarchical rows are wired verbatim");
   }
 
-  // endregion
-
-  // region D6: Optional Methods are created unconditionally
-
   /**
-   * D6, pinned as shipped: the optional-exclusion gate exists only for Object and Variable members.
-   * An Optional Method member is created unconditionally and {@code includeOptionalNode} is never
+   * Pinned as shipped: the optional-exclusion gate exists only for Object and Variable members. An
+   * Optional Method member is created unconditionally and {@code includeOptionalNode} is never
    * consulted for it; an Optional Variable member alongside it is consulted and excluded. Method
    * instances copy the declaration's attributes.
    */
   @Test
-  public void d6OptionalMethodsCreatedUnconditionally() throws Exception {
+  public void optionalMethodsCreatedUnconditionally() throws Exception {
     UaObjectTypeNode typeNode = addObjectType("D6Type", NodeIds.BaseObjectType);
     UaMethodNode methodDecl =
         addMethodDeclaration(typeNode, "OptMethod", NodeIds.ModellingRule_Optional);
@@ -526,7 +505,7 @@ public class NodeFactoryCharacterizationTest {
     NodeId methodInstanceId = new NodeId(1, testPrefix + ":D6Root/1:OptMethod");
     assertTrue(
         nodeManager.containsNode(methodInstanceId),
-        "Optional Method created despite the exclude-all callback (D6)");
+        "Optional Method created despite the exclude-all callback");
     assertFalse(
         nodeManager.containsNode(new NodeId(1, testPrefix + ":D6Root/1:OptVar")),
         "Optional Variable was excluded as requested");
@@ -534,7 +513,7 @@ public class NodeFactoryCharacterizationTest {
     assertTrue(
         recorder.includeCalls.stream()
             .noneMatch(c -> c.browseName().equals(new QualifiedName(1, "OptMethod"))),
-        "includeOptionalNode never consulted for the Optional Method (D6)");
+        "includeOptionalNode never consulted for the Optional Method");
     assertTrue(
         recorder.includeCalls.stream()
             .anyMatch(c -> c.browseName().equals(new QualifiedName(1, "OptVar"))),
@@ -546,10 +525,6 @@ public class NodeFactoryCharacterizationTest {
     assertEquals(methodDecl.isExecutable(), methodInstance.isExecutable());
     assertEquals(methodDecl.isUserExecutable(), methodInstance.isUserExecutable());
   }
-
-  // endregion
-
-  // region Silent collision replacement
 
   /**
    * Pinned as shipped: instantiating with a root NodeId that already exists silently replaces the
@@ -596,8 +571,8 @@ public class NodeFactoryCharacterizationTest {
   }
 
   /**
-   * The D13 latent NPE, pinned as shipped: because reference-map state under a replaced NodeId is
-   * not cleared, a pre-existing node's stale forward {@code HasTypeDefinition} reference (here to a
+   * The latent NPE, pinned as shipped: because reference-map state under a replaced NodeId is not
+   * cleared, a pre-existing node's stale forward {@code HasTypeDefinition} reference (here to a
    * VariableType) is found first by {@code getTypeDefinitionNode()} during the notification phase,
    * which then throws {@link NullPointerException} — after every node of the tree has already been
    * created and stored, with no cleanup.
@@ -632,10 +607,6 @@ public class NodeFactoryCharacterizationTest {
         nodeManager.containsNode(new NodeId(1, testPrefix + ":NpeCollisionRoot/1:Foo")),
         "nodes created before the notification-phase NPE are left behind");
   }
-
-  // endregion
-
-  // region Attribute propagation
 
   /**
    * The exact Variable attribute propagation set, as shipped: instances copy
@@ -811,15 +782,11 @@ public class NodeFactoryCharacterizationTest {
     assertEquals(varType.getBrowseName(), varRoot.getBrowseName());
   }
 
-  // endregion
-
-  // region Reference wiring
-
   /**
    * Pinned as shipped: {@code HasModellingRule} references are excluded from instances; every other
    * declaration reference row is wired verbatim — absolute targets as-is, so non-hierarchical
-   * references between declarations point at the <em>type's</em> declaration nodes (the D4
-   * behavior), and inverse rows are re-emitted as forward references (direction is not preserved).
+   * references between declarations point at the <em>type's</em> declaration nodes, and inverse
+   * rows are re-emitted as forward references (direction is not preserved).
    */
   @Test
   public void modellingRuleExcludedOtherReferencesWiredVerbatim() throws Exception {
@@ -860,7 +827,7 @@ public class NodeFactoryCharacterizationTest {
                     r.isForward()
                         && NodeIds.HasCause.equals(r.getReferenceTypeId())
                         && r.getTargetNodeId().equals(barDecl.getNodeId().expanded())),
-        "non-hierarchical reference wired verbatim to the type's declaration node (D4)");
+        "non-hierarchical reference wired verbatim to the type's declaration node");
     assertTrue(
         fooReferences.stream()
             .noneMatch(
@@ -880,10 +847,6 @@ public class NodeFactoryCharacterizationTest {
                         && r.getTargetNodeId().equals(fooDecl.getNodeId().expanded())),
         "inverse declaration row forced forward on the instance");
   }
-
-  // endregion
-
-  // region Fixture helpers
 
   private NodeId newNodeId(String id) {
     return new NodeId(1, testPrefix + ":" + id);
@@ -1048,6 +1011,4 @@ public class NodeFactoryCharacterizationTest {
       variableEvents.add(new NodeEvent(parent, instance));
     }
   }
-
-  // endregion
 }

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/factories/NodeFactoryCharacterizationTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/factories/NodeFactoryCharacterizationTest.java
@@ -1,0 +1,1053 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.nodes.factories;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ubyte;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.eclipse.milo.opcua.sdk.core.AccessLevel;
+import org.eclipse.milo.opcua.sdk.core.Reference;
+import org.eclipse.milo.opcua.sdk.core.typetree.ReferenceTypeTree;
+import org.eclipse.milo.opcua.sdk.server.AddressSpaceManager;
+import org.eclipse.milo.opcua.sdk.server.NodeManager;
+import org.eclipse.milo.opcua.sdk.server.ObjectTypeManager;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.sdk.server.UaNodeManager;
+import org.eclipse.milo.opcua.sdk.server.VariableTypeManager;
+import org.eclipse.milo.opcua.sdk.server.model.ObjectTypeInitializer;
+import org.eclipse.milo.opcua.sdk.server.model.VariableTypeInitializer;
+import org.eclipse.milo.opcua.sdk.server.namespaces.loader.NodeLoader;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaMethodNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNodeContext;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableTypeNode;
+import org.eclipse.milo.opcua.sdk.server.typetree.ReferenceTypeTreeBuilder;
+import org.eclipse.milo.opcua.stack.core.NamespaceTable;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
+import org.eclipse.milo.opcua.stack.core.encoding.OpcUaEncodingManager;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
+import org.eclipse.milo.opcua.stack.core.types.structured.AccessRestrictionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.PermissionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.RolePermissionType;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
+
+/**
+ * Characterization tests pinning the observable behavior of {@link NodeFactory} and {@link
+ * InstanceDeclarationHierarchy} exactly as shipped, before the replacement node-instantiation
+ * engine lands.
+ *
+ * <p>These tests are the fixture required by the replacement design's G7 ("legacy untouched"): they
+ * assert what the legacy code <em>actually does today</em>, including behavior the design catalogs
+ * as defective (D1, D2, D5, D6, silent collision replacement, the child NodeId formula's
+ * ambiguities). A test failure here means legacy behavior drifted. Any deliberate, reviewed legacy
+ * fix must update this fixture in the same commit — that is the audit trail G7 requires. Do not
+ * "fix" a failing assertion by changing it to the spec-correct expectation.
+ *
+ * <p><b>Nondeterminism (design risk R3):</b> node publication order — the order nodes are added to
+ * the {@link NodeManager} — follows {@code HashMap} iteration order in {@code
+ * NodeFactory.createNodeTree} and is not deterministic. Callback iteration follows the browse-path
+ * tree. No test here asserts publication or callback <em>ordering</em>; assertions are on set
+ * membership and per-node state only. G7 verification is therefore narrowed to this deterministic
+ * subset, with ordering documented as unspecified.
+ *
+ * <p><b>Isolation note:</b> {@code NodeFactory} keeps a static JVM-global IDH cache keyed by type
+ * NodeId alone (the D8 hazard). Every synthetic type in these tests gets a NodeId unique across the
+ * whole test run ({@link #testPrefix}) so a cached hierarchy from one test can never be observed by
+ * another.
+ */
+public class NodeFactoryCharacterizationTest {
+
+  private static final AtomicInteger TEST_COUNTER = new AtomicInteger();
+
+  private static final String TEST_NAMESPACE_URI = "urn:eclipse:milo:test:characterization";
+
+  /** Unique per test method; prefixes every synthetic NodeId to defeat the static IDH cache. */
+  private String testPrefix;
+
+  private OpcUaServer server;
+  private NamespaceTable namespaceTable;
+  private UaNodeManager nodeManager;
+  private UaNodeContext context;
+  private NodeFactory nodeFactory;
+
+  @BeforeEach
+  public void setup() throws Exception {
+    testPrefix = "NodeFactoryCharacterization" + TEST_COUNTER.incrementAndGet();
+
+    server = Mockito.mock(OpcUaServer.class);
+
+    namespaceTable = new NamespaceTable();
+    namespaceTable.add(TEST_NAMESPACE_URI);
+    Mockito.when(server.getNamespaceTable()).thenReturn(namespaceTable);
+
+    nodeManager = new UaNodeManager();
+
+    AddressSpaceManager addressSpaceManager = Mockito.mock(AddressSpaceManager.class);
+
+    Mockito.when(addressSpaceManager.getManagedNode(Mockito.any(NodeId.class)))
+        .then(
+            (Answer<Optional<UaNode>>)
+                invocation -> nodeManager.getNode(invocation.getArgument(0)));
+
+    Mockito.when(addressSpaceManager.getManagedNode(Mockito.any(ExpandedNodeId.class)))
+        .then(
+            (Answer<Optional<UaNode>>)
+                invocation -> nodeManager.getNode(invocation.getArgument(0), namespaceTable));
+
+    Mockito.when(addressSpaceManager.getManagedReferences(Mockito.any(NodeId.class)))
+        .then(
+            (Answer<List<Reference>>)
+                invocation -> nodeManager.getReferences(invocation.getArgument(0)));
+
+    Mockito.when(addressSpaceManager.getManagedReferences(Mockito.any(NodeId.class), Mockito.any()))
+        .then(
+            (Answer<List<Reference>>)
+                invocation ->
+                    nodeManager.getReferences(
+                        invocation.getArgument(0), invocation.getArgument(1)));
+
+    Mockito.when(server.getAddressSpaceManager()).thenReturn(addressSpaceManager);
+    Mockito.when(server.getStaticEncodingContext()).thenReturn(DefaultEncodingContext.INSTANCE);
+    Mockito.when(server.getEncodingManager()).thenReturn(OpcUaEncodingManager.getInstance());
+
+    context =
+        new UaNodeContext() {
+          @Override
+          public OpcUaServer getServer() {
+            return server;
+          }
+
+          @Override
+          public NodeManager<UaNode> getNodeManager() {
+            return nodeManager;
+          }
+        };
+
+    new NodeLoader(context, nodeManager).loadNodes();
+
+    // InstanceDeclarationHierarchy consults the ReferenceTypeTree to classify non-hierarchical
+    // references; the tree must be built after ns0 is loaded, and outside the when() call
+    // because building it interacts with the same mock.
+    ReferenceTypeTree referenceTypeTree = ReferenceTypeTreeBuilder.build(server);
+    Mockito.when(server.getReferenceTypeTree()).thenReturn(referenceTypeTree);
+
+    ObjectTypeManager objectTypeManager = new ObjectTypeManager();
+    ObjectTypeInitializer.initialize(namespaceTable, objectTypeManager);
+
+    VariableTypeManager variableTypeManager = new VariableTypeManager();
+    VariableTypeInitializer.initialize(namespaceTable, variableTypeManager);
+
+    nodeFactory = new NodeFactory(context, objectTypeManager, variableTypeManager);
+  }
+
+  // region Child NodeId formula
+
+  /**
+   * Child NodeIds are the root identifier string-concatenated with the joined browse path
+   * (separator "/", namespace-index-prefixed names), always a String identifier in the root's
+   * namespace, at every depth.
+   */
+  @Test
+  public void childNodeIdFormula() throws Exception {
+    UaObjectTypeNode typeNode = addObjectType("FormulaType", NodeIds.BaseObjectType);
+    UaObjectNode child =
+        addObjectDeclaration(
+            typeNode, "Child", NodeIds.BaseObjectType, NodeIds.ModellingRule_Mandatory);
+    addVariableDeclaration(
+        child, "Leaf", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+    NodeId rootNodeId = new NodeId(1, testPrefix + ":TestRoot");
+    UaNode root = nodeFactory.createNode(rootNodeId, typeNode.getNodeId());
+
+    assertEquals(rootNodeId, root.getNodeId());
+
+    NodeId childId = new NodeId(1, testPrefix + ":TestRoot/1:Child");
+    NodeId leafId = new NodeId(1, testPrefix + ":TestRoot/1:Child/1:Leaf");
+
+    assertTrue(nodeManager.containsNode(childId), "child at rootIdentifier + /1:Child");
+    assertTrue(nodeManager.containsNode(leafId), "grandchild at rootIdentifier + /1:Child/1:Leaf");
+
+    // The instance hierarchy is wired: root -> child -> leaf via forward HasComponent.
+    assertTrue(
+        nodeManager.getReferences(rootNodeId).stream()
+            .anyMatch(
+                r ->
+                    r.isForward()
+                        && NodeIds.HasComponent.equals(r.getReferenceTypeId())
+                        && r.getTargetNodeId().equals(childId.expanded())));
+    assertTrue(
+        nodeManager.getReferences(childId).stream()
+            .anyMatch(
+                r ->
+                    r.isForward()
+                        && NodeIds.HasComponent.equals(r.getReferenceTypeId())
+                        && r.getTargetNodeId().equals(leafId.expanded())));
+  }
+
+  /**
+   * The formula is unescaped {@code String.format("%s%s", rootIdentifier, joinedPath)}: a numeric
+   * root identifier {@code 7} and a String root identifier {@code "7"} derive <em>identical</em>
+   * child NodeIds, and the second instantiation silently replaces the first's children.
+   */
+  @Test
+  public void childNodeIdFormulaNumericVsStringRootAmbiguity() throws Exception {
+    UaObjectTypeNode typeNode = addObjectType("AmbiguousRootType", NodeIds.BaseObjectType);
+    addVariableDeclaration(
+        typeNode, "Foo", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+    NodeId derivedChildId = new NodeId(1, "7/1:Foo");
+
+    nodeFactory.createNode(new NodeId(1, uint(7)), typeNode.getNodeId());
+    UaNode childOfNumericRoot = nodeManager.getNode(derivedChildId).orElse(null);
+    assertNotNull(childOfNumericRoot, "numeric root 7 derives String child id \"7/1:Foo\"");
+
+    nodeFactory.createNode(new NodeId(1, "7"), typeNode.getNodeId());
+    UaNode childOfStringRoot = nodeManager.getNode(derivedChildId).orElse(null);
+    assertNotNull(childOfStringRoot, "string root \"7\" derives the same child id \"7/1:Foo\"");
+
+    assertNotSame(
+        childOfNumericRoot,
+        childOfStringRoot,
+        "second instantiation replaced the first root's child at the shared NodeId");
+  }
+
+  /**
+   * The formula does not escape "/" or namespace-prefix-like text in BrowseNames: a single member
+   * named {@code "A/1:B"} derives the same NodeId as a nested member {@code A} containing {@code
+   * B}, and instantiating one over the other silently replaces the colliding node.
+   */
+  @Test
+  public void childNodeIdFormulaSlashInBrowseNameAmbiguity() throws Exception {
+    UaObjectTypeNode nestedType = addObjectType("NestedPathType", NodeIds.BaseObjectType);
+    UaObjectNode a =
+        addObjectDeclaration(
+            nestedType, "A", NodeIds.BaseObjectType, NodeIds.ModellingRule_Mandatory);
+    addVariableDeclaration(a, "B", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+    UaObjectTypeNode slashType = addObjectType("SlashNameType", NodeIds.BaseObjectType);
+    addVariableDeclaration(
+        slashType, "A/1:B", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+    NodeId rootNodeId = new NodeId(1, testPrefix + ":AmbigRoot");
+    NodeId collidingId = new NodeId(1, testPrefix + ":AmbigRoot/1:A/1:B");
+
+    nodeFactory.createNode(rootNodeId, nestedType.getNodeId());
+    UaNode nested = nodeManager.getNode(collidingId).orElse(null);
+    assertNotNull(nested, "nested member A/B lands at .../1:A/1:B");
+    assertEquals(new QualifiedName(1, "B"), nested.getBrowseName());
+
+    nodeFactory.createNode(rootNodeId, slashType.getNodeId());
+    UaNode slash = nodeManager.getNode(collidingId).orElse(null);
+    assertNotNull(slash, "member named \"A/1:B\" derives the identical NodeId");
+    assertEquals(new QualifiedName(1, "A/1:B"), slash.getBrowseName());
+    assertNotSame(nested, slash, "distinct logical members collide on one NodeId");
+  }
+
+  // endregion
+
+  // region Callback timing and contract
+
+  /**
+   * Callbacks fire after <em>every</em> node of the tree has been stored in the NodeManager; the
+   * root fires with {@code parent == null}; {@code includeOptionalNode} receives the
+   * <em>member's</em> type definition id (not, as its Javadoc claims, the type being instantiated).
+   * Callback ordering is browse-path-tree traversal over HashMap-grouped children and is not
+   * asserted (see class Javadoc).
+   */
+  @Test
+  public void callbackTimingAndContract() throws Exception {
+    UaObjectTypeNode typeNode = addObjectType("CallbackType", NodeIds.BaseObjectType);
+    addVariableDeclaration(
+        typeNode, "Var", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+    addObjectDeclaration(typeNode, "Obj", NodeIds.BaseObjectType, NodeIds.ModellingRule_Mandatory);
+    addMethodDeclaration(typeNode, "Method", NodeIds.ModellingRule_Mandatory);
+    addVariableDeclaration(
+        typeNode, "OptVar", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Optional);
+
+    NodeId rootNodeId = new NodeId(1, testPrefix + ":CallbackRoot");
+
+    List<NodeId> expectedStoredIds =
+        List.of(
+            rootNodeId,
+            new NodeId(1, testPrefix + ":CallbackRoot/1:Var"),
+            new NodeId(1, testPrefix + ":CallbackRoot/1:Obj"),
+            new NodeId(1, testPrefix + ":CallbackRoot/1:Method"),
+            new NodeId(1, testPrefix + ":CallbackRoot/1:OptVar"));
+
+    var recorder =
+        new RecordingCallback(true) {
+          @Override
+          void onAnyAdded(@Nullable UaNode parent, UaNode instance) {
+            // Timing pin: at callback time the entire tree is already stored.
+            for (NodeId id : expectedStoredIds) {
+              assertTrue(
+                  nodeManager.containsNode(id),
+                  "all nodes stored before any callback fires (missing " + id + ")");
+            }
+            super.onAnyAdded(parent, instance);
+          }
+        };
+
+    UaNode root = nodeFactory.createNode(rootNodeId, typeNode.getNodeId(), recorder);
+
+    // Root fires with parent == null.
+    assertTrue(
+        recorder.objectEvents.stream().anyMatch(e -> e.parent() == null && e.instance() == root),
+        "root object callback fired with parent == null");
+
+    // Members fire with the root as parent; assert set membership, not order.
+    assertTrue(
+        recorder.variableEvents.stream()
+            .anyMatch(e -> e.parent() == root && nameOf(e.instance()).equals("Var")));
+    assertTrue(
+        recorder.objectEvents.stream()
+            .anyMatch(e -> e.parent() == root && nameOf(e.instance()).equals("Obj")));
+    assertTrue(
+        recorder.methodEvents.stream()
+            .anyMatch(e -> e.parent() == root && nameOf(e.instance()).equals("Method")));
+    assertTrue(
+        recorder.variableEvents.stream()
+            .anyMatch(e -> e.parent() == root && nameOf(e.instance()).equals("OptVar")));
+
+    // Contract pin (the D7 mismatch, as shipped): includeOptionalNode received the *member's*
+    // type definition id, not the id of the type being instantiated.
+    assertEquals(1, recorder.includeCalls.size(), "one optional member consulted once");
+    RecordingCallback.IncludeCall call = recorder.includeCalls.get(0);
+    assertEquals(new QualifiedName(1, "OptVar"), call.browseName());
+    assertEquals(NodeIds.BaseDataVariableType, call.typeDefinitionId());
+  }
+
+  // endregion
+
+  // region D1: excluded optional orphans its mandatory descendants
+
+  /**
+   * D1, pinned as shipped: excluding an Optional member prevents only that node's creation. Its
+   * Mandatory descendants are still created and stored — unreachable, with no hierarchical
+   * reference connecting them to anything — and their callbacks fire with {@code parent == null},
+   * indistinguishable from the root signal.
+   */
+  @Test
+  public void d1ExcludedOptionalStillCreatesMandatoryDescendants() throws Exception {
+    UaObjectTypeNode typeNode = addObjectType("D1Type", NodeIds.BaseObjectType);
+    UaObjectNode optObj =
+        addObjectDeclaration(
+            typeNode, "OptObj", NodeIds.BaseObjectType, NodeIds.ModellingRule_Optional);
+    addVariableDeclaration(
+        optObj, "M", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+    var recorder = new RecordingCallback(false); // exclude all optionals
+
+    NodeId rootNodeId = new NodeId(1, testPrefix + ":D1Root");
+    UaNode root = nodeFactory.createNode(rootNodeId, typeNode.getNodeId(), recorder);
+
+    NodeId optObjId = new NodeId(1, testPrefix + ":D1Root/1:OptObj");
+    NodeId orphanId = new NodeId(1, testPrefix + ":D1Root/1:OptObj/1:M");
+
+    assertFalse(nodeManager.containsNode(optObjId), "excluded optional itself is not created");
+    assertTrue(
+        nodeManager.containsNode(orphanId),
+        "the excluded optional's mandatory descendant IS created and stored (D1)");
+
+    // The orphan has no hierarchical reference linking it to a parent: only its
+    // HasTypeDefinition reference was wired (HasModellingRule is skipped, and the
+    // HasComponent row's source — the excluded optional — was never created).
+    List<Reference> orphanReferences = nodeManager.getReferences(orphanId);
+    assertTrue(
+        orphanReferences.stream()
+            .anyMatch(
+                r -> r.isForward() && NodeIds.HasTypeDefinition.equals(r.getReferenceTypeId())));
+    assertTrue(
+        orphanReferences.stream()
+            .noneMatch(r -> NodeIds.HasComponent.equals(r.getReferenceTypeId())),
+        "orphan is unreachable: no hierarchical reference at all");
+
+    // Its callback fired with parent == null — the documented "this is the root" signal.
+    assertTrue(
+        recorder.variableEvents.stream()
+            .anyMatch(e -> e.parent() == null && e.instance().getNodeId().equals(orphanId)),
+        "orphan callback fired with parent == null");
+
+    // And the actual root also fired with parent == null; the two are indistinguishable.
+    assertTrue(
+        recorder.objectEvents.stream().anyMatch(e -> e.parent() == null && e.instance() == root));
+  }
+
+  // endregion
+
+  // region D2: nested member types are only shallowly expanded (A1 evidence)
+
+  /**
+   * D2, pinned as shipped (A1 runtime evidence): a member whose type definition is a
+   * <em>subtype</em> is expanded without the subtype's supertype-declared members — the nested
+   * type-definition recursion does not build the member type's fully-inherited hierarchy. A member
+   * typed directly as the declaring supertype gets the member (control case).
+   */
+  @Test
+  public void d2NestedMemberTypeMissingSupertypeMembers() throws Exception {
+    // BaseSMType declares a Mandatory CurrentState; DerivedSMType subtypes it, adding nothing.
+    UaObjectTypeNode baseSmType = addObjectType("BaseSMType", NodeIds.BaseObjectType);
+    addVariableDeclaration(
+        baseSmType, "CurrentState", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+    UaObjectTypeNode derivedSmType = addObjectType("DerivedSMType", baseSmType.getNodeId());
+
+    UaObjectTypeNode typeNode = addObjectType("D2Type", NodeIds.BaseObjectType);
+    addObjectDeclaration(
+        typeNode, "SM", derivedSmType.getNodeId(), NodeIds.ModellingRule_Mandatory);
+    addObjectDeclaration(typeNode, "SM2", baseSmType.getNodeId(), NodeIds.ModellingRule_Mandatory);
+
+    NodeId rootNodeId = new NodeId(1, testPrefix + ":D2Root");
+    nodeFactory.createNode(rootNodeId, typeNode.getNodeId());
+
+    assertTrue(nodeManager.containsNode(new NodeId(1, testPrefix + ":D2Root/1:SM")));
+    assertFalse(
+        nodeManager.containsNode(new NodeId(1, testPrefix + ":D2Root/1:SM/1:CurrentState")),
+        "member typed as a subtype is MISSING its supertype-declared mandatory member (D2)");
+
+    assertTrue(
+        nodeManager.containsNode(new NodeId(1, testPrefix + ":D2Root/1:SM2/1:CurrentState")),
+        "control: member typed directly as the declaring type gets the member");
+  }
+
+  // endregion
+
+  // region D5: type-declared entry wins over on-declaration override (A1 evidence)
+
+  /**
+   * D5, pinned as shipped (A1 runtime evidence): for a member with both an on-declaration child and
+   * a same-named child declared by the member's type definition, the <em>type's</em> entry
+   * overwrites the on-declaration override (backwards relative to Part 3 §6.3.3.3), and the
+   * duplicate hierarchical rows produced by the two walks are both wired onto the instance.
+   */
+  @Test
+  public void d5TypeDeclaredChildShadowsOnDeclarationOverride() throws Exception {
+    UaObjectTypeNode memberType = addObjectType("D5MemberType", NodeIds.BaseObjectType);
+    UaVariableNode typeChild =
+        addVariableDeclaration(
+            memberType, "Child", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+    typeChild.setDataType(NodeIds.String);
+    typeChild.setValue(new DataValue(new Variant("fromType")));
+
+    UaObjectTypeNode typeNode = addObjectType("D5Type", NodeIds.BaseObjectType);
+    UaObjectNode m =
+        addObjectDeclaration(
+            typeNode, "M", memberType.getNodeId(), NodeIds.ModellingRule_Mandatory);
+    UaVariableNode declChild =
+        addVariableDeclaration(
+            m, "Child", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+    declChild.setDataType(NodeIds.Int32);
+    declChild.setValue(new DataValue(new Variant(42)));
+
+    NodeId rootNodeId = new NodeId(1, testPrefix + ":D5Root");
+    nodeFactory.createNode(rootNodeId, typeNode.getNodeId());
+
+    NodeId childInstanceId = new NodeId(1, testPrefix + ":D5Root/1:M/1:Child");
+    UaVariableNode childInstance =
+        (UaVariableNode) nodeManager.getNode(childInstanceId).orElseThrow();
+
+    assertEquals(
+        NodeIds.String,
+        childInstance.getDataType(),
+        "the type-declared child won; the on-declaration override was silently discarded (D5)");
+    assertEquals(new Variant("fromType"), childInstance.getValue().getValue());
+
+    // Both walks appended a hierarchical row for the same parent/child pair; the factory wires
+    // both, so the member instance carries the duplicate forward HasComponent reference.
+    NodeId memberInstanceId = new NodeId(1, testPrefix + ":D5Root/1:M");
+    long duplicateRows =
+        nodeManager.getReferences(memberInstanceId).stream()
+            .filter(
+                r ->
+                    r.isForward()
+                        && NodeIds.HasComponent.equals(r.getReferenceTypeId())
+                        && r.getTargetNodeId().equals(childInstanceId.expanded()))
+            .count();
+    assertEquals(2, duplicateRows, "duplicate hierarchical rows are wired verbatim (D5)");
+  }
+
+  // endregion
+
+  // region D6: Optional Methods are created unconditionally
+
+  /**
+   * D6, pinned as shipped: the optional-exclusion gate exists only for Object and Variable members.
+   * An Optional Method member is created unconditionally and {@code includeOptionalNode} is never
+   * consulted for it; an Optional Variable member alongside it is consulted and excluded. Method
+   * instances copy the declaration's attributes.
+   */
+  @Test
+  public void d6OptionalMethodsCreatedUnconditionally() throws Exception {
+    UaObjectTypeNode typeNode = addObjectType("D6Type", NodeIds.BaseObjectType);
+    UaMethodNode methodDecl =
+        addMethodDeclaration(typeNode, "OptMethod", NodeIds.ModellingRule_Optional);
+    addVariableDeclaration(
+        typeNode, "OptVar", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Optional);
+
+    var recorder = new RecordingCallback(false); // exclude all optionals
+
+    NodeId rootNodeId = new NodeId(1, testPrefix + ":D6Root");
+    nodeFactory.createNode(rootNodeId, typeNode.getNodeId(), recorder);
+
+    NodeId methodInstanceId = new NodeId(1, testPrefix + ":D6Root/1:OptMethod");
+    assertTrue(
+        nodeManager.containsNode(methodInstanceId),
+        "Optional Method created despite the exclude-all callback (D6)");
+    assertFalse(
+        nodeManager.containsNode(new NodeId(1, testPrefix + ":D6Root/1:OptVar")),
+        "Optional Variable was excluded as requested");
+
+    assertTrue(
+        recorder.includeCalls.stream()
+            .noneMatch(c -> c.browseName().equals(new QualifiedName(1, "OptMethod"))),
+        "includeOptionalNode never consulted for the Optional Method (D6)");
+    assertTrue(
+        recorder.includeCalls.stream()
+            .anyMatch(c -> c.browseName().equals(new QualifiedName(1, "OptVar"))),
+        "includeOptionalNode consulted for the Optional Variable");
+
+    UaMethodNode methodInstance =
+        (UaMethodNode) nodeManager.getNode(methodInstanceId).orElseThrow();
+    assertEquals(methodDecl.getBrowseName(), methodInstance.getBrowseName());
+    assertEquals(methodDecl.isExecutable(), methodInstance.isExecutable());
+    assertEquals(methodDecl.isUserExecutable(), methodInstance.isUserExecutable());
+  }
+
+  // endregion
+
+  // region Silent collision replacement
+
+  /**
+   * Pinned as shipped: instantiating with a root NodeId that already exists silently replaces the
+   * existing node in the NodeManager's node map, and the previous node's reference-map state is
+   * <em>not</em> cleared — stale references remain recorded under the replaced NodeId.
+   *
+   * <p>The pre-existing node here deliberately carries no {@code HasTypeDefinition} reference; if
+   * it did, the stale row would derail the notification phase (see the companion NPE test below).
+   */
+  @Test
+  public void silentCollisionReplacement() throws Exception {
+    UaObjectTypeNode typeNode = addObjectType("CollisionType", NodeIds.BaseObjectType);
+    addVariableDeclaration(
+        typeNode, "Foo", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+    NodeId collidingId = new NodeId(1, testPrefix + ":CollisionRoot");
+
+    UaVariableNode existing =
+        new UaVariableNode(
+            context,
+            collidingId,
+            new QualifiedName(1, "Existing"),
+            LocalizedText.english("Existing"),
+            LocalizedText.NULL_VALUE,
+            UInteger.MIN,
+            UInteger.MIN);
+    nodeManager.addNode(existing);
+
+    Reference staleReference =
+        new Reference(collidingId, NodeIds.Organizes, NodeIds.ObjectsFolder.expanded(), false);
+    existing.addReference(staleReference);
+
+    UaNode replacement = nodeFactory.createNode(collidingId, typeNode.getNodeId());
+
+    assertSame(
+        replacement,
+        nodeManager.getNode(collidingId).orElseThrow(),
+        "existing node silently replaced");
+    assertNotSame(existing, nodeManager.getNode(collidingId).orElseThrow());
+
+    assertTrue(
+        nodeManager.getReferences(collidingId).contains(staleReference),
+        "previous node's reference-map state is not cleared");
+  }
+
+  /**
+   * The D13 latent NPE, pinned as shipped: because reference-map state under a replaced NodeId is
+   * not cleared, a pre-existing node's stale forward {@code HasTypeDefinition} reference (here to a
+   * VariableType) is found first by {@code getTypeDefinitionNode()} during the notification phase,
+   * which then throws {@link NullPointerException} — after every node of the tree has already been
+   * created and stored, with no cleanup.
+   */
+  @Test
+  public void collisionWithStaleTypeDefinitionThrowsNpeDuringNotification() {
+    UaObjectTypeNode typeNode = addObjectType("NpeCollisionType", NodeIds.BaseObjectType);
+    addVariableDeclaration(
+        typeNode, "Foo", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+    NodeId collidingId = new NodeId(1, testPrefix + ":NpeCollisionRoot");
+
+    // The builder adds a default HasTypeDefinition -> BaseDataVariableType reference, which
+    // becomes the stale row that getTypeDefinitionNode() resolves first.
+    UaVariableNode existing =
+        UaVariableNode.build(
+            context,
+            b ->
+                b.setNodeId(collidingId)
+                    .setBrowseName(new QualifiedName(1, "Existing"))
+                    .setDisplayName(LocalizedText.english("Existing"))
+                    .build());
+    nodeManager.addNode(existing);
+
+    assertThrows(
+        NullPointerException.class,
+        () -> nodeFactory.createNode(collidingId, typeNode.getNodeId()));
+
+    // The replacement and its child were already stored when the notification phase blew up.
+    assertNotSame(existing, nodeManager.getNode(collidingId).orElseThrow());
+    assertTrue(
+        nodeManager.containsNode(new NodeId(1, testPrefix + ":NpeCollisionRoot/1:Foo")),
+        "nodes created before the notification-phase NPE are left behind");
+  }
+
+  // endregion
+
+  // region Attribute propagation
+
+  /**
+   * The exact Variable attribute propagation set, as shipped: instances copy
+   * Value/DataType/ValueRank/ArrayDimensions/AccessLevel/UserAccessLevel from the declaration;
+   * MinimumSamplingInterval, Historizing, and AccessLevelEx are never copied (defaults apply);
+   * RolePermissions/UserRolePermissions/AccessRestrictions come from the member's <em>type
+   * node</em>, never from the declaration; and the instance stores the declaration's {@link
+   * DataValue} verbatim — same Variant and source timestamp, no fresh source timestamp (the value
+   * getter re-stamps serverTime on a per-read copy).
+   */
+  @Test
+  public void attributePropagationVariables() throws Exception {
+    NodeId customVarTypeId = newNodeId("AttrVarType");
+    UaVariableTypeNode customVarType =
+        new UaVariableTypeNode(
+            context,
+            customVarTypeId,
+            new QualifiedName(1, "AttrVarType"),
+            LocalizedText.english("AttrVarType"),
+            LocalizedText.NULL_VALUE,
+            UInteger.MIN,
+            UInteger.MIN,
+            null,
+            null,
+            new AccessRestrictionType(UShort.valueOf(1)),
+            new DataValue(new Variant("typeValue")),
+            NodeIds.String,
+            -1,
+            null,
+            false);
+    customVarType.addReference(
+        new Reference(
+            customVarTypeId, NodeIds.HasSubtype, NodeIds.BaseDataVariableType.expanded(), false));
+    nodeManager.addNode(customVarType);
+
+    UaObjectTypeNode typeNode = addObjectType("AttrType", NodeIds.BaseObjectType);
+
+    DataValue declarationValue = new DataValue(new Variant(42));
+    RolePermissionType[] declarationRolePermissions = {
+      new RolePermissionType(NodeIds.WellKnownRole_Anonymous, new PermissionType(uint(1)))
+    };
+
+    NodeId declId = newNodeId("AttrType.V");
+    UaVariableNode declaration =
+        new UaVariableNode(
+            context,
+            declId,
+            new QualifiedName(1, "V"),
+            LocalizedText.english("V"),
+            LocalizedText.NULL_VALUE,
+            UInteger.MIN,
+            UInteger.MIN,
+            declarationRolePermissions,
+            declarationRolePermissions,
+            new AccessRestrictionType(UShort.valueOf(2)),
+            declarationValue,
+            NodeIds.Int32,
+            -1,
+            null,
+            AccessLevel.toValue(AccessLevel.READ_WRITE),
+            AccessLevel.toValue(AccessLevel.READ_WRITE),
+            100.0,
+            true,
+            null);
+    declaration.addReference(
+        new Reference(declId, NodeIds.HasTypeDefinition, customVarTypeId.expanded(), true));
+    declaration.addReference(
+        new Reference(
+            declId, NodeIds.HasModellingRule, NodeIds.ModellingRule_Mandatory.expanded(), true));
+    nodeManager.addNode(declaration);
+    typeNode.addReference(
+        new Reference(typeNode.getNodeId(), NodeIds.HasComponent, declId.expanded(), true));
+
+    NodeId rootNodeId = new NodeId(1, testPrefix + ":AttrRoot");
+    nodeFactory.createNode(rootNodeId, typeNode.getNodeId());
+
+    UaVariableNode instance =
+        (UaVariableNode)
+            nodeManager.getNode(new NodeId(1, testPrefix + ":AttrRoot/1:V")).orElseThrow();
+
+    // Copied from the declaration. The stored DataValue is the declaration's object verbatim —
+    // same Variant, StatusCode, and source timestamp objects, no fresh source timestamp — but
+    // UaVariableNode.getAttribute(Value) returns a copy with serverTime re-stamped on every
+    // read, so verbatim sharing is observed on the copy's constituents rather than assertSame.
+    DataValue instanceValue = instance.getValue();
+    assertSame(declarationValue.getValue(), instanceValue.getValue());
+    assertSame(declarationValue.getStatusCode(), instanceValue.getStatusCode());
+    assertSame(
+        declarationValue.getSourceTime(),
+        instanceValue.getSourceTime(),
+        "instance shares the declaration's DataValue verbatim (no fresh source timestamp)");
+    assertEquals(NodeIds.Int32, instance.getDataType());
+    assertEquals(-1, (int) instance.getValueRank());
+    assertNull(instance.getArrayDimensions());
+    assertEquals(AccessLevel.toValue(AccessLevel.READ_WRITE), instance.getAccessLevel());
+    assertEquals(AccessLevel.toValue(AccessLevel.READ_WRITE), instance.getUserAccessLevel());
+    assertEquals(declaration.getBrowseName(), instance.getBrowseName());
+    assertEquals(declaration.getDisplayName(), instance.getDisplayName());
+
+    // Never copied from the declaration (defaults apply):
+    assertEquals(
+        -1.0, (double) instance.getMinimumSamplingInterval(), "MinimumSamplingInterval not copied");
+    assertFalse(instance.getHistorizing(), "Historizing not copied");
+    assertNull(instance.getAccessLevelEx(), "AccessLevelEx not copied");
+
+    // Security attributes come from the member's TYPE node, not the declaration:
+    assertEquals(
+        new AccessRestrictionType(UShort.valueOf(1)),
+        instance.getAccessRestrictions(),
+        "AccessRestrictions taken from the type node, not the declaration");
+    assertNull(instance.getRolePermissions(), "RolePermissions taken from the (null) type node");
+    assertNull(instance.getUserRolePermissions());
+  }
+
+  /**
+   * Object instances copy EventNotifier from the declaration; a root instance keeps the
+   * <em>type's</em> BrowseName and DisplayName (the universal post-hoc rename burden, pinned
+   * as-is); a Variable root takes the type node's Value verbatim (same {@link DataValue} object).
+   */
+  @Test
+  public void attributePropagationObjectsAndRoot() throws Exception {
+    UaObjectTypeNode typeNode = addObjectType("RootAttrType", NodeIds.BaseObjectType);
+    UaObjectNode objDecl =
+        addObjectDeclaration(
+            typeNode, "Obj", NodeIds.BaseObjectType, NodeIds.ModellingRule_Mandatory);
+    objDecl.setEventNotifier(ubyte(1));
+
+    NodeId rootNodeId = new NodeId(1, testPrefix + ":RootAttrRoot");
+    UaNode root = nodeFactory.createNode(rootNodeId, typeNode.getNodeId());
+
+    // Root keeps the type's names.
+    assertEquals(typeNode.getBrowseName(), root.getBrowseName());
+    assertEquals(typeNode.getDisplayName(), root.getDisplayName());
+
+    // Object child copies EventNotifier from the declaration.
+    UaObjectNode objInstance =
+        (UaObjectNode)
+            nodeManager.getNode(new NodeId(1, testPrefix + ":RootAttrRoot/1:Obj")).orElseThrow();
+    assertEquals(ubyte(1), objInstance.getEventNotifier());
+
+    // A Variable root takes the type's Value verbatim.
+    DataValue typeValue = new DataValue(new Variant("rootTypeValue"));
+    NodeId varTypeId = newNodeId("RootVarType");
+    UaVariableTypeNode varType =
+        new UaVariableTypeNode(
+            context,
+            varTypeId,
+            new QualifiedName(1, "RootVarType"),
+            LocalizedText.english("RootVarType"),
+            LocalizedText.NULL_VALUE,
+            UInteger.MIN,
+            UInteger.MIN,
+            typeValue,
+            NodeIds.String,
+            -1,
+            null,
+            false);
+    varType.addReference(
+        new Reference(
+            varTypeId, NodeIds.HasSubtype, NodeIds.BaseDataVariableType.expanded(), false));
+    nodeManager.addNode(varType);
+
+    UaVariableNode varRoot =
+        (UaVariableNode) nodeFactory.createNode(new NodeId(1, testPrefix + ":VarRoot"), varTypeId);
+
+    // Stored verbatim; getValue() returns a copy with serverTime re-stamped on each read.
+    DataValue varRootValue = varRoot.getValue();
+    assertSame(typeValue.getValue(), varRootValue.getValue());
+    assertSame(
+        typeValue.getSourceTime(),
+        varRootValue.getSourceTime(),
+        "variable root takes the type's Value verbatim");
+    assertEquals(varType.getBrowseName(), varRoot.getBrowseName());
+  }
+
+  // endregion
+
+  // region Reference wiring
+
+  /**
+   * Pinned as shipped: {@code HasModellingRule} references are excluded from instances; every other
+   * declaration reference row is wired verbatim — absolute targets as-is, so non-hierarchical
+   * references between declarations point at the <em>type's</em> declaration nodes (the D4
+   * behavior), and inverse rows are re-emitted as forward references (direction is not preserved).
+   */
+  @Test
+  public void modellingRuleExcludedOtherReferencesWiredVerbatim() throws Exception {
+    UaObjectTypeNode typeNode = addObjectType("RefType", NodeIds.BaseObjectType);
+    UaObjectNode fooDecl =
+        addObjectDeclaration(
+            typeNode, "Foo", NodeIds.BaseObjectType, NodeIds.ModellingRule_Mandatory);
+    UaVariableNode barDecl =
+        addVariableDeclaration(
+            typeNode, "Bar", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+    // A non-hierarchical reference between the two declarations. addReference also records the
+    // auto-added inverse on Bar.
+    fooDecl.addReference(
+        new Reference(fooDecl.getNodeId(), NodeIds.HasCause, barDecl.getNodeId().expanded(), true));
+
+    NodeId rootNodeId = new NodeId(1, testPrefix + ":RefRoot");
+    nodeFactory.createNode(rootNodeId, typeNode.getNodeId());
+
+    NodeId fooInstanceId = new NodeId(1, testPrefix + ":RefRoot/1:Foo");
+    NodeId barInstanceId = new NodeId(1, testPrefix + ":RefRoot/1:Bar");
+
+    // No instance carries a HasModellingRule reference.
+    for (NodeId id : List.of(rootNodeId, fooInstanceId, barInstanceId)) {
+      assertTrue(
+          nodeManager.getReferences(id).stream()
+              .noneMatch(r -> NodeIds.HasModellingRule.equals(r.getReferenceTypeId())),
+          "HasModellingRule excluded from instance " + id);
+    }
+
+    // Foo instance points at the *declaration* Bar (absolute target verbatim), not at the
+    // sibling instance.
+    List<Reference> fooReferences = nodeManager.getReferences(fooInstanceId);
+    assertTrue(
+        fooReferences.stream()
+            .anyMatch(
+                r ->
+                    r.isForward()
+                        && NodeIds.HasCause.equals(r.getReferenceTypeId())
+                        && r.getTargetNodeId().equals(barDecl.getNodeId().expanded())),
+        "non-hierarchical reference wired verbatim to the type's declaration node (D4)");
+    assertTrue(
+        fooReferences.stream()
+            .noneMatch(
+                r ->
+                    NodeIds.HasCause.equals(r.getReferenceTypeId())
+                        && r.getTargetNodeId().equals(barInstanceId.expanded())),
+        "it is NOT re-mapped onto the sibling instance");
+
+    // The auto-added inverse row on the Bar declaration is re-emitted as a *forward* reference
+    // on the Bar instance: direction is not preserved.
+    assertTrue(
+        nodeManager.getReferences(barInstanceId).stream()
+            .anyMatch(
+                r ->
+                    r.isForward()
+                        && NodeIds.HasCause.equals(r.getReferenceTypeId())
+                        && r.getTargetNodeId().equals(fooDecl.getNodeId().expanded())),
+        "inverse declaration row forced forward on the instance");
+  }
+
+  // endregion
+
+  // region Fixture helpers
+
+  private NodeId newNodeId(String id) {
+    return new NodeId(1, testPrefix + ":" + id);
+  }
+
+  private static String nameOf(UaNode node) {
+    return node.getBrowseName().name();
+  }
+
+  /**
+   * Creates an ObjectType node subtyping {@code supertypeId} and adds it to the NodeManager.
+   * References are wired single-direction (the inverse is auto-added) to avoid the duplicate-row
+   * noise of {@code addComponent}-style helpers, keeping each pin focused.
+   */
+  private UaObjectTypeNode addObjectType(String name, NodeId supertypeId) {
+    UaObjectTypeNode typeNode =
+        new UaObjectTypeNode(
+            context,
+            newNodeId(name),
+            new QualifiedName(1, name),
+            LocalizedText.english(name),
+            LocalizedText.NULL_VALUE,
+            UInteger.MIN,
+            UInteger.MIN,
+            false);
+
+    typeNode.addReference(
+        new Reference(typeNode.getNodeId(), NodeIds.HasSubtype, supertypeId.expanded(), false));
+
+    nodeManager.addNode(typeNode);
+
+    return typeNode;
+  }
+
+  private UaObjectNode addObjectDeclaration(
+      UaNode parent, String name, NodeId typeDefinitionId, NodeId modellingRuleId) {
+
+    NodeId nodeId = newNodeId(parent.getBrowseName().name() + "." + name);
+
+    UaObjectNode declaration =
+        new UaObjectNode(
+            context,
+            nodeId,
+            new QualifiedName(1, name),
+            LocalizedText.english(name),
+            LocalizedText.NULL_VALUE,
+            UInteger.MIN,
+            UInteger.MIN,
+            ubyte(0));
+
+    declaration.addReference(
+        new Reference(nodeId, NodeIds.HasTypeDefinition, typeDefinitionId.expanded(), true));
+    declaration.addReference(
+        new Reference(nodeId, NodeIds.HasModellingRule, modellingRuleId.expanded(), true));
+
+    nodeManager.addNode(declaration);
+
+    parent.addReference(
+        new Reference(parent.getNodeId(), NodeIds.HasComponent, nodeId.expanded(), true));
+
+    return declaration;
+  }
+
+  private UaVariableNode addVariableDeclaration(
+      UaNode parent, String name, NodeId typeDefinitionId, NodeId modellingRuleId) {
+
+    NodeId nodeId = newNodeId(parent.getBrowseName().name() + "." + name);
+
+    UaVariableNode declaration =
+        new UaVariableNode(
+            context,
+            nodeId,
+            new QualifiedName(1, name),
+            LocalizedText.english(name),
+            LocalizedText.NULL_VALUE,
+            UInteger.MIN,
+            UInteger.MIN);
+
+    declaration.addReference(
+        new Reference(nodeId, NodeIds.HasTypeDefinition, typeDefinitionId.expanded(), true));
+    declaration.addReference(
+        new Reference(nodeId, NodeIds.HasModellingRule, modellingRuleId.expanded(), true));
+
+    nodeManager.addNode(declaration);
+
+    parent.addReference(
+        new Reference(parent.getNodeId(), NodeIds.HasComponent, nodeId.expanded(), true));
+
+    return declaration;
+  }
+
+  private UaMethodNode addMethodDeclaration(UaNode parent, String name, NodeId modellingRuleId) {
+
+    NodeId nodeId = newNodeId(parent.getBrowseName().name() + "." + name);
+
+    UaMethodNode declaration =
+        new UaMethodNode(
+            context,
+            nodeId,
+            new QualifiedName(1, name),
+            LocalizedText.english(name),
+            LocalizedText.NULL_VALUE,
+            UInteger.MIN,
+            UInteger.MIN,
+            true,
+            true);
+
+    declaration.addReference(
+        new Reference(nodeId, NodeIds.HasModellingRule, modellingRuleId.expanded(), true));
+
+    nodeManager.addNode(declaration);
+
+    parent.addReference(
+        new Reference(parent.getNodeId(), NodeIds.HasComponent, nodeId.expanded(), true));
+
+    return declaration;
+  }
+
+  /** Records every callback invocation; makes no ordering assumptions. */
+  private static class RecordingCallback implements NodeFactory.InstantiationCallback {
+
+    record IncludeCall(NodeId typeDefinitionId, QualifiedName browseName) {}
+
+    record NodeEvent(@Nullable UaNode parent, UaNode instance) {}
+
+    final List<IncludeCall> includeCalls = new ArrayList<>();
+    final List<NodeEvent> methodEvents = new ArrayList<>();
+    final List<NodeEvent> objectEvents = new ArrayList<>();
+    final List<NodeEvent> variableEvents = new ArrayList<>();
+
+    private final boolean includeOptionals;
+
+    RecordingCallback(boolean includeOptionals) {
+      this.includeOptionals = includeOptionals;
+    }
+
+    void onAnyAdded(@Nullable UaNode parent, UaNode instance) {}
+
+    @Override
+    public boolean includeOptionalNode(NodeId typeDefinitionId, QualifiedName browseName) {
+      includeCalls.add(new IncludeCall(typeDefinitionId, browseName));
+      return includeOptionals;
+    }
+
+    @Override
+    public void onMethodAdded(@Nullable UaObjectNode parent, UaMethodNode instance) {
+      onAnyAdded(parent, instance);
+      methodEvents.add(new NodeEvent(parent, instance));
+    }
+
+    @Override
+    public void onObjectAdded(
+        @Nullable UaNode parent, UaObjectNode instance, NodeId typeDefinitionId) {
+      onAnyAdded(parent, instance);
+      objectEvents.add(new NodeEvent(parent, instance));
+    }
+
+    @Override
+    public void onVariableAdded(
+        @Nullable UaNode parent, UaVariableNode instance, NodeId typeDefinitionId) {
+      onAnyAdded(parent, instance);
+      variableEvents.add(new NodeEvent(parent, instance));
+    }
+  }
+
+  // endregion
+}

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/EventInstantiatorTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/EventInstantiatorTest.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.UUID;
+import org.eclipse.milo.opcua.sdk.server.AddressSpaceManager;
+import org.eclipse.milo.opcua.sdk.server.NodeManager;
+import org.eclipse.milo.opcua.sdk.server.model.ObjectTypeInitializer;
+import org.eclipse.milo.opcua.sdk.server.model.VariableTypeInitializer;
+import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Tests for {@link EventInstantiator}, the replacement for the legacy {@code EventFactory}: events
+ * are created with all optionals included into the component's private NodeManager, the EventType
+ * Property is set as part of the instantiation, and an incompatible root class fails at plan time
+ * with no residue — the legacy factory's cast failed after its nodes were already stored.
+ */
+public class EventInstantiatorTest {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(EventInstantiatorTest.class);
+
+  private TypeFixtures fx;
+  private EventInstantiator eventInstantiator;
+
+  @BeforeEach
+  void setUp() {
+    fx = TypeFixtures.create();
+
+    ObjectTypeInitializer.initialize(fx.namespaceTable(), fx.objectTypeManager());
+    VariableTypeInitializer.initialize(fx.namespaceTable(), fx.variableTypeManager());
+
+    // Everything a stubbing statement needs is resolved up front: creating the instantiator and
+    // fetching the AddressSpaceManager both invoke the same server mock, which is illegal while
+    // another stubbing is in progress.
+    NodeInstantiator instantiator = fx.instantiator();
+    AddressSpaceManager addressSpaceManager = fx.server().getAddressSpaceManager();
+
+    Mockito.when(fx.server().getNodeInstantiator()).thenReturn(instantiator);
+
+    // The mocked AddressSpaceManager's register() must actually register, so node-level
+    // navigation of created events resolves against the private manager like on a real server.
+    Mockito.doAnswer(
+            invocation -> {
+              fx.registerWithAddressSpace(invocation.getArgument(0));
+              return null;
+            })
+        .when(addressSpaceManager)
+        .register(Mockito.<NodeManager<UaNode>>any());
+
+    eventInstantiator = new EventInstantiator(fx.server());
+    eventInstantiator.startup();
+  }
+
+  /**
+   * The replacement reproduces the legacy contract: the result is a {@link BaseEventTypeNode},
+   * every Optional member is included (BaseEventType's Optional {@code LocalTime} property is
+   * instantiated), the EventType Property carries the type definition id, and every created node
+   * lands in the component's private NodeManager — not in the server's source manager.
+   */
+  @Test
+  public void createEventIncludesOptionalsAndSetsEventType() throws UaException {
+    NodeId nodeId = new NodeId(1, UUID.randomUUID());
+
+    BaseEventTypeNode eventNode = eventInstantiator.createEvent(nodeId, NodeIds.BaseEventType);
+
+    assertNotNull(eventNode);
+    assertEquals(nodeId, eventNode.getNodeId());
+    assertEquals(NodeIds.BaseEventType, eventNode.getEventType());
+    assertNotNull(eventNode.getLocalTimeNode(), "Optional LocalTime property expected");
+
+    assertTrue(eventInstantiator.getNodeManager().containsNode(nodeId));
+    assertFalse(fx.nodeManager().containsNode(nodeId));
+
+    eventNode.delete();
+    assertTrue(
+        eventInstantiator.getNodeManager().getNodes().isEmpty(),
+        "delete() removes the event's nodes from the private manager");
+  }
+
+  /**
+   * Typed plan-time preflight replacing the legacy cast: creating an "event" of a type whose
+   * resolved Java class is not a {@link BaseEventTypeNode} fails before any node is created,
+   * leaving no residue in the private manager. The legacy factory threw {@link ClassCastException}
+   * after its nodes were already stored.
+   */
+  @Test
+  public void incompatibleRootClassFailsAtPlanTimeWithNoResidue() {
+    NodeId nodeId = new NodeId(1, UUID.randomUUID());
+
+    InstantiationException e =
+        assertThrows(
+            InstantiationException.class,
+            () -> eventInstantiator.createEvent(nodeId, NodeIds.FolderType));
+
+    assertTrue(
+        e.getDiagnostics().stream()
+            .anyMatch(d -> d.code() == InstantiationDiagnostic.Code.INVALID_ROOT_CLASS));
+    assertTrue(
+        eventInstantiator.getNodeManager().getNodes().isEmpty(),
+        "no nodes stored for a failed plan");
+  }
+
+  /**
+   * Sanity-profiles per-event creation against the legacy {@code EventFactory} — events are the
+   * high-frequency path, so the replacement must stay in the same order of magnitude. Numbers are
+   * logged as evidence, not asserted: absolute timings vary by machine, and the legacy factory
+   * additionally benefits from its JVM-global hierarchy cache.
+   */
+  @Test
+  @SuppressWarnings("deprecation")
+  public void timingSanityAgainstLegacyEventFactory() throws UaException {
+    var legacyFactory =
+        new org.eclipse.milo.opcua.sdk.server.nodes.factories.EventFactory(
+            fx.server(), fx.objectTypeManager(), fx.variableTypeManager());
+    legacyFactory.startup();
+
+    int warmup = 50;
+    int iterations = 200;
+
+    for (int i = 0; i < warmup; i++) {
+      legacyFactory.createEvent(new NodeId(1, UUID.randomUUID()), NodeIds.BaseEventType).delete();
+      eventInstantiator
+          .createEvent(new NodeId(1, UUID.randomUUID()), NodeIds.BaseEventType)
+          .delete();
+    }
+
+    long legacyStart = System.nanoTime();
+    for (int i = 0; i < iterations; i++) {
+      legacyFactory.createEvent(new NodeId(1, UUID.randomUUID()), NodeIds.BaseEventType).delete();
+    }
+    long legacyNanos = System.nanoTime() - legacyStart;
+
+    long replacementStart = System.nanoTime();
+    for (int i = 0; i < iterations; i++) {
+      eventInstantiator
+          .createEvent(new NodeId(1, UUID.randomUUID()), NodeIds.BaseEventType)
+          .delete();
+    }
+    long replacementNanos = System.nanoTime() - replacementStart;
+
+    LOGGER.info(
+        "per-event creation over {} iterations: legacy EventFactory {} us/event,"
+            + " EventInstantiator {} us/event",
+        iterations,
+        legacyNanos / iterations / 1_000,
+        replacementNanos / iterations / 1_000);
+
+    legacyFactory.shutdown();
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/InstantiationPlanTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/InstantiationPlanTest.java
@@ -407,7 +407,6 @@ public class InstantiationPlanTest {
           fx.instantiator()
               .plan(objectRequest(typeNode.getNodeId(), "Dev").includeAllOptionals().build());
 
-      assertFalse(plan.hasErrors());
       assertEquals(
           SkippedDeclaration.Reason.PLACEHOLDER, skippedAt(plan, path("OptPlaceholder")).reason());
       assertEquals(
@@ -415,7 +414,9 @@ public class InstantiationPlanTest {
       assertEquals(
           SkippedDeclaration.Reason.EXPOSES_ITS_ARRAY, skippedAt(plan, path("Exposed")).reason());
 
-      assertTrue(hasWarning(plan, InstantiationDiagnostic.Code.MANDATORY_PLACEHOLDER_UNSATISFIED));
+      // A MandatoryPlaceholder left without a realization fails the plan; ExposesItsArray is
+      // advisory only.
+      assertTrue(hasError(plan, InstantiationDiagnostic.Code.MANDATORY_PLACEHOLDER_UNSATISFIED));
       assertTrue(hasWarning(plan, InstantiationDiagnostic.Code.EXPOSES_ITS_ARRAY_NOT_MATERIALIZED));
     }
 

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/InstantiationPlanTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/InstantiationPlanTest.java
@@ -160,7 +160,7 @@ public class InstantiationPlanTest {
           (plan.plannedNodes().size() - 1) + plan.skippedDeclarations().size());
     }
 
-    /** Selecting a nested path implies its ancestors (U4). */
+    /** Selecting a nested path implies its ancestors. */
     @Test
     void includingNestedPathImpliesAncestors() throws Exception {
       UaObjectTypeNode typeNode = fx.addObjectType("ImplyType", NodeIds.BaseObjectType);
@@ -185,6 +185,39 @@ public class InstantiationPlanTest {
       assertTrue(
           plan.plannedNode(path("OptA", "Leaf")).isPresent(),
           "Mandatory under a selected Optional exists");
+    }
+
+    /**
+     * An included path that resolves to nothing in the model implies nothing: it warns as
+     * unmatched, and its would-be ancestors are not materialized on the strength of a typo.
+     */
+    @Test
+    void unmatchedIncludedPathDoesNotImplyAncestors() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("TypoImplyType", NodeIds.BaseObjectType);
+      UaObjectNode optA =
+          fx.addObjectDeclaration(
+              typeNode, "OptA", NodeIds.BaseObjectType, NodeIds.ModellingRule_Optional);
+      fx.addVariableDeclaration(
+          optA, "Leaf", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Optional);
+
+      InstantiationPlan<UaObjectNode> plan =
+          fx.instantiator()
+              .plan(
+                  objectRequest(typeNode.getNodeId(), "Dev")
+                      .includeOptional(path("OptA", "Typo"))
+                      .build());
+
+      assertFalse(plan.hasErrors());
+      assertTrue(
+          plan.plannedNode(path("OptA")).isEmpty(),
+          "an unmatched include must not materialize its ancestors");
+      assertTrue(
+          plan.diagnostics().stream()
+              .anyMatch(
+                  d ->
+                      d.code() == InstantiationDiagnostic.Code.UNMATCHED_PATH
+                          && path("OptA", "Typo").equals(d.browsePath())),
+          "the typo'd include is reported as unmatched");
     }
 
     /** {@code includeAllOptionals()} selects Optionals but not vendor-rule declarations. */
@@ -229,7 +262,7 @@ public class InstantiationPlanTest {
       assertTrue(plan.plannedNode(path("Vendor")).isPresent());
     }
 
-    /** The context-rich predicate escape hatch decides otherwise-undecided declarations (L2). */
+    /** The context-rich predicate escape hatch decides otherwise-undecided declarations. */
     @Test
     void predicateEscapeHatchSelectsByDeclarationContext() throws Exception {
       UaObjectTypeNode typeNode = fx.addObjectType("PredType", NodeIds.BaseObjectType);
@@ -250,7 +283,7 @@ public class InstantiationPlanTest {
       assertTrue(plan.plannedNode(path("OptNo")).isEmpty());
     }
 
-    /** Optional Methods obey selection like everything else — the D6 fix. */
+    /** Optional Methods obey selection like everything else. */
     @Test
     void optionalMethodObeysSelection() throws Exception {
       UaObjectTypeNode typeNode = fx.addObjectType("MethodSelType", NodeIds.BaseObjectType);
@@ -275,7 +308,7 @@ public class InstantiationPlanTest {
     /**
      * Excluding an Optional prunes its whole subtree: mandatory descendants are {@code
      * ANCESTOR_OMITTED} (their BrowsePath does not exist — the valid exception, input b), never
-     * planned, never referenced — the D1 orphan fix.
+     * planned, never referenced, so no orphaned references escape the plan.
      */
     @Test
     void excludingOptionalPrunesSubtreeWithoutOrphans() throws Exception {
@@ -326,7 +359,7 @@ public class InstantiationPlanTest {
       assertEquals(SkippedDeclaration.Reason.EXCLUDED, skippedAt(plan, path("Mand")).reason());
     }
 
-    /** Two same-named Optionals at different paths select independently — the D7 fix. */
+    /** Two same-named Optionals at different paths select independently. */
     @Test
     void sameNamedOptionalsAtDifferentPathsSelectIndependently() throws Exception {
       UaObjectTypeNode typeNode = fx.addObjectType("D7Type", NodeIds.BaseObjectType);
@@ -353,10 +386,7 @@ public class InstantiationPlanTest {
       assertTrue(plan.plannedNode(path("B", "Opt")).isEmpty());
     }
 
-    /**
-     * Placeholders are never auto-expanded; ExposesItsArray is surfaced but not materialized
-     * (KD10).
-     */
+    /** Placeholders are never auto-expanded; ExposesItsArray is surfaced but not materialized. */
     @Test
     void placeholdersAndExposesItsArrayAreSkippedWithDiagnostics() throws Exception {
       UaObjectTypeNode typeNode = fx.addObjectType("PlaceholderType", NodeIds.BaseObjectType);
@@ -532,8 +562,8 @@ public class InstantiationPlanTest {
 
     /**
      * The full attribute set propagates from declarations by rule — including
-     * MinimumSamplingInterval, Historizing, and the three security attributes legacy dropped (D10)
-     * — with the absent / explicit-null distinction preserved.
+     * MinimumSamplingInterval, Historizing, and the three security attributes the legacy factory
+     * dropped — with the absent / explicit-null distinction preserved.
      */
     @Test
     void fullAttributeSetPropagatesIncludingSecurityAttributes() throws Exception {
@@ -674,10 +704,7 @@ public class InstantiationPlanTest {
       assertEquals(NodeClass.Variable, attributes.getOrNull(AttributeId.NodeClass));
     }
 
-    /**
-     * Root BrowseName precedence: request &gt; DefaultInstanceBrowseName &gt; type BrowseName
-     * (D11/U8).
-     */
+    /** Root BrowseName precedence: request &gt; DefaultInstanceBrowseName &gt; type BrowseName. */
     @Test
     void rootBrowseNamePrecedence() throws Exception {
       UaObjectTypeNode plainType = fx.addObjectType("PlainType", NodeIds.BaseObjectType);
@@ -786,8 +813,8 @@ public class InstantiationPlanTest {
     }
 
     /**
-     * Q2: an unregistered subtype resolves to the nearest registered ancestor's class by walking
-     * the {@code HasSubtype} chain, two levels deep here.
+     * An unregistered subtype resolves to the nearest registered ancestor's class by walking the
+     * {@code HasSubtype} chain, two levels deep here.
      */
     @Test
     void unregisteredSubtypeFallsBackToNearestRegisteredAncestor() throws Exception {
@@ -1019,7 +1046,7 @@ public class InstantiationPlanTest {
 
     /**
      * A declaration-internal non-hierarchical reference is re-mapped onto the corresponding
-     * instances exactly once, forward — the D4 fix, §6.4.3 direct-connection consistency.
+     * instances exactly once, forward — §6.4.3 direct-connection consistency.
      */
     @Test
     void internalNonHierarchicalRowRemappedExactlyOnce() throws Exception {
@@ -1081,7 +1108,7 @@ public class InstantiationPlanTest {
           "no planned edge to an omitted target");
     }
 
-    /** External rows are copied verbatim by default and droppable via the named policy (KD7). */
+    /** External rows are copied verbatim by default and droppable via the named policy. */
     @Test
     void externalRowsFollowReplicationPolicy() throws Exception {
       UaReferenceTypeNode refType =
@@ -1124,8 +1151,7 @@ public class InstantiationPlanTest {
     }
 
     /**
-     * {@code HasModellingRule} is dropped for normal instances, retained for INSTANCE_DECLARATION
-     * (U14).
+     * {@code HasModellingRule} is dropped for normal instances, retained for INSTANCE_DECLARATION.
      */
     @Test
     void hasModellingRuleRetentionIsPurposeDependent() throws Exception {
@@ -1179,9 +1205,7 @@ public class InstantiationPlanTest {
   @Nested
   class NodeIdAllocation {
 
-    /**
-     * The strategy receives full context and supports any identifier scheme; pins win over it (U6).
-     */
+    /** The strategy receives full context and supports any identifier scheme; pins win over it. */
     @Test
     void strategyReceivesFullContextAndPinningWins() throws Exception {
       UaObjectTypeNode typeNode = fx.addObjectType("IdType", NodeIds.BaseObjectType);
@@ -1219,9 +1243,9 @@ public class InstantiationPlanTest {
     }
 
     /**
-     * The default allocator escapes reserved characters, so the two WP1-pinned legacy ambiguities
-     * cannot collide: a member named {@code "A/1:B"} vs a nested member {@code A}/{@code B}, and a
-     * numeric root {@code 7} vs a String root {@code "7"}.
+     * The default allocator escapes reserved characters, so the two characterized legacy
+     * ambiguities cannot collide: a member named {@code "A/1:B"} vs a nested member {@code
+     * A}/{@code B}, and a numeric root {@code 7} vs a String root {@code "7"}.
      */
     @Test
     void defaultAllocatorEscapesReservedCharacters() throws Exception {
@@ -1255,7 +1279,7 @@ public class InstantiationPlanTest {
 
       NodeId nestedLeafId = nested.plannedNode(path("A", "B")).orElseThrow().nodeId();
       NodeId slashLeafId = slash.plannedNode(path("A/1:B")).orElseThrow().nodeId();
-      assertNotEquals(nestedLeafId, slashLeafId, "escaping disambiguates the WP1 collision");
+      assertNotEquals(nestedLeafId, slashLeafId, "escaping disambiguates the legacy collision");
 
       // Numeric vs String root identifiers cannot derive identical child ids either.
       UaObjectTypeNode rootAmbigType = fx.addObjectType("RootAmbigType", NodeIds.BaseObjectType);
@@ -1280,12 +1304,44 @@ public class InstantiationPlanTest {
       assertNotEquals(
           numericRoot.plannedNode(path("Foo")).orElseThrow().nodeId(),
           stringRoot.plannedNode(path("Foo")).orElseThrow().nodeId());
+
+      // A String root spelled like a rendered numeric root ("i=7") cannot collide with the
+      // numeric root either, and a String root containing the separator syntax cannot collide
+      // with another root's derived member.
+      InstantiationPlan<UaObjectNode> markerRoot =
+          fx.instantiator()
+              .plan(
+                  InstantiationRequest.of(UaObjectNode.class, rootAmbigType.getNodeId())
+                      .nodeId(new NodeId(1, "i=7"))
+                      .target(target)
+                      .build());
+      assertNotEquals(
+          numericRoot.plannedNode(path("Foo")).orElseThrow().nodeId(),
+          markerRoot.plannedNode(path("Foo")).orElseThrow().nodeId());
+
+      UaObjectTypeNode bOnlyType = fx.addObjectType("BOnlyType", NodeIds.BaseObjectType);
+      fx.addVariableDeclaration(
+          bOnlyType, "B", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+      InstantiationPlan<UaObjectNode> separatorRoot =
+          fx.instantiator()
+              .plan(
+                  InstantiationRequest.of(UaObjectNode.class, bOnlyType.getNodeId())
+                      .nodeId(new NodeId(1, "AmbigRoot/1:A"))
+                      .target(target)
+                      .build());
+      assertNotEquals(
+          nestedLeafId,
+          separatorRoot.plannedNode(path("B")).orElseThrow().nodeId(),
+          "a root containing the separator syntax cannot collide with another root's nested"
+              + " member");
     }
 
     /**
-     * {@code legacyPathStrings()} reproduces the WP1-pinned formula exactly: root identifier
-     * string-concatenated with {@code /ns:name} per element, a String identifier in the root's
-     * namespace — including the pinned numeric-root case ({@code 7} deriving {@code "7/1:Foo"}).
+     * {@code legacyPathStrings()} reproduces the characterized legacy formula exactly: root
+     * identifier string-concatenated with {@code /ns:name} per element, a String identifier in the
+     * root's namespace — including the pinned numeric-root case ({@code 7} deriving {@code
+     * "7/1:Foo"}).
      */
     @Test
     void legacyPathStringsReproducesCharacterizedFormula() throws Exception {
@@ -1334,7 +1390,7 @@ public class InstantiationPlanTest {
   @Nested
   class Methods {
 
-    /** Methods are copied by default; SHARE references the type's Method node per call (KD9/L6). */
+    /** Methods are copied by default; SHARE references the type's Method node per call. */
     @Test
     void methodCopyByDefaultShareByRequest() throws Exception {
       UaObjectTypeNode typeNode = fx.addObjectType("MethodType", NodeIds.BaseObjectType);
@@ -1416,8 +1472,8 @@ public class InstantiationPlanTest {
 
     /**
      * Plan is provably side-effect free: neither the target manager nor the source address space is
-     * mutated — checked with WP4's generation tracking plus node/reference counts and a sampled
-     * identity check.
+     * mutated — checked with NodeManager generation tracking plus node/reference counts and a
+     * sampled identity check.
      */
     @Test
     void planPerformsZeroMutation() throws Exception {

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/InstantiationPlanTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/InstantiationPlanTest.java
@@ -1,0 +1,1537 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
+
+import static org.eclipse.milo.opcua.sdk.server.nodes.instantiation.TypeFixtures.path;
+import static org.eclipse.milo.opcua.sdk.server.nodes.instantiation.TypeFixtures.qn;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ubyte;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.eclipse.milo.opcua.sdk.core.Reference;
+import org.eclipse.milo.opcua.sdk.server.NodeManager;
+import org.eclipse.milo.opcua.sdk.server.UaNodeManager;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaMethodNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNodeContext;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaReferenceTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableTypeNode;
+import org.eclipse.milo.opcua.stack.core.AttributeId;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
+import org.eclipse.milo.opcua.stack.core.types.structured.AccessRestrictionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.PermissionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.RolePermissionType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@code NodeInstantiator.plan}: declaration selection, typed class resolution, NodeId
+ * allocation and collision preflight, effective attributes, and reference rewrite — all as pure
+ * computation over a model snapshot, mutating nothing.
+ */
+public class InstantiationPlanTest {
+
+  private TypeFixtures fx;
+  private UaNodeManager target;
+
+  @BeforeEach
+  void setUp() {
+    fx = TypeFixtures.create();
+    target = fx.newTargetManager();
+  }
+
+  private InstantiationRequest.Builder<UaObjectNode> objectRequest(NodeId typeId, String rootId) {
+    return InstantiationRequest.of(UaObjectNode.class, typeId)
+        .nodeId(fx.newNodeId(rootId))
+        .target(target);
+  }
+
+  private static boolean hasDiagnostic(
+      InstantiationPlan<?> plan,
+      InstantiationDiagnostic.Severity severity,
+      InstantiationDiagnostic.Code code) {
+
+    return plan.diagnostics().stream().anyMatch(d -> d.severity() == severity && d.code() == code);
+  }
+
+  private static boolean hasError(InstantiationPlan<?> plan, InstantiationDiagnostic.Code code) {
+    return hasDiagnostic(plan, InstantiationDiagnostic.Severity.ERROR, code);
+  }
+
+  private static boolean hasWarning(InstantiationPlan<?> plan, InstantiationDiagnostic.Code code) {
+    return hasDiagnostic(plan, InstantiationDiagnostic.Severity.WARNING, code);
+  }
+
+  private static SkippedDeclaration skippedAt(InstantiationPlan<?> plan, BrowsePath path) {
+    return plan.skippedDeclarations().stream()
+        .filter(s -> s.declaration().browsePath().equals(path))
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("expected a skipped declaration at " + path));
+  }
+
+  private static long countReferences(
+      InstantiationPlan<?> plan, NodeId sourceNodeId, NodeId referenceTypeId, NodeId targetNodeId) {
+
+    return plan.references().stream()
+        .filter(
+            r ->
+                r.getSourceNodeId().equals(sourceNodeId)
+                    && r.getReferenceTypeId().equals(referenceTypeId)
+                    && r.getTargetNodeId().equals(targetNodeId.expanded())
+                    && r.isForward())
+        .count();
+  }
+
+  /** A distinct registrable node class for typed-registry resolution tests. */
+  static class TestObjectNode extends UaObjectNode {
+    TestObjectNode(
+        UaNodeContext context, NodeId nodeId, QualifiedName browseName, LocalizedText displayName) {
+      super(
+          context,
+          nodeId,
+          browseName,
+          displayName,
+          LocalizedText.NULL_VALUE,
+          UInteger.MIN,
+          UInteger.MIN,
+          ubyte(0));
+    }
+  }
+
+  @Nested
+  class Selection {
+
+    /**
+     * The defaults per Part 3 §6.4.4.4.2–.3: Mandatory members exist at every depth, Optional
+     * members do not, and every skipped declaration is accounted for with a reason.
+     */
+    @Test
+    void mandatoryPlannedAtEveryDepthOptionalOmittedByDefault() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("DeviceType", NodeIds.BaseObjectType);
+      UaObjectNode child =
+          fx.addObjectDeclaration(
+              typeNode, "Child", NodeIds.BaseObjectType, NodeIds.ModellingRule_Mandatory);
+      fx.addVariableDeclaration(
+          child, "Leaf", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+      fx.addVariableDeclaration(
+          typeNode, "Opt", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Optional);
+
+      InstantiationPlan<UaObjectNode> plan =
+          fx.instantiator().plan(objectRequest(typeNode.getNodeId(), "Dev").build());
+
+      assertFalse(plan.hasErrors());
+      assertTrue(plan.plannedNode(path("Child")).isPresent());
+      assertTrue(plan.plannedNode(path("Child", "Leaf")).isPresent());
+      assertTrue(plan.plannedNode(path("Opt")).isEmpty());
+      assertEquals(
+          SkippedDeclaration.Reason.OPTIONAL_NOT_SELECTED, skippedAt(plan, path("Opt")).reason());
+
+      // Every declaration is accounted for: planned + skipped = model declarations.
+      assertEquals(
+          plan.model().declarations().size(),
+          (plan.plannedNodes().size() - 1) + plan.skippedDeclarations().size());
+    }
+
+    /** Selecting a nested path implies its ancestors (U4). */
+    @Test
+    void includingNestedPathImpliesAncestors() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("ImplyType", NodeIds.BaseObjectType);
+      UaObjectNode optA =
+          fx.addObjectDeclaration(
+              typeNode, "OptA", NodeIds.BaseObjectType, NodeIds.ModellingRule_Optional);
+      fx.addVariableDeclaration(
+          optA, "Leaf", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+      fx.addVariableDeclaration(
+          optA, "LeafOpt", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Optional);
+
+      InstantiationPlan<UaObjectNode> plan =
+          fx.instantiator()
+              .plan(
+                  objectRequest(typeNode.getNodeId(), "Dev")
+                      .includeOptional(path("OptA", "LeafOpt"))
+                      .build());
+
+      assertFalse(plan.hasErrors());
+      assertTrue(plan.plannedNode(path("OptA")).isPresent(), "ancestor implied");
+      assertTrue(plan.plannedNode(path("OptA", "LeafOpt")).isPresent());
+      assertTrue(
+          plan.plannedNode(path("OptA", "Leaf")).isPresent(),
+          "Mandatory under a selected Optional exists");
+    }
+
+    /** {@code includeAllOptionals()} selects Optionals but not vendor-rule declarations. */
+    @Test
+    void includeAllOptionalsSelectsOptionalsNotVendorRules() throws Exception {
+      NodeId vendorRuleId = addVendorModellingRule("VendorRule1");
+
+      UaObjectTypeNode typeNode = fx.addObjectType("AllOptType", NodeIds.BaseObjectType);
+      fx.addVariableDeclaration(
+          typeNode, "Opt", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Optional);
+      fx.addVariableDeclaration(typeNode, "Vendor", NodeIds.BaseDataVariableType, vendorRuleId);
+
+      InstantiationPlan<UaObjectNode> plan =
+          fx.instantiator()
+              .plan(objectRequest(typeNode.getNodeId(), "Dev").includeAllOptionals().build());
+
+      assertFalse(plan.hasErrors());
+      assertTrue(plan.plannedNode(path("Opt")).isPresent());
+      assertTrue(plan.plannedNode(path("Vendor")).isEmpty());
+      assertEquals(SkippedDeclaration.Reason.VENDOR_RULE, skippedAt(plan, path("Vendor")).reason());
+    }
+
+    /**
+     * A vendor-rule declaration is planned when explicitly selected (classification, not
+     * filtering).
+     */
+    @Test
+    void vendorRuleDeclarationPlannedWhenExplicitlyIncluded() throws Exception {
+      NodeId vendorRuleId = addVendorModellingRule("VendorRule2");
+
+      UaObjectTypeNode typeNode = fx.addObjectType("VendorType", NodeIds.BaseObjectType);
+      fx.addVariableDeclaration(typeNode, "Vendor", NodeIds.BaseDataVariableType, vendorRuleId);
+
+      InstantiationPlan<UaObjectNode> plan =
+          fx.instantiator()
+              .plan(
+                  objectRequest(typeNode.getNodeId(), "Dev")
+                      .includeOptional(path("Vendor"))
+                      .build());
+
+      assertFalse(plan.hasErrors());
+      assertTrue(plan.plannedNode(path("Vendor")).isPresent());
+    }
+
+    /** The context-rich predicate escape hatch decides otherwise-undecided declarations (L2). */
+    @Test
+    void predicateEscapeHatchSelectsByDeclarationContext() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("PredType", NodeIds.BaseObjectType);
+      fx.addVariableDeclaration(
+          typeNode, "OptYes", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Optional);
+      fx.addVariableDeclaration(
+          typeNode, "OptNo", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Optional);
+
+      InstantiationPlan<UaObjectNode> plan =
+          fx.instantiator()
+              .plan(
+                  objectRequest(typeNode.getNodeId(), "Dev")
+                      .includeOptionals(d -> "OptYes".equals(d.browseName().name()))
+                      .build());
+
+      assertFalse(plan.hasErrors());
+      assertTrue(plan.plannedNode(path("OptYes")).isPresent());
+      assertTrue(plan.plannedNode(path("OptNo")).isEmpty());
+    }
+
+    /** Optional Methods obey selection like everything else — the D6 fix. */
+    @Test
+    void optionalMethodObeysSelection() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("MethodSelType", NodeIds.BaseObjectType);
+      fx.addMethodDeclaration(typeNode, "OptMethod", NodeIds.ModellingRule_Optional);
+
+      InstantiationPlan<UaObjectNode> omitted =
+          fx.instantiator().plan(objectRequest(typeNode.getNodeId(), "Dev1").build());
+      assertTrue(omitted.plannedNode(path("OptMethod")).isEmpty(), "not created unconditionally");
+      assertEquals(
+          SkippedDeclaration.Reason.OPTIONAL_NOT_SELECTED,
+          skippedAt(omitted, path("OptMethod")).reason());
+
+      InstantiationPlan<UaObjectNode> included =
+          fx.instantiator()
+              .plan(
+                  objectRequest(typeNode.getNodeId(), "Dev2")
+                      .includeOptional(path("OptMethod"))
+                      .build());
+      assertTrue(included.plannedNode(path("OptMethod")).isPresent());
+    }
+
+    /**
+     * Excluding an Optional prunes its whole subtree: mandatory descendants are {@code
+     * ANCESTOR_OMITTED} (their BrowsePath does not exist — the valid exception, input b), never
+     * planned, never referenced — the D1 orphan fix.
+     */
+    @Test
+    void excludingOptionalPrunesSubtreeWithoutOrphans() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("PruneType", NodeIds.BaseObjectType);
+      UaObjectNode optA =
+          fx.addObjectDeclaration(
+              typeNode, "OptA", NodeIds.BaseObjectType, NodeIds.ModellingRule_Optional);
+      fx.addVariableDeclaration(
+          optA, "MandLeaf", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+      InstantiationPlan<UaObjectNode> plan =
+          fx.instantiator()
+              .plan(
+                  objectRequest(typeNode.getNodeId(), "Dev")
+                      .includeAllOptionals()
+                      .excludeOptional(path("OptA"))
+                      .build());
+
+      assertFalse(plan.hasErrors(), "pruning an omitted ancestor's subtree is not an error");
+      assertEquals(SkippedDeclaration.Reason.EXCLUDED, skippedAt(plan, path("OptA")).reason());
+      assertEquals(
+          SkippedDeclaration.Reason.ANCESTOR_OMITTED,
+          skippedAt(plan, path("OptA", "MandLeaf")).reason());
+
+      // No reference row may point at anything that was not planned.
+      List<NodeId> plannedIds = plan.plannedNodes().stream().map(PlannedNode::nodeId).toList();
+      NodeId parentlessTarget = fx.newNodeId("Dev/1:OptA/1:MandLeaf");
+      assertTrue(
+          plan.references().stream()
+              .noneMatch(r -> r.getTargetNodeId().equals(parentlessTarget.expanded())),
+          "no planned edge to an omitted target");
+      assertFalse(plannedIds.contains(parentlessTarget));
+    }
+
+    /** Omitting a Mandatory declaration whose parent path exists is always a plan error. */
+    @Test
+    void mandatoryOmissionAtExistingPathIsPlanError() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("MandType", NodeIds.BaseObjectType);
+      fx.addVariableDeclaration(
+          typeNode, "Mand", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+      InstantiationPlan<UaObjectNode> plan =
+          fx.instantiator()
+              .plan(
+                  objectRequest(typeNode.getNodeId(), "Dev").excludeOptional(path("Mand")).build());
+
+      assertTrue(hasError(plan, InstantiationDiagnostic.Code.MANDATORY_OMITTED));
+      assertEquals(SkippedDeclaration.Reason.EXCLUDED, skippedAt(plan, path("Mand")).reason());
+    }
+
+    /** Two same-named Optionals at different paths select independently — the D7 fix. */
+    @Test
+    void sameNamedOptionalsAtDifferentPathsSelectIndependently() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("D7Type", NodeIds.BaseObjectType);
+      UaObjectNode a =
+          fx.addObjectDeclaration(
+              typeNode, "A", NodeIds.BaseObjectType, NodeIds.ModellingRule_Mandatory);
+      UaObjectNode b =
+          fx.addObjectDeclaration(
+              typeNode, "B", NodeIds.BaseObjectType, NodeIds.ModellingRule_Mandatory);
+      fx.addVariableDeclaration(
+          a, "Opt", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Optional);
+      fx.addVariableDeclaration(
+          b, "Opt", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Optional);
+
+      InstantiationPlan<UaObjectNode> plan =
+          fx.instantiator()
+              .plan(
+                  objectRequest(typeNode.getNodeId(), "Dev")
+                      .includeOptional(path("A", "Opt"))
+                      .build());
+
+      assertFalse(plan.hasErrors());
+      assertTrue(plan.plannedNode(path("A", "Opt")).isPresent());
+      assertTrue(plan.plannedNode(path("B", "Opt")).isEmpty());
+    }
+
+    /**
+     * Placeholders are never auto-expanded; ExposesItsArray is surfaced but not materialized
+     * (KD10).
+     */
+    @Test
+    void placeholdersAndExposesItsArrayAreSkippedWithDiagnostics() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("PlaceholderType", NodeIds.BaseObjectType);
+      fx.addObjectDeclaration(
+          typeNode,
+          "OptPlaceholder",
+          NodeIds.BaseObjectType,
+          NodeIds.ModellingRule_OptionalPlaceholder);
+      fx.addObjectDeclaration(
+          typeNode,
+          "MandPlaceholder",
+          NodeIds.BaseObjectType,
+          NodeIds.ModellingRule_MandatoryPlaceholder);
+      fx.addVariableDeclaration(
+          typeNode, "Exposed", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_ExposesItsArray);
+
+      InstantiationPlan<UaObjectNode> plan =
+          fx.instantiator()
+              .plan(objectRequest(typeNode.getNodeId(), "Dev").includeAllOptionals().build());
+
+      assertFalse(plan.hasErrors());
+      assertEquals(
+          SkippedDeclaration.Reason.PLACEHOLDER, skippedAt(plan, path("OptPlaceholder")).reason());
+      assertEquals(
+          SkippedDeclaration.Reason.PLACEHOLDER, skippedAt(plan, path("MandPlaceholder")).reason());
+      assertEquals(
+          SkippedDeclaration.Reason.EXPOSES_ITS_ARRAY, skippedAt(plan, path("Exposed")).reason());
+
+      assertTrue(hasWarning(plan, InstantiationDiagnostic.Code.MANDATORY_PLACEHOLDER_UNSATISFIED));
+      assertTrue(hasWarning(plan, InstantiationDiagnostic.Code.EXPOSES_ITS_ARRAY_NOT_MATERIALIZED));
+    }
+
+    private NodeId addVendorModellingRule(String name) {
+      NodeId ruleId = fx.newNodeId(name);
+      UaObjectNode rule =
+          new UaObjectNode(
+              fx.context(),
+              ruleId,
+              qn(name),
+              LocalizedText.english(name),
+              LocalizedText.NULL_VALUE,
+              UInteger.MIN,
+              UInteger.MIN,
+              ubyte(0));
+      rule.addReference(
+          new Reference(
+              ruleId, NodeIds.HasTypeDefinition, NodeIds.ModellingRuleType.expanded(), true));
+      fx.nodeManager().addNode(rule);
+      return ruleId;
+    }
+  }
+
+  @Nested
+  class CollisionPreflight {
+
+    /** Two planned nodes may not share a NodeId, whatever the conflict policy. */
+    @Test
+    void intraPlanCollisionIsPlanError() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("IntraType", NodeIds.BaseObjectType);
+      fx.addVariableDeclaration(
+          typeNode, "A", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+      fx.addVariableDeclaration(
+          typeNode, "B", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+      NodeId sharedId = fx.newNodeId("shared");
+      InstantiationPlan<UaObjectNode> plan =
+          fx.instantiator()
+              .plan(
+                  objectRequest(typeNode.getNodeId(), "Dev")
+                      .assignNodeId(path("A"), sharedId)
+                      .assignNodeId(path("B"), sharedId)
+                      .build());
+
+      assertTrue(hasError(plan, InstantiationDiagnostic.Code.NODE_ID_COLLISION));
+    }
+
+    /** Under {@link ConflictPolicy#FAIL} an existing node in the target is a precise plan error. */
+    @Test
+    void targetCollisionUnderFailIsPlanError() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("FailType", NodeIds.BaseObjectType);
+      fx.addVariableDeclaration(
+          typeNode, "M", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+      NodeId collidingId = fx.newNodeId("Dev/1:M");
+      target.addNode(newTargetVariable(collidingId, qn("Other")));
+
+      InstantiationPlan<UaObjectNode> plan =
+          fx.instantiator().plan(objectRequest(typeNode.getNodeId(), "Dev").build());
+
+      assertTrue(hasError(plan, InstantiationDiagnostic.Code.NODE_ID_COLLISION));
+      InstantiationDiagnostic diagnostic =
+          plan.errors().stream()
+              .filter(d -> d.code() == InstantiationDiagnostic.Code.NODE_ID_COLLISION)
+              .findFirst()
+              .orElseThrow();
+      assertEquals(path("M"), diagnostic.browsePath());
+      assertEquals(collidingId, diagnostic.nodeId());
+    }
+
+    /**
+     * {@link ConflictPolicy#REUSE_COMPATIBLE} adopts a compatible existing node as {@code REUSE} —
+     * never modified, and no HasTypeDefinition reference is planned for it.
+     */
+    @Test
+    void reuseCompatibleAdoptsCompatibleExistingNode() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("ReuseType", NodeIds.BaseObjectType);
+      fx.addVariableDeclaration(
+          typeNode, "M", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+      NodeId existingId = fx.newNodeId("Dev/1:M");
+      target.addNode(newTargetVariable(existingId, qn("M")));
+      target.addReference(
+          new Reference(
+              existingId,
+              NodeIds.HasTypeDefinition,
+              NodeIds.BaseDataVariableType.expanded(),
+              true));
+
+      InstantiationPlan<UaObjectNode> plan =
+          fx.instantiator()
+              .plan(
+                  objectRequest(typeNode.getNodeId(), "Dev")
+                      .conflictPolicy(ConflictPolicy.REUSE_COMPATIBLE)
+                      .build());
+
+      assertFalse(plan.hasErrors());
+      PlannedNode reused = plan.plannedNode(path("M")).orElseThrow();
+      assertEquals(PlannedNode.Materialization.REUSE, reused.materialization());
+      assertEquals(existingId, reused.nodeId());
+      assertEquals(
+          0,
+          countReferences(
+              plan, existingId, NodeIds.HasTypeDefinition, NodeIds.BaseDataVariableType),
+          "a reused node keeps its own references; none are planned for it");
+    }
+
+    /**
+     * An incompatible existing node fails the plan instead of being silently adopted or replaced.
+     */
+    @Test
+    void incompatibleExistingNodeIsPlanError() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("IncompatType", NodeIds.BaseObjectType);
+      fx.addVariableDeclaration(
+          typeNode, "M", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+      NodeId existingId = fx.newNodeId("Dev/1:M");
+      target.addNode(newTargetVariable(existingId, qn("SomethingElse")));
+
+      InstantiationPlan<UaObjectNode> plan =
+          fx.instantiator()
+              .plan(
+                  objectRequest(typeNode.getNodeId(), "Dev")
+                      .conflictPolicy(ConflictPolicy.REUSE_COMPATIBLE)
+                      .build());
+
+      assertTrue(hasError(plan, InstantiationDiagnostic.Code.INCOMPATIBLE_REUSE));
+    }
+
+    private UaVariableNode newTargetVariable(NodeId nodeId, QualifiedName browseName) {
+      return new UaVariableNode(
+          fx.context(),
+          nodeId,
+          browseName,
+          LocalizedText.english(browseName.name()),
+          LocalizedText.NULL_VALUE,
+          UInteger.MIN,
+          UInteger.MIN);
+    }
+  }
+
+  @Nested
+  class EffectiveAttributes {
+
+    /**
+     * The full attribute set propagates from declarations by rule — including
+     * MinimumSamplingInterval, Historizing, and the three security attributes legacy dropped (D10)
+     * — with the absent / explicit-null distinction preserved.
+     */
+    @Test
+    void fullAttributeSetPropagatesIncludingSecurityAttributes() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("SecType", NodeIds.BaseObjectType);
+
+      RolePermissionType[] rolePermissions = {
+        new RolePermissionType(NodeIds.WellKnownRole_Anonymous, new PermissionType(uint(1)))
+      };
+
+      NodeId declId = fx.newNodeId("SecType.V");
+      UaVariableNode declaration =
+          new UaVariableNode(
+              fx.context(),
+              declId,
+              qn("V"),
+              LocalizedText.english("V"),
+              LocalizedText.NULL_VALUE,
+              UInteger.MIN,
+              UInteger.MIN,
+              rolePermissions,
+              rolePermissions,
+              new AccessRestrictionType(UShort.valueOf(2)),
+              new DataValue(new Variant(42)),
+              NodeIds.Int32,
+              -1,
+              null,
+              ubyte(3),
+              ubyte(3),
+              250.0,
+              true,
+              null);
+      declaration.addReference(
+          new Reference(
+              declId, NodeIds.HasTypeDefinition, NodeIds.BaseDataVariableType.expanded(), true));
+      declaration.addReference(
+          new Reference(
+              declId, NodeIds.HasModellingRule, NodeIds.ModellingRule_Mandatory.expanded(), true));
+      fx.nodeManager().addNode(declaration);
+      typeNode.addReference(
+          new Reference(typeNode.getNodeId(), NodeIds.HasComponent, declId.expanded(), true));
+
+      InstantiationPlan<UaObjectNode> plan =
+          fx.instantiator().plan(objectRequest(typeNode.getNodeId(), "Dev").build());
+
+      AttributeSnapshot attributes =
+          plan.plannedNode(path("V")).orElseThrow().effectiveAttributes();
+
+      assertEquals(NodeIds.Int32, attributes.dataType());
+      assertEquals(42, ((DataValue) attributes.getOrNull(AttributeId.Value)).getValue().getValue());
+      assertEquals(250.0, attributes.getOrNull(AttributeId.MinimumSamplingInterval));
+      assertEquals(true, attributes.getOrNull(AttributeId.Historizing));
+      assertNotNull(attributes.getOrNull(AttributeId.RolePermissions));
+      assertNotNull(attributes.getOrNull(AttributeId.UserRolePermissions));
+      assertEquals(
+          new AccessRestrictionType(UShort.valueOf(2)),
+          attributes.getOrNull(AttributeId.AccessRestrictions));
+
+      // Unset optional attributes stay absent, not null.
+      assertFalse(attributes.contains(AttributeId.ArrayDimensions));
+      assertFalse(attributes.contains(AttributeId.AccessLevelEx));
+    }
+
+    /**
+     * Member-type defaults fill what the declaration leaves unset (declaration &gt; member type
+     * &gt; class defaults): a declaration with no Value gets its VariableType's default Value; a
+     * declaration providing its own keeps it.
+     */
+    @Test
+    void memberTypeValueDefaultFillsUnsetDeclarationValue() throws Exception {
+      DataValue typeDefault = new DataValue(new Variant(7));
+      UaVariableTypeNode varType =
+          fx.addVariableType(
+              "DefaultingVarType", NodeIds.BaseDataVariableType, typeDefault, NodeIds.Int32, -1);
+
+      UaObjectTypeNode typeNode = fx.addObjectType("DefaultsType", NodeIds.BaseObjectType);
+      fx.addVariableDeclaration(
+          typeNode, "Unset", varType.getNodeId(), NodeIds.ModellingRule_Mandatory);
+      UaVariableNode withValue =
+          fx.addVariableDeclaration(
+              typeNode, "Set", varType.getNodeId(), NodeIds.ModellingRule_Mandatory);
+      withValue.setValue(new DataValue(new Variant(99)));
+
+      InstantiationPlan<UaObjectNode> plan =
+          fx.instantiator().plan(objectRequest(typeNode.getNodeId(), "Dev").build());
+
+      DataValue unsetValue =
+          (DataValue)
+              plan.plannedNode(path("Unset"))
+                  .orElseThrow()
+                  .effectiveAttributes()
+                  .getOrNull(AttributeId.Value);
+      assertNotNull(unsetValue, "type default fills the unset declaration Value");
+      assertEquals(7, unsetValue.getValue().getValue());
+
+      DataValue setValue =
+          (DataValue)
+              plan.plannedNode(path("Set"))
+                  .orElseThrow()
+                  .effectiveAttributes()
+                  .getOrNull(AttributeId.Value);
+      assertNotNull(setValue);
+      assertEquals(99, setValue.getValue().getValue(), "declaration wins over member type");
+    }
+
+    /** Root attributes come from the type per Part 3 §6.4.2, then request overrides. */
+    @Test
+    void rootAttributesComeFromTypeThenRequestOverrides() throws Exception {
+      UaVariableTypeNode varType =
+          fx.addVariableType(
+              "RootVarType",
+              NodeIds.BaseDataVariableType,
+              new DataValue(new Variant(3.14)),
+              NodeIds.Double,
+              -1);
+
+      InstantiationPlan<UaVariableNode> plan =
+          fx.instantiator()
+              .plan(
+                  InstantiationRequest.of(UaVariableNode.class, varType.getNodeId())
+                      .nodeId(fx.newNodeId("Rooted"))
+                      .target(target)
+                      .value(new DataValue(new Variant(2.71)))
+                      .displayName(LocalizedText.english("Rooted"))
+                      .build());
+
+      assertFalse(plan.hasErrors());
+      PlannedNode root = plan.root();
+      assertEquals(NodeClass.Variable, root.nodeClass());
+
+      AttributeSnapshot attributes = root.effectiveAttributes();
+      assertEquals(NodeIds.Double, attributes.dataType(), "DataType from the type");
+      assertEquals(
+          2.71,
+          ((DataValue) attributes.getOrNull(AttributeId.Value)).getValue().getValue(),
+          "Value overridden by the request");
+      assertEquals(LocalizedText.english("Rooted"), attributes.getOrNull(AttributeId.DisplayName));
+      assertFalse(attributes.contains(AttributeId.IsAbstract), "type-only attributes dropped");
+      assertEquals(NodeClass.Variable, attributes.getOrNull(AttributeId.NodeClass));
+    }
+
+    /**
+     * Root BrowseName precedence: request &gt; DefaultInstanceBrowseName &gt; type BrowseName
+     * (D11/U8).
+     */
+    @Test
+    void rootBrowseNamePrecedence() throws Exception {
+      UaObjectTypeNode plainType = fx.addObjectType("PlainType", NodeIds.BaseObjectType);
+      UaObjectTypeNode defaultingType = fx.addObjectType("DefaultingType", NodeIds.BaseObjectType);
+      fx.setDefaultInstanceBrowseName(defaultingType, qn("DefaultName"));
+
+      InstantiationPlan<UaObjectNode> requested =
+          fx.instantiator()
+              .plan(
+                  objectRequest(defaultingType.getNodeId(), "R1")
+                      .browseName(qn("Requested"))
+                      .build());
+      assertEquals(
+          qn("Requested"),
+          requested.root().effectiveAttributes().getOrNull(AttributeId.BrowseName));
+
+      InstantiationPlan<UaObjectNode> defaulted =
+          fx.instantiator().plan(objectRequest(defaultingType.getNodeId(), "R2").build());
+      assertEquals(
+          qn("DefaultName"),
+          defaulted.root().effectiveAttributes().getOrNull(AttributeId.BrowseName));
+
+      InstantiationPlan<UaObjectNode> typeName =
+          fx.instantiator().plan(objectRequest(plainType.getNodeId(), "R3").build());
+      assertEquals(
+          qn("PlainType"), typeName.root().effectiveAttributes().getOrNull(AttributeId.BrowseName));
+    }
+
+    /** A request override violating Part 3 §6.2.8 narrowing is a plan error. */
+    @Test
+    void rootNarrowingViolationIsPlanError() throws Exception {
+      UaVariableTypeNode varType =
+          fx.addVariableType(
+              "NumberVarType", NodeIds.BaseDataVariableType, null, NodeIds.Number, -1);
+
+      InstantiationPlan<UaVariableNode> violating =
+          fx.instantiator()
+              .plan(
+                  InstantiationRequest.of(UaVariableNode.class, varType.getNodeId())
+                      .nodeId(fx.newNodeId("V1"))
+                      .target(target)
+                      .rootAttribute(AttributeId.DataType, NodeIds.String)
+                      .build());
+      assertTrue(hasError(violating, InstantiationDiagnostic.Code.VARIABLE_NARROWING));
+
+      InstantiationPlan<UaVariableNode> narrowing =
+          fx.instantiator()
+              .plan(
+                  InstantiationRequest.of(UaVariableNode.class, varType.getNodeId())
+                      .nodeId(fx.newNodeId("V2"))
+                      .target(target)
+                      .rootAttribute(AttributeId.DataType, NodeIds.Int32)
+                      .build());
+      assertFalse(
+          hasError(narrowing, InstantiationDiagnostic.Code.VARIABLE_NARROWING),
+          "narrowing to a subtype is valid");
+    }
+  }
+
+  @Nested
+  class TypedClasses {
+
+    /**
+     * A registered snapshot constructor's class is selected at plan time, with its registry key.
+     */
+    @Test
+    void registeredClassSelectedAtPlanTime() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("RegisteredType", NodeIds.BaseObjectType);
+      fx.objectTypeManager()
+          .registerObjectType(
+              typeNode.getNodeId(),
+              TestObjectNode.class,
+              (context, nodeId, attributes) -> {
+                throw new UnsupportedOperationException("plan never constructs");
+              });
+
+      InstantiationPlan<TestObjectNode> plan =
+          fx.instantiator()
+              .plan(
+                  InstantiationRequest.of(TestObjectNode.class, typeNode.getNodeId())
+                      .nodeId(fx.newNodeId("Dev"))
+                      .target(target)
+                      .build());
+
+      assertFalse(plan.hasErrors());
+      assertEquals(TestObjectNode.class, plan.root().javaClass());
+      assertEquals(typeNode.getNodeId(), plan.root().constructorTypeId());
+    }
+
+    /**
+     * An unsatisfiable expected root class is {@code INVALID_ROOT_CLASS} at plan time, not a cast.
+     */
+    @Test
+    void invalidRootClassIsPlanTimeError() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("UnregisteredType", NodeIds.BaseObjectType);
+
+      InstantiationPlan<TestObjectNode> plan =
+          fx.instantiator()
+              .plan(
+                  InstantiationRequest.of(TestObjectNode.class, typeNode.getNodeId())
+                      .nodeId(fx.newNodeId("Dev"))
+                      .target(target)
+                      .build());
+
+      assertTrue(hasError(plan, InstantiationDiagnostic.Code.INVALID_ROOT_CLASS));
+    }
+
+    /**
+     * Q2: an unregistered subtype resolves to the nearest registered ancestor's class by walking
+     * the {@code HasSubtype} chain, two levels deep here.
+     */
+    @Test
+    void unregisteredSubtypeFallsBackToNearestRegisteredAncestor() throws Exception {
+      UaObjectTypeNode baseType = fx.addObjectType("FallbackBase", NodeIds.BaseObjectType);
+      UaObjectTypeNode midType = fx.addObjectType("FallbackMid", baseType.getNodeId());
+      UaObjectTypeNode leafType = fx.addObjectType("FallbackLeaf", midType.getNodeId());
+
+      fx.objectTypeManager()
+          .registerObjectType(
+              baseType.getNodeId(),
+              TestObjectNode.class,
+              (context, nodeId, attributes) -> {
+                throw new UnsupportedOperationException("plan never constructs");
+              });
+
+      InstantiationPlan<UaObjectNode> plan =
+          fx.instantiator().plan(objectRequest(leafType.getNodeId(), "Dev").build());
+
+      assertFalse(plan.hasErrors());
+      assertEquals(TestObjectNode.class, plan.root().javaClass());
+      assertEquals(
+          baseType.getNodeId(),
+          plan.root().constructorTypeId(),
+          "resolved from the nearest registered ancestor");
+    }
+
+    /** The per-request {@code classResolution(EXACT)} knob opts out of the fallback walk. */
+    @Test
+    void exactClassResolutionOptsOutOfFallback() throws Exception {
+      UaObjectTypeNode baseType = fx.addObjectType("ExactBase", NodeIds.BaseObjectType);
+      UaObjectTypeNode leafType = fx.addObjectType("ExactLeaf", baseType.getNodeId());
+
+      fx.objectTypeManager()
+          .registerObjectType(
+              baseType.getNodeId(),
+              TestObjectNode.class,
+              (context, nodeId, attributes) -> {
+                throw new UnsupportedOperationException("plan never constructs");
+              });
+
+      InstantiationPlan<UaObjectNode> plan =
+          fx.instantiator()
+              .plan(
+                  objectRequest(leafType.getNodeId(), "Dev")
+                      .classResolution(InstantiationRequest.ClassResolution.EXACT)
+                      .build());
+
+      assertFalse(plan.hasErrors());
+      assertEquals(UaObjectNode.class, plan.root().javaClass());
+      assertNull(plan.root().constructorTypeId());
+    }
+
+    /**
+     * R4: a legacy tuple-signature registration resolves under the new engine — same class, same
+     * registry key — while remaining resolvable by the untouched legacy lookup.
+     */
+    @Test
+    void legacyTupleRegistrationResolvesUnderBothEngines() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("TupleType", NodeIds.BaseObjectType);
+      fx.objectTypeManager()
+          .registerObjectType(
+              typeNode.getNodeId(),
+              TestObjectNode.class,
+              (context,
+                  nodeId,
+                  browseName,
+                  displayName,
+                  description,
+                  writeMask,
+                  userWriteMask,
+                  rolePermissions,
+                  userRolePermissions,
+                  accessRestrictions) -> {
+                throw new UnsupportedOperationException("plan never constructs");
+              });
+
+      InstantiationPlan<TestObjectNode> plan =
+          fx.instantiator()
+              .plan(
+                  InstantiationRequest.of(TestObjectNode.class, typeNode.getNodeId())
+                      .nodeId(fx.newNodeId("Dev"))
+                      .target(target)
+                      .build());
+
+      assertFalse(plan.hasErrors());
+      assertEquals(TestObjectNode.class, plan.root().javaClass());
+      assertEquals(typeNode.getNodeId(), plan.root().constructorTypeId());
+
+      assertTrue(
+          fx.objectTypeManager().getNodeConstructor(typeNode.getNodeId()).isPresent(),
+          "legacy lookup unchanged");
+    }
+
+    /** Instantiating an abstract root type is a plan error. */
+    @Test
+    void abstractRootTypeIsPlanError() throws Exception {
+      UaObjectTypeNode abstractType =
+          fx.addObjectType("AbstractRootType", NodeIds.BaseObjectType, true);
+
+      InstantiationPlan<UaObjectNode> plan =
+          fx.instantiator().plan(objectRequest(abstractType.getNodeId(), "Dev").build());
+
+      assertTrue(hasError(plan, InstantiationDiagnostic.Code.ABSTRACT_TYPE));
+    }
+  }
+
+  @Nested
+  class ConcreteTypes {
+
+    private UaObjectTypeNode typeNode;
+    private NodeId abstractChannelId;
+    private NodeId concreteChannelId;
+    private NodeId unrelatedTypeId;
+
+    @BeforeEach
+    void buildGraph() {
+      UaObjectTypeNode abstractChannel =
+          fx.addObjectType("AbstractChannel", NodeIds.BaseObjectType, true);
+      abstractChannelId = abstractChannel.getNodeId();
+      fx.addVariableDeclaration(
+          abstractChannel, "Base", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+      UaObjectTypeNode concreteChannel = fx.addObjectType("ConcreteChannel", abstractChannelId);
+      concreteChannelId = concreteChannel.getNodeId();
+      fx.addVariableDeclaration(
+          concreteChannel, "Extra", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+      unrelatedTypeId = fx.addObjectType("UnrelatedType", NodeIds.BaseObjectType).getNodeId();
+
+      typeNode = fx.addObjectType("DeviceWithChannel", NodeIds.BaseObjectType);
+      fx.addObjectDeclaration(
+          typeNode, "Channel", abstractChannelId, NodeIds.ModellingRule_Mandatory);
+    }
+
+    /** An abstract member type without a concreteType resolution is a plan error (input i). */
+    @Test
+    void abstractMemberWithoutResolutionIsPlanError() throws Exception {
+      InstantiationPlan<UaObjectNode> plan =
+          fx.instantiator().plan(objectRequest(typeNode.getNodeId(), "Dev").build());
+
+      assertTrue(hasError(plan, InstantiationDiagnostic.Code.ABSTRACT_MEMBER_TYPE));
+    }
+
+    /**
+     * A valid concreteType selection substitutes the member's TypeDefinition — on the planned node
+     * and its HasTypeDefinition reference — and warns that concrete-only members are not expanded.
+     */
+    @Test
+    void concreteTypeSelectionSubstitutesTypeDefinition() throws Exception {
+      InstantiationPlan<UaObjectNode> plan =
+          fx.instantiator()
+              .plan(
+                  objectRequest(typeNode.getNodeId(), "Dev")
+                      .concreteType(path("Channel"), concreteChannelId)
+                      .build());
+
+      assertFalse(plan.hasErrors());
+      PlannedNode channel = plan.plannedNode(path("Channel")).orElseThrow();
+      assertEquals(concreteChannelId, channel.typeDefinitionId());
+      assertEquals(
+          1, countReferences(plan, channel.nodeId(), NodeIds.HasTypeDefinition, concreteChannelId));
+      assertEquals(
+          0, countReferences(plan, channel.nodeId(), NodeIds.HasTypeDefinition, abstractChannelId));
+
+      // The declared type's members are planned; the concrete subtype's additions are not (yet).
+      assertTrue(plan.plannedNode(path("Channel", "Base")).isPresent());
+      assertTrue(plan.plannedNode(path("Channel", "Extra")).isEmpty());
+      assertTrue(hasWarning(plan, InstantiationDiagnostic.Code.CONCRETE_TYPE_NOT_EXPANDED));
+    }
+
+    /** A concreteType that is not the declared type or a subtype of it is rejected. */
+    @Test
+    void unrelatedConcreteTypeIsPlanError() throws Exception {
+      InstantiationPlan<UaObjectNode> plan =
+          fx.instantiator()
+              .plan(
+                  objectRequest(typeNode.getNodeId(), "Dev")
+                      .concreteType(path("Channel"), unrelatedTypeId)
+                      .build());
+
+      assertTrue(hasError(plan, InstantiationDiagnostic.Code.CONCRETE_TYPE_INVALID));
+    }
+
+    /** A concreteType that is itself abstract is rejected. */
+    @Test
+    void abstractConcreteTypeIsPlanError() throws Exception {
+      InstantiationPlan<UaObjectNode> plan =
+          fx.instantiator()
+              .plan(
+                  objectRequest(typeNode.getNodeId(), "Dev")
+                      .concreteType(path("Channel"), abstractChannelId)
+                      .build());
+
+      assertTrue(hasError(plan, InstantiationDiagnostic.Code.ABSTRACT_MEMBER_TYPE));
+    }
+  }
+
+  @Nested
+  class References {
+
+    /** Hierarchy edges are rewritten onto instance ids with their ReferenceTypes preserved. */
+    @Test
+    void hierarchyEdgesRewrittenWithReferenceTypesPreserved() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("EdgeType", NodeIds.BaseObjectType);
+      fx.addVariableDeclaration(
+          typeNode,
+          "Comp",
+          NodeIds.BaseDataVariableType,
+          NodeIds.ModellingRule_Mandatory,
+          NodeIds.HasComponent);
+      fx.addVariableDeclaration(
+          typeNode,
+          "Prop",
+          NodeIds.PropertyType,
+          NodeIds.ModellingRule_Mandatory,
+          NodeIds.HasProperty);
+
+      InstantiationPlan<UaObjectNode> plan =
+          fx.instantiator().plan(objectRequest(typeNode.getNodeId(), "Dev").build());
+
+      assertFalse(plan.hasErrors());
+      NodeId rootId = plan.root().nodeId();
+      NodeId compId = plan.plannedNode(path("Comp")).orElseThrow().nodeId();
+      NodeId propId = plan.plannedNode(path("Prop")).orElseThrow().nodeId();
+
+      assertEquals(1, countReferences(plan, rootId, NodeIds.HasComponent, compId));
+      assertEquals(1, countReferences(plan, rootId, NodeIds.HasProperty, propId));
+    }
+
+    /**
+     * A declaration-internal non-hierarchical reference is re-mapped onto the corresponding
+     * instances exactly once, forward — the D4 fix, §6.4.3 direct-connection consistency.
+     */
+    @Test
+    void internalNonHierarchicalRowRemappedExactlyOnce() throws Exception {
+      UaReferenceTypeNode causeType =
+          fx.addReferenceType("HasCauseX", NodeIds.NonHierarchicalReferences);
+
+      UaObjectTypeNode typeNode = fx.addObjectType("SMType", NodeIds.BaseObjectType);
+      UaObjectNode a =
+          fx.addObjectDeclaration(
+              typeNode, "A", NodeIds.BaseObjectType, NodeIds.ModellingRule_Mandatory);
+      UaObjectNode b =
+          fx.addObjectDeclaration(
+              typeNode, "B", NodeIds.BaseObjectType, NodeIds.ModellingRule_Mandatory);
+      a.addReference(
+          new Reference(a.getNodeId(), causeType.getNodeId(), b.getNodeId().expanded(), true));
+
+      InstantiationPlan<UaObjectNode> plan =
+          fx.instantiator().plan(objectRequest(typeNode.getNodeId(), "Dev").build());
+
+      assertFalse(plan.hasErrors());
+      NodeId aId = plan.plannedNode(path("A")).orElseThrow().nodeId();
+      NodeId bId = plan.plannedNode(path("B")).orElseThrow().nodeId();
+
+      assertEquals(1, countReferences(plan, aId, causeType.getNodeId(), bId));
+      // Nothing points back into the type's declarations.
+      assertTrue(
+          plan.references().stream()
+              .noneMatch(r -> r.getTargetNodeId().equals(a.getNodeId().expanded())),
+          "no instance reference may point at a declaration node");
+    }
+
+    /** An internal row whose target is omitted produces no reference at all. */
+    @Test
+    void internalRowToOmittedTargetIsDropped() throws Exception {
+      UaReferenceTypeNode causeType =
+          fx.addReferenceType("HasCauseY", NodeIds.NonHierarchicalReferences);
+
+      UaObjectTypeNode typeNode = fx.addObjectType("OmitType", NodeIds.BaseObjectType);
+      UaObjectNode a =
+          fx.addObjectDeclaration(
+              typeNode, "A", NodeIds.BaseObjectType, NodeIds.ModellingRule_Mandatory);
+      UaObjectNode opt =
+          fx.addObjectDeclaration(
+              typeNode, "Opt", NodeIds.BaseObjectType, NodeIds.ModellingRule_Optional);
+      a.addReference(
+          new Reference(a.getNodeId(), causeType.getNodeId(), opt.getNodeId().expanded(), true));
+
+      InstantiationPlan<UaObjectNode> plan =
+          fx.instantiator().plan(objectRequest(typeNode.getNodeId(), "Dev").build());
+
+      assertFalse(plan.hasErrors());
+      NodeId aId = plan.plannedNode(path("A")).orElseThrow().nodeId();
+      assertTrue(
+          plan.references().stream()
+              .noneMatch(
+                  r ->
+                      r.getSourceNodeId().equals(aId)
+                          && r.getReferenceTypeId().equals(causeType.getNodeId())),
+          "no planned edge to an omitted target");
+    }
+
+    /** External rows are copied verbatim by default and droppable via the named policy (KD7). */
+    @Test
+    void externalRowsFollowReplicationPolicy() throws Exception {
+      UaReferenceTypeNode refType =
+          fx.addReferenceType("RefersToX", NodeIds.NonHierarchicalReferences);
+
+      UaObjectTypeNode typeNode = fx.addObjectType("ExtType", NodeIds.BaseObjectType);
+      UaObjectNode a =
+          fx.addObjectDeclaration(
+              typeNode, "A", NodeIds.BaseObjectType, NodeIds.ModellingRule_Mandatory);
+      a.addReference(
+          new Reference(a.getNodeId(), refType.getNodeId(), NodeIds.Server.expanded(), true));
+
+      InstantiationPlan<UaObjectNode> copied =
+          fx.instantiator().plan(objectRequest(typeNode.getNodeId(), "Dev1").build());
+      assertFalse(copied.hasErrors());
+      NodeId aId = copied.plannedNode(path("A")).orElseThrow().nodeId();
+      assertEquals(
+          1,
+          countReferences(copied, aId, refType.getNodeId(), NodeIds.Server),
+          "external target copied verbatim (absolute)");
+
+      InstantiationPlan<UaObjectNode> omitted =
+          fx.instantiator()
+              .plan(
+                  objectRequest(typeNode.getNodeId(), "Dev2")
+                      .referenceReplication(
+                          new ReferenceReplicationPolicy(
+                              ReferenceReplicationPolicy.InternalReferences.REMAP,
+                              ReferenceReplicationPolicy.ExternalReferences.OMIT))
+                      .build());
+      assertFalse(omitted.hasErrors());
+      NodeId aId2 = omitted.plannedNode(path("A")).orElseThrow().nodeId();
+      assertTrue(
+          omitted.references().stream()
+              .noneMatch(
+                  r ->
+                      r.getSourceNodeId().equals(aId2)
+                          && r.getReferenceTypeId().equals(refType.getNodeId())),
+          "external rows droppable by policy");
+    }
+
+    /**
+     * {@code HasModellingRule} is dropped for normal instances, retained for INSTANCE_DECLARATION
+     * (U14).
+     */
+    @Test
+    void hasModellingRuleRetentionIsPurposeDependent() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("PurposeType", NodeIds.BaseObjectType);
+      fx.addVariableDeclaration(
+          typeNode, "M", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+      InstantiationPlan<UaObjectNode> normal =
+          fx.instantiator().plan(objectRequest(typeNode.getNodeId(), "Dev1").build());
+      assertTrue(
+          normal.references().stream()
+              .noneMatch(r -> r.getReferenceTypeId().equals(NodeIds.HasModellingRule)),
+          "normal instances carry no ModellingRules (Part 3 §6.4.4.3)");
+
+      InstantiationPlan<UaObjectNode> declarationPurpose =
+          fx.instantiator()
+              .plan(
+                  objectRequest(typeNode.getNodeId(), "Dev2")
+                      .purpose(InstantiationPurpose.INSTANCE_DECLARATION)
+                      .build());
+      NodeId mId = declarationPurpose.plannedNode(path("M")).orElseThrow().nodeId();
+      assertEquals(
+          1,
+          countReferences(
+              declarationPurpose, mId, NodeIds.HasModellingRule, NodeIds.ModellingRule_Mandatory));
+    }
+
+    /**
+     * The root's HasTypeDefinition and the parent attachment are planned references like any other.
+     */
+    @Test
+    void rootTypeDefinitionAndParentAttachmentPlanned() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("AttachType", NodeIds.BaseObjectType);
+      NodeId parentId = fx.newNodeId("SomeFolder");
+
+      InstantiationPlan<UaObjectNode> plan =
+          fx.instantiator()
+              .plan(
+                  objectRequest(typeNode.getNodeId(), "Dev")
+                      .parent(parentId, NodeIds.Organizes)
+                      .build());
+
+      assertFalse(plan.hasErrors());
+      NodeId rootId = plan.root().nodeId();
+      assertEquals(
+          1, countReferences(plan, rootId, NodeIds.HasTypeDefinition, typeNode.getNodeId()));
+      assertEquals(1, countReferences(plan, parentId, NodeIds.Organizes, rootId));
+    }
+  }
+
+  @Nested
+  class NodeIdAllocation {
+
+    /**
+     * The strategy receives full context and supports any identifier scheme; pins win over it (U6).
+     */
+    @Test
+    void strategyReceivesFullContextAndPinningWins() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("IdType", NodeIds.BaseObjectType);
+      fx.addVariableDeclaration(
+          typeNode, "A", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+      fx.addVariableDeclaration(
+          typeNode, "B", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+      NodeId rootId = fx.newNodeId("Dev");
+      NodeId pinnedId = new NodeId(1, uint(4242));
+      List<NodeIdContext> contexts = new ArrayList<>();
+
+      InstantiationPlan<UaObjectNode> plan =
+          fx.instantiator()
+              .plan(
+                  InstantiationRequest.of(UaObjectNode.class, typeNode.getNodeId())
+                      .nodeId(rootId)
+                      .target(target)
+                      .nodeIdStrategy(
+                          ctx -> {
+                            contexts.add(ctx);
+                            return new NodeId(1, uint(1000 + ctx.path().depth()));
+                          })
+                      .assignNodeId(path("B"), pinnedId)
+                      .build());
+
+      assertFalse(plan.hasErrors());
+      assertEquals(new NodeId(1, uint(1001)), plan.plannedNode(path("A")).orElseThrow().nodeId());
+      assertEquals(pinnedId, plan.plannedNode(path("B")).orElseThrow().nodeId());
+
+      assertEquals(1, contexts.size(), "pinned paths bypass the strategy");
+      assertEquals(rootId, contexts.get(0).rootNodeId());
+      assertEquals(path("A"), contexts.get(0).path());
+      assertEquals(qn("A"), contexts.get(0).declaration().browseName());
+    }
+
+    /**
+     * The default allocator escapes reserved characters, so the two WP1-pinned legacy ambiguities
+     * cannot collide: a member named {@code "A/1:B"} vs a nested member {@code A}/{@code B}, and a
+     * numeric root {@code 7} vs a String root {@code "7"}.
+     */
+    @Test
+    void defaultAllocatorEscapesReservedCharacters() throws Exception {
+      UaObjectTypeNode nestedType = fx.addObjectType("NestedPathType", NodeIds.BaseObjectType);
+      UaObjectNode a =
+          fx.addObjectDeclaration(
+              nestedType, "A", NodeIds.BaseObjectType, NodeIds.ModellingRule_Mandatory);
+      fx.addVariableDeclaration(
+          a, "B", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+      UaObjectTypeNode slashType = fx.addObjectType("SlashNameType", NodeIds.BaseObjectType);
+      fx.addVariableDeclaration(
+          slashType, "A/1:B", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+      NodeId rootId = fx.newNodeId("AmbigRoot");
+
+      InstantiationPlan<UaObjectNode> nested =
+          fx.instantiator()
+              .plan(
+                  InstantiationRequest.of(UaObjectNode.class, nestedType.getNodeId())
+                      .nodeId(rootId)
+                      .target(target)
+                      .build());
+      InstantiationPlan<UaObjectNode> slash =
+          fx.instantiator()
+              .plan(
+                  InstantiationRequest.of(UaObjectNode.class, slashType.getNodeId())
+                      .nodeId(rootId)
+                      .target(target)
+                      .build());
+
+      NodeId nestedLeafId = nested.plannedNode(path("A", "B")).orElseThrow().nodeId();
+      NodeId slashLeafId = slash.plannedNode(path("A/1:B")).orElseThrow().nodeId();
+      assertNotEquals(nestedLeafId, slashLeafId, "escaping disambiguates the WP1 collision");
+
+      // Numeric vs String root identifiers cannot derive identical child ids either.
+      UaObjectTypeNode rootAmbigType = fx.addObjectType("RootAmbigType", NodeIds.BaseObjectType);
+      fx.addVariableDeclaration(
+          rootAmbigType, "Foo", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+      InstantiationPlan<UaObjectNode> numericRoot =
+          fx.instantiator()
+              .plan(
+                  InstantiationRequest.of(UaObjectNode.class, rootAmbigType.getNodeId())
+                      .nodeId(new NodeId(1, uint(7)))
+                      .target(target)
+                      .build());
+      InstantiationPlan<UaObjectNode> stringRoot =
+          fx.instantiator()
+              .plan(
+                  InstantiationRequest.of(UaObjectNode.class, rootAmbigType.getNodeId())
+                      .nodeId(new NodeId(1, "7"))
+                      .target(target)
+                      .build());
+
+      assertNotEquals(
+          numericRoot.plannedNode(path("Foo")).orElseThrow().nodeId(),
+          stringRoot.plannedNode(path("Foo")).orElseThrow().nodeId());
+    }
+
+    /**
+     * {@code legacyPathStrings()} reproduces the WP1-pinned formula exactly: root identifier
+     * string-concatenated with {@code /ns:name} per element, a String identifier in the root's
+     * namespace — including the pinned numeric-root case ({@code 7} deriving {@code "7/1:Foo"}).
+     */
+    @Test
+    void legacyPathStringsReproducesCharacterizedFormula() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("FormulaType", NodeIds.BaseObjectType);
+      UaObjectNode child =
+          fx.addObjectDeclaration(
+              typeNode, "Child", NodeIds.BaseObjectType, NodeIds.ModellingRule_Mandatory);
+      fx.addVariableDeclaration(
+          child, "Leaf", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+      InstantiationPlan<UaObjectNode> plan =
+          fx.instantiator()
+              .plan(
+                  InstantiationRequest.of(UaObjectNode.class, typeNode.getNodeId())
+                      .nodeId(new NodeId(1, "TestRoot"))
+                      .target(target)
+                      .legacyPathStrings()
+                      .build());
+
+      assertFalse(plan.hasErrors());
+      assertEquals(
+          new NodeId(1, "TestRoot/1:Child"),
+          plan.plannedNode(path("Child")).orElseThrow().nodeId());
+      assertEquals(
+          new NodeId(1, "TestRoot/1:Child/1:Leaf"),
+          plan.plannedNode(path("Child", "Leaf")).orElseThrow().nodeId());
+
+      UaObjectTypeNode fooType = fx.addObjectType("FooType", NodeIds.BaseObjectType);
+      fx.addVariableDeclaration(
+          fooType, "Foo", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+      InstantiationPlan<UaObjectNode> numericRoot =
+          fx.instantiator()
+              .plan(
+                  InstantiationRequest.of(UaObjectNode.class, fooType.getNodeId())
+                      .nodeId(new NodeId(1, uint(7)))
+                      .target(target)
+                      .legacyPathStrings()
+                      .build());
+
+      assertEquals(
+          new NodeId(1, "7/1:Foo"), numericRoot.plannedNode(path("Foo")).orElseThrow().nodeId());
+    }
+  }
+
+  @Nested
+  class Methods {
+
+    /** Methods are copied by default; SHARE references the type's Method node per call (KD9/L6). */
+    @Test
+    void methodCopyByDefaultShareByRequest() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("MethodType", NodeIds.BaseObjectType);
+      UaMethodNode method =
+          fx.addMethodDeclaration(typeNode, "Start", NodeIds.ModellingRule_Mandatory);
+      fx.addArgumentsProperty(method, "InputArguments", new Object[0]);
+
+      // The InputArguments property carries a ns0 BrowseName, so its path element is 0:.
+      BrowsePath argumentsPath = BrowsePath.of(qn("Start"), new QualifiedName(0, "InputArguments"));
+
+      InstantiationPlan<UaObjectNode> copied =
+          fx.instantiator().plan(objectRequest(typeNode.getNodeId(), "Dev1").build());
+      assertFalse(copied.hasErrors());
+      PlannedNode copiedMethod = copied.plannedNode(path("Start")).orElseThrow();
+      assertEquals(PlannedNode.Materialization.CREATE, copiedMethod.materialization());
+      assertEquals(UaMethodNode.class, copiedMethod.javaClass());
+      assertNotEquals(method.getNodeId(), copiedMethod.nodeId());
+      assertTrue(
+          copied.plannedNode(argumentsPath).isPresent(),
+          "argument properties copied with the method");
+
+      InstantiationPlan<UaObjectNode> shared =
+          fx.instantiator()
+              .plan(
+                  objectRequest(typeNode.getNodeId(), "Dev2")
+                      .methodInstantiation(MethodInstantiation.SHARE)
+                      .build());
+      assertFalse(shared.hasErrors());
+      PlannedNode sharedMethod = shared.plannedNode(path("Start")).orElseThrow();
+      assertEquals(PlannedNode.Materialization.SHARE, sharedMethod.materialization());
+      assertEquals(method.getNodeId(), sharedMethod.nodeId(), "the type's own Method node");
+      assertEquals(
+          SkippedDeclaration.Reason.METHOD_SHARED, skippedAt(shared, argumentsPath).reason());
+
+      // The hierarchy edge targets the shared node; nothing else is planned for it.
+      assertEquals(
+          1,
+          countReferences(
+              shared, shared.root().nodeId(), NodeIds.HasComponent, method.getNodeId()));
+      assertTrue(
+          shared.references().stream()
+              .noneMatch(r -> r.getSourceNodeId().equals(method.getNodeId())),
+          "a shared node keeps its own references; none are planned for it");
+    }
+
+    /** A bindMethod path that matches no planned Method produces a plan warning. */
+    @Test
+    void bindMethodPathMatchingNothingWarns() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("BindType", NodeIds.BaseObjectType);
+      fx.addMethodDeclaration(typeNode, "Start", NodeIds.ModellingRule_Mandatory);
+      fx.addVariableDeclaration(
+          typeNode, "NotAMethod", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+      InstantiationPlan<UaObjectNode> matched =
+          fx.instantiator()
+              .plan(
+                  objectRequest(typeNode.getNodeId(), "Dev1")
+                      .bindMethod(path("Start"), m -> {})
+                      .build());
+      assertFalse(hasWarning(matched, InstantiationDiagnostic.Code.UNMATCHED_PATH));
+
+      InstantiationPlan<UaObjectNode> unmatched =
+          fx.instantiator()
+              .plan(
+                  objectRequest(typeNode.getNodeId(), "Dev2")
+                      .bindMethod(path("NoSuchMethod"), m -> {})
+                      .bindMethod(path("NotAMethod"), m -> {})
+                      .build());
+      assertEquals(
+          2,
+          unmatched.warnings().stream()
+              .filter(d -> d.code() == InstantiationDiagnostic.Code.UNMATCHED_PATH)
+              .count());
+    }
+  }
+
+  @Nested
+  class PurityAndDeterminism {
+
+    /**
+     * Plan is provably side-effect free: neither the target manager nor the source address space is
+     * mutated — checked with WP4's generation tracking plus node/reference counts and a sampled
+     * identity check.
+     */
+    @Test
+    void planPerformsZeroMutation() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("PureType", NodeIds.BaseObjectType);
+      fx.addVariableDeclaration(
+          typeNode, "M", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+      fx.addVariableDeclaration(
+          typeNode, "Opt", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Optional);
+
+      // Pre-existing target content, so collision preflight has something to read.
+      NodeId existingId = fx.newNodeId("Dev/1:M");
+      UaVariableNode existing =
+          new UaVariableNode(
+              fx.context(),
+              existingId,
+              qn("M"),
+              LocalizedText.english("M"),
+              LocalizedText.NULL_VALUE,
+              UInteger.MIN,
+              UInteger.MIN);
+      target.addNode(existing);
+      target.addReference(
+          new Reference(
+              existingId,
+              NodeIds.HasTypeDefinition,
+              NodeIds.BaseDataVariableType.expanded(),
+              true));
+
+      NodeManager.Generation targetGeneration = target.getGeneration();
+      NodeManager.Generation sourceGeneration = fx.nodeManager().getGeneration();
+      List<NodeId> targetNodeIds = List.copyOf(target.getNodeIds());
+      int sourceNodeCount = fx.nodeManager().getNodes().size();
+
+      InstantiationPlan<UaObjectNode> plan =
+          fx.instantiator()
+              .plan(
+                  objectRequest(typeNode.getNodeId(), "Dev")
+                      .includeAllOptionals()
+                      .conflictPolicy(ConflictPolicy.REUSE_COMPATIBLE)
+                      .build());
+
+      assertFalse(plan.hasErrors());
+      assertTrue(targetGeneration.isCurrent(), "plan wrote nothing to the target");
+      assertTrue(sourceGeneration.isCurrent(), "plan wrote nothing to the source");
+      assertEquals(targetNodeIds, target.getNodeIds());
+      assertEquals(sourceNodeCount, fx.nodeManager().getNodes().size());
+
+      Optional<UaNode> sampled = target.getNode(existingId);
+      assertTrue(sampled.isPresent());
+      assertTrue(sampled.get() == existing, "sampled node is byte-identical (same instance)");
+      assertEquals(qn("M"), sampled.get().getBrowseName());
+    }
+
+    /** Plans are deterministic: the same model and request produce identical output, twice. */
+    @Test
+    void plansAreDeterministicAcrossRuns() throws Exception {
+      UaReferenceTypeNode causeType =
+          fx.addReferenceType("HasCauseZ", NodeIds.NonHierarchicalReferences);
+
+      UaObjectTypeNode typeNode = fx.addObjectType("DetType", NodeIds.BaseObjectType);
+      UaObjectNode a =
+          fx.addObjectDeclaration(
+              typeNode, "A", NodeIds.BaseObjectType, NodeIds.ModellingRule_Mandatory);
+      UaObjectNode b =
+          fx.addObjectDeclaration(
+              typeNode, "B", NodeIds.BaseObjectType, NodeIds.ModellingRule_Mandatory);
+      a.addReference(
+          new Reference(a.getNodeId(), causeType.getNodeId(), b.getNodeId().expanded(), true));
+      fx.addVariableDeclaration(
+          typeNode, "Opt", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Optional);
+
+      InstantiationRequest<UaObjectNode> request =
+          objectRequest(typeNode.getNodeId(), "Dev").includeAllOptionals().build();
+
+      InstantiationPlan<UaObjectNode> first = fx.instantiator().plan(request);
+      InstantiationPlan<UaObjectNode> second = fx.instantiator().plan(request);
+
+      assertEquals(
+          first.plannedNodes().stream().map(PlannedNode::browsePath).toList(),
+          second.plannedNodes().stream().map(PlannedNode::browsePath).toList());
+      assertEquals(
+          first.plannedNodes().stream().map(PlannedNode::nodeId).toList(),
+          second.plannedNodes().stream().map(PlannedNode::nodeId).toList());
+      assertEquals(first.references(), second.references());
+      assertEquals(
+          first.skippedDeclarations().stream().map(SkippedDeclaration::reason).toList(),
+          second.skippedDeclarations().stream().map(SkippedDeclaration::reason).toList());
+      assertEquals(
+          first.diagnostics().stream().map(InstantiationDiagnostic::message).toList(),
+          second.diagnostics().stream().map(InstantiationDiagnostic::message).toList());
+    }
+
+    /** Request paths that match nothing produce warnings instead of silent no-ops. */
+    @Test
+    void unmatchedRequestPathsWarn() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("WarnType", NodeIds.BaseObjectType);
+      fx.addVariableDeclaration(
+          typeNode, "Opt", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Optional);
+
+      InstantiationPlan<UaObjectNode> plan =
+          fx.instantiator()
+              .plan(
+                  objectRequest(typeNode.getNodeId(), "Dev")
+                      .includeOptional(path("NoSuchMember"))
+                      .assignNodeId(
+                          path("Opt"), fx.newNodeId("unused")) // skipped: pin has no effect
+                      .build());
+
+      assertFalse(plan.hasErrors());
+      assertEquals(
+          2,
+          plan.warnings().stream()
+              .filter(d -> d.code() == InstantiationDiagnostic.Code.UNMATCHED_PATH)
+              .count());
+    }
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/NodeInstantiatorApplyTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/NodeInstantiatorApplyTest.java
@@ -1,0 +1,1250 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
+
+import static java.util.Objects.requireNonNull;
+import static org.eclipse.milo.opcua.sdk.server.nodes.instantiation.TypeFixtures.path;
+import static org.eclipse.milo.opcua.sdk.server.nodes.instantiation.TypeFixtures.qn;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ubyte;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.eclipse.milo.opcua.sdk.core.Reference;
+import org.eclipse.milo.opcua.sdk.server.NodeManager;
+import org.eclipse.milo.opcua.sdk.server.NodeManagerBatch;
+import org.eclipse.milo.opcua.sdk.server.NodeManagerBatchException;
+import org.eclipse.milo.opcua.sdk.server.UaNodeManager;
+import org.eclipse.milo.opcua.sdk.server.model.VariableTypeInitializer;
+import org.eclipse.milo.opcua.sdk.server.model.variables.AnalogItemTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaMethodNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNodeContext;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableNode;
+import org.eclipse.milo.opcua.stack.core.AttributeId;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
+import org.eclipse.milo.opcua.stack.core.types.structured.AccessRestrictionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.PermissionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.RolePermissionType;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@code NodeInstantiator.apply} and {@code instantiate}: staged construction with full
+ * attributes, hooks against the staged graph, journaled commit into a real {@link UaNodeManager},
+ * failure injection at every apply stage with zero residue, and the ownership-explicit result.
+ */
+public class NodeInstantiatorApplyTest {
+
+  private TypeFixtures fx;
+  private UaNodeManager target;
+
+  @BeforeEach
+  void setUp() {
+    fx = TypeFixtures.create();
+    target = fx.newTargetManager();
+  }
+
+  /** An ObjectType with one Mandatory Variable member {@code Speed}. */
+  private UaObjectTypeNode simpleType(String name) {
+    UaObjectTypeNode typeNode = fx.addObjectType(name, NodeIds.BaseObjectType);
+    fx.addVariableDeclaration(
+        typeNode, "Speed", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+    return typeNode;
+  }
+
+  private InstantiationRequest.Builder<UaObjectNode> objectRequest(NodeId typeId, String rootId) {
+    return InstantiationRequest.of(UaObjectNode.class, typeId)
+        .nodeId(fx.newNodeId(rootId))
+        .target(target);
+  }
+
+  private static boolean hasDiagnostic(
+      InstantiationException e, InstantiationDiagnostic.Code code) {
+    return e.getDiagnostics().stream().anyMatch(d -> d.code() == code);
+  }
+
+  private static long countReferences(
+      UaNodeManager manager,
+      NodeId sourceNodeId,
+      NodeId referenceTypeId,
+      NodeId targetNodeId,
+      boolean forward) {
+
+    return manager.getReferences(sourceNodeId).stream()
+        .filter(
+            r ->
+                r.getReferenceTypeId().equals(referenceTypeId)
+                    && r.getTargetNodeId().equals(targetNodeId.expanded())
+                    && r.isForward() == forward)
+        .count();
+  }
+
+  /** Assert the target holds nothing and was never effectively mutated. */
+  private void assertNoResidue(NodeManager.Generation preApply) {
+    assertTrue(target.getNodes().isEmpty(), "expected no nodes in the target");
+    assertTrue(preApply.isCurrent(), "expected the target generation to be unchanged");
+  }
+
+  /** A distinct registrable node class proving typed construction reached the registry. */
+  static class TestObjectNode extends UaObjectNode {
+    TestObjectNode(
+        UaNodeContext context, NodeId nodeId, QualifiedName browseName, LocalizedText displayName) {
+      super(
+          context,
+          nodeId,
+          browseName,
+          displayName,
+          LocalizedText.NULL_VALUE,
+          UInteger.MIN,
+          UInteger.MIN,
+          ubyte(0));
+    }
+  }
+
+  private UaObjectNode newObjectNode(NodeId nodeId, QualifiedName browseName) {
+    return new UaObjectNode(
+        fx.context(),
+        nodeId,
+        browseName,
+        LocalizedText.english(browseName.name()),
+        LocalizedText.NULL_VALUE,
+        UInteger.MIN,
+        UInteger.MIN,
+        ubyte(0));
+  }
+
+  private UaVariableNode newVariableNode(NodeId nodeId, QualifiedName browseName) {
+    return new UaVariableNode(
+        fx.context(),
+        nodeId,
+        browseName,
+        LocalizedText.english(browseName.name()),
+        LocalizedText.NULL_VALUE,
+        UInteger.MIN,
+        UInteger.MIN);
+  }
+
+  @Nested
+  class ExampleCallSite {
+
+    /**
+     * The design's example call site, executed end to end against a real {@link UaNodeManager}: one
+     * request, typed result, zero post-hoc mutation.
+     */
+    @Test
+    void exampleCallSiteEndToEnd() throws Exception {
+      VariableTypeInitializer.initialize(fx.namespaceTable(), fx.variableTypeManager());
+      fx.registerWithAddressSpace(target);
+
+      UaObjectNode press1 = newObjectNode(fx.newNodeId("Press1"), qn("Press1"));
+      target.addNode(press1);
+
+      NodeId rootNodeId = fx.newNodeId("Devices/Press1/Pressure");
+      NodeId euRangeNodeId = fx.newNodeId("Devices/Press1/Pressure/EURange");
+      AtomicInteger hookInvocations = new AtomicInteger();
+
+      InstantiationResult<AnalogItemTypeNode> result =
+          fx.instantiator()
+              .instantiate(
+                  InstantiationRequest.of(AnalogItemTypeNode.class, NodeIds.AnalogItemType)
+                      .nodeId(rootNodeId)
+                      .browseName(qn("Pressure"))
+                      .displayName(LocalizedText.english("Pressure"))
+                      .parent(press1.getNodeId(), NodeIds.HasComponent)
+                      .target(target)
+                      .includeOptional(BrowsePath.of(new QualifiedName(0, "EngineeringUnits")))
+                      .nodeIdStrategy(NodeIdContext::defaultNodeId)
+                      .assignNodeId(BrowsePath.of(new QualifiedName(0, "EURange")), euRangeNodeId)
+                      .onNode(
+                          (declaration, node, parent, graph) -> hookInvocations.incrementAndGet())
+                      .build());
+
+      // Typed root, no cast; committed into the target with request identity.
+      AnalogItemTypeNode root = result.root();
+      assertSame(root, target.get(rootNodeId));
+      assertEquals(qn("Pressure"), root.getBrowseName());
+      assertEquals(LocalizedText.english("Pressure"), root.getDisplayName());
+
+      // The unset root Value follows the Bad_NoValue convention.
+      assertEquals(new StatusCode(StatusCodes.Bad_NoValue), root.getValue().getStatusCode());
+
+      // Parent attachment committed with the graph, both observable directions.
+      assertEquals(
+          1, countReferences(target, press1.getNodeId(), NodeIds.HasComponent, rootNodeId, true));
+      assertEquals(
+          1, countReferences(target, rootNodeId, NodeIds.HasComponent, press1.getNodeId(), false));
+
+      // Root HasTypeDefinition committed.
+      assertEquals(
+          1,
+          countReferences(
+              target, rootNodeId, NodeIds.HasTypeDefinition, NodeIds.AnalogItemType, true));
+
+      // The pinned EURange id and the selected optional both materialized.
+      assertTrue(target.containsNode(euRangeNodeId));
+      assertTrue(result.node(BrowsePath.of(new QualifiedName(0, "EngineeringUnits"))).isPresent());
+
+      // Generated typed getters resolve planned children through the committed references.
+      assertNotNull(root.getEuRangeNode());
+      assertNotNull(root.getEngineeringUnitsNode());
+
+      assertTrue(hookInvocations.get() > 0);
+      assertEquals(NodeManager.StorageGuarantee.ATOMIC, result.storageGuarantee());
+      assertEquals(result.materializedNodes().size() + 1, target.getNodes().size());
+    }
+  }
+
+  @Nested
+  class RootConstruction {
+
+    @Test
+    void tupleConstructorPlusOverlayDeliversFullAttributes() throws Exception {
+      UaObjectTypeNode typeNode = simpleType("TupleType");
+
+      fx.objectTypeManager()
+          .registerObjectType(
+              typeNode.getNodeId(),
+              TestObjectNode.class,
+              (context,
+                  nodeId,
+                  browseName,
+                  displayName,
+                  description,
+                  writeMask,
+                  userWriteMask,
+                  rolePermissions,
+                  userRolePermissions,
+                  accessRestrictions) -> {
+                TestObjectNode node = new TestObjectNode(context, nodeId, browseName, displayName);
+                node.setDescription(description);
+                node.setWriteMask(writeMask);
+                node.setUserWriteMask(userWriteMask);
+                node.setRolePermissions(rolePermissions);
+                node.setUserRolePermissions(userRolePermissions);
+                node.setAccessRestrictions(accessRestrictions);
+                return node;
+              });
+
+      RolePermissionType[] rolePermissions = {
+        new RolePermissionType(NodeIds.WellKnownRole_Anonymous, new PermissionType(uint(1)))
+      };
+
+      InstantiationResult<UaObjectNode> result =
+          fx.instantiator()
+              .instantiate(
+                  objectRequest(typeNode.getNodeId(), "Tuple1")
+                      .browseName(qn("Tuple1"))
+                      .displayName(LocalizedText.english("Tuple1"))
+                      .rootAttribute(AttributeId.WriteMask, uint(3))
+                      .rootAttribute(AttributeId.RolePermissions, rolePermissions)
+                      .rootAttribute(
+                          AttributeId.AccessRestrictions,
+                          new AccessRestrictionType(UShort.valueOf(2)))
+                      .rootAttribute(AttributeId.EventNotifier, ubyte(1))
+                      .build());
+
+      UaObjectNode root = assertInstanceOf(TestObjectNode.class, result.root());
+      assertEquals(uint(3), root.getWriteMask());
+      assertEquals(rolePermissions[0], root.getRolePermissions()[0]);
+      assertEquals(new AccessRestrictionType(UShort.valueOf(2)), root.getAccessRestrictions());
+
+      // EventNotifier is not part of the tuple signature; the engine's adaptation overlay set it.
+      assertEquals(ubyte(1), root.getEventNotifier());
+    }
+
+    @Test
+    void snapshotConstructorReceivesEffectiveAttributes() throws Exception {
+      UaObjectTypeNode typeNode = simpleType("SnapshotType");
+
+      AtomicReference<@Nullable AttributeSnapshot> received = new AtomicReference<>();
+      fx.objectTypeManager()
+          .registerObjectType(
+              typeNode.getNodeId(),
+              TestObjectNode.class,
+              (context, nodeId, attributes) -> {
+                received.set(attributes);
+                return new TestObjectNode(
+                    context,
+                    nodeId,
+                    (QualifiedName) requireNonNull(attributes.getOrNull(AttributeId.BrowseName)),
+                    (LocalizedText) requireNonNull(attributes.getOrNull(AttributeId.DisplayName)));
+              });
+
+      InstantiationResult<UaObjectNode> result =
+          fx.instantiator()
+              .instantiate(
+                  objectRequest(typeNode.getNodeId(), "Snap1").browseName(qn("Snap1")).build());
+
+      assertInstanceOf(TestObjectNode.class, result.root());
+      AttributeSnapshot snapshot = received.get();
+      assertNotNull(snapshot);
+      assertEquals(qn("Snap1"), snapshot.getOrNull(AttributeId.BrowseName));
+    }
+
+    @Test
+    void declarationAttributesPropagateAndValueIsFreshened() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("FreshType", NodeIds.BaseObjectType);
+      UaVariableNode declaration =
+          fx.addVariableDeclaration(
+              typeNode, "Speed", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+      DataValue declaredValue =
+          new DataValue(new Variant(42.0), StatusCode.GOOD, new DateTime(1234567890L));
+      declaration.setValue(declaredValue);
+      declaration.setDataType(NodeIds.Double);
+      declaration.setMinimumSamplingInterval(250.0);
+      declaration.setAccessLevel(ubyte(3));
+
+      InstantiationResult<UaObjectNode> result =
+          fx.instantiator().instantiate(objectRequest(typeNode.getNodeId(), "Fresh1").build());
+
+      UaVariableNode speed = result.require(path("Speed"), UaVariableNode.class);
+
+      // Attributes legacy never copied now propagate by policy.
+      assertEquals(250.0, speed.getMinimumSamplingInterval());
+      assertEquals(ubyte(3), speed.getAccessLevel());
+      assertEquals(NodeIds.Double, speed.getDataType());
+
+      // The committed value is a fresh DataValue: same content, new source timestamp, never the
+      // declaration's shared instance.
+      DataValue committed = speed.getValue();
+      assertNotSame(declaredValue, committed);
+      assertEquals(new Variant(42.0), committed.getValue());
+      assertNotNull(committed.getSourceTime());
+      assertNotEquals(new DateTime(1234567890L), committed.getSourceTime());
+    }
+
+    @Test
+    void unsetVariableValueFollowsBadNoValueConvention() throws Exception {
+      UaObjectTypeNode typeNode = simpleType("NoValueType");
+
+      InstantiationResult<UaObjectNode> result =
+          fx.instantiator().instantiate(objectRequest(typeNode.getNodeId(), "NoValue1").build());
+
+      UaVariableNode speed = result.require(path("Speed"), UaVariableNode.class);
+      assertEquals(new StatusCode(StatusCodes.Bad_NoValue), speed.getValue().getStatusCode());
+    }
+  }
+
+  @Nested
+  class FailureInjection {
+
+    @Test
+    void planWithErrorsIsRefusedBeforeAnyStage() {
+      UaObjectTypeNode typeNode = simpleType("RefusedType");
+
+      NodeManager.Generation generation = target.getGeneration();
+
+      InstantiationException e =
+          assertThrows(
+              InstantiationException.class,
+              () ->
+                  fx.instantiator()
+                      .instantiate(
+                          objectRequest(typeNode.getNodeId(), "Refused1")
+                              .excludeOptional(path("Speed")) // Mandatory omission: a plan error
+                              .build()));
+
+      assertEquals(InstantiationDiagnostic.Phase.PLAN, e.getPhase());
+      assertTrue(hasDiagnostic(e, InstantiationDiagnostic.Code.MANDATORY_OMITTED));
+      assertNoResidue(generation);
+    }
+
+    @Test
+    void stalePlanFailsWithModelChangedAndNoMutation() throws Exception {
+      UaObjectTypeNode typeNode = simpleType("StaleType");
+
+      InstantiationPlan<UaObjectNode> plan =
+          fx.instantiator().plan(objectRequest(typeNode.getNodeId(), "Stale1").build());
+
+      // The type mutates after planning; mutators must invalidate the cached model so apply can
+      // detect the stale plan by its recorded revision.
+      fx.addVariableDeclaration(
+          typeNode, "Extra", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+      fx.typeModelCache().invalidate(typeNode.getNodeId());
+
+      NodeManager.Generation generation = target.getGeneration();
+
+      InstantiationException e =
+          assertThrows(InstantiationException.class, () -> fx.instantiator().apply(plan));
+
+      assertTrue(hasDiagnostic(e, InstantiationDiagnostic.Code.MODEL_CHANGED));
+      assertNoResidue(generation);
+    }
+
+    @Test
+    void constructorFailureLeavesNoResidue() {
+      UaObjectTypeNode typeNode = simpleType("CtorFailType");
+
+      fx.objectTypeManager()
+          .registerObjectType(
+              typeNode.getNodeId(),
+              TestObjectNode.class,
+              (org.eclipse.milo.opcua.sdk.server.ObjectTypeManager.SnapshotConstructor)
+                  (context, nodeId, attributes) -> {
+                    throw new IllegalStateException("injected constructor failure");
+                  });
+
+      NodeManager.Generation generation = target.getGeneration();
+
+      InstantiationException e =
+          assertThrows(
+              InstantiationException.class,
+              () ->
+                  fx.instantiator()
+                      .instantiate(objectRequest(typeNode.getNodeId(), "CtorFail1").build()));
+
+      assertTrue(hasDiagnostic(e, InstantiationDiagnostic.Code.CONSTRUCTOR_FAILED));
+      assertNoResidue(generation);
+    }
+
+    @Test
+    void constructorReturningWrongClassFails() {
+      UaObjectTypeNode typeNode = simpleType("WrongClassType");
+
+      // Registered as TestObjectNode but constructs a plain UaObjectNode.
+      fx.objectTypeManager()
+          .registerObjectType(
+              typeNode.getNodeId(),
+              TestObjectNode.class,
+              (org.eclipse.milo.opcua.sdk.server.ObjectTypeManager.SnapshotConstructor)
+                  (context, nodeId, attributes) ->
+                      new UaObjectNode(
+                          context,
+                          nodeId,
+                          (QualifiedName) attributes.getOrNull(AttributeId.BrowseName),
+                          LocalizedText.english("wrong"),
+                          LocalizedText.NULL_VALUE,
+                          UInteger.MIN,
+                          UInteger.MIN,
+                          ubyte(0)));
+
+      NodeManager.Generation generation = target.getGeneration();
+
+      InstantiationException e =
+          assertThrows(
+              InstantiationException.class,
+              () ->
+                  fx.instantiator()
+                      .instantiate(objectRequest(typeNode.getNodeId(), "WrongClass1").build()));
+
+      assertTrue(hasDiagnostic(e, InstantiationDiagnostic.Code.CONSTRUCTOR_FAILED));
+      assertNoResidue(generation);
+    }
+
+    @Test
+    void onNodeHookFailureLeavesNoResidue() {
+      UaObjectTypeNode typeNode = simpleType("HookFailType");
+
+      NodeManager.Generation generation = target.getGeneration();
+
+      InstantiationException e =
+          assertThrows(
+              InstantiationException.class,
+              () ->
+                  fx.instantiator()
+                      .instantiate(
+                          objectRequest(typeNode.getNodeId(), "HookFail1")
+                              .onNode(
+                                  (declaration, node, parent, graph) -> {
+                                    throw new IllegalStateException("injected hook failure");
+                                  })
+                              .build()));
+
+      assertTrue(hasDiagnostic(e, InstantiationDiagnostic.Code.CUSTOMIZATION_FAILED));
+      assertNoResidue(generation);
+    }
+
+    @Test
+    void bindMethodFailureLeavesNoResidue() {
+      UaObjectTypeNode typeNode = fx.addObjectType("BindFailType", NodeIds.BaseObjectType);
+      fx.addMethodDeclaration(typeNode, "Start", NodeIds.ModellingRule_Mandatory);
+
+      InstantiationException e =
+          assertThrows(
+              InstantiationException.class,
+              () ->
+                  fx.instantiator()
+                      .instantiate(
+                          objectRequest(typeNode.getNodeId(), "BindFail1")
+                              .bindMethod(
+                                  path("Start"),
+                                  method -> {
+                                    throw new IllegalStateException("injected binder failure");
+                                  })
+                              .build()));
+
+      assertTrue(hasDiagnostic(e, InstantiationDiagnostic.Code.CUSTOMIZATION_FAILED));
+      // Binders run after the commit, so the failure rolls the committed batch back: the target
+      // holds no nodes, but its generation has necessarily advanced.
+      assertTrue(target.getNodes().isEmpty(), "expected no nodes in the target");
+    }
+
+    @Test
+    void collisionAppearingAfterPlanFailsWithNoStaleState() throws Exception {
+      UaObjectTypeNode typeNode = simpleType("LateCollisionType");
+
+      InstantiationPlan<UaObjectNode> plan =
+          fx.instantiator().plan(objectRequest(typeNode.getNodeId(), "Late1").build());
+
+      // A direct write claims a planned child id between plan and apply.
+      NodeId speedNodeId = plan.plannedNode(path("Speed")).orElseThrow().nodeId();
+      UaVariableNode squatter = newVariableNode(speedNodeId, qn("Squatter"));
+      target.addNode(squatter);
+
+      InstantiationException e =
+          assertThrows(InstantiationException.class, () -> fx.instantiator().apply(plan));
+
+      assertTrue(hasDiagnostic(e, InstantiationDiagnostic.Code.NODE_ID_COLLISION));
+
+      // No stale state: the squatter is untouched and nothing else landed.
+      assertEquals(List.of(squatter), target.getNodes());
+      assertTrue(target.getReferences(speedNodeId).isEmpty());
+    }
+
+    @Test
+    void atomicCommitFailureLeavesNoResidue() {
+      UaObjectTypeNode typeNode = simpleType("AtomicFailType");
+      FailingCommitManager failingTarget = new FailingCommitManager();
+
+      InstantiationException e =
+          assertThrows(
+              InstantiationException.class,
+              () ->
+                  fx.instantiator()
+                      .instantiate(
+                          InstantiationRequest.of(UaObjectNode.class, typeNode.getNodeId())
+                              .nodeId(fx.newNodeId("AtomicFail1"))
+                              .target(failingTarget)
+                              .build()));
+
+      assertTrue(hasDiagnostic(e, InstantiationDiagnostic.Code.COMMIT_FAILED));
+      assertFalse(hasDiagnostic(e, InstantiationDiagnostic.Code.ROLLBACK_FAILED));
+      assertTrue(failingTarget.getNodes().isEmpty());
+    }
+
+    @Test
+    void bestEffortPartialCommitIsRolledBackExactly() {
+      UaObjectTypeNode typeNode = simpleType("PartialFailType");
+      PartialCommitManager partialTarget = new PartialCommitManager();
+
+      InstantiationException e =
+          assertThrows(
+              InstantiationException.class,
+              () ->
+                  fx.instantiator()
+                      .instantiate(
+                          InstantiationRequest.of(UaObjectNode.class, typeNode.getNodeId())
+                              .nodeId(fx.newNodeId("PartialFail1"))
+                              .target(partialTarget)
+                              .build()));
+
+      assertTrue(hasDiagnostic(e, InstantiationDiagnostic.Code.COMMIT_FAILED));
+      assertFalse(hasDiagnostic(e, InstantiationDiagnostic.Code.ROLLBACK_FAILED));
+
+      // The partial journal was rolled back: the node and reference it applied are gone.
+      assertTrue(partialTarget.getNodes().isEmpty());
+      assertTrue(partialTarget.getReferences(fx.newNodeId("PartialFail1")).isEmpty());
+    }
+
+    @Test
+    void uncheckedCommitFailureIsReportedAsCommitFailed() {
+      UaObjectTypeNode typeNode = simpleType("UncheckedFailType");
+
+      UaNodeManager uncheckedTarget =
+          new UaNodeManager() {
+            @Override
+            public CommitResult commit(NodeManagerBatch<UaNode> batch) {
+              throw new IllegalStateException("injected unchecked commit failure");
+            }
+          };
+
+      InstantiationException e =
+          assertThrows(
+              InstantiationException.class,
+              () ->
+                  fx.instantiator()
+                      .instantiate(
+                          InstantiationRequest.of(UaObjectNode.class, typeNode.getNodeId())
+                              .nodeId(fx.newNodeId("UncheckedFail1"))
+                              .target(uncheckedTarget)
+                              .build()));
+
+      assertTrue(hasDiagnostic(e, InstantiationDiagnostic.Code.COMMIT_FAILED));
+      assertTrue(uncheckedTarget.getNodes().isEmpty());
+    }
+
+    @Test
+    void rollbackFailureIsLoudAndNamesTheResidue() {
+      UaObjectTypeNode typeNode = simpleType("RollbackFailType");
+      RollbackFailingManager rollbackFailingTarget = new RollbackFailingManager();
+
+      InstantiationException e =
+          assertThrows(
+              InstantiationException.class,
+              () ->
+                  fx.instantiator()
+                      .instantiate(
+                          InstantiationRequest.of(UaObjectNode.class, typeNode.getNodeId())
+                              .nodeId(fx.newNodeId("RollbackFail1"))
+                              .target(rollbackFailingTarget)
+                              .build()));
+
+      assertTrue(hasDiagnostic(e, InstantiationDiagnostic.Code.COMMIT_FAILED));
+
+      InstantiationDiagnostic rollbackFailed =
+          e.getDiagnostics().stream()
+              .filter(d -> d.code() == InstantiationDiagnostic.Code.ROLLBACK_FAILED)
+              .findFirst()
+              .orElseThrow(() -> new AssertionError("expected a ROLLBACK_FAILED diagnostic"));
+
+      // The diagnostic names what could not be removed, and the residue is really there.
+      assertNotNull(rollbackFailed.nodeId());
+      assertTrue(rollbackFailingTarget.containsNode(rollbackFailed.nodeId()));
+    }
+  }
+
+  @Nested
+  class ApplyCollisions {
+
+    @Test
+    void reuseRecheckFailsWhenAdoptedNodeTurnsIncompatible() throws Exception {
+      UaObjectTypeNode typeNode = simpleType("ReuseDriftType");
+
+      // A compatible node exists at the planned Speed id; the plan adopts it.
+      NodeId speedNodeId = fx.newNodeId("ReuseDrift1/1:Speed");
+      UaVariableNode compatible = newVariableNode(speedNodeId, qn("Speed"));
+      target.addNode(compatible);
+      target.addReference(
+          new Reference(
+              speedNodeId,
+              NodeIds.HasTypeDefinition,
+              NodeIds.BaseDataVariableType.expanded(),
+              true));
+
+      InstantiationPlan<UaObjectNode> plan =
+          fx.instantiator()
+              .plan(
+                  objectRequest(typeNode.getNodeId(), "ReuseDrift1")
+                      .legacyPathStrings()
+                      .conflictPolicy(ConflictPolicy.REUSE_COMPATIBLE)
+                      .build());
+
+      assertEquals(
+          PlannedNode.Materialization.REUSE,
+          plan.plannedNode(path("Speed")).orElseThrow().materialization());
+
+      // The adopted node is replaced by something incompatible before apply.
+      target.removeNode(speedNodeId);
+      target.removeReference(
+          new Reference(
+              speedNodeId,
+              NodeIds.HasTypeDefinition,
+              NodeIds.BaseDataVariableType.expanded(),
+              true));
+      UaObjectNode incompatible = newObjectNode(speedNodeId, qn("NotSpeed"));
+      target.addNode(incompatible);
+
+      InstantiationException e =
+          assertThrows(InstantiationException.class, () -> fx.instantiator().apply(plan));
+
+      assertTrue(hasDiagnostic(e, InstantiationDiagnostic.Code.INCOMPATIBLE_REUSE));
+
+      // No mutation beyond the pre-existing state.
+      assertEquals(List.of(incompatible), target.getNodes());
+    }
+  }
+
+  @Nested
+  class References {
+
+    @Test
+    void nonHierarchicalRowsMappedOntoInstancesExactlyOncePerDirection() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("WiredType", NodeIds.BaseObjectType);
+      NodeId relatesToId =
+          fx.addReferenceType("RelatesTo", NodeIds.NonHierarchicalReferences).getNodeId();
+
+      UaObjectNode declarationA =
+          fx.addObjectDeclaration(
+              typeNode, "A", NodeIds.BaseObjectType, NodeIds.ModellingRule_Mandatory);
+      UaVariableNode declarationB =
+          fx.addVariableDeclaration(
+              typeNode, "B", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Optional);
+
+      declarationA.addReference(
+          new Reference(
+              declarationA.getNodeId(), relatesToId, declarationB.getNodeId().expanded(), true));
+
+      InstantiationResult<UaObjectNode> result =
+          fx.instantiator()
+              .instantiate(
+                  objectRequest(typeNode.getNodeId(), "Wired1").includeOptional(path("B")).build());
+
+      NodeId instanceA = result.node(path("A")).orElseThrow().getNodeId();
+      NodeId instanceB = result.node(path("B")).orElseThrow().getNodeId();
+
+      // Exactly once in each observable direction, in the manager itself (not just the result).
+      assertEquals(1, countReferences(target, instanceA, relatesToId, instanceB, true));
+      assertEquals(1, countReferences(target, instanceB, relatesToId, instanceA, false));
+
+      // With B omitted, no edge to the omitted target lands anywhere.
+      UaNodeManager target2 = fx.newTargetManager();
+      InstantiationResult<UaObjectNode> result2 =
+          fx.instantiator()
+              .instantiate(
+                  InstantiationRequest.of(UaObjectNode.class, typeNode.getNodeId())
+                      .nodeId(fx.newNodeId("Wired2"))
+                      .target(target2)
+                      .build());
+
+      NodeId instanceA2 = result2.node(path("A")).orElseThrow().getNodeId();
+      assertTrue(
+          target2.getReferences(instanceA2).stream()
+              .noneMatch(r -> r.getReferenceTypeId().equals(relatesToId)));
+    }
+
+    @Test
+    void hierarchyEdgesCommittedWithInverses() throws Exception {
+      UaObjectTypeNode typeNode = simpleType("EdgeType");
+
+      InstantiationResult<UaObjectNode> result =
+          fx.instantiator().instantiate(objectRequest(typeNode.getNodeId(), "Edge1").build());
+
+      NodeId rootNodeId = result.root().getNodeId();
+      NodeId speedNodeId = result.node(path("Speed")).orElseThrow().getNodeId();
+
+      assertEquals(1, countReferences(target, rootNodeId, NodeIds.HasComponent, speedNodeId, true));
+      assertEquals(
+          1, countReferences(target, speedNodeId, NodeIds.HasComponent, rootNodeId, false));
+      assertEquals(
+          1,
+          countReferences(
+              target, speedNodeId, NodeIds.HasTypeDefinition, NodeIds.BaseDataVariableType, true));
+    }
+  }
+
+  @Nested
+  class HooksAndResult {
+
+    @Test
+    void hooksFireExactlyOncePerCreatedNodeAtTheStagedPhase() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("HookType", NodeIds.BaseObjectType);
+      fx.addVariableDeclaration(
+          typeNode, "Speed", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+      fx.addObjectDeclaration(
+          typeNode, "Motor", NodeIds.BaseObjectType, NodeIds.ModellingRule_Mandatory);
+
+      Map<NodeId, Integer> invocations = new LinkedHashMap<>();
+      List<String> failures = new ArrayList<>();
+
+      InstantiationResult<UaObjectNode> result =
+          fx.instantiator()
+              .instantiate(
+                  objectRequest(typeNode.getNodeId(), "Hook1")
+                      .onNode(
+                          (declaration, node, parent, graph) -> {
+                            invocations.merge(node.getNodeId(), 1, Integer::sum);
+
+                            if (target.containsNode(node.getNodeId())) {
+                              failures.add(node.getNodeId() + " already published during hook");
+                            }
+                            boolean isRoot = declaration == null;
+                            if (isRoot != (parent == null)) {
+                              failures.add("parent nullity wrong for " + node.getNodeId());
+                            }
+                            if (graph.node(BrowsePath.root()).isEmpty()) {
+                              failures.add("staged graph missing the root");
+                            }
+                          })
+                      .build());
+
+      assertTrue(failures.isEmpty(), failures::toString);
+      assertEquals(3, invocations.size());
+      invocations.forEach((nodeId, count) -> assertEquals(1, count, nodeId.toString()));
+      assertEquals(3, result.materializedNodes().size());
+    }
+
+    @Test
+    void bindMethodBindsTheCopiedMethodBeforeApplyReturns() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("BindType", NodeIds.BaseObjectType);
+      fx.addMethodDeclaration(typeNode, "Start", NodeIds.ModellingRule_Mandatory);
+
+      InstantiationResult<UaObjectNode> result =
+          fx.instantiator()
+              .instantiate(
+                  objectRequest(typeNode.getNodeId(), "Bind1")
+                      .bindMethod(
+                          path("Start"),
+                          method -> method.setDescription(LocalizedText.english("bound")))
+                      .build());
+
+      UaMethodNode start = result.require(path("Start"), UaMethodNode.class);
+      assertEquals(LocalizedText.english("bound"), start.getDescription());
+      assertTrue(target.containsNode(start.getNodeId()));
+      assertEquals(
+          MaterializedNode.Provenance.CREATED,
+          result.materializedNode(path("Start")).orElseThrow().provenance());
+    }
+
+    @Test
+    void sharedMethodBinderReceivesTheDeclarationNode() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("ShareType", NodeIds.BaseObjectType);
+      UaMethodNode declaration =
+          fx.addMethodDeclaration(typeNode, "Start", NodeIds.ModellingRule_Mandatory);
+
+      AtomicReference<@Nullable UaMethodNode> bound = new AtomicReference<>();
+
+      InstantiationResult<UaObjectNode> result =
+          fx.instantiator()
+              .instantiate(
+                  objectRequest(typeNode.getNodeId(), "Share1")
+                      .methodInstantiation(MethodInstantiation.SHARE)
+                      .bindMethod(path("Start"), bound::set)
+                      .build());
+
+      assertSame(declaration, bound.get());
+
+      MaterializedNode shared = result.materializedNode(path("Start")).orElseThrow();
+      assertEquals(MaterializedNode.Provenance.SHARED, shared.provenance());
+      assertSame(declaration, shared.node());
+
+      // The shared Method is referenced, not copied into the target.
+      assertFalse(target.containsNode(declaration.getNodeId()));
+      assertEquals(
+          1,
+          countReferences(
+              target,
+              result.root().getNodeId(),
+              NodeIds.HasComponent,
+              declaration.getNodeId(),
+              true));
+    }
+
+    @Test
+    void afterCommitObserverIsNotificationOnly() throws Exception {
+      UaObjectTypeNode typeNode = simpleType("ObserverType");
+
+      AtomicReference<@Nullable InstantiationResult<UaObjectNode>> observed =
+          new AtomicReference<>();
+
+      InstantiationResult<UaObjectNode> result =
+          fx.instantiator()
+              .instantiate(
+                  objectRequest(typeNode.getNodeId(), "Observer1")
+                      .afterCommit(
+                          r -> {
+                            throw new IllegalStateException("observer failure is swallowed");
+                          })
+                      .afterCommit(observed::set)
+                      .build());
+
+      // The throwing observer affected nothing; the second still ran, after commit.
+      assertSame(result, observed.get());
+      assertTrue(target.containsNode(result.root().getNodeId()));
+    }
+
+    @Test
+    void resultLookupsAreCompleteAndTyped() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("LookupType", NodeIds.BaseObjectType);
+      fx.addVariableDeclaration(
+          typeNode, "Speed", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+      fx.addVariableDeclaration(
+          typeNode, "Extra", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Optional);
+
+      InstantiationResult<UaObjectNode> result =
+          fx.instantiator().instantiate(objectRequest(typeNode.getNodeId(), "Lookup1").build());
+
+      // No null entries: every materialized entry has a node, every planned path resolves.
+      assertFalse(result.materializedNodes().isEmpty());
+      result
+          .materializedNodes()
+          .forEach(
+              m -> {
+                assertNotNull(m.node());
+                assertTrue(result.node(m.browsePath()).isPresent());
+              });
+
+      // Skipped occurrences are indexed, not silently absent.
+      assertTrue(
+          result.skippedDeclarations().stream()
+              .anyMatch(
+                  s ->
+                      s.declaration().browsePath().equals(path("Extra"))
+                          && s.reason() == SkippedDeclaration.Reason.OPTIONAL_NOT_SELECTED));
+
+      // Checked lookups fail with precise status codes instead of returning null.
+      UaException notFound =
+          assertThrows(
+              UaException.class, () -> result.require(path("Extra"), UaVariableNode.class));
+      assertEquals(StatusCodes.Bad_NotFound, notFound.getStatusCode().getValue());
+
+      UaException mismatch =
+          assertThrows(UaException.class, () -> result.require(path("Speed"), UaMethodNode.class));
+      assertEquals(StatusCodes.Bad_TypeMismatch, mismatch.getStatusCode().getValue());
+    }
+  }
+
+  @Nested
+  class ReuseAndCleanup {
+
+    @Test
+    void compatibleReuseIsAdoptedAndDeleteCreatedIsOwnershipSafe() throws Exception {
+      UaObjectTypeNode typeNode = simpleType("ReuseType");
+
+      // A compatible node pre-exists at the planned Speed id, with its own reference row.
+      NodeId speedNodeId = fx.newNodeId("Reuse1/1:Speed");
+      UaVariableNode existing = newVariableNode(speedNodeId, qn("Speed"));
+      target.addNode(existing);
+      Reference preExistingRow =
+          new Reference(
+              speedNodeId,
+              NodeIds.HasTypeDefinition,
+              NodeIds.BaseDataVariableType.expanded(),
+              true);
+      target.addReference(preExistingRow);
+
+      InstantiationResult<UaObjectNode> result =
+          fx.instantiator()
+              .instantiate(
+                  objectRequest(typeNode.getNodeId(), "Reuse1")
+                      .legacyPathStrings()
+                      .conflictPolicy(ConflictPolicy.REUSE_COMPATIBLE)
+                      .build());
+
+      MaterializedNode speed = result.materializedNode(path("Speed")).orElseThrow();
+      assertEquals(MaterializedNode.Provenance.REUSED, speed.provenance());
+      assertSame(existing, speed.node());
+
+      NodeId rootNodeId = result.root().getNodeId();
+      assertEquals(1, countReferences(target, rootNodeId, NodeIds.HasComponent, speedNodeId, true));
+
+      // Cleanup removes exactly what this instantiation created: the root and its rows go, the
+      // reused node and its pre-existing row stay. Idempotent.
+      result.deleteCreated();
+      result.deleteCreated();
+
+      assertFalse(target.containsNode(rootNodeId));
+      assertTrue(target.containsNode(speedNodeId));
+      assertTrue(target.getReferences(speedNodeId).contains(preExistingRow));
+      assertEquals(
+          0, countReferences(target, speedNodeId, NodeIds.HasComponent, rootNodeId, false));
+    }
+  }
+
+  @Nested
+  class Concurrency {
+
+    @Test
+    void concurrentDifferentRootsBothSucceed() throws Exception {
+      UaObjectTypeNode typeNode = simpleType("ConcurrentType");
+      NodeInstantiator instantiator = fx.instantiator();
+
+      ExecutorService executor = Executors.newFixedThreadPool(2);
+      try {
+        CountDownLatch start = new CountDownLatch(1);
+
+        List<Future<InstantiationResult<UaObjectNode>>> futures = new ArrayList<>();
+        for (String rootId : List.of("Concurrent1", "Concurrent2")) {
+          futures.add(
+              executor.submit(
+                  () -> {
+                    start.await();
+                    return instantiator.instantiate(
+                        objectRequest(typeNode.getNodeId(), rootId).build());
+                  }));
+        }
+        start.countDown();
+
+        for (Future<InstantiationResult<UaObjectNode>> future : futures) {
+          assertNotNull(future.get().root());
+        }
+
+        assertTrue(target.containsNode(fx.newNodeId("Concurrent1")));
+        assertTrue(target.containsNode(fx.newNodeId("Concurrent2")));
+      } finally {
+        executor.shutdownNow();
+      }
+    }
+
+    @Test
+    void concurrentSameRootExactlyOneWins() throws Exception {
+      UaObjectTypeNode typeNode = simpleType("RaceType");
+      NodeInstantiator instantiator = fx.instantiator();
+
+      ExecutorService executor = Executors.newFixedThreadPool(2);
+      try {
+        CountDownLatch start = new CountDownLatch(1);
+
+        List<Future<InstantiationResult<UaObjectNode>>> futures = new ArrayList<>();
+        for (int i = 0; i < 2; i++) {
+          futures.add(
+              executor.submit(
+                  () -> {
+                    start.await();
+                    return instantiator.instantiate(
+                        objectRequest(typeNode.getNodeId(), "Race1").build());
+                  }));
+        }
+        start.countDown();
+
+        int successes = 0;
+        InstantiationResult<UaObjectNode> winner = null;
+        for (Future<InstantiationResult<UaObjectNode>> future : futures) {
+          try {
+            winner = future.get();
+            successes++;
+          } catch (java.util.concurrent.ExecutionException e) {
+            assertInstanceOf(InstantiationException.class, e.getCause());
+          }
+        }
+
+        assertEquals(1, successes);
+        assertNotNull(winner);
+
+        // Exactly one instance graph landed; the loser left no residue.
+        assertEquals(winner.materializedNodes().size(), target.getNodes().size());
+      } finally {
+        executor.shutdownNow();
+      }
+    }
+  }
+
+  @Nested
+  class Regressions {
+
+    /** Request state must never contaminate the cached, shared model. */
+    @Test
+    void cachedModelIsIndependentOfRequestState() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("SharedModelType", NodeIds.BaseObjectType);
+      fx.addVariableDeclaration(
+          typeNode, "Speed", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+      fx.addObjectDeclaration(
+          typeNode, "Motor", NodeIds.BaseObjectType, NodeIds.ModellingRule_Optional);
+
+      NodeInstantiator instantiator = fx.instantiator();
+
+      InstantiationPlan<UaObjectNode> plan1 =
+          instantiator.plan(
+              objectRequest(typeNode.getNodeId(), "Shared1")
+                  .includeOptional(path("Motor"))
+                  .onNode((declaration, node, parent, graph) -> {})
+                  .build());
+
+      InstantiationPlan<UaObjectNode> plan2 =
+          instantiator.plan(objectRequest(typeNode.getNodeId(), "Shared2").build());
+
+      // One cached, request-free model instance serves both plans.
+      assertSame(plan1.model(), plan2.model());
+
+      InstantiationResult<UaObjectNode> result1 = instantiator.apply(plan1);
+      InstantiationResult<UaObjectNode> result2 = instantiator.apply(plan2);
+
+      // The first request's selection did not leak into the second.
+      assertTrue(result1.node(path("Motor")).isPresent());
+      assertTrue(result2.node(path("Motor")).isEmpty());
+      assertTrue(
+          result2.skippedDeclarations().stream()
+              .anyMatch(s -> s.declaration().browsePath().equals(path("Motor"))));
+    }
+
+    /** Cross-namespace identity: ids follow the root's namespace, BrowseNames keep their own. */
+    @Test
+    void crossNamespaceIdentityIsPreserved() throws Exception {
+      UaObjectTypeNode typeNode = simpleType("CrossNsType");
+
+      UShort otherNamespaceIndex = fx.namespaceTable().add("urn:eclipse:milo:test:other");
+
+      InstantiationResult<UaObjectNode> result =
+          fx.instantiator()
+              .instantiate(
+                  InstantiationRequest.of(UaObjectNode.class, typeNode.getNodeId())
+                      .nodeId(new NodeId(otherNamespaceIndex, "CrossNs1"))
+                      .target(target)
+                      .build());
+
+      UaNode speed = result.node(path("Speed")).orElseThrow();
+      assertEquals(otherNamespaceIndex, speed.getNodeId().getNamespaceIndex());
+      assertEquals(qn("Speed"), speed.getBrowseName());
+      assertEquals(1, speed.getBrowseName().namespaceIndex().intValue());
+    }
+
+    /**
+     * An unselected optional produces nothing — no orphaned descendants. Legacy NodeFactory created
+     * an omitted optional's subtree and then deleted it, which could leave residue.
+     */
+    @Test
+    void exclusionProducesNoOrphansInTheManager() throws Exception {
+      UaObjectTypeNode motorType = fx.addObjectType("OrphanMotorType", NodeIds.BaseObjectType);
+      fx.addVariableDeclaration(
+          motorType, "Temp", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+      UaObjectTypeNode typeNode = fx.addObjectType("OrphanType", NodeIds.BaseObjectType);
+      fx.addObjectDeclaration(
+          typeNode, "Motor", motorType.getNodeId(), NodeIds.ModellingRule_Optional);
+
+      InstantiationResult<UaObjectNode> result =
+          fx.instantiator().instantiate(objectRequest(typeNode.getNodeId(), "Orphan1").build());
+
+      // The manager holds exactly the materialized set: the root, nothing under Motor.
+      assertEquals(result.materializedNodes().size(), target.getNodes().size());
+      assertTrue(target.getNodes().stream().noneMatch(n -> n.getBrowseName().equals(qn("Temp"))));
+    }
+
+    /** Nested-hierarchy correctness end to end, including supertype members of a member's type. */
+    @Test
+    void nestedHierarchyMaterializesAtEveryDepth() throws Exception {
+      UaObjectTypeNode baseMotorType =
+          fx.addObjectType("NestedBaseMotorType", NodeIds.BaseObjectType);
+      fx.addVariableDeclaration(
+          baseMotorType,
+          "CurrentState",
+          NodeIds.BaseDataVariableType,
+          NodeIds.ModellingRule_Mandatory);
+
+      UaObjectTypeNode derivedMotorType =
+          fx.addObjectType("NestedDerivedMotorType", baseMotorType.getNodeId());
+      fx.addVariableDeclaration(
+          derivedMotorType, "Temp", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+      UaObjectTypeNode typeNode = fx.addObjectType("NestedType", NodeIds.BaseObjectType);
+      fx.addObjectDeclaration(
+          typeNode, "Motor", derivedMotorType.getNodeId(), NodeIds.ModellingRule_Mandatory);
+
+      InstantiationResult<UaObjectNode> result =
+          fx.instantiator().instantiate(objectRequest(typeNode.getNodeId(), "Nested1").build());
+
+      // The member's own member and its supertype-declared member both exist, correctly wired —
+      // supertype-declared members of a member's type are exactly what legacy NodeFactory loses
+      // in nested hierarchies, held correct here end to end through apply.
+      UaNode motor = result.node(path("Motor")).orElseThrow();
+      UaNode temp = result.node(path("Motor", "Temp")).orElseThrow();
+      UaNode currentState = result.node(path("Motor", "CurrentState")).orElseThrow();
+
+      assertEquals(NodeClass.Object, motor.getNodeClass());
+      assertEquals(
+          1,
+          countReferences(target, motor.getNodeId(), NodeIds.HasComponent, temp.getNodeId(), true));
+      assertEquals(
+          1,
+          countReferences(
+              target, motor.getNodeId(), NodeIds.HasComponent, currentState.getNodeId(), true));
+      assertEquals(
+          1,
+          countReferences(
+              target,
+              motor.getNodeId(),
+              NodeIds.HasTypeDefinition,
+              derivedMotorType.getNodeId(),
+              true));
+    }
+  }
+
+  // region Failure-injection managers
+
+  /** A target whose commit always fails atomically: nothing applied, empty journal. */
+  static class FailingCommitManager extends UaNodeManager {
+    @Override
+    public CommitResult commit(NodeManagerBatch<UaNode> batch) throws NodeManagerBatchException {
+      throw new NodeManagerBatchException(
+          StatusCodes.Bad_InternalError,
+          "injected commit failure",
+          new CommitResult(List.of(), List.of()));
+    }
+  }
+
+  /**
+   * A degraded-path target: applies the first node and first reference of the batch, then fails
+   * reporting that partial journal — the shape a failed best-effort emulation produces.
+   */
+  static class PartialCommitManager extends UaNodeManager {
+    @Override
+    public CommitResult commit(NodeManagerBatch<UaNode> batch) throws NodeManagerBatchException {
+      List<NodeId> addedNodes = new ArrayList<>();
+      List<Reference> addedReferences = new ArrayList<>();
+
+      if (!batch.getNodeAdditions().isEmpty()) {
+        UaNode first = batch.getNodeAdditions().get(0);
+        addNode(first);
+        addedNodes.add(first.getNodeId());
+      }
+      if (!batch.getReferenceAdditions().isEmpty()) {
+        Reference first = batch.getReferenceAdditions().get(0);
+        addReference(first);
+        addedReferences.add(first);
+      }
+
+      throw new NodeManagerBatchException(
+          StatusCodes.Bad_InternalError,
+          "injected mid-batch failure",
+          new CommitResult(addedNodes, addedReferences));
+    }
+
+    @Override
+    public StorageGuarantee getStorageGuarantee() {
+      return StorageGuarantee.BEST_EFFORT;
+    }
+  }
+
+  /** A partial-commit target whose rollback removals also fail. */
+  static class RollbackFailingManager extends PartialCommitManager {
+    private boolean committed = false;
+
+    @Override
+    public CommitResult commit(NodeManagerBatch<UaNode> batch) throws NodeManagerBatchException {
+      committed = true;
+      return super.commit(batch);
+    }
+
+    @Override
+    public java.util.Optional<UaNode> removeNode(NodeId nodeId) {
+      if (committed) {
+        throw new IllegalStateException("injected rollback failure");
+      }
+      return super.removeNode(nodeId);
+    }
+  }
+
+  // endregion
+}

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/PlaceholderInstantiationTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/PlaceholderInstantiationTest.java
@@ -1,0 +1,570 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
+
+import static org.eclipse.milo.opcua.sdk.server.nodes.instantiation.TypeFixtures.path;
+import static org.eclipse.milo.opcua.sdk.server.nodes.instantiation.TypeFixtures.qn;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.eclipse.milo.opcua.sdk.server.UaNodeManager;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectTypeNode;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for placeholder-driven creation: request-time expansion binding realizations to a
+ * placeholder path, MandatoryPlaceholder cardinality, post-hoc {@code forPlaceholder} creation
+ * under an existing instance, and ExposesItsArray's surfaced-but-never-materialized contract — all
+ * flowing through the same plan/apply machinery as ordinary requests.
+ */
+public class PlaceholderInstantiationTest {
+
+  private TypeFixtures fx;
+  private UaNodeManager target;
+
+  @BeforeEach
+  void setUp() {
+    fx = TypeFixtures.create();
+    target = fx.newTargetManager();
+  }
+
+  /** An ObjectType with one Mandatory Variable {@code Setpoint} and one Optional {@code Units}. */
+  private UaObjectTypeNode channelType() {
+    UaObjectTypeNode channelType = fx.addObjectType("ChannelType", NodeIds.BaseObjectType);
+    fx.addVariableDeclaration(
+        channelType, "Setpoint", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+    fx.addVariableDeclaration(
+        channelType, "Units", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Optional);
+    return channelType;
+  }
+
+  /**
+   * An ObjectType with one Mandatory Variable {@code Status} and an OptionalPlaceholder {@code
+   * <Channel>} of {@code channelTypeId}, attached by {@code placeholderReferenceTypeId}.
+   */
+  private UaObjectTypeNode deviceType(NodeId channelTypeId, NodeId placeholderReferenceTypeId) {
+    UaObjectTypeNode deviceType = fx.addObjectType("DeviceType", NodeIds.BaseObjectType);
+    fx.addVariableDeclaration(
+        deviceType, "Status", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+    fx.addObjectDeclaration(
+        deviceType,
+        "<Channel>",
+        channelTypeId,
+        NodeIds.ModellingRule_OptionalPlaceholder,
+        placeholderReferenceTypeId);
+    return deviceType;
+  }
+
+  private InstantiationRequest.Builder<UaObjectNode> objectRequest(NodeId typeId, String rootId) {
+    return InstantiationRequest.of(UaObjectNode.class, typeId)
+        .nodeId(fx.newNodeId(rootId))
+        .target(target);
+  }
+
+  private static boolean hasError(InstantiationPlan<?> plan, InstantiationDiagnostic.Code code) {
+    return plan.diagnostics().stream()
+        .anyMatch(d -> d.severity() == InstantiationDiagnostic.Severity.ERROR && d.code() == code);
+  }
+
+  private static long countReferences(
+      UaNodeManager manager, NodeId sourceNodeId, NodeId referenceTypeId, NodeId targetNodeId) {
+
+    return manager.getReferences(sourceNodeId).stream()
+        .filter(
+            r ->
+                r.getReferenceTypeId().equals(referenceTypeId)
+                    && r.getTargetNodeId().equals(targetNodeId.expanded())
+                    && r.isForward())
+        .count();
+  }
+
+  @Nested
+  class Expansion {
+
+    /**
+     * Placeholders never auto-instantiate, whatever the selection: a default request (and an
+     * all-optionals one) applies with zero realizations and the placeholder accounted for as
+     * skipped — expansion to zero members is simply not binding any.
+     */
+    @Test
+    void placeholdersNeverAutoInstantiate() throws Exception {
+      UaObjectTypeNode channelType = channelType();
+      UaObjectTypeNode deviceType = deviceType(channelType.getNodeId(), NodeIds.HasComponent);
+
+      InstantiationResult<UaObjectNode> result =
+          fx.instantiator()
+              .instantiate(
+                  objectRequest(deviceType.getNodeId(), "Dev").includeAllOptionals().build());
+
+      assertTrue(result.node(path("<Channel>")).isEmpty());
+      assertEquals(
+          SkippedDeclaration.Reason.PLACEHOLDER,
+          result.skippedDeclarations().stream()
+              .filter(s -> s.declaration().browsePath().equals(path("<Channel>")))
+              .findFirst()
+              .orElseThrow()
+              .reason());
+
+      // Exactly the root and Status were committed; nothing placeholder-derived exists.
+      assertEquals(2, target.getNodes().size());
+    }
+
+    /** Expansion binds N realizations: names, pinned ids, and the placeholder's attachment. */
+    @Test
+    void optionalPlaceholderExpandsToNMembers() throws Exception {
+      UaObjectTypeNode channelType = channelType();
+      UaObjectTypeNode deviceType = deviceType(channelType.getNodeId(), NodeIds.HasComponent);
+
+      NodeId pinnedId = fx.newNodeId("pinned-channel-2");
+
+      InstantiationResult<UaObjectNode> result =
+          fx.instantiator()
+              .instantiate(
+                  objectRequest(deviceType.getNodeId(), "Dev")
+                      .expandPlaceholder(
+                          path("<Channel>"),
+                          PlaceholderRealization.of(qn("Channel1")),
+                          PlaceholderRealization.of(qn("Channel2")).withNodeId(pinnedId))
+                      .build());
+
+      UaObjectNode channel1 = result.require(path("Channel1"), UaObjectNode.class);
+      UaObjectNode channel2 = result.require(path("Channel2"), UaObjectNode.class);
+
+      assertEquals(qn("Channel1"), channel1.getBrowseName());
+      assertEquals("Channel1", channel1.getDisplayName().getText());
+      assertEquals(pinnedId, channel2.getNodeId());
+
+      // The full member hierarchy of the placeholder's type is realized beneath each realization:
+      // Mandatory members exist, Optional members follow ordinary selection (not selected here).
+      assertTrue(result.node(path("Channel1", "Setpoint")).isPresent());
+      assertTrue(result.node(path("Channel2", "Setpoint")).isPresent());
+      assertTrue(result.node(path("Channel1", "Units")).isEmpty());
+
+      // Each realization attaches with the placeholder's own reference and carries the
+      // placeholder's type.
+      NodeId rootNodeId = result.root().getNodeId();
+      assertEquals(
+          1, countReferences(target, rootNodeId, NodeIds.HasComponent, channel1.getNodeId()));
+      assertEquals(
+          1,
+          countReferences(
+              target, channel1.getNodeId(), NodeIds.HasTypeDefinition, channelType.getNodeId()));
+
+      // The placeholder itself is still accounted for as skipped, not silently absent.
+      assertTrue(
+          result.skippedDeclarations().stream()
+              .anyMatch(
+                  s ->
+                      s.declaration().browsePath().equals(path("<Channel>"))
+                          && s.reason() == SkippedDeclaration.Reason.PLACEHOLDER));
+    }
+
+    /** Optional members inside a realized subtree are selectable like any other path. */
+    @Test
+    void optionalMemberInsideRealizedSubtreeIsSelectable() throws Exception {
+      UaObjectTypeNode channelType = channelType();
+      UaObjectTypeNode deviceType = deviceType(channelType.getNodeId(), NodeIds.HasComponent);
+
+      InstantiationResult<UaObjectNode> result =
+          fx.instantiator()
+              .instantiate(
+                  objectRequest(deviceType.getNodeId(), "Dev")
+                      .expandPlaceholder(
+                          path("<Channel>"), PlaceholderRealization.of(qn("Channel1")))
+                      .includeOptional(path("Channel1", "Units"))
+                      .build());
+
+      assertTrue(result.node(path("Channel1", "Units")).isPresent());
+      assertFalse(
+          result.diagnostics().stream()
+              .anyMatch(d -> d.code() == InstantiationDiagnostic.Code.UNMATCHED_PATH));
+    }
+
+    /**
+     * A realization may instantiate a concrete subtype of the placeholder's declared type; the
+     * subtype's full hierarchy — inherited and additional members — is realized, and the
+     * realization's HasTypeDefinition names the subtype.
+     */
+    @Test
+    void realizationWithConcreteSubtype() throws Exception {
+      UaObjectTypeNode channelType = channelType();
+      UaObjectTypeNode specialType =
+          fx.addObjectType("SpecialChannelType", channelType.getNodeId());
+      fx.addVariableDeclaration(
+          specialType, "Gain", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+      UaObjectTypeNode deviceType = deviceType(channelType.getNodeId(), NodeIds.HasComponent);
+
+      InstantiationResult<UaObjectNode> result =
+          fx.instantiator()
+              .instantiate(
+                  objectRequest(deviceType.getNodeId(), "Dev")
+                      .expandPlaceholder(
+                          path("<Channel>"),
+                          PlaceholderRealization.of(qn("ChannelX"))
+                              .withConcreteType(specialType.getNodeId()))
+                      .build());
+
+      UaObjectNode channelX = result.require(path("ChannelX"), UaObjectNode.class);
+
+      assertTrue(result.node(path("ChannelX", "Setpoint")).isPresent());
+      assertTrue(result.node(path("ChannelX", "Gain")).isPresent());
+      assertEquals(
+          1,
+          countReferences(
+              target, channelX.getNodeId(), NodeIds.HasTypeDefinition, specialType.getNodeId()));
+    }
+
+    /** A realization's concrete type must be the declared placeholder type or a subtype of it. */
+    @Test
+    void realizationWithInvalidConcreteTypeIsPlanError() throws Exception {
+      UaObjectTypeNode channelType = channelType();
+      UaObjectTypeNode unrelatedType = fx.addObjectType("UnrelatedType", NodeIds.BaseObjectType);
+      UaObjectTypeNode deviceType = deviceType(channelType.getNodeId(), NodeIds.HasComponent);
+
+      InstantiationPlan<UaObjectNode> plan =
+          fx.instantiator()
+              .plan(
+                  objectRequest(deviceType.getNodeId(), "Dev")
+                      .expandPlaceholder(
+                          path("<Channel>"),
+                          PlaceholderRealization.of(qn("Channel1"))
+                              .withConcreteType(unrelatedType.getNodeId()))
+                      .build());
+
+      assertTrue(hasError(plan, InstantiationDiagnostic.Code.CONCRETE_TYPE_INVALID));
+    }
+
+    /** Expansion is a directive to create: a binding that matches nothing is a plan error. */
+    @Test
+    void unmatchedExpansionPathIsPlanError() throws Exception {
+      UaObjectTypeNode channelType = channelType();
+      UaObjectTypeNode deviceType = deviceType(channelType.getNodeId(), NodeIds.HasComponent);
+
+      InstantiationPlan<UaObjectNode> plan =
+          fx.instantiator()
+              .plan(
+                  objectRequest(deviceType.getNodeId(), "Dev")
+                      .expandPlaceholder(
+                          path("<Mistyped>"), PlaceholderRealization.of(qn("Channel1")))
+                      .build());
+
+      assertTrue(hasError(plan, InstantiationDiagnostic.Code.PLACEHOLDER_EXPANSION_INVALID));
+    }
+
+    /** A realization may not shadow a declared sibling or repeat another realization's name. */
+    @Test
+    void realizationNameCollisionsArePlanErrors() throws Exception {
+      UaObjectTypeNode channelType = channelType();
+      UaObjectTypeNode deviceType = deviceType(channelType.getNodeId(), NodeIds.HasComponent);
+
+      InstantiationPlan<UaObjectNode> siblingCollision =
+          fx.instantiator()
+              .plan(
+                  objectRequest(deviceType.getNodeId(), "Dev")
+                      .expandPlaceholder(path("<Channel>"), PlaceholderRealization.of(qn("Status")))
+                      .build());
+
+      assertTrue(
+          hasError(siblingCollision, InstantiationDiagnostic.Code.PLACEHOLDER_EXPANSION_INVALID));
+
+      InstantiationPlan<UaObjectNode> duplicateNames =
+          fx.instantiator()
+              .plan(
+                  objectRequest(deviceType.getNodeId(), "Dev")
+                      .expandPlaceholder(
+                          path("<Channel>"),
+                          PlaceholderRealization.of(qn("Channel1")),
+                          PlaceholderRealization.of(qn("Channel1")))
+                      .build());
+
+      assertTrue(
+          hasError(duplicateNames, InstantiationDiagnostic.Code.PLACEHOLDER_EXPANSION_INVALID));
+    }
+
+    /**
+     * A placeholder nested inside a realized subtree is expandable by its realized path, and its
+     * MandatoryPlaceholder obligation applies there like anywhere else.
+     */
+    @Test
+    void nestedPlaceholderInsideRealizedSubtree() throws Exception {
+      UaObjectTypeNode signalType = fx.addObjectType("SignalType", NodeIds.BaseObjectType);
+      fx.addVariableDeclaration(
+          signalType, "Raw", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+      UaObjectTypeNode channelType = fx.addObjectType("SigChannelType", NodeIds.BaseObjectType);
+      fx.addObjectDeclaration(
+          channelType,
+          "<Signal>",
+          signalType.getNodeId(),
+          NodeIds.ModellingRule_MandatoryPlaceholder);
+
+      UaObjectTypeNode deviceType = fx.addObjectType("SigDeviceType", NodeIds.BaseObjectType);
+      fx.addObjectDeclaration(
+          deviceType,
+          "<Channel>",
+          channelType.getNodeId(),
+          NodeIds.ModellingRule_OptionalPlaceholder);
+
+      // Realizing the channel without satisfying its own MandatoryPlaceholder fails the plan.
+      InstantiationPlan<UaObjectNode> unsatisfied =
+          fx.instantiator()
+              .plan(
+                  objectRequest(deviceType.getNodeId(), "Dev")
+                      .expandPlaceholder(path("<Channel>"), PlaceholderRealization.of(qn("Ch1")))
+                      .build());
+
+      assertTrue(
+          hasError(unsatisfied, InstantiationDiagnostic.Code.MANDATORY_PLACEHOLDER_UNSATISFIED));
+
+      // Binding the nested placeholder by its realized path satisfies it end to end.
+      InstantiationResult<UaObjectNode> result =
+          fx.instantiator()
+              .instantiate(
+                  objectRequest(deviceType.getNodeId(), "Dev")
+                      .expandPlaceholder(path("<Channel>"), PlaceholderRealization.of(qn("Ch1")))
+                      .expandPlaceholder(
+                          path("Ch1", "<Signal>"), PlaceholderRealization.of(qn("Sig1")))
+                      .build());
+
+      assertTrue(result.node(path("Ch1", "Sig1")).isPresent());
+      assertTrue(result.node(path("Ch1", "Sig1", "Raw")).isPresent());
+    }
+  }
+
+  @Nested
+  class MandatoryCardinality {
+
+    private UaObjectTypeNode machineType(NodeId channelTypeId) {
+      UaObjectTypeNode machineType = fx.addObjectType("MachineType", NodeIds.BaseObjectType);
+      fx.addObjectDeclaration(
+          machineType, "<Slot>", channelTypeId, NodeIds.ModellingRule_MandatoryPlaceholder);
+      return machineType;
+    }
+
+    /** MandatoryPlaceholder with zero bindings fails the plan, and apply refuses the plan. */
+    @Test
+    void zeroRealizationsFailsThePlan() throws Exception {
+      UaObjectTypeNode machineType = machineType(channelType().getNodeId());
+
+      InstantiationPlan<UaObjectNode> plan =
+          fx.instantiator().plan(objectRequest(machineType.getNodeId(), "M1").build());
+
+      assertTrue(hasError(plan, InstantiationDiagnostic.Code.MANDATORY_PLACEHOLDER_UNSATISFIED));
+
+      InstantiationException e =
+          assertThrows(InstantiationException.class, () -> fx.instantiator().apply(plan));
+      assertTrue(
+          e.getDiagnostics().stream()
+              .anyMatch(
+                  d -> d.code() == InstantiationDiagnostic.Code.MANDATORY_PLACEHOLDER_UNSATISFIED));
+
+      assertTrue(target.getNodes().isEmpty());
+    }
+
+    /** One realization satisfies the ≥1 obligation. */
+    @Test
+    void oneRealizationSatisfiesTheObligation() throws Exception {
+      UaObjectTypeNode machineType = machineType(channelType().getNodeId());
+
+      InstantiationResult<UaObjectNode> result =
+          fx.instantiator()
+              .instantiate(
+                  objectRequest(machineType.getNodeId(), "M1")
+                      .expandPlaceholder(path("<Slot>"), PlaceholderRealization.of(qn("Slot1")))
+                      .build());
+
+      assertTrue(result.node(path("Slot1")).isPresent());
+      assertTrue(result.node(path("Slot1", "Setpoint")).isPresent());
+    }
+
+    /** Excluding a MandatoryPlaceholder does not silence its obligation. */
+    @Test
+    void excludedMandatoryPlaceholderFailsThePlan() throws Exception {
+      UaObjectTypeNode machineType = machineType(channelType().getNodeId());
+
+      InstantiationPlan<UaObjectNode> plan =
+          fx.instantiator()
+              .plan(
+                  objectRequest(machineType.getNodeId(), "M1")
+                      .excludeOptional(path("<Slot>"))
+                      .expandPlaceholder(path("<Slot>"), PlaceholderRealization.of(qn("Slot1")))
+                      .build());
+
+      assertTrue(hasError(plan, InstantiationDiagnostic.Code.MANDATORY_PLACEHOLDER_UNSATISFIED));
+      // The bindings could not be honored either — surfaced, not silently dropped.
+      assertTrue(hasError(plan, InstantiationDiagnostic.Code.PLACEHOLDER_EXPANSION_INVALID));
+    }
+  }
+
+  @Nested
+  class ForPlaceholder {
+
+    /**
+     * Post-hoc creation under an existing instance: the realization attaches with the placeholder
+     * declaration's own ReferenceType (Organizes here, proving it is resolved rather than
+     * defaulted), member ids flow through the request's strategy, the result is typed, and
+     * deleteCreated removes exactly the addition.
+     */
+    @Test
+    void forPlaceholderCreatesUnderExistingInstance() throws Exception {
+      UaObjectTypeNode channelType = channelType();
+      UaObjectTypeNode deviceType = deviceType(channelType.getNodeId(), NodeIds.Organizes);
+
+      InstantiationResult<UaObjectNode> device =
+          fx.instantiator().instantiate(objectRequest(deviceType.getNodeId(), "Dev").build());
+      NodeId deviceNodeId = device.root().getNodeId();
+
+      TypeInstantiationModel model = fx.instantiator().describe(deviceType.getNodeId());
+      InstanceDeclaration placeholder = model.placeholders().get(0);
+      assertEquals(path("<Channel>"), placeholder.browsePath());
+
+      List<BrowsePath> strategyPaths = new ArrayList<>();
+
+      InstantiationResult<UaObjectNode> channel =
+          fx.instantiator()
+              .instantiate(
+                  InstantiationRequest.forPlaceholder(UaObjectNode.class, deviceNodeId, placeholder)
+                      .nodeId(fx.newNodeId("Dev/Channel1"))
+                      .browseName(qn("Channel1"))
+                      .target(target)
+                      .nodeIdStrategy(
+                          ctx -> {
+                            strategyPaths.add(ctx.path());
+                            return ctx.defaultNodeId();
+                          })
+                      .build());
+
+      UaObjectNode channelRoot = channel.root();
+      assertEquals(qn("Channel1"), channelRoot.getBrowseName());
+
+      // Attached with the placeholder's own reference type, resolved from the declaration.
+      assertEquals(
+          1, countReferences(target, deviceNodeId, NodeIds.Organizes, channelRoot.getNodeId()));
+      assertEquals(
+          1,
+          countReferences(
+              target, channelRoot.getNodeId(), NodeIds.HasTypeDefinition, channelType.getNodeId()));
+
+      // Member ids went through the request's strategy.
+      assertTrue(strategyPaths.contains(path("Setpoint")));
+      assertTrue(channel.node(path("Setpoint")).isPresent());
+
+      // Cleanup removes only the addition: the device instance is untouched.
+      channel.deleteCreated();
+      assertTrue(target.getNode(channelRoot.getNodeId()).isEmpty());
+      assertTrue(target.getNode(deviceNodeId).isPresent());
+      assertTrue(
+          device.node(path("Status")).map(n -> target.containsNode(n.getNodeId())).orElse(false));
+      assertEquals(
+          0, countReferences(target, deviceNodeId, NodeIds.Organizes, channelRoot.getNodeId()));
+    }
+
+    /** A concrete subtype of the placeholder's declared type is selected at the root path. */
+    @Test
+    void forPlaceholderWithConcreteSubtype() throws Exception {
+      UaObjectTypeNode channelType = channelType();
+      UaObjectTypeNode specialType =
+          fx.addObjectType("SpecialChannelType", channelType.getNodeId());
+      fx.addVariableDeclaration(
+          specialType, "Gain", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+      UaObjectTypeNode deviceType = deviceType(channelType.getNodeId(), NodeIds.HasComponent);
+
+      InstantiationResult<UaObjectNode> device =
+          fx.instantiator().instantiate(objectRequest(deviceType.getNodeId(), "Dev").build());
+
+      TypeInstantiationModel model = fx.instantiator().describe(deviceType.getNodeId());
+      InstanceDeclaration placeholder = model.placeholders().get(0);
+
+      InstantiationResult<UaObjectNode> channel =
+          fx.instantiator()
+              .instantiate(
+                  InstantiationRequest.forPlaceholder(
+                          UaObjectNode.class, device.root().getNodeId(), placeholder)
+                      .nodeId(fx.newNodeId("Dev/ChannelX"))
+                      .browseName(qn("ChannelX"))
+                      .concreteType(BrowsePath.root(), specialType.getNodeId())
+                      .target(target)
+                      .build());
+
+      assertEquals(
+          1,
+          countReferences(
+              target,
+              channel.root().getNodeId(),
+              NodeIds.HasTypeDefinition,
+              specialType.getNodeId()));
+      assertTrue(channel.node(path("Setpoint")).isPresent());
+      assertTrue(channel.node(path("Gain")).isPresent());
+    }
+
+    /** A non-placeholder declaration is rejected before a request is even built. */
+    @Test
+    void forPlaceholderRejectsNonPlaceholderDeclarations() throws Exception {
+      UaObjectTypeNode channelType = channelType();
+      UaObjectTypeNode deviceType = deviceType(channelType.getNodeId(), NodeIds.HasComponent);
+
+      TypeInstantiationModel model = fx.instantiator().describe(deviceType.getNodeId());
+      InstanceDeclaration status = model.get(path("Status")).orElseThrow();
+
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> InstantiationRequest.forPlaceholder(fx.newNodeId("Dev"), status));
+    }
+  }
+
+  @Nested
+  class ExposesItsArray {
+
+    /** ExposesItsArray is visible in the model and warned about, but never materialized. */
+    @Test
+    void surfacedInModelWarnedInPlanNeverMaterialized() throws Exception {
+      UaObjectTypeNode arrayType = fx.addObjectType("ArrayHostType", NodeIds.BaseObjectType);
+      fx.addVariableDeclaration(
+          arrayType, "Elements", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+      fx.addVariableDeclaration(
+          arrayType,
+          "Element",
+          NodeIds.BaseDataVariableType,
+          NodeIds.ModellingRule_ExposesItsArray);
+
+      TypeInstantiationModel model = fx.instantiator().describe(arrayType.getNodeId());
+      assertEquals(
+          ModellingRule.EXPOSES_ITS_ARRAY, model.get(path("Element")).orElseThrow().rule());
+
+      InstantiationResult<UaObjectNode> result =
+          fx.instantiator()
+              .instantiate(
+                  objectRequest(arrayType.getNodeId(), "Host").includeAllOptionals().build());
+
+      assertTrue(
+          result.diagnostics().stream()
+              .anyMatch(
+                  d ->
+                      d.code() == InstantiationDiagnostic.Code.EXPOSES_ITS_ARRAY_NOT_MATERIALIZED));
+      assertTrue(result.node(path("Element")).isEmpty());
+      assertTrue(
+          result.skippedDeclarations().stream()
+              .anyMatch(
+                  s ->
+                      s.declaration().browsePath().equals(path("Element"))
+                          && s.reason() == SkippedDeclaration.Reason.EXPOSES_ITS_ARRAY));
+    }
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/TypeFixtures.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/TypeFixtures.java
@@ -19,8 +19,10 @@ import org.eclipse.milo.opcua.sdk.core.Reference;
 import org.eclipse.milo.opcua.sdk.core.typetree.ReferenceTypeTree;
 import org.eclipse.milo.opcua.sdk.server.AddressSpaceManager;
 import org.eclipse.milo.opcua.sdk.server.NodeManager;
+import org.eclipse.milo.opcua.sdk.server.ObjectTypeManager;
 import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
 import org.eclipse.milo.opcua.sdk.server.UaNodeManager;
+import org.eclipse.milo.opcua.sdk.server.VariableTypeManager;
 import org.eclipse.milo.opcua.sdk.server.namespaces.loader.NodeLoader;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaMethodNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
@@ -71,6 +73,9 @@ public class TypeFixtures {
   private final NamespaceTable namespaceTable;
   private final UaNodeManager nodeManager;
   private final UaNodeContext context;
+  private final ObjectTypeManager objectTypeManager;
+  private final VariableTypeManager variableTypeManager;
+  private final TypeModelCache typeModelCache;
 
   private TypeFixtures() throws Exception {
     server = Mockito.mock(OpcUaServer.class);
@@ -122,6 +127,17 @@ public class TypeFixtures {
           }
         };
 
+    objectTypeManager = new ObjectTypeManager();
+    Mockito.when(server.getObjectTypeManager()).thenReturn(objectTypeManager);
+
+    variableTypeManager = new VariableTypeManager();
+    Mockito.when(server.getVariableTypeManager()).thenReturn(variableTypeManager);
+
+    // The cache's supplier goes through compiler() so each compilation sees a ReferenceType tree
+    // rebuilt from current state (custom ReferenceTypes added by tests included).
+    typeModelCache = new TypeModelCache(this::compiler);
+    Mockito.when(server.getTypeModelCache()).thenReturn(typeModelCache);
+
     new NodeLoader(context, nodeManager).loadNodes();
 
     rebuildReferenceTypeTree();
@@ -164,6 +180,44 @@ public class TypeFixtures {
    */
   public UaNodeContext context() {
     return context;
+  }
+
+  /**
+   * @return the real {@link ObjectTypeManager} wired into the mocked server.
+   */
+  public ObjectTypeManager objectTypeManager() {
+    return objectTypeManager;
+  }
+
+  /**
+   * @return the real {@link VariableTypeManager} wired into the mocked server.
+   */
+  public VariableTypeManager variableTypeManager() {
+    return variableTypeManager;
+  }
+
+  /**
+   * @return the real {@link TypeModelCache} wired into the mocked server.
+   */
+  public TypeModelCache typeModelCache() {
+    return typeModelCache;
+  }
+
+  /**
+   * @return a {@link NodeInstantiator} over this fixture's mocked server. The ReferenceType tree is
+   *     rebuilt first so types added by the test are classified correctly.
+   */
+  public NodeInstantiator instantiator() {
+    rebuildReferenceTypeTree();
+    return new NodeInstantiator(server);
+  }
+
+  /**
+   * @return a fresh, empty destination {@link UaNodeManager}, distinct from the source manager
+   *     holding ns0 and the synthetic types.
+   */
+  public UaNodeManager newTargetManager() {
+    return new UaNodeManager();
   }
 
   /**

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/TypeFixtures.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/TypeFixtures.java
@@ -1,0 +1,494 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ubyte;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import org.eclipse.milo.opcua.sdk.core.Reference;
+import org.eclipse.milo.opcua.sdk.core.typetree.ReferenceTypeTree;
+import org.eclipse.milo.opcua.sdk.server.AddressSpaceManager;
+import org.eclipse.milo.opcua.sdk.server.NodeManager;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.sdk.server.UaNodeManager;
+import org.eclipse.milo.opcua.sdk.server.namespaces.loader.NodeLoader;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaMethodNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNodeContext;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaReferenceTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableTypeNode;
+import org.eclipse.milo.opcua.sdk.server.typetree.ReferenceTypeTreeBuilder;
+import org.eclipse.milo.opcua.stack.core.NamespaceTable;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
+import org.eclipse.milo.opcua.stack.core.encoding.OpcUaEncodingManager;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.jspecify.annotations.Nullable;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
+
+/**
+ * Shared synthetic type-graph builder for the node-instantiation test suite. The compiler tests
+ * build on it; later suites in this package extend it.
+ *
+ * <p>Bootstraps the same mocked environment as the legacy {@code NodeFactoryCharacterizationTest}
+ * fixture: a mocked {@link OpcUaServer} over a real {@link UaNodeManager} with namespace zero
+ * loaded, an {@link AddressSpaceManager} stub delegating to the node manager, and a {@link
+ * ReferenceTypeTree} built <em>after</em> ns0 is loaded and outside any {@code when(...)} stubbing
+ * call (building it interacts with the same mock). Custom ReferenceTypes added by a test are picked
+ * up because {@link #compiler()} rebuilds the tree on every call.
+ *
+ * <p>Synthetic nodes live in namespace index 1 ({@value #TEST_NAMESPACE_URI}). Declaration helpers
+ * wire references single-direction (the inverse is auto-added by {@link
+ * UaNode#addReference(Reference)}), mirroring the characterization test helpers.
+ */
+public class TypeFixtures {
+
+  public static final String TEST_NAMESPACE_URI = "urn:eclipse:milo:test:instantiation";
+
+  public static final int TEST_NAMESPACE_INDEX = 1;
+
+  private final OpcUaServer server;
+  private final NamespaceTable namespaceTable;
+  private final UaNodeManager nodeManager;
+  private final UaNodeContext context;
+
+  private TypeFixtures() throws Exception {
+    server = Mockito.mock(OpcUaServer.class);
+
+    namespaceTable = new NamespaceTable();
+    namespaceTable.add(TEST_NAMESPACE_URI);
+    Mockito.when(server.getNamespaceTable()).thenReturn(namespaceTable);
+
+    nodeManager = new UaNodeManager();
+
+    AddressSpaceManager addressSpaceManager = Mockito.mock(AddressSpaceManager.class);
+
+    Mockito.when(addressSpaceManager.getManagedNode(Mockito.any(NodeId.class)))
+        .then(
+            (Answer<Optional<UaNode>>)
+                invocation -> nodeManager.getNode(invocation.getArgument(0)));
+
+    Mockito.when(addressSpaceManager.getManagedNode(Mockito.any(ExpandedNodeId.class)))
+        .then(
+            (Answer<Optional<UaNode>>)
+                invocation -> nodeManager.getNode(invocation.getArgument(0), namespaceTable));
+
+    Mockito.when(addressSpaceManager.getManagedReferences(Mockito.any(NodeId.class)))
+        .then(
+            (Answer<List<Reference>>)
+                invocation -> nodeManager.getReferences(invocation.getArgument(0)));
+
+    Mockito.when(addressSpaceManager.getManagedReferences(Mockito.any(NodeId.class), Mockito.any()))
+        .then(
+            (Answer<List<Reference>>)
+                invocation ->
+                    nodeManager.getReferences(
+                        invocation.getArgument(0), invocation.getArgument(1)));
+
+    Mockito.when(server.getAddressSpaceManager()).thenReturn(addressSpaceManager);
+    Mockito.when(server.getStaticEncodingContext()).thenReturn(DefaultEncodingContext.INSTANCE);
+    Mockito.when(server.getEncodingManager()).thenReturn(OpcUaEncodingManager.getInstance());
+
+    context =
+        new UaNodeContext() {
+          @Override
+          public OpcUaServer getServer() {
+            return server;
+          }
+
+          @Override
+          public NodeManager<UaNode> getNodeManager() {
+            return nodeManager;
+          }
+        };
+
+    new NodeLoader(context, nodeManager).loadNodes();
+
+    rebuildReferenceTypeTree();
+  }
+
+  /**
+   * @return a new fixture over a fresh node manager with namespace zero loaded.
+   */
+  public static TypeFixtures create() {
+    try {
+      return new TypeFixtures();
+    } catch (Exception e) {
+      throw new RuntimeException("fixture bootstrap failed", e);
+    }
+  }
+
+  /**
+   * @return the mocked server backing this fixture.
+   */
+  public OpcUaServer server() {
+    return server;
+  }
+
+  /**
+   * @return the node manager holding ns0 and all synthetic nodes.
+   */
+  public UaNodeManager nodeManager() {
+    return nodeManager;
+  }
+
+  /**
+   * @return the fixture's namespace table (ns0 + the test namespace at index 1).
+   */
+  public NamespaceTable namespaceTable() {
+    return namespaceTable;
+  }
+
+  /**
+   * @return the node context synthetic nodes are constructed with.
+   */
+  public UaNodeContext context() {
+    return context;
+  }
+
+  /**
+   * @return a fresh compiler over this fixture's address space. The ReferenceType tree is rebuilt
+   *     first so custom ReferenceTypes added by the test are classified correctly.
+   */
+  public TypeModelCompiler compiler() {
+    rebuildReferenceTypeTree();
+    return new TypeModelCompiler(server);
+  }
+
+  /** Rebuild the ReferenceType tree from current state and restub the server mock with it. */
+  public void rebuildReferenceTypeTree() {
+    // Built outside the when() call: building interacts with the same mock.
+    ReferenceTypeTree referenceTypeTree = ReferenceTypeTreeBuilder.build(server);
+    Mockito.when(server.getReferenceTypeTree()).thenReturn(referenceTypeTree);
+  }
+
+  /**
+   * @param name the identifier text.
+   * @return a String NodeId in the test namespace.
+   */
+  public NodeId newNodeId(String name) {
+    return new NodeId(TEST_NAMESPACE_INDEX, name);
+  }
+
+  /**
+   * @param name the browse name text.
+   * @return a {@link QualifiedName} in the test namespace.
+   */
+  public static QualifiedName qn(String name) {
+    return new QualifiedName(TEST_NAMESPACE_INDEX, name);
+  }
+
+  /**
+   * @param names browse name texts, outermost first, all in the test namespace.
+   * @return the {@link BrowsePath} of those names.
+   */
+  public static BrowsePath path(String... names) {
+    return BrowsePath.of(Arrays.stream(names).map(TypeFixtures::qn).toList());
+  }
+
+  /**
+   * Create an ObjectType node subtyping {@code supertypeId} and add it to the node manager. The
+   * supertype id need not exist yet (cycle fixtures rely on that).
+   */
+  public UaObjectTypeNode addObjectType(String name, NodeId supertypeId) {
+    return addObjectType(name, supertypeId, false);
+  }
+
+  /** Create an ObjectType node, optionally abstract. */
+  public UaObjectTypeNode addObjectType(String name, NodeId supertypeId, boolean isAbstract) {
+    UaObjectTypeNode typeNode =
+        new UaObjectTypeNode(
+            context,
+            newNodeId(name),
+            qn(name),
+            LocalizedText.english(name),
+            LocalizedText.NULL_VALUE,
+            UInteger.MIN,
+            UInteger.MIN,
+            isAbstract);
+
+    typeNode.addReference(
+        new Reference(typeNode.getNodeId(), NodeIds.HasSubtype, supertypeId.expanded(), false));
+
+    nodeManager.addNode(typeNode);
+
+    return typeNode;
+  }
+
+  /** Create a VariableType node subtyping {@code supertypeId} and add it to the node manager. */
+  public UaVariableTypeNode addVariableType(
+      String name, NodeId supertypeId, @Nullable DataValue value, NodeId dataType, int valueRank) {
+
+    UaVariableTypeNode typeNode =
+        new UaVariableTypeNode(
+            context,
+            newNodeId(name),
+            qn(name),
+            LocalizedText.english(name),
+            LocalizedText.NULL_VALUE,
+            UInteger.MIN,
+            UInteger.MIN,
+            value,
+            dataType,
+            valueRank,
+            null,
+            false);
+
+    typeNode.addReference(
+        new Reference(typeNode.getNodeId(), NodeIds.HasSubtype, supertypeId.expanded(), false));
+
+    nodeManager.addNode(typeNode);
+
+    return typeNode;
+  }
+
+  /** Create an interface type (an ObjectType subtyping BaseInterfaceType). */
+  public UaObjectTypeNode addInterfaceType(String name) {
+    return addObjectType(name, NodeIds.BaseInterfaceType, true);
+  }
+
+  /** Create a concrete ReferenceType subtyping {@code supertypeId}. */
+  public UaReferenceTypeNode addReferenceType(String name, NodeId supertypeId) {
+    UaReferenceTypeNode referenceTypeNode =
+        new UaReferenceTypeNode(
+            context,
+            newNodeId(name),
+            qn(name),
+            LocalizedText.english(name),
+            LocalizedText.NULL_VALUE,
+            UInteger.MIN,
+            UInteger.MIN,
+            false,
+            false,
+            LocalizedText.english("InverseOf" + name));
+
+    referenceTypeNode.addReference(
+        new Reference(
+            referenceTypeNode.getNodeId(), NodeIds.HasSubtype, supertypeId.expanded(), false));
+
+    nodeManager.addNode(referenceTypeNode);
+
+    return referenceTypeNode;
+  }
+
+  /**
+   * Give {@code typeNode} a rule-less {@code DefaultInstanceBrowseName} property (ns0 name, as the
+   * spec defines it) carrying {@code defaultName}.
+   */
+  public UaVariableNode setDefaultInstanceBrowseName(UaNode typeNode, QualifiedName defaultName) {
+    NodeId nodeId = newNodeId(typeNode.getBrowseName().name() + ".DefaultInstanceBrowseName");
+
+    UaVariableNode property =
+        new UaVariableNode(
+            context,
+            nodeId,
+            new QualifiedName(0, "DefaultInstanceBrowseName"),
+            LocalizedText.english("DefaultInstanceBrowseName"),
+            LocalizedText.NULL_VALUE,
+            UInteger.MIN,
+            UInteger.MIN);
+    property.setValue(new DataValue(new Variant(defaultName)));
+    property.setDataType(NodeIds.QualifiedName);
+    property.addReference(
+        new Reference(nodeId, NodeIds.HasTypeDefinition, NodeIds.PropertyType.expanded(), true));
+
+    nodeManager.addNode(property);
+
+    typeNode.addReference(
+        new Reference(typeNode.getNodeId(), NodeIds.HasProperty, nodeId.expanded(), true));
+
+    return property;
+  }
+
+  /** Add an Object declaration under {@code parent} via forward HasComponent. */
+  public UaObjectNode addObjectDeclaration(
+      UaNode parent, String name, NodeId typeDefinitionId, NodeId modellingRuleId) {
+    return addObjectDeclaration(
+        parent, name, typeDefinitionId, modellingRuleId, NodeIds.HasComponent);
+  }
+
+  /** Add an Object declaration under {@code parent} via the given hierarchical ReferenceType. */
+  public UaObjectNode addObjectDeclaration(
+      UaNode parent,
+      String name,
+      NodeId typeDefinitionId,
+      NodeId modellingRuleId,
+      NodeId referenceTypeId) {
+
+    NodeId nodeId = newNodeId(parent.getBrowseName().name() + "." + name);
+
+    UaObjectNode declaration =
+        new UaObjectNode(
+            context,
+            nodeId,
+            qn(name),
+            LocalizedText.english(name),
+            LocalizedText.NULL_VALUE,
+            UInteger.MIN,
+            UInteger.MIN,
+            ubyte(0));
+
+    declaration.addReference(
+        new Reference(nodeId, NodeIds.HasTypeDefinition, typeDefinitionId.expanded(), true));
+    declaration.addReference(
+        new Reference(nodeId, NodeIds.HasModellingRule, modellingRuleId.expanded(), true));
+
+    nodeManager.addNode(declaration);
+
+    parent.addReference(
+        new Reference(parent.getNodeId(), referenceTypeId, nodeId.expanded(), true));
+
+    return declaration;
+  }
+
+  /** Add a Variable declaration under {@code parent} via forward HasComponent. */
+  public UaVariableNode addVariableDeclaration(
+      UaNode parent, String name, NodeId typeDefinitionId, NodeId modellingRuleId) {
+    return addVariableDeclaration(
+        parent, name, typeDefinitionId, modellingRuleId, NodeIds.HasComponent);
+  }
+
+  /** Add a Variable declaration under {@code parent} via the given hierarchical ReferenceType. */
+  public UaVariableNode addVariableDeclaration(
+      UaNode parent,
+      String name,
+      NodeId typeDefinitionId,
+      NodeId modellingRuleId,
+      NodeId referenceTypeId) {
+
+    NodeId nodeId = newNodeId(parent.getBrowseName().name() + "." + name);
+
+    UaVariableNode declaration =
+        new UaVariableNode(
+            context,
+            nodeId,
+            qn(name),
+            LocalizedText.english(name),
+            LocalizedText.NULL_VALUE,
+            UInteger.MIN,
+            UInteger.MIN);
+
+    declaration.addReference(
+        new Reference(nodeId, NodeIds.HasTypeDefinition, typeDefinitionId.expanded(), true));
+    declaration.addReference(
+        new Reference(nodeId, NodeIds.HasModellingRule, modellingRuleId.expanded(), true));
+
+    nodeManager.addNode(declaration);
+
+    parent.addReference(
+        new Reference(parent.getNodeId(), referenceTypeId, nodeId.expanded(), true));
+
+    return declaration;
+  }
+
+  /**
+   * Add a Variable under {@code parent} with a TypeDefinition but <em>no</em> ModellingRule — not
+   * an InstanceDeclaration per Part 3 §6.2.2; it belongs to the type node only.
+   */
+  public UaVariableNode addRuleLessVariable(UaNode parent, String name, NodeId typeDefinitionId) {
+    NodeId nodeId = newNodeId(parent.getBrowseName().name() + "." + name);
+
+    UaVariableNode node =
+        new UaVariableNode(
+            context,
+            nodeId,
+            qn(name),
+            LocalizedText.english(name),
+            LocalizedText.NULL_VALUE,
+            UInteger.MIN,
+            UInteger.MIN);
+
+    node.addReference(
+        new Reference(nodeId, NodeIds.HasTypeDefinition, typeDefinitionId.expanded(), true));
+
+    nodeManager.addNode(node);
+
+    parent.addReference(
+        new Reference(parent.getNodeId(), NodeIds.HasComponent, nodeId.expanded(), true));
+
+    return node;
+  }
+
+  /** Add a Method declaration under {@code parent} via forward HasComponent. */
+  public UaMethodNode addMethodDeclaration(UaNode parent, String name, NodeId modellingRuleId) {
+    NodeId nodeId = newNodeId(parent.getBrowseName().name() + "." + name);
+
+    UaMethodNode declaration =
+        new UaMethodNode(
+            context,
+            nodeId,
+            qn(name),
+            LocalizedText.english(name),
+            LocalizedText.NULL_VALUE,
+            UInteger.MIN,
+            UInteger.MIN,
+            true,
+            true);
+
+    declaration.addReference(
+        new Reference(nodeId, NodeIds.HasModellingRule, modellingRuleId.expanded(), true));
+
+    nodeManager.addNode(declaration);
+
+    parent.addReference(
+        new Reference(parent.getNodeId(), NodeIds.HasComponent, nodeId.expanded(), true));
+
+    return declaration;
+  }
+
+  /**
+   * Add an argument property ({@code InputArguments} / {@code OutputArguments}, ns0 names) to a
+   * Method declaration, its Value holding the raw {@code Argument[]}.
+   */
+  public UaVariableNode addArgumentsProperty(
+      UaMethodNode method, String propertyName, Object argumentArray) {
+
+    // Derive from the method's NodeId, not its BrowseName: two methods overriding one another
+    // share a BrowseName and their properties must not collide on one NodeId.
+    NodeId nodeId = newNodeId(method.getNodeId().getIdentifier() + "." + propertyName);
+
+    UaVariableNode property =
+        new UaVariableNode(
+            context,
+            nodeId,
+            new QualifiedName(0, propertyName),
+            LocalizedText.english(propertyName),
+            LocalizedText.NULL_VALUE,
+            UInteger.MIN,
+            UInteger.MIN);
+    property.setValue(new DataValue(new Variant(argumentArray)));
+    property.setDataType(NodeIds.Argument);
+    property.addReference(
+        new Reference(nodeId, NodeIds.HasTypeDefinition, NodeIds.PropertyType.expanded(), true));
+    property.addReference(
+        new Reference(
+            nodeId, NodeIds.HasModellingRule, NodeIds.ModellingRule_Mandatory.expanded(), true));
+
+    nodeManager.addNode(property);
+
+    method.addReference(
+        new Reference(method.getNodeId(), NodeIds.HasProperty, nodeId.expanded(), true));
+
+    return property;
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/TypeFixtures.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/TypeFixtures.java
@@ -15,6 +15,7 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
 import org.eclipse.milo.opcua.sdk.core.Reference;
 import org.eclipse.milo.opcua.sdk.core.typetree.ReferenceTypeTree;
 import org.eclipse.milo.opcua.sdk.server.AddressSpaceManager;
@@ -72,6 +73,7 @@ public class TypeFixtures {
   private final OpcUaServer server;
   private final NamespaceTable namespaceTable;
   private final UaNodeManager nodeManager;
+  private final List<UaNodeManager> registeredManagers = new CopyOnWriteArrayList<>();
   private final UaNodeContext context;
   private final ObjectTypeManager objectTypeManager;
   private final VariableTypeManager variableTypeManager;
@@ -85,30 +87,52 @@ public class TypeFixtures {
     Mockito.when(server.getNamespaceTable()).thenReturn(namespaceTable);
 
     nodeManager = new UaNodeManager();
+    registeredManagers.add(nodeManager);
 
     AddressSpaceManager addressSpaceManager = Mockito.mock(AddressSpaceManager.class);
 
     Mockito.when(addressSpaceManager.getManagedNode(Mockito.any(NodeId.class)))
         .then(
             (Answer<Optional<UaNode>>)
-                invocation -> nodeManager.getNode(invocation.getArgument(0)));
+                invocation ->
+                    registeredManagers.stream()
+                        .flatMap(m -> m.getNode(invocation.<NodeId>getArgument(0)).stream())
+                        .findFirst());
 
     Mockito.when(addressSpaceManager.getManagedNode(Mockito.any(ExpandedNodeId.class)))
         .then(
             (Answer<Optional<UaNode>>)
-                invocation -> nodeManager.getNode(invocation.getArgument(0), namespaceTable));
+                invocation ->
+                    registeredManagers.stream()
+                        .flatMap(
+                            m ->
+                                m
+                                    .getNode(
+                                        invocation.<ExpandedNodeId>getArgument(0), namespaceTable)
+                                    .stream())
+                        .findFirst());
 
     Mockito.when(addressSpaceManager.getManagedReferences(Mockito.any(NodeId.class)))
         .then(
             (Answer<List<Reference>>)
-                invocation -> nodeManager.getReferences(invocation.getArgument(0)));
+                invocation ->
+                    registeredManagers.stream()
+                        .flatMap(m -> m.getReferences(invocation.<NodeId>getArgument(0)).stream())
+                        .toList());
 
     Mockito.when(addressSpaceManager.getManagedReferences(Mockito.any(NodeId.class), Mockito.any()))
         .then(
             (Answer<List<Reference>>)
                 invocation ->
-                    nodeManager.getReferences(
-                        invocation.getArgument(0), invocation.getArgument(1)));
+                    registeredManagers.stream()
+                        .flatMap(
+                            m ->
+                                m
+                                    .getReferences(
+                                        invocation.<NodeId>getArgument(0),
+                                        invocation.getArgument(1))
+                                    .stream())
+                        .toList());
 
     Mockito.when(server.getAddressSpaceManager()).thenReturn(addressSpaceManager);
     Mockito.when(server.getStaticEncodingContext()).thenReturn(DefaultEncodingContext.INSTANCE);
@@ -218,6 +242,18 @@ public class TypeFixtures {
    */
   public UaNodeManager newTargetManager() {
     return new UaNodeManager();
+  }
+
+  /**
+   * Make {@code manager} visible through the mocked {@link AddressSpaceManager}, mirroring a real
+   * server registering a destination manager: node-level navigation (typed getters, {@code
+   * getPropertyNode}, {@code getReferences()}) resolves through the address space, so committed
+   * instances are only navigable once their manager is registered.
+   *
+   * @param manager the manager to register.
+   */
+  public void registerWithAddressSpace(UaNodeManager manager) {
+    registeredManagers.add(manager);
   }
 
   /**

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/TypeModelCacheTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/TypeModelCacheTest.java
@@ -1,0 +1,332 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
+
+import static org.eclipse.milo.opcua.sdk.server.nodes.instantiation.TypeFixtures.path;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectTypeNode;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link TypeModelCache}: per-server isolation, dependency-aware transitive invalidation,
+ * fingerprint behavior across invalidation, and the recompile-on-miss path that makes eviction
+ * harmless.
+ */
+public class TypeModelCacheTest {
+
+  private TypeFixtures fx;
+  private TypeModelCache cache;
+
+  @BeforeEach
+  void setUp() {
+    fx = TypeFixtures.create();
+    cache = new TypeModelCache(fx::compiler);
+  }
+
+  /** A cache that counts how many times it asks its factory for a compiler. */
+  private TypeModelCache newCountingCache(AtomicInteger compilerRequests) {
+    return new TypeModelCache(
+        () -> {
+          compilerRequests.incrementAndGet();
+          return fx.compiler();
+        });
+  }
+
+  /** Model caching is per server; identical NodeIds in different servers never share models. */
+  @Nested
+  class Isolation {
+
+    /**
+     * The legacy {@code NodeFactory} cached InstanceDeclarationHierarchies in a static JVM-global
+     * map, so two servers whose address spaces assign the same NodeId to different types served
+     * each other's hierarchies. Per-server caches must not cross-contaminate.
+     */
+    @Test
+    void cachesOverDifferentAddressSpacesDoNotShareModelsForTheSameNodeId() throws Exception {
+      TypeFixtures fxB = TypeFixtures.create();
+      TypeModelCache cacheB = new TypeModelCache(fxB::compiler);
+
+      UaObjectTypeNode typeA = fx.addObjectType("CollidingType", NodeIds.BaseObjectType);
+      fx.addVariableDeclaration(
+          typeA, "OnlyInA", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+      UaObjectTypeNode typeB = fxB.addObjectType("CollidingType", NodeIds.BaseObjectType);
+      fxB.addVariableDeclaration(
+          typeB, "OnlyInB", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+      assertEquals(
+          typeA.getNodeId(), typeB.getNodeId(), "precondition: the two types collide on NodeId");
+
+      TypeInstantiationModel modelA = cache.getOrCompile(typeA.getNodeId());
+      TypeInstantiationModel modelB = cacheB.getOrCompile(typeB.getNodeId());
+
+      assertTrue(modelA.get(path("OnlyInA")).isPresent());
+      assertTrue(
+          modelA.get(path("OnlyInB")).isEmpty(),
+          "server A's model must not contain server B's declaration");
+      assertTrue(
+          modelB.get(path("OnlyInB")).isPresent(),
+          "server B compiled after A must get its own model, not A's cached one");
+      assertTrue(
+          modelB.get(path("OnlyInA")).isEmpty(),
+          "server B's model must not contain server A's declaration");
+    }
+  }
+
+  /**
+   * {@link TypeModelCache#invalidate(NodeId)} drops every model whose dependency closure contains
+   * the changed node — transitively, at every depth.
+   */
+  @Nested
+  class Invalidation {
+
+    /**
+     * A model is compiled from its whole supertype chain, so editing a supertype must invalidate
+     * every cached subtype model, including subtypes-of-subtypes.
+     */
+    @Test
+    void supertypeEditInvalidatesAllDependentSubtypeModelsTransitively() throws Exception {
+      UaObjectTypeNode base = fx.addObjectType("Base", NodeIds.BaseObjectType);
+      UaObjectTypeNode derived = fx.addObjectType("Derived", base.getNodeId());
+      UaObjectTypeNode grandchild = fx.addObjectType("Grandchild", derived.getNodeId());
+      UaObjectTypeNode unrelated = fx.addObjectType("Unrelated", NodeIds.BaseObjectType);
+
+      cache.getOrCompile(derived.getNodeId());
+      cache.getOrCompile(grandchild.getNodeId());
+      cache.getOrCompile(unrelated.getNodeId());
+
+      fx.addVariableDeclaration(
+          base, "NewMember", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+      cache.invalidate(base.getNodeId());
+
+      assertTrue(cache.getIfPresent(derived.getNodeId()).isEmpty());
+      assertTrue(
+          cache.getIfPresent(grandchild.getNodeId()).isEmpty(),
+          "transitive: two subtype levels below the edited supertype");
+      assertTrue(
+          cache.getIfPresent(unrelated.getNodeId()).isPresent(),
+          "control: a model not built from the edited node stays cached");
+
+      assertTrue(
+          cache.getOrCompile(grandchild.getNodeId()).get(path("NewMember")).isPresent(),
+          "recompiling after invalidation must observe the supertype edit");
+    }
+
+    /**
+     * Member types are compiled into the containing model at every nesting depth, so editing one
+     * must invalidate every cached model whose dependency closure contains it.
+     */
+    @Test
+    void memberTypeEditInvalidatesEveryModelWhoseClosureContainsIt() throws Exception {
+      UaObjectTypeNode memberType = fx.addObjectType("MemberType", NodeIds.BaseObjectType);
+      UaObjectTypeNode container = fx.addObjectType("Container", NodeIds.BaseObjectType);
+      fx.addObjectDeclaration(
+          container, "M", memberType.getNodeId(), NodeIds.ModellingRule_Mandatory);
+      UaObjectTypeNode outer = fx.addObjectType("Outer", NodeIds.BaseObjectType);
+      fx.addObjectDeclaration(outer, "C", container.getNodeId(), NodeIds.ModellingRule_Mandatory);
+      UaObjectTypeNode unrelated = fx.addObjectType("Unrelated", NodeIds.BaseObjectType);
+
+      cache.getOrCompile(container.getNodeId());
+      cache.getOrCompile(outer.getNodeId());
+      cache.getOrCompile(unrelated.getNodeId());
+
+      fx.addVariableDeclaration(
+          memberType, "NewMember", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+      cache.invalidate(memberType.getNodeId());
+
+      assertTrue(cache.getIfPresent(container.getNodeId()).isEmpty());
+      assertTrue(
+          cache.getIfPresent(outer.getNodeId()).isEmpty(),
+          "transitive: the member type is two nesting levels below Outer");
+      assertTrue(
+          cache.getIfPresent(unrelated.getNodeId()).isPresent(),
+          "control: a model not built from the edited member type stays cached");
+
+      assertTrue(
+          cache.getOrCompile(outer.getNodeId()).get(path("C", "M", "NewMember")).isPresent(),
+          "recompiling after invalidation must observe the member-type edit");
+    }
+
+    /**
+     * Invalidation keys on the full dependency set, not just type nodes: a change to any node a
+     * model was built from — here an instance declaration — must invalidate it.
+     */
+    @Test
+    void editToAnyNodeAModelWasBuiltFromInvalidatesIt() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("SomeType", NodeIds.BaseObjectType);
+      NodeId declarationId =
+          fx.addVariableDeclaration(
+                  typeNode, "Member", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory)
+              .getNodeId();
+
+      cache.getOrCompile(typeNode.getNodeId());
+
+      cache.invalidate(declarationId);
+
+      assertTrue(
+          cache.getIfPresent(typeNode.getNodeId()).isEmpty(),
+          "a declaration node is part of the model's dependency closure");
+    }
+  }
+
+  /**
+   * {@link TypeInstantiationModel#modelRevision()} behavior through the cache: apply-time
+   * revalidation depends on edits changing the fingerprint and no-op recompiles preserving it.
+   */
+  @Nested
+  class Fingerprints {
+
+    @Test
+    void invalidateAndRecompileAfterAnEditYieldsANewFingerprint() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("EditedType", NodeIds.BaseObjectType);
+      fx.addVariableDeclaration(
+          typeNode, "Member", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+      long before = cache.getOrCompile(typeNode.getNodeId()).modelRevision();
+
+      fx.addVariableDeclaration(
+          typeNode, "Extra", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+      cache.invalidate(typeNode.getNodeId());
+
+      long after = cache.getOrCompile(typeNode.getNodeId()).modelRevision();
+
+      assertNotEquals(before, after, "an edited type must recompile to a new fingerprint");
+    }
+
+    @Test
+    void unchangedTypeRecompilesToAnEqualFingerprint() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("StableType", NodeIds.BaseObjectType);
+      fx.addVariableDeclaration(
+          typeNode, "Member", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+      long before = cache.getOrCompile(typeNode.getNodeId()).modelRevision();
+
+      cache.invalidateAll();
+
+      long after = cache.getOrCompile(typeNode.getNodeId()).modelRevision();
+
+      assertEquals(
+          before, after, "recompiling an unchanged type must not spuriously fail revalidation");
+    }
+  }
+
+  /**
+   * The cache is an optimization with correctness obligations, not a correctness mechanism: entries
+   * may be dropped at any time and the recompile path restores an equivalent model.
+   */
+  @Nested
+  class Eviction {
+
+    @Test
+    void evictionAtAnyPointIsHarmlessRecompileYieldsAnEquivalentModel() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("EvictedType", NodeIds.BaseObjectType);
+      fx.addVariableDeclaration(
+          typeNode, "Member", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+      TypeInstantiationModel first = cache.getOrCompile(typeNode.getNodeId());
+
+      cache.invalidateAll();
+      assertEquals(0, cache.size(), "precondition: every entry evicted");
+
+      TypeInstantiationModel second = cache.getOrCompile(typeNode.getNodeId());
+
+      assertNotSame(first, second, "the entry was dropped, so this is a fresh compilation");
+      assertEquals(first.modelRevision(), second.modelRevision());
+      assertEquals(first.declarations(), second.declarations());
+      assertEquals(first.hierarchy(), second.hierarchy());
+      assertEquals(first.references(), second.references());
+    }
+  }
+
+  /** Cache-hit and single-compilation semantics of {@link TypeModelCache#getOrCompile(NodeId)}. */
+  @Nested
+  class Compilation {
+
+    @Test
+    void repeatedGetsReturnTheCachedInstanceWithoutRecompiling() throws Exception {
+      AtomicInteger compilerRequests = new AtomicInteger(0);
+      TypeModelCache countingCache = newCountingCache(compilerRequests);
+
+      UaObjectTypeNode typeNode = fx.addObjectType("CachedType", NodeIds.BaseObjectType);
+
+      TypeInstantiationModel first = countingCache.getOrCompile(typeNode.getNodeId());
+      TypeInstantiationModel second = countingCache.getOrCompile(typeNode.getNodeId());
+
+      assertSame(first, second);
+      assertEquals(1, compilerRequests.get(), "a cache hit must not compile again");
+    }
+
+    /**
+     * Concurrent describes of one type must not compile two observably different models; callers
+     * racing on the same key share a single compilation and observe one model instance.
+     */
+    @Test
+    void concurrentGetsForTheSameTypeShareOneCompilation() throws Exception {
+      AtomicInteger compilerRequests = new AtomicInteger(0);
+      TypeModelCache countingCache = newCountingCache(compilerRequests);
+
+      UaObjectTypeNode typeNode = fx.addObjectType("ContendedType", NodeIds.BaseObjectType);
+      NodeId typeId = typeNode.getNodeId();
+
+      int threads = 4;
+      ExecutorService executor = Executors.newFixedThreadPool(threads);
+      try {
+        List<Callable<TypeInstantiationModel>> calls =
+            Collections.nCopies(threads, () -> countingCache.getOrCompile(typeId));
+
+        List<Future<TypeInstantiationModel>> results =
+            executor.invokeAll(calls, 30, TimeUnit.SECONDS);
+
+        TypeInstantiationModel first = results.get(0).get();
+        for (Future<TypeInstantiationModel> result : results) {
+          assertSame(first, result.get(), "every racing caller must observe the same model");
+        }
+        assertEquals(1, compilerRequests.get(), "racing callers must share one compilation");
+      } finally {
+        executor.shutdownNow();
+      }
+    }
+
+    /**
+     * Failed compilations propagate as {@link ModelCompilationException} and are not cached: once
+     * the type exists, the same lookup succeeds.
+     */
+    @Test
+    void failedCompilationIsNotCachedAndSucceedsOnceTheTypeExists() throws Exception {
+      NodeId typeId = fx.newNodeId("NotYetAdded");
+
+      assertThrows(ModelCompilationException.class, () -> cache.getOrCompile(typeId));
+
+      UaObjectTypeNode typeNode = fx.addObjectType("NotYetAdded", NodeIds.BaseObjectType);
+      assertEquals(typeId, typeNode.getNodeId(), "precondition: same NodeId as the failed lookup");
+
+      assertEquals(typeId, cache.getOrCompile(typeId).typeDefinitionId());
+    }
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/TypeModelCompilerTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/TypeModelCompilerTest.java
@@ -1,0 +1,1834 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
+
+import static org.eclipse.milo.opcua.sdk.server.nodes.instantiation.TypeFixtures.path;
+import static org.eclipse.milo.opcua.sdk.server.nodes.instantiation.TypeFixtures.qn;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ubyte;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.eclipse.milo.opcua.sdk.core.AccessLevel;
+import org.eclipse.milo.opcua.sdk.core.Reference;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaMethodNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaReferenceTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableTypeNode;
+import org.eclipse.milo.opcua.stack.core.AttributeId;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
+import org.eclipse.milo.opcua.stack.core.types.structured.AccessRestrictionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.Argument;
+import org.eclipse.milo.opcua.stack.core.types.structured.PermissionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.RolePermissionType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link TypeModelCompiler}: core model semantics plus validation, diagnostics, reference
+ * rows, and robustness.
+ *
+ * <p>The nested-inheritance and declaration-override tests encode the <em>spec-correct</em>
+ * behavior — the opposite of the legacy defects pinned in {@code NodeFactoryCharacterizationTest}
+ * ({@code nestedMemberTypeMissingSupertypeMembers}, {@code
+ * typeDeclaredChildShadowsOnDeclarationOverride}); they fail against legacy semantics by
+ * construction.
+ */
+public class TypeModelCompilerTest {
+
+  private TypeFixtures fx;
+
+  @BeforeEach
+  void setUp() {
+    fx = TypeFixtures.create();
+  }
+
+  /** Members typed as subtypes expand with their full inherited hierarchy. */
+  @Nested
+  class NestedMemberTypeExpansion {
+
+    /**
+     * Spec-correct per Part 3 §6.3.3.2 ("instances are described by the fully-inherited IDH ... at
+     * every level of nesting"): a member typed as a subtype includes its supertype-declared
+     * mandatory members. Legacy omits them (pinned in the characterization tests).
+     */
+    @Test
+    void nestedMemberTypeIncludesSupertypeDeclaredMembers() throws Exception {
+      UaObjectTypeNode baseSmType = fx.addObjectType("BaseSMType", NodeIds.BaseObjectType);
+      fx.addVariableDeclaration(
+          baseSmType,
+          "CurrentState",
+          NodeIds.BaseDataVariableType,
+          NodeIds.ModellingRule_Mandatory);
+      UaObjectTypeNode derivedSmType = fx.addObjectType("DerivedSMType", baseSmType.getNodeId());
+
+      UaObjectTypeNode typeNode = fx.addObjectType("D2Type", NodeIds.BaseObjectType);
+      fx.addObjectDeclaration(
+          typeNode, "SM", derivedSmType.getNodeId(), NodeIds.ModellingRule_Mandatory);
+      fx.addObjectDeclaration(
+          typeNode, "SM2", baseSmType.getNodeId(), NodeIds.ModellingRule_Mandatory);
+
+      TypeInstantiationModel model = fx.compiler().compile(typeNode.getNodeId());
+
+      InstanceDeclaration nested =
+          model
+              .get(path("SM", "CurrentState"))
+              .orElseThrow(
+                  () ->
+                      new AssertionError(
+                          "member typed as a subtype must include supertype-declared members"));
+      assertEquals(ModellingRule.MANDATORY, nested.rule());
+      assertEquals(
+          baseSmType.getNodeId(),
+          nested.declaringTypeId(),
+          "provenance: contributed by the member type's supertype");
+
+      assertTrue(
+          model.get(path("SM2", "CurrentState")).isPresent(),
+          "control: member typed directly as the declaring type has the member too");
+    }
+  }
+
+  /**
+   * Explicit declarations override member-type defaults, retaining distinct inherited references.
+   */
+  @Nested
+  class Overrides {
+
+    /**
+     * Spec-correct per Part 3 §6.3.3.3: a same-path on-declaration child overrides the member
+     * type's default, and the two walks' hierarchical rows canonicalize to one logical edge. Legacy
+     * discards the override and wires the duplicate rows (pinned in the characterization tests).
+     */
+    @Test
+    void explicitDeclarationWinsOverTypeDefaultWithSingleLogicalEdge() throws Exception {
+      UaObjectTypeNode memberType = fx.addObjectType("D5MemberType", NodeIds.BaseObjectType);
+      UaVariableNode typeChild =
+          fx.addVariableDeclaration(
+              memberType, "Child", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+      typeChild.setDataType(NodeIds.BaseDataType);
+      typeChild.setValue(new DataValue(new Variant("fromType")));
+
+      UaObjectTypeNode typeNode = fx.addObjectType("D5Type", NodeIds.BaseObjectType);
+      UaObjectNode m =
+          fx.addObjectDeclaration(
+              typeNode, "M", memberType.getNodeId(), NodeIds.ModellingRule_Mandatory);
+      UaVariableNode declChild =
+          fx.addVariableDeclaration(
+              m, "Child", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+      declChild.setDataType(NodeIds.Int32);
+      declChild.setValue(new DataValue(new Variant(42)));
+
+      TypeInstantiationModel model = fx.compiler().compile(typeNode.getNodeId());
+
+      InstanceDeclaration child = model.get(path("M", "Child")).orElseThrow();
+      assertEquals(declChild.getNodeId(), child.declarationNodeId(), "explicit declaration wins");
+      assertEquals(NodeIds.Int32, child.attributes().dataType());
+      DataValue childValue = child.attributes().value();
+      assertNotNull(childValue);
+      assertEquals(new Variant(42), childValue.getValue());
+      assertEquals(
+          List.of(typeChild.getNodeId()),
+          child.overriddenDeclarations(),
+          "the member-type default is recorded as overridden");
+
+      long edges =
+          model.hierarchy().stream()
+              .filter(
+                  e -> e.parentPath().equals(path("M")) && e.childPath().equals(path("M", "Child")))
+              .count();
+      assertEquals(1, edges, "duplicate hierarchical rows canonicalize to one logical edge");
+    }
+
+    /**
+     * Overriding a declaration replaces only same-or-subtype references between the same pair (Part
+     * 3 §6.3.3.3); distinct inherited relationships — a different hierarchical ReferenceType, a
+     * non-hierarchical row — remain in the merged model. Only the singular HasTypeDefinition /
+     * HasModellingRule rows are replaced by the winner's own.
+     */
+    @Test
+    void overrideRetainsDistinctInheritedReferences() throws Exception {
+      UaObjectTypeNode base = fx.addObjectType("RefBase", NodeIds.BaseObjectType);
+      UaObjectNode baseB =
+          fx.addObjectDeclaration(
+              base, "B", NodeIds.BaseObjectType, NodeIds.ModellingRule_Mandatory);
+      baseB.addReference(
+          new Reference(
+              baseB.getNodeId(), NodeIds.HasCause, NodeIds.ObjectsFolder.expanded(), true));
+
+      UaObjectTypeNode sub = fx.addObjectType("RefSub", base.getNodeId());
+      fx.addObjectDeclaration(
+          sub, "B", NodeIds.FolderType, NodeIds.ModellingRule_Mandatory, NodeIds.HasNotifier);
+
+      TypeInstantiationModel model = fx.compiler().compile(sub.getNodeId());
+
+      assertTrue(
+          model
+              .hierarchy()
+              .contains(new DeclarationEdge(BrowsePath.root(), NodeIds.HasNotifier, path("B"))),
+          "the subtype's own edge stands");
+      assertTrue(
+          model
+              .hierarchy()
+              .contains(new DeclarationEdge(BrowsePath.root(), NodeIds.HasComponent, path("B"))),
+          "the inherited HasComponent edge is a distinct relationship and remains");
+
+      assertTrue(
+          model
+              .references()
+              .contains(
+                  ReferenceRow.absolute(
+                      path("B"),
+                      NodeIds.HasCause,
+                      Reference.Direction.FORWARD,
+                      NodeIds.ObjectsFolder.expanded())),
+          "inherited non-hierarchical rows remain on the overridden path");
+
+      List<ReferenceRow> typeDefinitionRows =
+          model.references().stream()
+              .filter(
+                  r ->
+                      path("B").equals(r.sourcePath())
+                          && NodeIds.HasTypeDefinition.equals(r.referenceTypeId()))
+              .toList();
+      assertEquals(
+          List.of(
+              ReferenceRow.absolute(
+                  path("B"),
+                  NodeIds.HasTypeDefinition,
+                  Reference.Direction.FORWARD,
+                  NodeIds.FolderType.expanded())),
+          typeDefinitionRows,
+          "the singular HasTypeDefinition is replaced by the winner's");
+    }
+  }
+
+  /** Expansion depth, override precedence and provenance, and non-declaration exclusion. */
+  @Nested
+  class Inheritance {
+
+    /** Nested Mandatory members expand at every depth and edges keep their ReferenceTypes. */
+    @Test
+    void nestedMandatoryExpansionAtEveryDepthPreservesReferenceTypes() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("DeepType", NodeIds.BaseObjectType);
+      UaObjectNode obj =
+          fx.addObjectDeclaration(
+              typeNode, "Obj", NodeIds.BaseObjectType, NodeIds.ModellingRule_Mandatory);
+      UaObjectNode inner =
+          fx.addObjectDeclaration(
+              obj, "Inner", NodeIds.BaseObjectType, NodeIds.ModellingRule_Mandatory);
+      fx.addVariableDeclaration(
+          inner,
+          "Leaf",
+          NodeIds.PropertyType,
+          NodeIds.ModellingRule_Mandatory,
+          NodeIds.HasProperty);
+
+      TypeInstantiationModel model = fx.compiler().compile(typeNode.getNodeId());
+
+      assertTrue(model.get(path("Obj")).isPresent());
+      assertTrue(model.get(path("Obj", "Inner")).isPresent());
+      assertTrue(model.get(path("Obj", "Inner", "Leaf")).isPresent());
+
+      assertTrue(
+          model
+              .hierarchy()
+              .contains(new DeclarationEdge(BrowsePath.root(), NodeIds.HasComponent, path("Obj"))));
+      assertTrue(
+          model
+              .hierarchy()
+              .contains(
+                  new DeclarationEdge(path("Obj"), NodeIds.HasComponent, path("Obj", "Inner"))));
+      assertTrue(
+          model
+              .hierarchy()
+              .contains(
+                  new DeclarationEdge(
+                      path("Obj", "Inner"), NodeIds.HasProperty, path("Obj", "Inner", "Leaf"))),
+          "HasProperty preserved on the deep edge");
+    }
+
+    /**
+     * Three-level inheritance with a same-path override at each level: the most-derived entry wins,
+     * provenance names the declaring type, and the override chain runs nearest-first to base-most.
+     */
+    @Test
+    void threeLevelInheritanceOverrideProvenanceAndPrecedence() throws Exception {
+      UaObjectTypeNode grand = fx.addObjectType("GrandType", NodeIds.BaseObjectType);
+      UaVariableNode grandV =
+          fx.addVariableDeclaration(
+              grand, "V", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Optional);
+      fx.addVariableDeclaration(
+          grand, "W", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+      UaObjectTypeNode mid = fx.addObjectType("MidType", grand.getNodeId());
+      UaVariableNode midV =
+          fx.addVariableDeclaration(
+              mid, "V", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+      UaObjectTypeNode leaf = fx.addObjectType("LeafType", mid.getNodeId());
+      UaVariableNode leafV =
+          fx.addVariableDeclaration(
+              leaf, "V", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+      TypeInstantiationModel model = fx.compiler().compile(leaf.getNodeId());
+
+      InstanceDeclaration v = model.get(path("V")).orElseThrow();
+      assertEquals(leafV.getNodeId(), v.declarationNodeId());
+      assertEquals(leaf.getNodeId(), v.declaringTypeId());
+      assertEquals(ModellingRule.MANDATORY, v.rule());
+      assertEquals(
+          List.of(midV.getNodeId(), grandV.getNodeId()),
+          v.overriddenDeclarations(),
+          "override chain nearest first, base-most last");
+
+      InstanceDeclaration w = model.get(path("W")).orElseThrow();
+      assertEquals(grand.getNodeId(), w.declaringTypeId(), "un-overridden member keeps provenance");
+      assertTrue(w.overriddenDeclarations().isEmpty());
+
+      assertTrue(
+          model.diagnostics().stream()
+              .noneMatch(d -> d.code() == ModelDiagnostic.Code.MODELLING_RULE_TIGHTENING),
+          "Optional -> Mandatory and Mandatory -> Mandatory are valid tightenings");
+    }
+
+    /** A rule-less node is excluded with a traceable diagnostic, never silently (Part 3 §6.2.2). */
+    @Test
+    void ruleLessNodeExcludedWithTraceableDiagnostic() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("RuleLessType", NodeIds.BaseObjectType);
+      fx.addVariableDeclaration(
+          typeNode, "Configured", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+      UaVariableNode plain =
+          fx.addRuleLessVariable(typeNode, "Plain", NodeIds.BaseDataVariableType);
+
+      TypeInstantiationModel model = fx.compiler().compile(typeNode.getNodeId());
+
+      assertTrue(model.get(path("Configured")).isPresent());
+      assertTrue(model.get(path("Plain")).isEmpty(), "rule-less node is not a declaration");
+
+      assertTrue(
+          model.diagnostics().stream()
+              .anyMatch(
+                  d ->
+                      d.code() == ModelDiagnostic.Code.NOT_AN_INSTANCE_DECLARATION
+                          && d.severity() == ModelDiagnostic.Severity.INFO
+                          && path("Plain").equals(d.browsePath())
+                          && plain.getNodeId().equals(d.nodeId())),
+          "exclusion is traceable to the path and node");
+    }
+  }
+
+  /** Malformed input rejects with diagnostics and no partial model. */
+  @Nested
+  class ErrorCases {
+
+    @Test
+    void unknownTypeRejected() {
+      NodeId bogus = fx.newNodeId("DoesNotExist");
+
+      ModelCompilationException e =
+          assertThrows(ModelCompilationException.class, () -> fx.compiler().compile(bogus));
+
+      assertEquals(bogus, e.getTypeDefinitionId());
+      assertTrue(
+          e.getDiagnostics().stream()
+              .anyMatch(d -> d.isError() && d.code() == ModelDiagnostic.Code.TYPE_NOT_FOUND));
+    }
+
+    @Test
+    void wrongNodeClassRejected() {
+      UaObjectTypeNode typeNode = fx.addObjectType("HostType", NodeIds.BaseObjectType);
+      UaVariableNode notAType =
+          fx.addVariableDeclaration(
+              typeNode, "V", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+      ModelCompilationException e =
+          assertThrows(
+              ModelCompilationException.class, () -> fx.compiler().compile(notAType.getNodeId()));
+
+      assertTrue(
+          e.getDiagnostics().stream()
+              .anyMatch(
+                  d -> d.isError() && d.code() == ModelDiagnostic.Code.TYPE_NODE_CLASS_INVALID));
+    }
+
+    /** A member whose TypeDefinition targets a remote (unresolvable) node rejects the compile. */
+    @Test
+    void remoteMemberTypeRejected() {
+      UaObjectTypeNode typeNode = fx.addObjectType("RemoteMemberType", NodeIds.BaseObjectType);
+
+      NodeId declId = fx.newNodeId("RemoteMemberType.R");
+      UaObjectNode declaration =
+          new UaObjectNode(
+              fx.context(),
+              declId,
+              qn("R"),
+              LocalizedText.english("R"),
+              LocalizedText.NULL_VALUE,
+              UInteger.MIN,
+              UInteger.MIN,
+              ubyte(0));
+      declaration.addReference(
+          new Reference(
+              declId,
+              NodeIds.HasTypeDefinition,
+              ExpandedNodeId.of("urn:remote:server:namespace", "RemoteType"),
+              true));
+      declaration.addReference(
+          new Reference(
+              declId, NodeIds.HasModellingRule, NodeIds.ModellingRule_Mandatory.expanded(), true));
+      fx.nodeManager().addNode(declaration);
+      typeNode.addReference(
+          new Reference(typeNode.getNodeId(), NodeIds.HasComponent, declId.expanded(), true));
+
+      ModelCompilationException e =
+          assertThrows(
+              ModelCompilationException.class, () -> fx.compiler().compile(typeNode.getNodeId()));
+
+      assertTrue(
+          e.getDiagnostics().stream()
+              .anyMatch(
+                  d ->
+                      d.isError()
+                          && d.code() == ModelDiagnostic.Code.TYPE_NOT_FOUND
+                          && path("R").equals(d.browsePath())));
+    }
+
+    /**
+     * A forward hierarchical reference to a missing node rejects the compile — never a silently
+     * truncated hierarchy.
+     */
+    @Test
+    void missingHierarchicalTargetRejected() {
+      UaObjectTypeNode typeNode = fx.addObjectType("MissingChildType", NodeIds.BaseObjectType);
+      typeNode.addReference(
+          new Reference(
+              typeNode.getNodeId(),
+              NodeIds.HasComponent,
+              fx.newNodeId("MissingChildType.Gone").expanded(),
+              true));
+
+      ModelCompilationException e =
+          assertThrows(
+              ModelCompilationException.class, () -> fx.compiler().compile(typeNode.getNodeId()));
+
+      assertTrue(
+          e.getDiagnostics().stream()
+              .anyMatch(
+                  d -> d.isError() && d.code() == ModelDiagnostic.Code.REFERENCE_TARGET_MISSING));
+    }
+
+    /** An unresolvable (remote) supertype rejects — it must not demote the type to a root. */
+    @Test
+    void unresolvableSupertypeRejected() {
+      NodeId remoteId = fx.newNodeId("RemoteSupertypeType");
+      UaObjectTypeNode remote =
+          new UaObjectTypeNode(
+              fx.context(),
+              remoteId,
+              qn("RemoteSupertypeType"),
+              LocalizedText.english("RemoteSupertypeType"),
+              LocalizedText.NULL_VALUE,
+              UInteger.MIN,
+              UInteger.MIN,
+              false);
+      remote.addReference(
+          new Reference(
+              remoteId,
+              NodeIds.HasSubtype,
+              ExpandedNodeId.of("urn:remote:server:namespace", "SuperType"),
+              false));
+      fx.nodeManager().addNode(remote);
+
+      ModelCompilationException e =
+          assertThrows(ModelCompilationException.class, () -> fx.compiler().compile(remoteId));
+
+      assertTrue(
+          e.getDiagnostics().stream()
+              .anyMatch(d -> d.isError() && d.code() == ModelDiagnostic.Code.TYPE_NOT_FOUND));
+    }
+
+    /** Multiple supertypes have no defined merge order (single inheritance): reject. */
+    @Test
+    void multipleSupertypesRejected() {
+      UaObjectTypeNode multi = fx.addObjectType("MultiParentType", NodeIds.BaseObjectType);
+      multi.addReference(
+          new Reference(
+              multi.getNodeId(), NodeIds.HasSubtype, NodeIds.FolderType.expanded(), false));
+
+      ModelCompilationException e =
+          assertThrows(
+              ModelCompilationException.class, () -> fx.compiler().compile(multi.getNodeId()));
+
+      assertTrue(
+          e.getDiagnostics().stream()
+              .anyMatch(d -> d.isError() && d.code() == ModelDiagnostic.Code.MULTIPLE_SUPERTYPES));
+    }
+
+    /** Cross-family ancestry — an ObjectType inheriting from a VariableType — rejects. */
+    @Test
+    void crossFamilySupertypeRejected() {
+      UaObjectTypeNode cross = fx.addObjectType("CrossFamilyType", NodeIds.BaseDataVariableType);
+
+      ModelCompilationException e =
+          assertThrows(
+              ModelCompilationException.class, () -> fx.compiler().compile(cross.getNodeId()));
+
+      assertTrue(
+          e.getDiagnostics().stream()
+              .anyMatch(d -> d.isError() && d.code() == ModelDiagnostic.Code.NODE_CLASS_MISMATCH));
+    }
+
+    /** Objects and Variables require exactly one TypeDefinition; several reject the compile. */
+    @Test
+    void multipleTypeDefinitionsRejected() {
+      UaObjectTypeNode typeNode = fx.addObjectType("TwoTypeDefsType", NodeIds.BaseObjectType);
+      UaObjectNode declaration =
+          fx.addObjectDeclaration(
+              typeNode, "D", NodeIds.BaseObjectType, NodeIds.ModellingRule_Mandatory);
+      declaration.addReference(
+          new Reference(
+              declaration.getNodeId(),
+              NodeIds.HasTypeDefinition,
+              NodeIds.FolderType.expanded(),
+              true));
+
+      ModelCompilationException e =
+          assertThrows(
+              ModelCompilationException.class, () -> fx.compiler().compile(typeNode.getNodeId()));
+
+      assertTrue(
+          e.getDiagnostics().stream()
+              .anyMatch(
+                  d ->
+                      d.isError()
+                          && d.code() == ModelDiagnostic.Code.MULTIPLE_TYPE_DEFINITIONS
+                          && path("D").equals(d.browsePath())));
+    }
+
+    /**
+     * An override changing the NodeClass is one no instance can satisfy: reject the compile instead
+     * of escaping as a usable warning (Part 3 §6.3.3.3).
+     */
+    @Test
+    void nodeClassChangingOverrideRejected() {
+      UaObjectTypeNode classBase = fx.addObjectType("ClassBase", NodeIds.BaseObjectType);
+      fx.addVariableDeclaration(
+          classBase, "V", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+      UaObjectTypeNode classSub = fx.addObjectType("ClassSub", classBase.getNodeId());
+      fx.addObjectDeclaration(
+          classSub, "V", NodeIds.BaseObjectType, NodeIds.ModellingRule_Mandatory);
+
+      ModelCompilationException e =
+          assertThrows(
+              ModelCompilationException.class, () -> fx.compiler().compile(classSub.getNodeId()));
+
+      assertTrue(
+          e.getDiagnostics().stream()
+              .anyMatch(
+                  d ->
+                      d.isError()
+                          && d.code() == ModelDiagnostic.Code.NODE_CLASS_MISMATCH
+                          && path("V").equals(d.browsePath())));
+    }
+
+    /**
+     * An override replacing the TypeDefinition with an unrelated (non-subtype) type is one no
+     * instance can satisfy: reject the compile (Part 3 §6.3.3.3).
+     */
+    @Test
+    void unrelatedTypeDefinitionOverrideRejected() {
+      UaObjectTypeNode unrelated = fx.addObjectType("UnrelatedType", NodeIds.BaseObjectType);
+      UaObjectTypeNode typeBase = fx.addObjectType("TypeDefBase", NodeIds.BaseObjectType);
+      fx.addObjectDeclaration(typeBase, "M", NodeIds.FolderType, NodeIds.ModellingRule_Mandatory);
+      UaObjectTypeNode typeSub = fx.addObjectType("TypeDefSub", typeBase.getNodeId());
+      fx.addObjectDeclaration(typeSub, "M", unrelated.getNodeId(), NodeIds.ModellingRule_Mandatory);
+
+      ModelCompilationException e =
+          assertThrows(
+              ModelCompilationException.class, () -> fx.compiler().compile(typeSub.getNodeId()));
+
+      assertTrue(
+          e.getDiagnostics().stream()
+              .anyMatch(
+                  d ->
+                      d.isError()
+                          && d.code() == ModelDiagnostic.Code.TYPE_INCOMPATIBLE
+                          && path("M").equals(d.browsePath())));
+    }
+
+    /**
+     * An abstract member type compiles with a classifying warning: the model must stay usable
+     * (every supertype chain ends at abstract base types), and requiring a concrete-subtype
+     * resolution is a plan-time obligation the warning marks.
+     */
+    @Test
+    void abstractMemberTypeWarnsButModelIsUsable() throws Exception {
+      UaObjectTypeNode abstractType =
+          fx.addObjectType("AbstractMember", NodeIds.BaseObjectType, true);
+      fx.addVariableDeclaration(
+          abstractType, "Inner", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+      UaObjectTypeNode typeNode = fx.addObjectType("AbstractHostType", NodeIds.BaseObjectType);
+      fx.addObjectDeclaration(
+          typeNode, "A", abstractType.getNodeId(), NodeIds.ModellingRule_Mandatory);
+
+      TypeInstantiationModel model = fx.compiler().compile(typeNode.getNodeId());
+
+      assertTrue(
+          model.diagnostics().stream()
+              .anyMatch(
+                  d ->
+                      d.code() == ModelDiagnostic.Code.ABSTRACT_MEMBER_TYPE
+                          && d.severity() == ModelDiagnostic.Severity.WARNING
+                          && path("A").equals(d.browsePath())));
+
+      assertTrue(model.get(path("A")).isPresent());
+      assertTrue(model.get(path("A", "Inner")).isPresent(), "expansion is not truncated");
+    }
+  }
+
+  /** Snapshot fidelity, sourcing, and isolation. */
+  @Nested
+  class AttributeSnapshots {
+
+    /**
+     * The full 1.04+ attribute set is snapshotted from the declaration: the declaration's Value
+     * constituents verbatim (serverTime normalized away), MinimumSamplingInterval and Historizing
+     * carried (legacy dropped them), security attributes from the declaration (a deliberate fix;
+     * legacy took them from the type node), unset optionals absent.
+     */
+    @Test
+    void attributeSnapshotFidelity() throws Exception {
+      NodeId customVarTypeId = fx.newNodeId("AttrVarType");
+      UaVariableTypeNode customVarType =
+          new UaVariableTypeNode(
+              fx.context(),
+              customVarTypeId,
+              qn("AttrVarType"),
+              LocalizedText.english("AttrVarType"),
+              LocalizedText.NULL_VALUE,
+              UInteger.MIN,
+              UInteger.MIN,
+              null,
+              NodeIds.BaseDataType,
+              -1,
+              null,
+              false);
+      customVarType.addReference(
+          new Reference(
+              customVarTypeId, NodeIds.HasSubtype, NodeIds.BaseDataVariableType.expanded(), false));
+      fx.nodeManager().addNode(customVarType);
+
+      UaObjectTypeNode typeNode = fx.addObjectType("AttrType", NodeIds.BaseObjectType);
+
+      DataValue declarationValue = new DataValue(new Variant(42));
+      RolePermissionType[] declarationRolePermissions = {
+        new RolePermissionType(NodeIds.WellKnownRole_Anonymous, new PermissionType(uint(1)))
+      };
+
+      NodeId declId = fx.newNodeId("AttrType.V");
+      UaVariableNode declaration =
+          new UaVariableNode(
+              fx.context(),
+              declId,
+              qn("V"),
+              LocalizedText.english("V"),
+              LocalizedText.NULL_VALUE,
+              UInteger.MIN,
+              UInteger.MIN,
+              declarationRolePermissions,
+              declarationRolePermissions,
+              new AccessRestrictionType(UShort.valueOf(2)),
+              declarationValue,
+              NodeIds.Int32,
+              -1,
+              null,
+              AccessLevel.toValue(AccessLevel.READ_WRITE),
+              AccessLevel.toValue(AccessLevel.READ_WRITE),
+              100.0,
+              true,
+              null);
+      declaration.addReference(
+          new Reference(declId, NodeIds.HasTypeDefinition, customVarTypeId.expanded(), true));
+      declaration.addReference(
+          new Reference(
+              declId, NodeIds.HasModellingRule, NodeIds.ModellingRule_Mandatory.expanded(), true));
+      fx.nodeManager().addNode(declaration);
+      typeNode.addReference(
+          new Reference(typeNode.getNodeId(), NodeIds.HasComponent, declId.expanded(), true));
+
+      TypeInstantiationModel model = fx.compiler().compile(typeNode.getNodeId());
+      AttributeSnapshot attributes = model.get(path("V")).orElseThrow().attributes();
+
+      // Value: source-side constituents verbatim, serverTime normalized away.
+      DataValue value = attributes.value();
+      assertNotNull(value);
+      assertSame(declarationValue.getValue(), value.getValue());
+      assertSame(declarationValue.getStatusCode(), value.getStatusCode());
+      assertSame(declarationValue.getSourceTime(), value.getSourceTime());
+      assertNull(value.getServerTime(), "serverTime normalized for snapshot stability");
+
+      assertEquals(NodeIds.Int32, attributes.dataType());
+      assertEquals(Integer.valueOf(-1), attributes.valueRank());
+      assertEquals(
+          AccessLevel.toValue(AccessLevel.READ_WRITE),
+          attributes.getOrNull(AttributeId.AccessLevel));
+      assertEquals(
+          AccessLevel.toValue(AccessLevel.READ_WRITE),
+          attributes.getOrNull(AttributeId.UserAccessLevel));
+
+      // Carried where legacy dropped them:
+      assertEquals(100.0, attributes.getOrNull(AttributeId.MinimumSamplingInterval));
+      assertEquals(true, attributes.getOrNull(AttributeId.Historizing));
+
+      // Security attributes come from the declaration (legacy read the type node),
+      // defensively copied per the immutable-snapshot contract:
+      RolePermissionType[] snapshotRolePermissions =
+          (RolePermissionType[]) attributes.getOrNull(AttributeId.RolePermissions);
+      assertArrayEquals(declarationRolePermissions, snapshotRolePermissions);
+      assertNotSame(declarationRolePermissions, snapshotRolePermissions);
+      assertEquals(
+          new AccessRestrictionType(UShort.valueOf(2)),
+          attributes.getOrNull(AttributeId.AccessRestrictions));
+
+      // Unset optional attributes are absent, not null:
+      assertFalse(attributes.contains(AttributeId.ArrayDimensions));
+      assertFalse(attributes.contains(AttributeId.AccessLevelEx));
+    }
+
+    /**
+     * Root attributes are snapshotted from the type node itself (Part 3 §6.4.2 source), with unset
+     * optional attributes absent — a VariableType with no Value yields a root snapshot without one.
+     */
+    @Test
+    void rootAttributesSnapshotFromTypeNode() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("RootAttrType", NodeIds.BaseObjectType);
+
+      TypeInstantiationModel model = fx.compiler().compile(typeNode.getNodeId());
+
+      assertEquals(
+          typeNode.getBrowseName(), model.rootAttributes().getOrNull(AttributeId.BrowseName));
+      assertEquals(NodeClass.ObjectType, model.rootAttributes().getOrNull(AttributeId.NodeClass));
+      assertEquals(false, model.rootAttributes().getOrNull(AttributeId.IsAbstract));
+
+      UaVariableTypeNode noValueVarType =
+          fx.addVariableType(
+              "NoValueVarType", NodeIds.BaseDataVariableType, null, NodeIds.BaseDataType, -1);
+
+      TypeInstantiationModel varTypeModel = fx.compiler().compile(noValueVarType.getNodeId());
+      assertFalse(
+          varTypeModel.rootAttributes().contains(AttributeId.Value),
+          "a VariableType without a Value yields a root snapshot with the attribute absent");
+    }
+
+    /**
+     * The explicit-null attribute state is representable and distinct from absent, so a consumer
+     * can tell "clear this attribute" apart from "not specified".
+     */
+    @Test
+    void attributeSnapshotDistinguishesExplicitNullFromAbsent() {
+      AttributeSnapshot withNull =
+          AttributeSnapshot.builder().put(AttributeId.Description, null).build();
+
+      assertTrue(withNull.contains(AttributeId.Description));
+      assertTrue(withNull.isNull(AttributeId.Description));
+      assertTrue(withNull.get(AttributeId.Description).isEmpty());
+      assertFalse(withNull.contains(AttributeId.DisplayName));
+    }
+
+    /**
+     * The snapshot is deeply isolated: mutating node-owned arrays after compilation, or arrays read
+     * back from the snapshot, never changes the snapshot — a prerequisite for caching compiled
+     * models.
+     */
+    @Test
+    void attributeSnapshotDefensiveCopies() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("CopyType", NodeIds.BaseObjectType);
+      UaVariableNode declaration =
+          fx.addVariableDeclaration(
+              typeNode, "V", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+      Integer[] valueArray = {1, 2, 3};
+      UInteger[] dimensions = {uint(3)};
+      RolePermissionType[] rolePermissions = {
+        new RolePermissionType(NodeIds.WellKnownRole_Anonymous, new PermissionType(uint(1)))
+      };
+      declaration.setValue(new DataValue(new Variant(valueArray)));
+      declaration.setDataType(NodeIds.Int32);
+      declaration.setArrayDimensions(dimensions);
+      declaration.setRolePermissions(rolePermissions);
+
+      AttributeSnapshot attributes =
+          fx.compiler().compile(typeNode.getNodeId()).get(path("V")).orElseThrow().attributes();
+
+      // Ingress isolation: mutating the node-owned values does not change the snapshot.
+      valueArray[0] = 99;
+      dimensions[0] = uint(9);
+      rolePermissions[0] =
+          new RolePermissionType(
+              NodeIds.WellKnownRole_AuthenticatedUser, new PermissionType(uint(2)));
+
+      assertEquals(1, snapshotValueArray(attributes)[0]);
+      assertEquals(uint(3), snapshotArrayDimensions(attributes)[0]);
+      RolePermissionType[] snapshotRolePermissions =
+          (RolePermissionType[]) attributes.getOrNull(AttributeId.RolePermissions);
+      assertNotNull(snapshotRolePermissions);
+      assertEquals(NodeIds.WellKnownRole_Anonymous, snapshotRolePermissions[0].getRoleId());
+
+      // Egress isolation: mutating a value read from the snapshot does not change the snapshot.
+      snapshotArrayDimensions(attributes)[0] = uint(7);
+      assertEquals(uint(3), snapshotArrayDimensions(attributes)[0]);
+      snapshotValueArray(attributes)[0] = 42;
+      assertEquals(1, snapshotValueArray(attributes)[0]);
+    }
+
+    /** Reads the snapshot's Value attribute as an {@code Integer[]}, asserting it is present. */
+    private static Integer[] snapshotValueArray(AttributeSnapshot attributes) {
+      DataValue value = attributes.value();
+      assertNotNull(value);
+      Integer[] array = (Integer[]) value.getValue().getValue();
+      assertNotNull(array);
+      return array;
+    }
+
+    /** Reads the snapshot's ArrayDimensions attribute, asserting it is present. */
+    private static UInteger[] snapshotArrayDimensions(AttributeSnapshot attributes) {
+      UInteger[] dimensions = attributes.arrayDimensions();
+      assertNotNull(dimensions);
+      return dimensions;
+    }
+  }
+
+  /** Variable narrowing and Method signature compatibility across overrides. */
+  @Nested
+  class SignatureValidation {
+
+    @Test
+    void variableNarrowingViolationDiagnosed() throws Exception {
+      UaObjectTypeNode base = fx.addObjectType("NarrowBase", NodeIds.BaseObjectType);
+      UaVariableNode baseV =
+          fx.addVariableDeclaration(
+              base, "V", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+      baseV.setDataType(NodeIds.Int32);
+
+      UaObjectTypeNode sub = fx.addObjectType("NarrowSub", base.getNodeId());
+      UaVariableNode subV =
+          fx.addVariableDeclaration(
+              sub, "V", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+      subV.setDataType(NodeIds.String);
+
+      TypeInstantiationModel model = fx.compiler().compile(sub.getNodeId());
+
+      assertTrue(
+          model.diagnostics().stream()
+              .anyMatch(
+                  d ->
+                      d.code() == ModelDiagnostic.Code.VARIABLE_NARROWING
+                          && d.severity() == ModelDiagnostic.Severity.WARNING
+                          && path("V").equals(d.browsePath())),
+          "String does not narrow Int32 (Part 3 §6.2.8)");
+
+      assertEquals(
+          NodeIds.String,
+          model.get(path("V")).orElseThrow().attributes().dataType(),
+          "the override still stands, classified");
+    }
+
+    @Test
+    void methodSignatureMismatchDiagnosed() throws Exception {
+      UaObjectTypeNode base = fx.addObjectType("SigBase", NodeIds.BaseObjectType);
+      UaMethodNode baseMethod =
+          fx.addMethodDeclaration(base, "Op", NodeIds.ModellingRule_Mandatory);
+      fx.addArgumentsProperty(
+          baseMethod, "InputArguments", new Argument[] {argument("A"), argument("B")});
+
+      UaObjectTypeNode sub = fx.addObjectType("SigSub", base.getNodeId());
+      UaMethodNode subMethod = fx.addMethodDeclaration(sub, "Op", NodeIds.ModellingRule_Mandatory);
+      fx.addArgumentsProperty(subMethod, "InputArguments", new Argument[] {argument("A")});
+
+      TypeInstantiationModel model = fx.compiler().compile(sub.getNodeId());
+
+      assertTrue(
+          model.diagnostics().stream()
+              .anyMatch(
+                  d ->
+                      d.code() == ModelDiagnostic.Code.METHOD_SIGNATURE_MISMATCH
+                          && path("Op").equals(d.browsePath())),
+          "removing arguments violates Part 3 §6.3.3.3");
+    }
+
+    /**
+     * Method overrides validate argument content, not only count and name: a concrete DataType
+     * shall not change, an abstract DataType may be specialized to a subtype, and the argument
+     * property cannot disappear (Part 3 §6.3.3.3).
+     */
+    @Test
+    void methodArgumentCompatibilityValidated() throws Exception {
+      UaObjectTypeNode base = fx.addObjectType("ArgBase", NodeIds.BaseObjectType);
+      UaMethodNode baseTyped =
+          fx.addMethodDeclaration(base, "Typed", NodeIds.ModellingRule_Mandatory);
+      fx.addArgumentsProperty(
+          baseTyped,
+          "InputArguments",
+          new Argument[] {new Argument("A", NodeIds.Int32, -1, null, LocalizedText.english("A"))});
+      UaMethodNode baseGone =
+          fx.addMethodDeclaration(base, "Gone", NodeIds.ModellingRule_Mandatory);
+      fx.addArgumentsProperty(baseGone, "InputArguments", new Argument[] {argument("A")});
+      UaMethodNode baseSpec =
+          fx.addMethodDeclaration(base, "Spec", NodeIds.ModellingRule_Mandatory);
+      fx.addArgumentsProperty(
+          baseSpec,
+          "InputArguments",
+          new Argument[] {new Argument("A", NodeIds.Number, -1, null, LocalizedText.english("A"))});
+
+      UaObjectTypeNode sub = fx.addObjectType("ArgSub", base.getNodeId());
+      UaMethodNode subTyped =
+          fx.addMethodDeclaration(sub, "Typed", NodeIds.ModellingRule_Mandatory);
+      fx.addArgumentsProperty(
+          subTyped,
+          "InputArguments",
+          new Argument[] {new Argument("A", NodeIds.String, -1, null, LocalizedText.english("A"))});
+      fx.addMethodDeclaration(sub, "Gone", NodeIds.ModellingRule_Mandatory);
+      UaMethodNode subSpec = fx.addMethodDeclaration(sub, "Spec", NodeIds.ModellingRule_Mandatory);
+      fx.addArgumentsProperty(
+          subSpec,
+          "InputArguments",
+          new Argument[] {new Argument("A", NodeIds.Int32, -1, null, LocalizedText.english("A"))});
+
+      TypeInstantiationModel model = fx.compiler().compile(sub.getNodeId());
+
+      List<ModelDiagnostic> mismatches =
+          model.diagnostics().stream()
+              .filter(d -> d.code() == ModelDiagnostic.Code.METHOD_SIGNATURE_MISMATCH)
+              .toList();
+
+      assertTrue(
+          mismatches.stream()
+              .anyMatch(
+                  d -> path("Typed").equals(d.browsePath()) && d.message().contains("DataType")),
+          "changing a concrete argument DataType is diagnosed");
+      assertTrue(
+          mismatches.stream()
+              .anyMatch(
+                  d -> path("Gone").equals(d.browsePath()) && d.message().contains("removes")),
+          "removing the whole argument property is diagnosed");
+      assertTrue(
+          mismatches.stream().noneMatch(d -> path("Spec").equals(d.browsePath())),
+          "specializing an abstract argument DataType to a subtype is permitted");
+    }
+
+    private static Argument argument(String name) {
+      return new Argument(name, NodeIds.String, -1, null, LocalizedText.english(name));
+    }
+  }
+
+  /** Occurrences, duplicate BrowseNames, placeholders, and vendor modelling rules. */
+  @Nested
+  class DeclarationClassification {
+
+    /**
+     * Multiple BrowsePaths reaching one declaration node are distinct occurrences (Part 3
+     * §6.3.3.2).
+     */
+    @Test
+    void multiplePathsToOneDeclarationAreDistinctOccurrences() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("MultiPathType", NodeIds.BaseObjectType);
+      UaObjectNode a =
+          fx.addObjectDeclaration(
+              typeNode, "A", NodeIds.BaseObjectType, NodeIds.ModellingRule_Mandatory);
+      UaObjectNode b =
+          fx.addObjectDeclaration(
+              typeNode, "B", NodeIds.BaseObjectType, NodeIds.ModellingRule_Mandatory);
+      UaVariableNode n =
+          fx.addVariableDeclaration(
+              a, "N", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+      b.addReference(
+          new Reference(b.getNodeId(), NodeIds.HasComponent, n.getNodeId().expanded(), true));
+
+      TypeInstantiationModel model = fx.compiler().compile(typeNode.getNodeId());
+
+      InstanceDeclaration underA = model.get(path("A", "N")).orElseThrow();
+      InstanceDeclaration underB = model.get(path("B", "N")).orElseThrow();
+      assertEquals(n.getNodeId(), underA.declarationNodeId());
+      assertEquals(n.getNodeId(), underB.declarationNodeId());
+      assertNotEquals(underA.browsePath(), underB.browsePath());
+    }
+
+    /** Duplicate sibling BrowseNames reject the compile with a precise diagnostic. */
+    @Test
+    void duplicateSiblingBrowseNamesRejectedPrecisely() {
+      UaObjectTypeNode typeNode = fx.addObjectType("DupType", NodeIds.BaseObjectType);
+      UaVariableNode first =
+          fx.addVariableDeclaration(
+              typeNode, "X", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+      NodeId secondId = fx.newNodeId("DupType.X2");
+      UaVariableNode second =
+          new UaVariableNode(
+              fx.context(),
+              secondId,
+              qn("X"),
+              LocalizedText.english("X"),
+              LocalizedText.NULL_VALUE,
+              UInteger.MIN,
+              UInteger.MIN);
+      second.addReference(
+          new Reference(
+              secondId, NodeIds.HasTypeDefinition, NodeIds.BaseDataVariableType.expanded(), true));
+      second.addReference(
+          new Reference(
+              secondId,
+              NodeIds.HasModellingRule,
+              NodeIds.ModellingRule_Mandatory.expanded(),
+              true));
+      fx.nodeManager().addNode(second);
+      typeNode.addReference(
+          new Reference(typeNode.getNodeId(), NodeIds.HasComponent, secondId.expanded(), true));
+
+      ModelCompilationException e =
+          assertThrows(
+              ModelCompilationException.class, () -> fx.compiler().compile(typeNode.getNodeId()));
+
+      assertTrue(
+          e.getDiagnostics().stream()
+              .anyMatch(
+                  d ->
+                      d.isError()
+                          && d.code() == ModelDiagnostic.Code.DUPLICATE_BROWSE_NAME
+                          && path("X").equals(d.browsePath())
+                          && secondId.equals(d.nodeId())),
+          "the diagnostic pinpoints the colliding path and sibling; first kept: "
+              + first.getNodeId());
+    }
+
+    /**
+     * Sibling BrowseName uniqueness (Part 3 §4.6.4) covers rule-less children too, so validity is
+     * not NodeId-order dependent: a rule-less X walked before a Mandatory X still collides.
+     */
+    @Test
+    void ruleLessSiblingCollisionIsOrderIndependent() {
+      UaObjectTypeNode typeNode = fx.addObjectType("RuleLessDupType", NodeIds.BaseObjectType);
+      fx.addRuleLessVariable(typeNode, "X", NodeIds.BaseDataVariableType);
+
+      NodeId declaredId = fx.newNodeId("RuleLessDupType.X2");
+      UaVariableNode declared =
+          new UaVariableNode(
+              fx.context(),
+              declaredId,
+              qn("X"),
+              LocalizedText.english("X"),
+              LocalizedText.NULL_VALUE,
+              UInteger.MIN,
+              UInteger.MIN);
+      declared.addReference(
+          new Reference(
+              declaredId,
+              NodeIds.HasTypeDefinition,
+              NodeIds.BaseDataVariableType.expanded(),
+              true));
+      declared.addReference(
+          new Reference(
+              declaredId,
+              NodeIds.HasModellingRule,
+              NodeIds.ModellingRule_Mandatory.expanded(),
+              true));
+      fx.nodeManager().addNode(declared);
+      typeNode.addReference(
+          new Reference(typeNode.getNodeId(), NodeIds.HasComponent, declaredId.expanded(), true));
+
+      ModelCompilationException e =
+          assertThrows(
+              ModelCompilationException.class, () -> fx.compiler().compile(typeNode.getNodeId()));
+
+      assertTrue(
+          e.getDiagnostics().stream()
+              .anyMatch(
+                  d ->
+                      d.isError()
+                          && d.code() == ModelDiagnostic.Code.DUPLICATE_BROWSE_NAME
+                          && path("X").equals(d.browsePath())));
+    }
+
+    /**
+     * Placeholders are surfaced as extension points and recorded shallowly: neither their type's
+     * members nor their on-declaration children enter the model (Part 3 §6.4.4.4.4–.5).
+     */
+    @Test
+    void placeholdersSurfacedShallowly() throws Exception {
+      UaObjectTypeNode phMemberType = fx.addObjectType("PHMemberType", NodeIds.BaseObjectType);
+      fx.addVariableDeclaration(
+          phMemberType, "Inner", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+      UaObjectTypeNode typeNode = fx.addObjectType("PHType", NodeIds.BaseObjectType);
+      UaObjectNode optionalPh =
+          fx.addObjectDeclaration(
+              typeNode,
+              "<Element>",
+              phMemberType.getNodeId(),
+              NodeIds.ModellingRule_OptionalPlaceholder);
+      fx.addVariableDeclaration(
+          optionalPh, "DeclChild", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+      fx.addObjectDeclaration(
+          typeNode,
+          "<Required>",
+          phMemberType.getNodeId(),
+          NodeIds.ModellingRule_MandatoryPlaceholder);
+
+      TypeInstantiationModel model = fx.compiler().compile(typeNode.getNodeId());
+
+      assertEquals(
+          List.of(path("<Element>"), path("<Required>")),
+          model.placeholders().stream().map(InstanceDeclaration::browsePath).toList());
+      assertEquals(
+          ModellingRule.OPTIONAL_PLACEHOLDER, model.get(path("<Element>")).orElseThrow().rule());
+      assertEquals(
+          ModellingRule.MANDATORY_PLACEHOLDER, model.get(path("<Required>")).orElseThrow().rule());
+      assertEquals(
+          phMemberType.getNodeId(),
+          model.get(path("<Element>")).orElseThrow().typeDefinitionId(),
+          "the placeholder's type is visible for later placeholder-driven creation");
+
+      assertTrue(model.get(path("<Element>", "Inner")).isEmpty(), "type members not expanded");
+      assertTrue(model.get(path("<Element>", "DeclChild")).isEmpty(), "subtree not considered");
+      assertEquals(2, model.declarations().size());
+    }
+
+    /** Shallow recording skips subtree expansion, not validation of the recorded type metadata. */
+    @Test
+    void shallowDeclarationTypeClassValidated() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("BadPlaceholderType", NodeIds.BaseObjectType);
+      fx.addObjectDeclaration(
+          typeNode, "<P>", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_OptionalPlaceholder);
+
+      TypeInstantiationModel model = fx.compiler().compile(typeNode.getNodeId());
+
+      assertTrue(
+          model.diagnostics().stream()
+              .anyMatch(
+                  d ->
+                      d.code() == ModelDiagnostic.Code.NODE_CLASS_MISMATCH
+                          && d.severity() == ModelDiagnostic.Severity.WARNING
+                          && path("<P>").equals(d.browsePath())),
+          "an Object placeholder typed by a VariableType is diagnosed");
+      assertTrue(model.get(path("<P>")).isPresent(), "the placeholder itself stays surfaced");
+    }
+
+    /** ExposesItsArray is classified and surfaced but not expanded: model visibility only. */
+    @Test
+    void exposesItsArraySurfacedNotExpanded() throws Exception {
+      UaObjectTypeNode elementType = fx.addObjectType("ElementType", NodeIds.BaseObjectType);
+      fx.addVariableDeclaration(
+          elementType, "Inner", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+      UaObjectTypeNode typeNode = fx.addObjectType("ArrayType", NodeIds.BaseObjectType);
+      fx.addObjectDeclaration(
+          typeNode, "Element", elementType.getNodeId(), NodeIds.ModellingRule_ExposesItsArray);
+
+      TypeInstantiationModel model = fx.compiler().compile(typeNode.getNodeId());
+
+      InstanceDeclaration element = model.get(path("Element")).orElseThrow();
+      assertEquals(ModellingRule.EXPOSES_ITS_ARRAY, element.rule());
+      assertFalse(element.isPlaceholder());
+      assertTrue(model.placeholders().isEmpty());
+      assertTrue(model.get(path("Element", "Inner")).isEmpty(), "not expanded");
+    }
+
+    /** Vendor rules classify as OTHER with the raw id preserved and the walk continuing. */
+    @Test
+    void vendorRuleClassifiedOtherWithRawIdAndWalkContinues() throws Exception {
+      NodeId vendorRuleId = fx.newNodeId("VendorRule");
+
+      UaObjectTypeNode typeNode = fx.addObjectType("VendorType", NodeIds.BaseObjectType);
+      UaObjectNode member =
+          fx.addObjectDeclaration(typeNode, "V", NodeIds.BaseObjectType, vendorRuleId);
+      fx.addVariableDeclaration(
+          member, "Child", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+      TypeInstantiationModel model = fx.compiler().compile(typeNode.getNodeId());
+
+      InstanceDeclaration v = model.get(path("V")).orElseThrow();
+      assertEquals(ModellingRule.OTHER, v.rule());
+      assertEquals(vendorRuleId, v.modellingRuleId(), "raw rule id preserved");
+
+      assertTrue(
+          model.diagnostics().stream()
+              .anyMatch(
+                  d ->
+                      d.code() == ModelDiagnostic.Code.VENDOR_MODELLING_RULE
+                          && d.severity() == ModelDiagnostic.Severity.WARNING));
+
+      assertTrue(
+          model.get(path("V", "Child")).isPresent(),
+          "classification, not filtering: the walk continues beneath a vendor rule");
+    }
+
+    /** A custom hierarchical ReferenceType subtype extends the hierarchy like its ancestors. */
+    @Test
+    void customReferenceTypeSubtypeExtendsHierarchy() throws Exception {
+      UaReferenceTypeNode hasWidget = fx.addReferenceType("HasWidget", NodeIds.HasComponent);
+
+      UaObjectTypeNode typeNode = fx.addObjectType("WidgetType", NodeIds.BaseObjectType);
+      fx.addVariableDeclaration(
+          typeNode,
+          "W",
+          NodeIds.BaseDataVariableType,
+          NodeIds.ModellingRule_Mandatory,
+          hasWidget.getNodeId());
+
+      TypeInstantiationModel model = fx.compiler().compile(typeNode.getNodeId());
+
+      assertTrue(model.get(path("W")).isPresent());
+      assertTrue(
+          model
+              .hierarchy()
+              .contains(new DeclarationEdge(BrowsePath.root(), hasWidget.getNodeId(), path("W"))),
+          "the edge keeps the custom ReferenceType");
+    }
+  }
+
+  /** Reference rows: relative vs absolute, canonicalization, occurrence resolution. */
+  @Nested
+  class ReferenceRows {
+
+    /**
+     * A non-hierarchical reference between two declarations becomes exactly one relative row,
+     * canonicalized forward (its auto-added inverse is the same logical reference); rows to nodes
+     * outside the model — HasTypeDefinition, HasModellingRule — stay absolute with direction.
+     */
+    @Test
+    void declarationInternalRowsRelativeExternalRowsAbsolute() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("RowType", NodeIds.BaseObjectType);
+      UaObjectNode foo =
+          fx.addObjectDeclaration(
+              typeNode, "Foo", NodeIds.BaseObjectType, NodeIds.ModellingRule_Mandatory);
+      UaVariableNode bar =
+          fx.addVariableDeclaration(
+              typeNode, "Bar", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+      foo.addReference(
+          new Reference(foo.getNodeId(), NodeIds.HasCause, bar.getNodeId().expanded(), true));
+
+      TypeInstantiationModel model = fx.compiler().compile(typeNode.getNodeId());
+
+      List<ReferenceRow> causeRows =
+          model.references().stream()
+              .filter(r -> NodeIds.HasCause.equals(r.referenceTypeId()))
+              .toList();
+      assertEquals(
+          List.of(ReferenceRow.relative(path("Foo"), NodeIds.HasCause, path("Bar"))),
+          causeRows,
+          "one relative forward row per logical reference (both stored directions canonicalized)");
+
+      assertTrue(
+          model
+              .references()
+              .contains(
+                  ReferenceRow.absolute(
+                      path("Foo"),
+                      NodeIds.HasTypeDefinition,
+                      Reference.Direction.FORWARD,
+                      NodeIds.BaseObjectType.expanded())),
+          "HasTypeDefinition stays absolute");
+      assertTrue(
+          model
+              .references()
+              .contains(
+                  ReferenceRow.absolute(
+                      path("Foo"),
+                      NodeIds.HasModellingRule,
+                      Reference.Direction.FORWARD,
+                      NodeIds.ModellingRule_Mandatory.expanded())),
+          "HasModellingRule is recorded (retention is a purpose-dependent planning decision)");
+    }
+
+    /**
+     * A multi-occurrence declaration's internal references resolve through occurrence context: each
+     * occurrence's self-reference maps to its own occurrence rather than freezing absolute.
+     */
+    @Test
+    void multiOccurrenceSelfReferenceResolvesPerOccurrence() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("SelfRefType", NodeIds.BaseObjectType);
+      UaObjectNode a =
+          fx.addObjectDeclaration(
+              typeNode, "A", NodeIds.BaseObjectType, NodeIds.ModellingRule_Mandatory);
+      UaObjectNode b =
+          fx.addObjectDeclaration(
+              typeNode, "B", NodeIds.BaseObjectType, NodeIds.ModellingRule_Mandatory);
+      UaVariableNode n =
+          fx.addVariableDeclaration(
+              a, "N", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+      b.addReference(
+          new Reference(b.getNodeId(), NodeIds.HasComponent, n.getNodeId().expanded(), true));
+      n.addReference(
+          new Reference(n.getNodeId(), NodeIds.HasCause, n.getNodeId().expanded(), true));
+
+      TypeInstantiationModel model = fx.compiler().compile(typeNode.getNodeId());
+
+      List<ReferenceRow> causeRows =
+          model.references().stream()
+              .filter(r -> NodeIds.HasCause.equals(r.referenceTypeId()))
+              .toList();
+      assertEquals(
+          List.of(
+              ReferenceRow.relative(path("A", "N"), NodeIds.HasCause, path("A", "N")),
+              ReferenceRow.relative(path("B", "N"), NodeIds.HasCause, path("B", "N"))),
+          causeRows,
+          "each occurrence's self-reference stays relative to its own occurrence");
+      assertTrue(
+          model.diagnostics().stream()
+              .noneMatch(d -> d.code() == ModelDiagnostic.Code.AMBIGUOUS_REFERENCE_TARGET));
+    }
+  }
+
+  /**
+   * Modelling rule classification, tightening transitions, rule targets, and
+   * DefaultInstanceBrowseName.
+   */
+  @Nested
+  class ModellingRules {
+
+    @Test
+    void modellingRuleTighteningValidation() throws Exception {
+      UaObjectTypeNode base = fx.addObjectType("TightBase", NodeIds.BaseObjectType);
+      fx.addVariableDeclaration(
+          base, "O", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Optional);
+      fx.addVariableDeclaration(
+          base, "M", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+      fx.addObjectDeclaration(
+          base, "P", NodeIds.BaseObjectType, NodeIds.ModellingRule_OptionalPlaceholder);
+
+      UaObjectTypeNode sub = fx.addObjectType("TightSub", base.getNodeId());
+      fx.addVariableDeclaration(
+          sub, "O", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+      fx.addVariableDeclaration(
+          sub, "M", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Optional);
+      fx.addObjectDeclaration(
+          sub, "P", NodeIds.BaseObjectType, NodeIds.ModellingRule_MandatoryPlaceholder);
+
+      TypeInstantiationModel model = fx.compiler().compile(sub.getNodeId());
+
+      List<ModelDiagnostic> tightening =
+          model.diagnostics().stream()
+              .filter(d -> d.code() == ModelDiagnostic.Code.MODELLING_RULE_TIGHTENING)
+              .toList();
+
+      assertTrue(
+          tightening.stream().noneMatch(d -> path("O").equals(d.browsePath())),
+          "Optional -> Mandatory is a valid tightening, silent");
+      assertTrue(
+          tightening.stream()
+              .anyMatch(
+                  d ->
+                      path("M").equals(d.browsePath())
+                          && d.severity() == ModelDiagnostic.Severity.WARNING),
+          "Mandatory -> Optional violates Table 21: warn, model stays usable");
+      assertTrue(
+          tightening.stream()
+              .anyMatch(d -> path("P").equals(d.browsePath()) && d.message().contains("contested")),
+          "OptionalPlaceholder -> MandatoryPlaceholder is a contested transition: warn");
+    }
+
+    /**
+     * Method placeholder overrides follow §6.4.4.4.4–.5, not the generic Table 21: the rule shall
+     * change to Optional/Mandatory (OptionalPlaceholder) or Mandatory (MandatoryPlaceholder), and
+     * an unchanged placeholder on an override is diagnosed.
+     */
+    @Test
+    void methodPlaceholderTransitionsUseMethodRules() throws Exception {
+      UaObjectTypeNode base = fx.addObjectType("MethodRuleBase", NodeIds.BaseObjectType);
+      fx.addMethodDeclaration(base, "Op", NodeIds.ModellingRule_OptionalPlaceholder);
+      fx.addMethodDeclaration(base, "Keep", NodeIds.ModellingRule_OptionalPlaceholder);
+      fx.addMethodDeclaration(base, "Must", NodeIds.ModellingRule_MandatoryPlaceholder);
+
+      UaObjectTypeNode sub = fx.addObjectType("MethodRuleSub", base.getNodeId());
+      fx.addMethodDeclaration(sub, "Op", NodeIds.ModellingRule_Optional);
+      fx.addMethodDeclaration(sub, "Keep", NodeIds.ModellingRule_OptionalPlaceholder);
+      fx.addMethodDeclaration(sub, "Must", NodeIds.ModellingRule_Mandatory);
+
+      TypeInstantiationModel model = fx.compiler().compile(sub.getNodeId());
+
+      List<ModelDiagnostic> tightening =
+          model.diagnostics().stream()
+              .filter(d -> d.code() == ModelDiagnostic.Code.MODELLING_RULE_TIGHTENING)
+              .toList();
+
+      assertTrue(
+          tightening.stream().noneMatch(d -> path("Op").equals(d.browsePath())),
+          "OptionalPlaceholder -> Optional is the required Method transition: silent");
+      assertTrue(
+          tightening.stream().noneMatch(d -> path("Must").equals(d.browsePath())),
+          "MandatoryPlaceholder -> Mandatory is the required Method transition: silent");
+      assertTrue(
+          tightening.stream().anyMatch(d -> path("Keep").equals(d.browsePath())),
+          "keeping the placeholder rule on a Method override is diagnosed");
+    }
+
+    /**
+     * A HasModellingRule target that only resolves remotely rejects the compile: excluding the
+     * declaration instead would silently truncate the hierarchy.
+     */
+    @Test
+    void unresolvableModellingRuleTargetRejected() {
+      UaObjectTypeNode unresolvableHost =
+          fx.addObjectType("UnresolvableRuleType", NodeIds.BaseObjectType);
+      NodeId declId = fx.newNodeId("UnresolvableRuleType.D");
+      UaObjectNode decl =
+          new UaObjectNode(
+              fx.context(),
+              declId,
+              qn("D"),
+              LocalizedText.english("D"),
+              LocalizedText.NULL_VALUE,
+              UInteger.MIN,
+              UInteger.MIN,
+              ubyte(0));
+      decl.addReference(
+          new Reference(
+              declId, NodeIds.HasTypeDefinition, NodeIds.BaseObjectType.expanded(), true));
+      decl.addReference(
+          new Reference(
+              declId,
+              NodeIds.HasModellingRule,
+              ExpandedNodeId.of("urn:remote:server:namespace", "Rule"),
+              true));
+      fx.nodeManager().addNode(decl);
+      unresolvableHost.addReference(
+          new Reference(
+              unresolvableHost.getNodeId(), NodeIds.HasComponent, declId.expanded(), true));
+
+      ModelCompilationException e =
+          assertThrows(
+              ModelCompilationException.class,
+              () -> fx.compiler().compile(unresolvableHost.getNodeId()));
+
+      assertTrue(
+          e.getDiagnostics().stream()
+              .anyMatch(
+                  d ->
+                      d.isError()
+                          && d.code() == ModelDiagnostic.Code.MODELLING_RULE_INVALID
+                          && path("D").equals(d.browsePath())));
+    }
+
+    /**
+     * A HasModellingRule target node missing locally warns, with the declaration still classified.
+     */
+    @Test
+    void missingModellingRuleNodeWarnsAndStillClassifies() throws Exception {
+      UaObjectTypeNode missingHost =
+          fx.addObjectType("MissingRuleNodeType", NodeIds.BaseObjectType);
+      fx.addObjectDeclaration(missingHost, "M", NodeIds.BaseObjectType, fx.newNodeId("NoSuchRule"));
+
+      TypeInstantiationModel missingModel = fx.compiler().compile(missingHost.getNodeId());
+
+      assertTrue(
+          missingModel.diagnostics().stream()
+              .anyMatch(
+                  d ->
+                      d.code() == ModelDiagnostic.Code.MODELLING_RULE_INVALID
+                          && d.severity() == ModelDiagnostic.Severity.WARNING
+                          && path("M").equals(d.browsePath())),
+          "a missing rule node is diagnosed with the declaration still classified");
+      assertEquals(ModellingRule.OTHER, missingModel.get(path("M")).orElseThrow().rule());
+    }
+
+    /** A HasModellingRule target of the wrong NodeClass warns with a classifying message. */
+    @Test
+    void wrongClassModellingRuleTargetWarns() throws Exception {
+      UaObjectTypeNode wrongClassHost =
+          fx.addObjectType("WrongClassRuleType", NodeIds.BaseObjectType);
+      UaVariableNode notARule =
+          fx.addRuleLessVariable(wrongClassHost, "NotARule", NodeIds.BaseDataVariableType);
+      fx.addObjectDeclaration(wrongClassHost, "W", NodeIds.BaseObjectType, notARule.getNodeId());
+
+      TypeInstantiationModel wrongClassModel = fx.compiler().compile(wrongClassHost.getNodeId());
+
+      assertTrue(
+          wrongClassModel.diagnostics().stream()
+              .anyMatch(
+                  d ->
+                      d.code() == ModelDiagnostic.Code.MODELLING_RULE_INVALID
+                          && path("W").equals(d.browsePath())
+                          && d.message().contains("not an Object")),
+          "a wrong-class rule target is diagnosed");
+    }
+
+    @Test
+    void defaultInstanceBrowseNameExposedAndInherited() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("NamedType", NodeIds.BaseObjectType);
+      fx.setDefaultInstanceBrowseName(typeNode, qn("DefaultName"));
+
+      UaObjectTypeNode subType = fx.addObjectType("NamedSubType", typeNode.getNodeId());
+
+      TypeInstantiationModel model = fx.compiler().compile(typeNode.getNodeId());
+      assertEquals(qn("DefaultName"), model.defaultInstanceBrowseName().orElseThrow());
+      assertTrue(
+          model.diagnostics().stream()
+              .noneMatch(d -> d.code() == ModelDiagnostic.Code.NOT_AN_INSTANCE_DECLARATION),
+          "the consumed DefaultInstanceBrowseName property is not noise");
+
+      TypeInstantiationModel subModel = fx.compiler().compile(subType.getNodeId());
+      assertEquals(
+          qn("DefaultName"),
+          subModel.defaultInstanceBrowseName().orElseThrow(),
+          "inherited from the nearest supertype providing one");
+    }
+  }
+
+  /** Deterministic output, revision fingerprints, and dependency tracking. */
+  @Nested
+  class Determinism {
+
+    /**
+     * Output is deterministic across independent compilations: browse-path ordering and revision.
+     */
+    @Test
+    void deterministicOrderingAndStableFingerprint() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("OrderType", NodeIds.BaseObjectType);
+      // Insertion order deliberately unsorted.
+      fx.addVariableDeclaration(
+          typeNode, "Zed", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+      UaObjectNode mid =
+          fx.addObjectDeclaration(
+              typeNode, "Mid", NodeIds.BaseObjectType, NodeIds.ModellingRule_Mandatory);
+      fx.addVariableDeclaration(
+          mid, "Nested", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Optional);
+      fx.addVariableDeclaration(
+          typeNode, "Alpha", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+      TypeInstantiationModel first = fx.compiler().compile(typeNode.getNodeId());
+      TypeInstantiationModel second = fx.compiler().compile(typeNode.getNodeId());
+
+      List<BrowsePath> expectedOrder =
+          List.of(path("Alpha"), path("Mid"), path("Mid", "Nested"), path("Zed"));
+      assertEquals(
+          expectedOrder,
+          first.declarations().stream().map(InstanceDeclaration::browsePath).toList());
+      assertEquals(
+          expectedOrder,
+          second.declarations().stream().map(InstanceDeclaration::browsePath).toList());
+
+      assertEquals(first.modelRevision(), second.modelRevision(), "unchanged type, equal revision");
+      assertEquals(first.hierarchy(), second.hierarchy());
+      assertEquals(first.references(), second.references());
+    }
+
+    /** The revision fingerprint tracks content, and dependencies name every contributing node. */
+    @Test
+    void fingerprintChangesWithDependenciesAndDependenciesAreComplete() throws Exception {
+      UaObjectTypeNode memberType = fx.addObjectType("DepMemberType", NodeIds.BaseObjectType);
+      UaVariableNode inner =
+          fx.addVariableDeclaration(
+              memberType, "Inner", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+      UaObjectTypeNode typeNode = fx.addObjectType("DepType", NodeIds.BaseObjectType);
+      UaObjectNode member =
+          fx.addObjectDeclaration(
+              typeNode, "M", memberType.getNodeId(), NodeIds.ModellingRule_Mandatory);
+
+      TypeInstantiationModel before = fx.compiler().compile(typeNode.getNodeId());
+
+      assertTrue(before.dependencies().contains(typeNode.getNodeId()));
+      assertTrue(before.dependencies().contains(NodeIds.BaseObjectType), "supertype chain");
+      assertTrue(before.dependencies().contains(member.getNodeId()), "declaration node");
+      assertTrue(before.dependencies().contains(memberType.getNodeId()), "member type");
+      assertTrue(before.dependencies().contains(inner.getNodeId()), "member type's declaration");
+
+      // A change to a node in the dependency closure produces a different fingerprint.
+      inner.setValue(new DataValue(new Variant("changed")));
+
+      TypeInstantiationModel after = fx.compiler().compile(typeNode.getNodeId());
+      assertNotEquals(before.modelRevision(), after.modelRevision());
+    }
+
+    /**
+     * The revision fingerprints full value content: deterministic Java hash collisions ("Aa"/"BB")
+     * must not collide the revision.
+     */
+    @Test
+    void fingerprintDistinguishesCollidingValueHashes() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("FpType", NodeIds.BaseObjectType);
+      UaVariableNode v =
+          fx.addVariableDeclaration(
+              typeNode, "V", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+      v.setDisplayName(LocalizedText.english("Aa"));
+
+      long before = fx.compiler().compile(typeNode.getNodeId()).modelRevision();
+      v.setDisplayName(LocalizedText.english("BB"));
+      long after = fx.compiler().compile(typeNode.getNodeId()).modelRevision();
+
+      assertNotEquals(before, after, "colliding 32-bit value hashes must not collide the revision");
+    }
+
+    /**
+     * The revision fingerprints diagnostics-relevant metadata of nested member types: an edit that
+     * changes plan-time requirements (IsAbstract) must move the containing type's revision.
+     */
+    @Test
+    void fingerprintTracksNestedMemberTypeEdits() throws Exception {
+      UaObjectTypeNode memberType = fx.addObjectType("FpMemberType", NodeIds.BaseObjectType);
+      UaObjectTypeNode host = fx.addObjectType("FpHostType", NodeIds.BaseObjectType);
+      fx.addObjectDeclaration(host, "M", memberType.getNodeId(), NodeIds.ModellingRule_Mandatory);
+
+      long concrete = fx.compiler().compile(host.getNodeId()).modelRevision();
+      memberType.setIsAbstract(true);
+      long abstractRevision = fx.compiler().compile(host.getNodeId()).modelRevision();
+
+      assertNotEquals(
+          concrete,
+          abstractRevision,
+          "a nested TypeDefinition's IsAbstract edit must change the containing revision");
+    }
+  }
+
+  /** Cycles, self-recursion, and depth/width limits. */
+  @Nested
+  class Robustness {
+
+    @Test
+    void subtypeCycleRejected() {
+      NodeId aId = fx.newNodeId("CycleA");
+      NodeId bId = fx.newNodeId("CycleB");
+      fx.addObjectType("CycleA", bId);
+      fx.addObjectType("CycleB", aId);
+
+      ModelCompilationException e =
+          assertThrows(ModelCompilationException.class, () -> fx.compiler().compile(aId));
+
+      assertTrue(
+          e.getDiagnostics().stream()
+              .anyMatch(d -> d.isError() && d.code() == ModelDiagnostic.Code.TYPE_CYCLE));
+    }
+
+    @Test
+    void memberTypeSelfRecursionRejected() {
+      UaObjectTypeNode typeNode = fx.addObjectType("SelfType", NodeIds.BaseObjectType);
+      fx.addObjectDeclaration(
+          typeNode, "Self", typeNode.getNodeId(), NodeIds.ModellingRule_Mandatory);
+
+      ModelCompilationException e =
+          assertThrows(
+              ModelCompilationException.class, () -> fx.compiler().compile(typeNode.getNodeId()));
+
+      assertTrue(
+          e.getDiagnostics().stream()
+              .anyMatch(d -> d.isError() && d.code() == ModelDiagnostic.Code.TYPE_CYCLE));
+    }
+
+    @Test
+    void declarationLoopRejectedWithoutStackOverflow() {
+      UaObjectTypeNode typeNode = fx.addObjectType("LoopType", NodeIds.BaseObjectType);
+      UaObjectNode x =
+          fx.addObjectDeclaration(
+              typeNode, "X", NodeIds.BaseObjectType, NodeIds.ModellingRule_Mandatory);
+      x.addReference(
+          new Reference(x.getNodeId(), NodeIds.HasComponent, x.getNodeId().expanded(), true));
+
+      ModelCompilationException e =
+          assertThrows(
+              ModelCompilationException.class, () -> fx.compiler().compile(typeNode.getNodeId()));
+
+      assertTrue(
+          e.getDiagnostics().stream()
+              .anyMatch(d -> d.isError() && d.code() == ModelDiagnostic.Code.DECLARATION_CYCLE));
+    }
+
+    /** Deep and wide hierarchies compile without stack overflow, fully ordered. */
+    @Test
+    void deepAndWideHierarchyCompiles() throws Exception {
+      UaObjectTypeNode typeNode = fx.addObjectType("BigType", NodeIds.BaseObjectType);
+
+      UaNode parent = typeNode;
+      String[] deepNames = new String[150];
+      for (int i = 0; i < 150; i++) {
+        deepNames[i] = "D" + i;
+        parent =
+            fx.addObjectDeclaration(
+                parent, "D" + i, NodeIds.BaseObjectType, NodeIds.ModellingRule_Mandatory);
+      }
+      for (int i = 0; i < 40; i++) {
+        fx.addVariableDeclaration(
+            typeNode, "Wide" + i, NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+      }
+
+      TypeInstantiationModel model = fx.compiler().compile(typeNode.getNodeId());
+
+      assertEquals(190, model.declarations().size());
+      assertTrue(model.get(path(deepNames)).isPresent(), "deepest path present");
+
+      List<BrowsePath> paths =
+          model.declarations().stream().map(InstanceDeclaration::browsePath).toList();
+      assertEquals(paths.stream().sorted().toList(), paths, "declarations are browse-path ordered");
+    }
+
+    /** A graph deeper than the compiler's bound rejects with a structured diagnostic. */
+    @Test
+    void depthBeyondLimitRejectedWithStructuredDiagnostic() {
+      UaObjectTypeNode typeNode = fx.addObjectType("VeryDeepType", NodeIds.BaseObjectType);
+      UaNode parent = typeNode;
+      for (int i = 0; i < TypeModelCompiler.MAX_DEPTH + 10; i++) {
+        parent =
+            fx.addObjectDeclaration(
+                parent, "D" + i, NodeIds.BaseObjectType, NodeIds.ModellingRule_Mandatory);
+      }
+
+      ModelCompilationException e =
+          assertThrows(
+              ModelCompilationException.class, () -> fx.compiler().compile(typeNode.getNodeId()));
+
+      assertTrue(
+          e.getDiagnostics().stream()
+              .anyMatch(d -> d.isError() && d.code() == ModelDiagnostic.Code.DEPTH_LIMIT_EXCEEDED));
+    }
+  }
+
+  /** Applied-interface validation (Part 3 §4.10.2). */
+  @Nested
+  class Interfaces {
+
+    /**
+     * Applied interfaces are validated, not materialized (Part 3 §4.10.2): a Mandatory interface
+     * member with no counterpart on the implementing type is diagnosed as a warning, but interface
+     * declarations never contribute planned nodes; a type that satisfies the interface compiles
+     * with no interface diagnostics.
+     */
+    @Test
+    void interfaceMembersValidatedButNotMaterialized() throws Exception {
+      UaObjectTypeNode machineInterface = fx.addInterfaceType("IMachine");
+      fx.addVariableDeclaration(
+          machineInterface, "Speed", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+      UaObjectTypeNode missing = fx.addObjectType("NoSpeedType", NodeIds.BaseObjectType);
+      missing.addReference(
+          new Reference(
+              missing.getNodeId(),
+              NodeIds.HasInterface,
+              machineInterface.getNodeId().expanded(),
+              true));
+
+      TypeInstantiationModel missingModel = fx.compiler().compile(missing.getNodeId());
+      assertTrue(
+          missingModel.diagnostics().stream()
+              .anyMatch(
+                  d ->
+                      d.code() == ModelDiagnostic.Code.INTERFACE_MEMBER_MISSING
+                          && d.severity() == ModelDiagnostic.Severity.WARNING
+                          && path("Speed").equals(d.browsePath())));
+      assertTrue(
+          missingModel.get(path("Speed")).isEmpty(),
+          "validation only: the interface contributes no planned nodes");
+
+      UaObjectTypeNode satisfied = fx.addObjectType("SpeedType", NodeIds.BaseObjectType);
+      fx.addVariableDeclaration(
+          satisfied, "Speed", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+      satisfied.addReference(
+          new Reference(
+              satisfied.getNodeId(),
+              NodeIds.HasInterface,
+              machineInterface.getNodeId().expanded(),
+              true));
+
+      TypeInstantiationModel satisfiedModel = fx.compiler().compile(satisfied.getNodeId());
+      assertTrue(
+          satisfiedModel.diagnostics().stream()
+              .noneMatch(
+                  d ->
+                      d.code() == ModelDiagnostic.Code.INTERFACE_MEMBER_MISSING
+                          || d.code() == ModelDiagnostic.Code.INTERFACE_MEMBER_INCOMPATIBLE),
+          "control: a satisfying implementer compiles with no interface diagnostics");
+    }
+
+    /**
+     * A Mandatory interface member must be represented by a Mandatory declaration on the
+     * implementer (Part 3 §4.10.2); an Optional local declaration is diagnosed as incompatible.
+     */
+    @Test
+    void optionalDeclarationDoesNotSatisfyMandatoryInterfaceMember() throws Exception {
+      UaObjectTypeNode machineInterface = fx.addInterfaceType("ISpeed");
+      fx.addVariableDeclaration(
+          machineInterface, "Speed", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+
+      UaObjectTypeNode optionalImpl = fx.addObjectType("OptionalSpeedType", NodeIds.BaseObjectType);
+      fx.addVariableDeclaration(
+          optionalImpl, "Speed", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Optional);
+      optionalImpl.addReference(
+          new Reference(
+              optionalImpl.getNodeId(),
+              NodeIds.HasInterface,
+              machineInterface.getNodeId().expanded(),
+              true));
+
+      TypeInstantiationModel optionalModel = fx.compiler().compile(optionalImpl.getNodeId());
+
+      assertTrue(
+          optionalModel.diagnostics().stream()
+              .anyMatch(
+                  d ->
+                      d.code() == ModelDiagnostic.Code.INTERFACE_MEMBER_INCOMPATIBLE
+                          && path("Speed").equals(d.browsePath())),
+          "an Optional local declaration does not satisfy a Mandatory interface member");
+    }
+
+    /**
+     * Every interface BrowsePath collision is validated, Optional interface members included: an
+     * Optional interface member colliding with a dissimilar local node is diagnosed (Part 3
+     * §4.10.2).
+     */
+    @Test
+    void interfaceMemberCollidingWithDissimilarLocalNodeDiagnosed() throws Exception {
+      UaObjectTypeNode modeInterface = fx.addInterfaceType("IMode");
+      fx.addVariableDeclaration(
+          modeInterface, "Mode", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Optional);
+
+      UaObjectTypeNode collidingImpl =
+          fx.addObjectType("CollidingModeType", NodeIds.BaseObjectType);
+      fx.addObjectDeclaration(
+          collidingImpl, "Mode", NodeIds.BaseObjectType, NodeIds.ModellingRule_Mandatory);
+      collidingImpl.addReference(
+          new Reference(
+              collidingImpl.getNodeId(),
+              NodeIds.HasInterface,
+              modeInterface.getNodeId().expanded(),
+              true));
+
+      TypeInstantiationModel collidingModel = fx.compiler().compile(collidingImpl.getNodeId());
+
+      assertTrue(
+          collidingModel.diagnostics().stream()
+              .anyMatch(
+                  d ->
+                      d.code() == ModelDiagnostic.Code.INTERFACE_MEMBER_INCOMPATIBLE
+                          && path("Mode").equals(d.browsePath())),
+          "an Optional interface member colliding with a dissimilar local node is diagnosed");
+    }
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/TypeModelCompilerTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/TypeModelCompilerTest.java
@@ -230,6 +230,92 @@ public class TypeModelCompilerTest {
           typeDefinitionRows,
           "the singular HasTypeDefinition is replaced by the winner's");
     }
+
+    /**
+     * A supertype's explicit specialization of a member type's child survives into the subtype's
+     * model when the subtype re-declares the member without re-declaring the child: the inherited
+     * explicit declaration beats the member-type default the subtype's own walk re-grafted, and
+     * validation runs in the matching direction (no spurious narrowing warning).
+     */
+    @Test
+    void inheritedExplicitSpecializationBeatsRegraftedMemberTypeDefault() throws Exception {
+      UaObjectTypeNode memberType = fx.addObjectType("GraftMemberType", NodeIds.BaseObjectType);
+      UaVariableNode typeChild =
+          fx.addVariableDeclaration(
+              memberType, "B", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+      typeChild.setDataType(NodeIds.Number);
+
+      UaObjectTypeNode superType = fx.addObjectType("GraftSuperType", NodeIds.BaseObjectType);
+      UaObjectNode d =
+          fx.addObjectDeclaration(
+              superType, "D", memberType.getNodeId(), NodeIds.ModellingRule_Mandatory);
+      UaVariableNode specialized =
+          fx.addVariableDeclaration(
+              d, "B", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+      specialized.setDataType(NodeIds.Int32);
+
+      UaObjectTypeNode subType = fx.addObjectType("GraftSubType", superType.getNodeId());
+      fx.addObjectDeclaration(
+          subType, "D", memberType.getNodeId(), NodeIds.ModellingRule_Mandatory);
+
+      TypeInstantiationModel model = fx.compiler().compile(subType.getNodeId());
+
+      InstanceDeclaration child = model.get(path("D", "B")).orElseThrow();
+      assertEquals(
+          specialized.getNodeId(),
+          child.declarationNodeId(),
+          "the inherited explicit specialization wins over the re-grafted member-type default");
+      assertEquals(NodeIds.Int32, child.attributes().dataType());
+      assertTrue(
+          child.overriddenDeclarations().contains(typeChild.getNodeId()),
+          "the member-type default is recorded as overridden");
+      assertTrue(
+          model.diagnostics().stream()
+              .noneMatch(diag -> diag.code() == ModelDiagnostic.Code.VARIABLE_NARROWING),
+          "no narrowing warning: Int32 narrowing Number is validated in the correct direction");
+    }
+
+    /**
+     * Two inherited references between the same declaration pair (Part 3 §6.4.3) both survive an
+     * override of the child by an unrelated ReferenceType: an edge folded from the supertype must
+     * not suppress a sibling edge folded by the same merge, whatever their subtype relationship or
+     * iteration order.
+     */
+    @Test
+    void siblingInheritedEdgesAtOverriddenPathDoNotSuppressEachOther() throws Exception {
+      // Named so the subtype reference sorts (and folds) before its supertype reference.
+      UaReferenceTypeNode vSuper = fx.addReferenceType("BWidgetRef", NodeIds.HasComponent);
+      UaReferenceTypeNode vSub = fx.addReferenceType("AWidgetRef", vSuper.getNodeId());
+
+      UaObjectTypeNode base = fx.addObjectType("EdgePairBase", NodeIds.BaseObjectType);
+      UaObjectNode baseC =
+          fx.addObjectDeclaration(
+              base, "C", NodeIds.BaseObjectType, NodeIds.ModellingRule_Mandatory, vSub.getNodeId());
+      base.addReference(
+          new Reference(base.getNodeId(), vSuper.getNodeId(), baseC.getNodeId().expanded(), true));
+
+      UaObjectTypeNode sub = fx.addObjectType("EdgePairSub", base.getNodeId());
+      fx.addObjectDeclaration(
+          sub, "C", NodeIds.BaseObjectType, NodeIds.ModellingRule_Mandatory, NodeIds.HasNotifier);
+
+      TypeInstantiationModel model = fx.compiler().compile(sub.getNodeId());
+
+      assertTrue(
+          model
+              .hierarchy()
+              .contains(new DeclarationEdge(BrowsePath.root(), NodeIds.HasNotifier, path("C"))),
+          "the subtype's own edge stands");
+      assertTrue(
+          model
+              .hierarchy()
+              .contains(new DeclarationEdge(BrowsePath.root(), vSub.getNodeId(), path("C"))),
+          "the first inherited edge remains");
+      assertTrue(
+          model
+              .hierarchy()
+              .contains(new DeclarationEdge(BrowsePath.root(), vSuper.getNodeId(), path("C"))),
+          "a sibling inherited edge folded by the same merge must not suppress this one");
+    }
   }
 
   /** Expansion depth, override precedence and provenance, and non-declaration exclusion. */

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/package-info.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/** Tests for the type-model-driven node instantiation package. */
+@NullMarked
+package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
+
+import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
## Summary

Add a new type-instantiation subsystem for the server SDK — `org.eclipse.milo.opcua.sdk.server.nodes.instantiation` — and deprecate the legacy `NodeFactory`/`EventFactory` subsystem it replaces. The new engine describes an entire instantiation up front as an immutable `InstantiationRequest`, computes a pure-data plan, and applies it as a staged, journaled batch.

- **`NodeInstantiator`**, a server-scoped facade with three separable phases: `describe` (compiled, cacheable type model), `plan` (pure computation — NodeIds allocated and collision-checked, references resolved, nothing mutated), and `apply` (staged construction, hooks against the unpublished graph, atomic-or-journaled commit with rollback). `instantiate(request)` wraps plan and apply for the common case.
- **`EventInstantiator`** replaces `EventFactory` on the new engine: expected Java class validated at plan time instead of cast after storage, so an incompatible event type fails cleanly with no residue. Timing checks show ~418 µs/event vs ~1078 µs for the legacy factory.
- **Placeholder support**: `expandPlaceholder` binds realizations at request time; `InstantiationRequest.forPlaceholder` realizes a placeholder under an existing instance post-hoc. Both flow through the same plan/apply machinery.
- **The legacy subsystem is deprecated, not removed** — retained with frozen behavior (including its known defects, now documented in Javadoc) and pinned by new characterization tests. Removal is a future major-version decision.
- **In-tree consumers migrated**: server diagnostics objects, examples, and test fixtures now use the new API; diagnostics keep legacy-derived child NodeIds via `legacyPathStrings()` so browsing clients see unchanged ids.
- A committed migration guide, `docs/features/node-instantiation-migration.md`, maps every legacy pattern to the new API and enumerates every observable behavior change. The new package ships as **experimental** for one minor release.

## Key Changes

- **Type model and compiler** (`TypeInstantiationModel`, `TypeModelCompiler`): the fully-inherited instance declaration hierarchy compiled into an immutable snapshot keyed by `BrowsePath`. Each `OpcUaServer` owns a `TypeModelCache` with transitive dependency-closure invalidation; the cache is an optimization only — entries can be dropped anytime and recompiled.
- **NodeManager batch primitives** (`NodeManagerBatch`, `commit`, `addNodeIfAbsent`, `getGeneration`, `getStorageGuarantee`): all default methods over the existing abstract surface, so third-party `NodeManager` implementations compile unchanged (pinned by a reflection test). `AbstractNodeManager` overrides them atomically with generation-based staleness detection; the defaults are sequential emulation reporting `BEST_EFFORT` and journaling partial application for rollback.
- **Request and plan**: `InstantiationRequest` is a builder-produced immutable value typed by expected root class — identity, placement, structured include/exclude paths, NodeId strategy plus per-path pinning, `FAIL`/`REUSE_COMPATIBLE` conflict policy, concrete-subtype selection, and `onNode`/`bindMethod` hooks carried as data. Plan failures land as structured `InstantiationDiagnostic`s rather than exceptions mid-construction.
- **Apply and result**: the complete graph is staged unpublished, `onNode` hooks run against the staged graph, then nodes and references commit as one batch; `bindMethod` binders run after commit. `InstantiationResult` distinguishes CREATED from REUSED nodes and offers `deleteCreated()`, which removes exactly what the instantiation created.
- **Behavior changes are opt-in**: migrating callers observe documented differences from legacy — optional Methods are now selected like any other optional, NodeId collisions fail instead of silently replacing, the full attribute set propagates (including `RolePermissions`/`AccessRestrictions`, which legacy silently dropped — a security-relevant fix flagged in the guide), and nothing is publicly visible until commit.
- **Registry evolution** (`ObjectTypeManager`, `VariableTypeManager`): additive snapshot-consuming constructor registration and a `getRegisteredType` lookup. Existing registrations resolve under both engines; the new engine walks `HasSubtype` to the nearest registered ancestor.
- **Mechanical portions**: the example/test-fixture migration commit and the deprecation commit (annotations and Javadoc only) can be skimmed; the substantive review targets are the `instantiation` package, the `NodeManager` primitives, and the diagnostics rewrite.

## References

- Migration guide (in this PR): `docs/features/node-instantiation-migration.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
