### PR TITLE
Port integration test speed and stability fixes from integration/1.2

### DIFF
--- a/opc-ua-sdk/integration-tests/pom.xml
+++ b/opc-ua-sdk/integration-tests/pom.xml
@@ -96,6 +96,19 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${maven-surefire-plugin.version}</version>
+        <configuration>
+          <!--
+            The integration tests own isolated servers and coordinate their loopback ports across
+            JVMs, so two reusable forks reduce wall-clock time without sharing mutable test state.
+          -->
+          <forkCount>2</forkCount>
+          <reuseForks>true</reuseForks>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
         <version>${maven-failsafe-plugin.version}</version>
         <executions>

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/SubscriptionTransferTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/SubscriptionTransferTest.java
@@ -21,14 +21,18 @@ public class SubscriptionTransferTest extends AbstractClientServerTest {
     subscription.create();
 
     var client2 = TestClient.create(server, cfg -> {});
-    client2.connect();
+    try {
+      client2.connect();
 
-    TransferSubscriptionsResponse response =
-        client2.transferSubscriptions(
-            List.of(subscription.getSubscriptionId().orElseThrow()), false);
+      TransferSubscriptionsResponse response =
+          client2.transferSubscriptions(
+              List.of(subscription.getSubscriptionId().orElseThrow()), false);
 
-    TransferResult result = requireNonNull(response.getResults())[0];
+      TransferResult result = requireNonNull(response.getResults())[0];
 
-    assertEquals(StatusCodes.Bad_UserAccessDenied, result.getStatusCode().getValue());
+      assertEquals(StatusCodes.Bad_UserAccessDenied, result.getStatusCode().getValue());
+    } finally {
+      client2.disconnect();
+    }
   }
 }

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/test/TestPortAllocator.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/test/TestPortAllocator.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.test;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.OverlappingFileLockException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Allocates loopback ports that remain reserved for Milo tests for the life of the test JVM. */
+public final class TestPortAllocator {
+
+  private static final int MAX_ALLOCATION_ATTEMPTS = 100;
+  private static final Path LOCK_DIRECTORY =
+      Path.of(System.getProperty("java.io.tmpdir"), "milo-test-port-locks");
+
+  private static final List<PortReservation> RESERVATIONS = new ArrayList<>();
+
+  private TestPortAllocator() {}
+
+  /**
+   * Allocate a currently available loopback port.
+   *
+   * <p>The allocation is coordinated with other Milo test JVMs and remains reserved to this JVM.
+   * The caller may bind a server to the returned port immediately.
+   *
+   * @return an available loopback port.
+   * @throws IOException if a port cannot be allocated.
+   */
+  public static synchronized int allocatePort() throws IOException {
+    Files.createDirectories(LOCK_DIRECTORY);
+
+    for (int attempt = 0; attempt < MAX_ALLOCATION_ATTEMPTS; attempt++) {
+      try (var socket = new ServerSocket()) {
+        socket.setReuseAddress(false);
+        socket.bind(new InetSocketAddress(InetAddress.getByName("localhost"), 0));
+
+        int port = socket.getLocalPort();
+        FileChannel channel =
+            FileChannel.open(
+                LOCK_DIRECTORY.resolve(port + ".lock"),
+                StandardOpenOption.CREATE,
+                StandardOpenOption.WRITE);
+
+        FileLock lock = tryLock(channel);
+        if (lock != null) {
+          RESERVATIONS.add(new PortReservation(channel, lock));
+          return port;
+        }
+
+        channel.close();
+      }
+    }
+
+    throw new IOException(
+        "unable to allocate a test port after " + MAX_ALLOCATION_ATTEMPTS + " attempts");
+  }
+
+  private static FileLock tryLock(FileChannel channel) throws IOException {
+    try {
+      return channel.tryLock();
+    } catch (OverlappingFileLockException ignored) {
+      return null;
+    }
+  }
+
+  @SuppressWarnings("unused")
+  private record PortReservation(FileChannel channel, FileLock lock) {}
+}

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/test/TestServer.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/test/TestServer.java
@@ -15,16 +15,13 @@ import static org.eclipse.milo.opcua.sdk.server.OpcUaServerConfig.USER_TOKEN_POL
 import static org.eclipse.milo.opcua.sdk.server.OpcUaServerConfig.USER_TOKEN_POLICY_X509;
 
 import java.io.File;
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.net.ServerSocket;
+import java.nio.file.Files;
 import java.security.KeyPair;
 import java.security.Security;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Random;
 import java.util.Set;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.eclipse.milo.opcua.sdk.server.EndpointConfig;
@@ -57,9 +54,10 @@ import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateBuilder;
 import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateGenerator;
 import org.eclipse.milo.opcua.stack.transport.server.tcp.OpcTcpServerTransport;
 import org.eclipse.milo.opcua.stack.transport.server.tcp.OpcTcpServerTransportConfig;
-import org.slf4j.LoggerFactory;
 
 public final class TestServer {
+
+  private static TestCertificateMaterial certificateMaterial;
 
   static {
     // Required for SecurityPolicy.Aes256_Sha256_RsaPss
@@ -98,19 +96,7 @@ public final class TestServer {
   }
 
   public static TestServer create(OpcUaServerConfigLimits limits) throws Exception {
-    int port = new Random().nextInt(65535 - 10000) + 10000;
-
-    try {
-      ServerSocket ss = new ServerSocket();
-      InetSocketAddress isa = new InetSocketAddress(InetAddress.getLocalHost(), port);
-      ss.bind(isa);
-      ss.close();
-
-      return create(port, limits);
-    } catch (Throwable t) {
-      t.printStackTrace(System.err);
-      return create(limits);
-    }
+    return create(TestPortAllocator.allocatePort(), limits);
   }
 
   public static TestServer create(int port) throws Exception {
@@ -118,17 +104,8 @@ public final class TestServer {
   }
 
   public static TestServer create(int port, OpcUaServerConfigLimits limits) throws Exception {
-    File securityTempDir = new File(System.getProperty("java.io.tmpdir"), "security");
-    if (!securityTempDir.exists() && !securityTempDir.mkdirs()) {
-      throw new Exception("unable to create security temp dir: " + securityTempDir);
-    }
-    LoggerFactory.getLogger(TestServer.class)
-        .info("security temp dir: {}", securityTempDir.getAbsolutePath());
-
-    File pkiDir = securityTempDir.toPath().resolve("pki").toFile();
-    LoggerFactory.getLogger(TestServer.class).info("pki dir: {}", pkiDir.getAbsolutePath());
-
-    KeyStoreLoader loader = new KeyStoreLoader().load(securityTempDir);
+    TestCertificateMaterial certificates = getCertificateMaterial();
+    KeyStoreLoader loader = certificates.keyStoreLoader();
 
     var trustListManager = new MemoryTrustListManager();
     var certificateStore = new MemoryCertificateStore();
@@ -156,20 +133,10 @@ public final class TestServer {
 
     var certificateManager = new DefaultCertificateManager(certificateQuarantine, defaultGroup);
 
-    // Generate test X509 identity certificates
-    KeyPair identityKeyPair1 = SelfSignedCertificateGenerator.generateRsaKeyPair(2048);
-    SelfSignedCertificateBuilder identityCertBuilder1 =
-        new SelfSignedCertificateBuilder(identityKeyPair1);
-    identityCertBuilder1.setCommonName("TestIdentity1");
-    identityCertBuilder1.setApplicationUri("urn:eclipse:milo:test:identity1");
-    X509Certificate identityCertificate1 = identityCertBuilder1.build();
-
-    KeyPair identityKeyPair2 = SelfSignedCertificateGenerator.generateRsaKeyPair(2048);
-    SelfSignedCertificateBuilder identityCertBuilder2 =
-        new SelfSignedCertificateBuilder(identityKeyPair2);
-    identityCertBuilder2.setCommonName("TestIdentity2");
-    identityCertBuilder2.setApplicationUri("urn:eclipse:milo:test:identity2");
-    X509Certificate identityCertificate2 = identityCertBuilder2.build();
+    TestIdentityCertificate identityCert1 = certificates.identityCert1();
+    TestIdentityCertificate identityCert2 = certificates.identityCert2();
+    X509Certificate identityCertificate1 = identityCert1.certificate();
+    X509Certificate identityCertificate2 = identityCert2.certificate();
 
     // Create trust list manager for user identity certificates
     var userIdentityTrustListManager = new MemoryTrustListManager();
@@ -256,11 +223,44 @@ public final class TestServer {
               }
             });
 
-    return new TestServer(
-        opcUaServer,
-        new TestIdentityCertificate(identityCertificate1, identityKeyPair1),
-        new TestIdentityCertificate(identityCertificate2, identityKeyPair2));
+    return new TestServer(opcUaServer, identityCert1, identityCert2);
   }
+
+  private static synchronized TestCertificateMaterial getCertificateMaterial() throws Exception {
+    if (certificateMaterial == null) {
+      File securityTempDir = Files.createTempDirectory("milo-test-security-").toFile();
+      securityTempDir.deleteOnExit();
+
+      File keyStoreFile = securityTempDir.toPath().resolve("example-server.pfx").toFile();
+      keyStoreFile.deleteOnExit();
+
+      KeyStoreLoader loader = new KeyStoreLoader().load(securityTempDir);
+
+      TestIdentityCertificate identityCert1 =
+          createIdentityCertificate("TestIdentity1", "urn:eclipse:milo:test:identity1");
+      TestIdentityCertificate identityCert2 =
+          createIdentityCertificate("TestIdentity2", "urn:eclipse:milo:test:identity2");
+
+      certificateMaterial = new TestCertificateMaterial(loader, identityCert1, identityCert2);
+    }
+
+    return certificateMaterial;
+  }
+
+  private static TestIdentityCertificate createIdentityCertificate(
+      String commonName, String applicationUri) throws Exception {
+    KeyPair keyPair = SelfSignedCertificateGenerator.generateRsaKeyPair(2048);
+    SelfSignedCertificateBuilder certificateBuilder = new SelfSignedCertificateBuilder(keyPair);
+    certificateBuilder.setCommonName(commonName);
+    certificateBuilder.setApplicationUri(applicationUri);
+
+    return new TestIdentityCertificate(certificateBuilder.build(), keyPair);
+  }
+
+  private record TestCertificateMaterial(
+      KeyStoreLoader keyStoreLoader,
+      TestIdentityCertificate identityCert1,
+      TestIdentityCertificate identityCert2) {}
 
   private static Set<EndpointConfig> createEndpointConfigs(X509Certificate certificate, int port) {
     Set<EndpointConfig> endpointConfigurations = new LinkedHashSet<>();

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/test/package-info.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/test/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/**
+ * Infrastructure for SDK integration tests.
+ *
+ * <p>{@link org.eclipse.milo.opcua.sdk.test.AbstractClientServerTest} owns a client, server, and
+ * namespace for one test class. {@link org.eclipse.milo.opcua.sdk.test.TestServer} reuses immutable
+ * certificate material within a test JVM while keeping each server's runtime state isolated.
+ *
+ * <p>Servers obtain loopback ports from {@link org.eclipse.milo.opcua.sdk.test.TestPortAllocator}.
+ * Allocations are coordinated between Milo test JVMs and retained until JVM exit, preventing
+ * concurrent test fixtures from selecting the same port.
+ */
+package org.eclipse.milo.opcua.sdk.test;

--- a/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/server/tcp/OpcTcpServerTransport.java
+++ b/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/server/tcp/OpcTcpServerTransport.java
@@ -91,23 +91,19 @@ public class OpcTcpServerTransport implements OpcServerTransport {
   public synchronized void unbind() {
     boundAddresses.clear();
 
-    channelReferences.forEach(
-        channel -> {
-          try {
-            channel.close().sync();
-          } catch (InterruptedException ignored) {
-          }
-        });
+    channelReferences.forEach(channel -> channel.close().syncUninterruptibly());
     channelReferences.clear();
 
+    Set<Channel> childChannels;
     synchronized (childChannelReferences) {
-      childChannelReferences.forEach(
-          channel -> {
-            LoggerFactory.getLogger(getClass()).info("Closing child channel: {}", channel);
-            channel.close();
-          });
+      childChannels = new HashSet<>(childChannelReferences);
       childChannelReferences.clear();
     }
+    childChannels.forEach(
+        channel -> {
+          LoggerFactory.getLogger(getClass()).info("Closing child channel: {}", channel);
+          channel.close().syncUninterruptibly();
+        });
 
     serverBootstrap.reset();
   }

--- a/opc-ua-stack/transport/src/test/java/org/eclipse/milo/opcua/stack/transport/TestPortAllocator.java
+++ b/opc-ua-stack/transport/src/test/java/org/eclipse/milo/opcua/stack/transport/TestPortAllocator.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.transport;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.channels.OverlappingFileLockException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Allocates loopback ports that remain reserved for Milo tests for the life of the test JVM. */
+public final class TestPortAllocator {
+
+  private static final int MAX_ALLOCATION_ATTEMPTS = 100;
+  private static final Path LOCK_DIRECTORY =
+      Path.of(System.getProperty("java.io.tmpdir"), "milo-test-port-locks");
+
+  private static final List<PortReservation> RESERVATIONS = new ArrayList<>();
+
+  private TestPortAllocator() {}
+
+  /**
+   * Allocate a currently available loopback port.
+   *
+   * <p>The allocation is coordinated with other Milo test JVMs and remains reserved to this JVM.
+   * The caller may bind a server to the returned port immediately.
+   *
+   * @return an available loopback port.
+   * @throws IOException if a port cannot be allocated.
+   */
+  public static synchronized int allocatePort() throws IOException {
+    Files.createDirectories(LOCK_DIRECTORY);
+
+    for (int attempt = 0; attempt < MAX_ALLOCATION_ATTEMPTS; attempt++) {
+      try (var socket = new ServerSocket()) {
+        socket.setReuseAddress(false);
+        socket.bind(new InetSocketAddress(InetAddress.getByName("localhost"), 0));
+
+        int port = socket.getLocalPort();
+        FileChannel channel =
+            FileChannel.open(
+                LOCK_DIRECTORY.resolve(port + ".lock"),
+                StandardOpenOption.CREATE,
+                StandardOpenOption.WRITE);
+
+        FileLock lock = tryLock(channel);
+        if (lock != null) {
+          RESERVATIONS.add(new PortReservation(channel, lock));
+          return port;
+        }
+
+        channel.close();
+      }
+    }
+
+    throw new IOException(
+        "unable to allocate a test port after " + MAX_ALLOCATION_ATTEMPTS + " attempts");
+  }
+
+  private static FileLock tryLock(FileChannel channel) throws IOException {
+    try {
+      return channel.tryLock();
+    } catch (OverlappingFileLockException ignored) {
+      return null;
+    }
+  }
+
+  @SuppressWarnings("unused")
+  private record PortReservation(FileChannel channel, FileLock lock) {}
+}

--- a/opc-ua-stack/transport/src/test/java/org/eclipse/milo/opcua/stack/transport/client/tcp/OpcTcpTransportTest.java
+++ b/opc-ua-stack/transport/src/test/java/org/eclipse/milo/opcua/stack/transport/client/tcp/OpcTcpTransportTest.java
@@ -12,6 +12,7 @@ package org.eclipse.milo.opcua.stack.transport.client.tcp;
 
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ubyte;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.eclipse.milo.opcua.stack.transport.TestPortAllocator.allocatePort;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.net.InetSocketAddress;
@@ -55,6 +56,7 @@ import org.eclipse.milo.opcua.stack.transport.server.ServerApplicationContext;
 import org.eclipse.milo.opcua.stack.transport.server.ServiceRequestContext;
 import org.eclipse.milo.opcua.stack.transport.server.tcp.OpcTcpServerTransport;
 import org.eclipse.milo.opcua.stack.transport.server.tcp.OpcTcpServerTransportConfig;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -66,9 +68,19 @@ class OpcTcpTransportTest extends SecurityFixture {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(OpcTcpTransportTest.class);
 
+  private InetSocketAddress serverAddress;
+  private OpcServerTransport serverTransport;
+
   static {
     // Required for SecurityPolicy.Aes256_Sha256_RsaPss
     Security.addProvider(new BouncyCastleProvider());
+  }
+
+  @AfterEach
+  void unbindServerTransport() throws Exception {
+    if (serverTransport != null) {
+      serverTransport.unbind();
+    }
   }
 
   private static Stream<Arguments> provideSecurityParameters() {
@@ -267,7 +279,7 @@ class OpcTcpTransportTest extends SecurityFixture {
     serverTransport.unbind();
   }
 
-  private static void createSession(OpcTcpClientTransport transport) throws Exception {
+  private void createSession(OpcTcpClientTransport transport) throws Exception {
     var header =
         new RequestHeader(
             NodeId.NULL_VALUE, DateTime.now(), uint(0), uint(0), null, uint(5_000), null);
@@ -278,7 +290,7 @@ class OpcTcpTransportTest extends SecurityFixture {
             new ApplicationDescription(
                 "", "", LocalizedText.NULL_VALUE, ApplicationType.Client, null, null, null),
             null,
-            "opc.tcp://localhost:12685",
+            endpointUrl(),
             "sessionName",
             ByteString.NULL_VALUE,
             ByteString.NULL_VALUE,
@@ -354,16 +366,17 @@ class OpcTcpTransportTest extends SecurityFixture {
 
     OpcTcpServerTransportConfig config = OpcTcpServerTransportConfig.newBuilder().build();
 
-    var transport = new OpcTcpServerTransport(config);
-    transport.bind(applicationContext, new InetSocketAddress("localhost", 12685));
-    return transport;
+    serverAddress = new InetSocketAddress("localhost", allocatePort());
+    serverTransport = new OpcTcpServerTransport(config);
+    serverTransport.bind(applicationContext, serverAddress);
+    return serverTransport;
   }
 
   private EndpointDescription newEndpointDescription(
       SecurityPolicy securityPolicy, MessageSecurityMode messageSecurityMode) {
 
     return new EndpointDescription(
-        "opc.tcp://localhost:12685",
+        endpointUrl(),
         new ApplicationDescription(
             "uri:server",
             "productUri",
@@ -371,7 +384,7 @@ class OpcTcpTransportTest extends SecurityFixture {
             ApplicationType.Server,
             null,
             null,
-            new String[] {"opc.tcp://localhost:12685"}),
+            new String[] {endpointUrl()}),
         ByteString.of(serverCertificateBytes),
         messageSecurityMode,
         securityPolicy.getUri(),
@@ -380,5 +393,9 @@ class OpcTcpTransportTest extends SecurityFixture {
         },
         TransportProfile.TCP_UASC_UABINARY.getUri(),
         ubyte(0));
+  }
+
+  private String endpointUrl() {
+    return "opc.tcp://localhost:" + serverAddress.getPort();
   }
 }

--- a/opc-ua-stack/transport/src/test/java/org/eclipse/milo/opcua/stack/transport/package-info.java
+++ b/opc-ua-stack/transport/src/test/java/org/eclipse/milo/opcua/stack/transport/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/**
+ * Shared support for transport tests that cross the JVM/network boundary.
+ *
+ * <p>Tests should let the operating system choose listener ports when the bound address is
+ * observable. When an API requires the port before binding, {@link
+ * org.eclipse.milo.opcua.stack.transport.TestPortAllocator} coordinates allocation across Milo test
+ * JVMs and keeps each assigned port exclusive to one JVM for its lifetime.
+ */
+package org.eclipse.milo.opcua.stack.transport;

--- a/opc-ua-stack/transport/src/test/java/org/eclipse/milo/opcua/stack/transport/server/tcp/OpcTcpServerTransportTest.java
+++ b/opc-ua-stack/transport/src/test/java/org/eclipse/milo/opcua/stack/transport/server/tcp/OpcTcpServerTransportTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.transport.server.tcp;
+
+import static org.eclipse.milo.opcua.stack.transport.TestPortAllocator.allocatePort;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.netty.channel.Channel;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
+import org.eclipse.milo.opcua.stack.core.security.CertificateManager;
+import org.eclipse.milo.opcua.stack.core.types.UaRequestMessageType;
+import org.eclipse.milo.opcua.stack.core.types.UaResponseMessageType;
+import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
+import org.eclipse.milo.opcua.stack.transport.server.ServerApplicationContext;
+import org.eclipse.milo.opcua.stack.transport.server.ServiceRequestContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class OpcTcpServerTransportTest {
+
+  private EventLoopGroup eventLoop;
+
+  @AfterEach
+  void tearDown() throws Exception {
+    if (eventLoop != null) {
+      eventLoop.shutdownGracefully(0, 0, TimeUnit.MILLISECONDS).sync();
+    }
+  }
+
+  // Unbind is the server teardown barrier; returning with accepted channels still open lets one
+  // test invocation leak network activity into the next.
+  @Test
+  void unbindClosesAcceptedChannelsBeforeReturning() throws Exception {
+    eventLoop = new NioEventLoopGroup(1);
+    var acceptedChannel = new AtomicReference<Channel>();
+    var channelAccepted = new CountDownLatch(1);
+
+    OpcTcpServerTransportConfig config =
+        OpcTcpServerTransportConfig.newBuilder()
+            .setEventLoop(eventLoop)
+            .setChannelPipelineCustomizer(
+                pipeline -> {
+                  acceptedChannel.set(pipeline.channel());
+                  channelAccepted.countDown();
+                })
+            .build();
+
+    var transport = new OpcTcpServerTransport(config);
+    var bindAddress = new InetSocketAddress("localhost", allocatePort());
+
+    try (var socket = new Socket()) {
+      transport.bind(newServerApplicationContext(), bindAddress);
+      socket.connect(bindAddress);
+
+      assertTrue(channelAccepted.await(3, TimeUnit.SECONDS));
+      Channel channel = acceptedChannel.get();
+
+      transport.unbind();
+
+      assertFalse(channel.isOpen());
+      assertTrue(channel.closeFuture().isDone());
+    } finally {
+      transport.unbind();
+    }
+  }
+
+  private static ServerApplicationContext newServerApplicationContext() {
+    return new ServerApplicationContext() {
+
+      @Override
+      public List<EndpointDescription> getEndpointDescriptions() {
+        return List.of();
+      }
+
+      @Override
+      public CertificateManager getCertificateManager() {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public EncodingContext getEncodingContext() {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public Long getNextSecureChannelId() {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public Long getNextSecureChannelTokenId() {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public CompletableFuture<UaResponseMessageType> handleServiceRequest(
+          ServiceRequestContext context, UaRequestMessageType requestMessage) {
+
+        throw new UnsupportedOperationException();
+      }
+    };
+  }
+}


### PR DESCRIPTION
Ports two integration-test commits from `integration/1.2` to `main` rather than waiting for the distant merge:

- `caf4baf10` — Speed up and stabilize integration tests
- `53a34760d` — Stabilize transport network tests (#1822)

## Transport

- `OpcTcpServerTransport.unbind()` now copies child channels out of the lock and closes them with `syncUninterruptibly()`, making unbind a real teardown barrier instead of returning while accepted channels are still open. Bind channels use `syncUninterruptibly()` too, replacing a loop that swallowed `InterruptedException`.
- New `TestPortAllocator` reserves loopback ports across test JVMs via file locks, replacing the fixed port `12685` shared by `OpcTcpTransportTest`.
- `OpcTcpTransportTest` threads the allocated port through a new `endpointUrl()` helper and unbinds in `@AfterEach`.

## SDK integration tests

- Surefire runs the module in two reusable forks.
- `TestServer` allocates its port through `TestPortAllocator` instead of a random port with an unbounded recursive retry, and reuses the KeyStore plus both X509 identity certificates per JVM rather than generating three 2048-bit RSA keypairs on every `TestServer.create()`. The keystore also moves from the shared `$TMPDIR/security` path to a per-JVM temp dir so parallel forks do not contend.
- `SubscriptionTransferTest` disconnects its second client in a `finally`.

## Not ported

The `EccSessionIntegrationTest` certificate cache and `ConditionRefreshTest` synchronization hunks — both files are 1.2-only (ECC security policies, Alarms and Conditions).

`53a34760d` placed its regression test in `OpcTcpServerTransportTest`, a file introduced by the 1.2-only reverse connect work. Rather than port the `unbind()` change untested, that file is created here with only `unbindClosesAcceptedChannelsBeforeReturning` and its `ServerApplicationContext` helper.

## Verification

`mvn clean verify` passes, spotless clean. The new unbind test was confirmed to be a genuine regression test: with the old `unbind()` body restored it fails on `assertFalse(channel.isOpen())`.

Integration test module time on one machine: ~69s before, ~45s after. 270 tests, 0 failures.

Note: `TestServer` now generates a fresh server certificate per JVM rather than reusing one persisted across runs. That is required for fork isolation and is harmless for these tests, but the server certificate is no longer stable between local runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)