### PR TITLE
SessionFsm Hardening

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/session/CreateSessionActionFailureTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/session/CreateSessionActionFailureTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.session;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClientConfig;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClientConfigBuilder;
+import org.eclipse.milo.opcua.sdk.client.OpcUaSession;
+import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
+import org.eclipse.milo.opcua.stack.core.transport.TransportProfile;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.ApplicationType;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.MessageSecurityMode;
+import org.eclipse.milo.opcua.stack.core.types.structured.ApplicationDescription;
+import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
+import org.junit.jupiter.api.Test;
+
+/**
+ * What the Session FSM does when the {@code createSession} that the {@code Creating} entry action
+ * launches throws instead of returning a future.
+ *
+ * <p>The FSM library sets the next state before it runs the matching transition actions, and it
+ * catches and logs whatever an action throws. An entry action that throws before it has attached
+ * the {@code whenComplete} that fires {@code CreateSessionSuccess}/{@code CreateSessionFailure}
+ * therefore leaves the FSM parked in {@code Creating} with no event pending, and no Session state
+ * has a timeout to kick it out again — so every caller waiting on {@code openSession()}, {@code
+ * getSession()} or {@code closeSession()} waits forever. {@code activateSession} and {@code
+ * reactivateSession} are already total for exactly this reason: they wrap their bodies and return a
+ * failed future rather than throwing.
+ *
+ * <p>Pins that {@code createSession} is total the same way, against the two synchronous throws it
+ * can produce before the request is ever sent: a user-supplied sessionName {@code Supplier} that
+ * throws, and an {@link EndpointDescription} carrying no {@code server} — the shape {@code
+ * SessionFsmTest} itself builds — which NPEs on {@code endpoint.getServer().getGatewayServerUri()}.
+ */
+class CreateSessionActionFailureTest {
+
+  /**
+   * How long to give the FSM's executor to run the single {@code Creating} entry action. The wedge
+   * this pins is permanent, so a longer wait cannot turn a failure into a pass.
+   */
+  private static final long TIMEOUT_SECONDS = 10;
+
+  @Test
+  void sessionNameSupplierThrows() throws Exception {
+    var failure = new IllegalStateException("sessionName Supplier");
+
+    OpcUaClientConfigBuilder config =
+        config(
+            new ApplicationDescription(
+                "urn:eclipse:milo:test:server",
+                "urn:eclipse:milo:test:server",
+                LocalizedText.english("Eclipse Milo Test Server"),
+                ApplicationType.Server,
+                null,
+                null,
+                null));
+
+    config.setSessionName(
+        () -> {
+          throw failure;
+        });
+
+    assertOpenSessionFails(config, failure);
+  }
+
+  @Test
+  void endpointHasNoServer() throws Exception {
+    assertOpenSessionFails(config(null), null);
+  }
+
+  /**
+   * Opens a Session against a client that cannot get as far as sending the CreateSessionRequest,
+   * and asserts that the failure reaches the caller instead of stranding it.
+   *
+   * @param expectedCause the Throwable the caller must be completed with, or {@code null} to accept
+   *     any.
+   */
+  private static void assertOpenSessionFails(
+      OpcUaClientConfigBuilder config, Throwable expectedCause) throws Exception {
+
+    OpcUaClient client = OpcUaClient.create(config.build());
+    SessionFsm sessionFsm = client.getSessionFsm();
+
+    try {
+      CompletableFuture<OpcUaSession> sessionFuture = sessionFsm.openSession();
+
+      ExecutionException ex =
+          assertThrows(
+              ExecutionException.class,
+              () -> sessionFuture.get(TIMEOUT_SECONDS, TimeUnit.SECONDS),
+              "openSession() never completed: createSession() threw out of the Creating entry"
+                  + " action, which leaves the FSM parked in Creating with nothing pending");
+
+      if (expectedCause != null) {
+        assertSame(expectedCause, ex.getCause());
+      }
+    } finally {
+      // Stop the CreatingWait -> Creating retry loop that a failed CreateSession starts.
+      sessionFsm.closeSession();
+    }
+  }
+
+  private static OpcUaClientConfigBuilder config(ApplicationDescription server) {
+    return OpcUaClientConfig.builder()
+        .setEndpoint(
+            new EndpointDescription(
+                "opc.tcp://localhost:12685",
+                server,
+                null,
+                MessageSecurityMode.None,
+                SecurityPolicy.None.getUri(),
+                null,
+                TransportProfile.TCP_UASC_UABINARY.getUri(),
+                null))
+        .setApplicationName(LocalizedText.english("Eclipse Milo Test Client"))
+        .setApplicationUri("urn:eclipse:milo:test:client");
+  }
+}

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/session/ReactivateSessionEscalationTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/session/ReactivateSessionEscalationTest.java
@@ -1,0 +1,290 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.session;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.netty.channel.Channel;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.sdk.test.TestClient;
+import org.eclipse.milo.opcua.sdk.test.TestServer;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.UaServiceFaultException;
+import org.eclipse.milo.opcua.stack.core.types.UaRequestMessageType;
+import org.eclipse.milo.opcua.stack.core.types.UaResponseMessageType;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DiagnosticInfo;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.structured.ActivateSessionRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.CreateSessionRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.ResponseHeader;
+import org.eclipse.milo.opcua.stack.core.types.structured.ServiceFault;
+import org.eclipse.milo.opcua.stack.transport.client.tcp.OpcTcpClientTransport;
+import org.eclipse.milo.opcua.stack.transport.client.tcp.OpcTcpClientTransportConfig;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Reactivation abandoned in favor of a new Session when ActivateSession tells the Client the
+ * Session is gone.
+ *
+ * <p>Part 4 §6.7: if ActivateSession fails the Client shall create a new Session. The Reactivating
+ * state decided that by exception class — only a {@link UaServiceFaultException} escalated to
+ * CreatingWait — but a StatusCode is not always delivered as an application-level ServiceFault. A
+ * Server that answers ActivateSession with a channel-level Error message instead has it turned into
+ * a plain {@link UaException} by {@code InboundUascResponseHandler}, which took the catch-all edge
+ * back to ReactivatingWait and re-sent the same doomed ActivateSession forever, at the 16s backoff
+ * cap, for a Session the Server has already told the Client it no longer has. It is the same
+ * defective-Server behaviour {@code SessionFsmFactory} already guards against on the
+ * TransferSubscriptions path.
+ *
+ * <p>Both tests arm the same StatusCode — {@code Bad_SessionIdInvalid}, one of the definitive
+ * session-level statuses — and differ only in how it is delivered, so the contrast isolates the
+ * exception class as the thing being (wrongly) dispatched on.
+ *
+ * <p>The failure is injected at the transport rather than provoked from the Server because a
+ * conformant Server, Milo's own included, always answers a stale ActivateSession with a
+ * ServiceFault and cannot be made to emit a channel-level Error through a {@code
+ * SessionServiceSet}.
+ */
+public class ReactivateSessionEscalationTest {
+
+  /**
+   * Reactivation retries at 1s, 2s, 4s, 8s..., so this covers four attempts: long enough that a
+   * client which escalates at all has escalated, and that a client which does not has visibly
+   * settled into the loop.
+   */
+  private static final long AWAIT_TIMEOUT_MILLIS = 15_000;
+
+  /**
+   * Control: the identical injection delivered as an application-level ServiceFault. It proves the
+   * fixture observes escalation at all, so the test below fails because of how the StatusCode
+   * arrived and not because a new Session is unobservable here.
+   */
+  @Test
+  void reactivationEscalatesOnAServiceFault() throws Exception {
+    try (var fixture = new Fixture(ActivateSessionFailure.SERVICE_FAULT)) {
+      fixture.loseConnection();
+
+      assertTrue(fixture.awaitReactivationAttempt(), "the client never tried to reactivate");
+
+      assertTrue(
+          fixture.awaitNewSession(),
+          "the client never created a new Session after ActivateSession answered"
+              + " Bad_SessionIdInvalid as a ServiceFault");
+    }
+  }
+
+  @Test
+  void reactivationEscalatesOnAChannelLevelError() throws Exception {
+    try (var fixture = new Fixture(ActivateSessionFailure.CHANNEL_LEVEL_ERROR)) {
+      fixture.loseConnection();
+
+      assertTrue(fixture.awaitReactivationAttempt(), "the client never tried to reactivate");
+
+      assertTrue(
+          fixture.awaitNewSession(),
+          "the client never created a new Session after ActivateSession answered"
+              + " Bad_SessionIdInvalid as a channel-level Error message: the failure carried the"
+              + " same definitive StatusCode as a ServiceFault would, but arrived as a plain"
+              + " UaException, so Reactivating kept re-sending ActivateSession for a Session the"
+              + " Server has already disowned");
+    }
+  }
+
+  // region helpers
+
+  /**
+   * How the transport hands the Client {@code Bad_SessionIdInvalid} in answer to ActivateSession.
+   */
+  private enum ActivateSessionFailure {
+
+    /** As an application-level ServiceFault, i.e. what a conformant Server sends. */
+    SERVICE_FAULT,
+
+    /**
+     * As a channel-level Error message, which {@code InboundUascResponseHandler} turns into a plain
+     * {@link UaException} before the SDK sees it.
+     */
+    CHANNEL_LEVEL_ERROR;
+
+    UaException create() {
+      if (this == SERVICE_FAULT) {
+        var responseHeader =
+            new ResponseHeader(
+                DateTime.now(),
+                uint(0),
+                new StatusCode(StatusCodes.Bad_SessionIdInvalid),
+                DiagnosticInfo.NULL_VALUE,
+                null,
+                null);
+
+        return new UaServiceFaultException(new ServiceFault(responseHeader));
+      } else {
+        return new UaException(StatusCodes.Bad_SessionIdInvalid);
+      }
+    }
+  }
+
+  /**
+   * An {@link OpcTcpClientTransport} that, once armed, answers every ActivateSessionRequest itself
+   * without sending it, and counts the CreateSessionRequests the Client sends.
+   */
+  private static final class SessionDisowningTransport extends OpcTcpClientTransport {
+
+    private final AtomicInteger createSessionRequests = new AtomicInteger(0);
+    private final AtomicInteger interceptedActivations = new AtomicInteger(0);
+
+    private final ActivateSessionFailure failure;
+
+    private volatile boolean armed = false;
+
+    SessionDisowningTransport(OpcTcpClientTransportConfig config, ActivateSessionFailure failure) {
+      super(config);
+
+      this.failure = failure;
+    }
+
+    void arm() {
+      armed = true;
+    }
+
+    void disarm() {
+      armed = false;
+    }
+
+    int createSessionCount() {
+      return createSessionRequests.get();
+    }
+
+    int interceptedActivationCount() {
+      return interceptedActivations.get();
+    }
+
+    @Override
+    public CompletableFuture<UaResponseMessageType> sendRequestMessage(
+        UaRequestMessageType requestMessage) {
+
+      if (requestMessage instanceof CreateSessionRequest) {
+        createSessionRequests.incrementAndGet();
+      }
+
+      if (armed && requestMessage instanceof ActivateSessionRequest) {
+        interceptedActivations.incrementAndGet();
+
+        var future = new CompletableFuture<UaResponseMessageType>();
+
+        // Completed on the transport's executor, which is where AbstractUascClientTransport fails a
+        // request, rather than inline on the caller's thread.
+        getConfig().getExecutor().execute(() -> future.completeExceptionally(failure.create()));
+
+        return future;
+      }
+
+      return super.sendRequestMessage(requestMessage);
+    }
+  }
+
+  /**
+   * A running Server and a connected client whose transport is armed to fail every subsequent
+   * ActivateSession, so the arming is strictly ordered before the connection loss that starts
+   * reactivation.
+   */
+  private static final class Fixture implements AutoCloseable {
+
+    private final OpcUaServer server;
+    private final OpcUaClient client;
+    private final SessionDisowningTransport transport;
+
+    private final int createSessionsBeforeArming;
+
+    Fixture(ActivateSessionFailure failure) throws Exception {
+      server = TestServer.create().getServer();
+      server.startup().get();
+
+      var transportHolder = new SessionDisowningTransport[1];
+
+      client =
+          TestClient.createWithTransport(
+              server,
+              transportConfig -> {
+                transportHolder[0] = new SessionDisowningTransport(transportConfig, failure);
+                return transportHolder[0];
+              },
+              // No keep-alive traffic within this test's own bounds: a keep-alive failure would
+              // reach ReactivatingWait by a different route than the connection loss being
+              // scripted.
+              cfg -> cfg.setKeepAliveInterval(uint(60_000)));
+
+      transport = transportHolder[0];
+
+      client.connect();
+
+      createSessionsBeforeArming = transport.createSessionCount();
+      transport.arm();
+    }
+
+    /**
+     * Drop the SecureChannel, which is what moves the SessionFsm from Active to ReactivatingWait.
+     */
+    void loseConnection() throws Exception {
+      Channel channel = transport.getChannelFsm().getChannel().get(10, SECONDS);
+      channel.close().syncUninterruptibly();
+    }
+
+    boolean awaitReactivationAttempt() throws Exception {
+      return awaitTrue(() -> transport.interceptedActivationCount() >= 1);
+    }
+
+    boolean awaitNewSession() throws Exception {
+      return awaitTrue(() -> transport.createSessionCount() > createSessionsBeforeArming);
+    }
+
+    @Override
+    public void close() throws Exception {
+      // Let the shutdown sequence talk to the Server again; a client stuck reactivating has a
+      // Session to close and cannot get there through an interception that never ends.
+      transport.disarm();
+      try {
+        client.disconnectAsync().get(10, SECONDS);
+      } finally {
+        server.shutdown().get(10, SECONDS);
+      }
+    }
+  }
+
+  /** Polls {@code condition} until it holds or {@link #AWAIT_TIMEOUT_MILLIS} elapses. */
+  private static boolean awaitTrue(ThrowingBooleanSupplier condition) throws Exception {
+    long deadline = System.nanoTime() + MILLISECONDS.toNanos(AWAIT_TIMEOUT_MILLIS);
+
+    while (System.nanoTime() < deadline) {
+      if (condition.get()) {
+        return true;
+      }
+      Thread.sleep(25);
+    }
+
+    return condition.get();
+  }
+
+  @FunctionalInterface
+  private interface ThrowingBooleanSupplier {
+    boolean get() throws Exception;
+  }
+
+  // endregion
+}

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmTest.java
@@ -11,6 +11,8 @@
 package org.eclipse.milo.opcua.sdk.client.session;
 
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -283,6 +285,63 @@ public class SessionFsmTest {
       assertTrue(
           sessionInactive.await(10, TimeUnit.SECONDS),
           "SessionFsm remained Active after the channel was lost during Session initialization");
+    } finally {
+      client.disconnect();
+      server.shutdown().get();
+    }
+  }
+
+  /**
+   * Verify that a Session is not left to expire because the configured keep-alive interval is
+   * longer than the session timeout the Server revised the request down to.
+   *
+   * <p>CreateSession answers with a RevisedSessionTimeout the Server is free to lower, and the
+   * Server terminates the Session if the Client issues no request within that interval (OPC UA Part
+   * 4, 5.7.2.2). The revised value is stored on the Session and exposed via {@link
+   * UaSession#getSessionTimeout()}; the keep-alive has to be bounded by it as well, because
+   * scheduling from the configured interval alone let the Session die between keep-alives and left
+   * the client churning Active to ReactivatingWait to Creating and back for as long as it stayed
+   * connected.
+   */
+  @Test
+  public void testKeepAliveIntervalHonorsRevisedSessionTimeout() throws Exception {
+    OpcUaServer server = TestServer.create().getServer();
+    server.startup().get();
+
+    // The Server floors its revision at 5000ms, so any smaller request yields a revised timeout of
+    // exactly 5000ms, well below the keep-alive interval configured here.
+    OpcUaClient client =
+        TestClient.create(
+            server, cfg -> cfg.setSessionTimeout(uint(1000)).setKeepAliveInterval(uint(20_000)));
+
+    var sessionClosed = new CountDownLatch(1);
+
+    server
+        .getSessionManager()
+        .addSessionListener(
+            new SessionListener() {
+              @Override
+              public void onSessionClosed(Session session) {
+                sessionClosed.countDown();
+              }
+            });
+
+    try {
+      client.connect();
+
+      UaSession session = client.getSessionFsm().getSession().get(10, TimeUnit.SECONDS);
+      assertEquals(
+          5000.0,
+          session.getSessionTimeout().doubleValue(),
+          "Server did not revise the session timeout to 5000");
+
+      // No application traffic, so the only thing that can keep the Session alive is the
+      // keep-alive. Long enough to cover two revised timeouts, short enough to end before the
+      // configured 20s keep-alive would fire and mask the expiry.
+      assertFalse(
+          sessionClosed.await(12, TimeUnit.SECONDS),
+          "Server terminated the Session: the keep-alive interval (20000ms) is longer than the"
+              + " revised session timeout (5000ms)");
     } finally {
       client.disconnect();
       server.shutdown().get();

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmTest.java
@@ -12,21 +12,33 @@ package org.eclipse.milo.opcua.sdk.client.session;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.security.KeyPair;
+import java.security.cert.X509Certificate;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
 import org.eclipse.milo.opcua.sdk.client.OpcUaClientConfig;
 import org.eclipse.milo.opcua.sdk.client.OpcUaSession;
+import org.eclipse.milo.opcua.sdk.client.identity.X509IdentityProvider;
 import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.sdk.server.Session;
+import org.eclipse.milo.opcua.sdk.server.SessionListener;
 import org.eclipse.milo.opcua.sdk.test.TestClient;
 import org.eclipse.milo.opcua.sdk.test.TestServer;
 import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
 import org.eclipse.milo.opcua.stack.core.transport.TransportProfile;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.MessageSecurityMode;
 import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
+import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateBuilder;
+import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateGenerator;
 import org.junit.jupiter.api.Test;
 
 public class SessionFsmTest {
@@ -108,5 +120,83 @@ public class SessionFsmTest {
     sessionFsm.closeSession();
 
     assertThrows(ExecutionException.class, () -> sessionFuture.get(5, TimeUnit.SECONDS));
+  }
+
+  /**
+   * Verify that a Session which CreateSession already established on the Server is closed when the
+   * rest of the establishment sequence fails.
+   *
+   * <p>ActivateSession failing moves the FSM from Activating to CreatingWait, where it retries on a
+   * backoff. Each retry establishes another Server-side Session, so unless the abandoned one is
+   * closed the Server accumulates orphans that survive until their Session timeout expires (120s
+   * with the default configuration).
+   */
+  @Test
+  public void testSessionClosedWhenActivateSessionFails() throws Exception {
+    OpcUaServer server = TestServer.create().getServer();
+    server.startup().get();
+
+    var sessionsCreated = new LinkedBlockingQueue<NodeId>();
+    Set<NodeId> sessionsClosed = ConcurrentHashMap.newKeySet();
+
+    server
+        .getSessionManager()
+        .addSessionListener(
+            new SessionListener() {
+              @Override
+              public void onSessionCreated(Session session) {
+                sessionsCreated.add(session.getSessionId());
+              }
+
+              @Override
+              public void onSessionClosed(Session session) {
+                sessionsClosed.add(session.getSessionId());
+              }
+            });
+
+    // An identity certificate the Server does not trust, so ActivateSession is rejected after
+    // CreateSession has already succeeded.
+    KeyPair untrustedKeyPair = SelfSignedCertificateGenerator.generateRsaKeyPair(2048);
+    var certificateBuilder = new SelfSignedCertificateBuilder(untrustedKeyPair);
+    certificateBuilder.setCommonName("UntrustedIdentity");
+    certificateBuilder.setApplicationUri("urn:eclipse:milo:test:untrusted");
+    X509Certificate untrustedCertificate = certificateBuilder.build();
+
+    OpcUaClient client =
+        TestClient.create(
+            server,
+            cfg ->
+                cfg.setIdentityProvider(
+                    new X509IdentityProvider(untrustedCertificate, untrustedKeyPair.getPrivate())));
+
+    try {
+      client.connectAsync();
+
+      NodeId firstSessionId = sessionsCreated.poll(30, TimeUnit.SECONDS);
+      assertNotNull(firstSessionId, "Server never created a Session");
+
+      // Observing the Session created by the next attempt proves the first attempt has already
+      // failed and been abandoned.
+      NodeId secondSessionId = sessionsCreated.poll(30, TimeUnit.SECONDS);
+      assertNotNull(secondSessionId, "Server never created a second Session");
+
+      // The close is sent before the retry is scheduled, but the Server dispatches requests onto
+      // an executor, so the two are not strictly ordered; wait for the close rather than requiring
+      // it to have been observed already.
+      long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(30);
+      while (!sessionsClosed.contains(firstSessionId) && System.nanoTime() < deadline) {
+        //noinspection BusyWait
+        Thread.sleep(100);
+      }
+
+      assertTrue(
+          sessionsClosed.contains(firstSessionId),
+          "Session "
+              + firstSessionId
+              + " was left open on the Server after ActivateSession failed");
+    } finally {
+      client.disconnect();
+      server.shutdown().get();
+    }
   }
 }

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmTest.java
@@ -292,6 +292,67 @@ public class SessionFsmTest {
   }
 
   /**
+   * Verify that the SessionFsm stops trying to reactivate once the transport has been deliberately
+   * disconnected, instead of retrying against a connection that can never come back.
+   *
+   * <p>An explicit Disconnect takes the ChannelFsm Connected to Disconnecting to NotConnected, and
+   * NotConnected has no outbound edge other than Connect: it never reconnects on its own, and
+   * getChannel() fails immediately with a plain "not connected". Every reactivation attempt
+   * therefore fails with an exception that carries no StatusCode, which Reactivating routes
+   * straight back to ReactivatingWait, so the FSM cycles between the two at the 16s backoff cap for
+   * as long as the client lives.
+   *
+   * <p>Not treating the deliberate disconnect as a lost connection is not sufficient on its own:
+   * the keep-alive is sent over the same dead channel and reaches the identical cycle one interval
+   * later.
+   */
+  @Test
+  public void testDeliberateTransportDisconnectDoesNotReactivateForever() throws Exception {
+    OpcUaServer server = TestServer.create().getServer();
+    server.startup().get();
+
+    // Short keep-alive interval so the keep-alive path, which reaches the same retry cycle as the
+    // ChannelFsm transition listener does, has had several chances to run inside the observation
+    // window below.
+    OpcUaClient client = TestClient.create(server, cfg -> cfg.setKeepAliveInterval(uint(1000)));
+
+    try {
+      client.connect();
+
+      SessionFsm sessionFsm = client.getSessionFsm();
+      ChannelFsm channelFsm = ((OpcTcpClientTransport) client.getTransport()).getChannelFsm();
+
+      channelFsm.disconnect().get(10, TimeUnit.SECONDS);
+
+      assertEquals(
+          com.digitalpetri.netty.fsm.State.NotConnected,
+          channelFsm.getState(),
+          "ChannelFsm did not end up NotConnected");
+
+      // Bounded negative observation: the reactivation backoff starts at 1s and doubles, so this
+      // window covers several attempts, and nothing that could happen after it can end the cycle -
+      // no event reconnects the ChannelFsm, and a reactivation failure over a dead channel never
+      // escalates.
+      long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(15);
+      State state = sessionFsm.getState();
+      while (System.nanoTime() < deadline) {
+        //noinspection BusyWait
+        Thread.sleep(100);
+        state = sessionFsm.getState();
+      }
+
+      assertFalse(
+          state == State.ReactivatingWait || state == State.Reactivating,
+          "SessionFsm is still retrying reactivation (state="
+              + state
+              + ") over a transport that will never reconnect");
+    } finally {
+      client.disconnect();
+      server.shutdown().get();
+    }
+  }
+
+  /**
    * Verify that a Session is not left to expire because the configured keep-alive interval is
    * longer than the session timeout the Server revised the request down to.
    *

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmTest.java
@@ -10,21 +10,26 @@
 
 package org.eclipse.milo.opcua.sdk.client.session;
 
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.digitalpetri.netty.fsm.ChannelFsm;
 import java.security.KeyPair;
 import java.security.cert.X509Certificate;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
 import org.eclipse.milo.opcua.sdk.client.OpcUaClientConfig;
 import org.eclipse.milo.opcua.sdk.client.OpcUaSession;
+import org.eclipse.milo.opcua.sdk.client.SessionActivityListener;
+import org.eclipse.milo.opcua.sdk.client.UaSession;
 import org.eclipse.milo.opcua.sdk.client.identity.X509IdentityProvider;
 import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
 import org.eclipse.milo.opcua.sdk.server.Session;
@@ -39,6 +44,8 @@ import org.eclipse.milo.opcua.stack.core.types.enumerated.MessageSecurityMode;
 import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
 import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateBuilder;
 import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateGenerator;
+import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.transport.client.tcp.OpcTcpClientTransport;
 import org.junit.jupiter.api.Test;
 
 public class SessionFsmTest {
@@ -194,6 +201,88 @@ public class SessionFsmTest {
           "Session "
               + firstSessionId
               + " was left open on the Server after ActivateSession failed");
+    } finally {
+      client.disconnect();
+      server.shutdown().get();
+    }
+  }
+
+  /**
+   * Verify that a SecureChannel lost while the SessionInitializers are running does not leave the
+   * FSM sitting in Active with a Session bound to a dead channel.
+   *
+   * <p>The ChannelFsm.TransitionListener that turns a channel drop into Event.ConnectionLost is
+   * only registered by the Initializing to Active transition action, and it reacts solely to the
+   * edge leaving Connected. netty-channel-fsm notifies listeners synchronously, from a
+   * TransitionAction, over the snapshot of its listener list taken while the event is evaluated, so
+   * a Connected to ReconnectWait edge evaluated before the listener is registered is lost
+   * permanently: the rest of the reconnect cycle (ReconnectWait to Reconnecting to Connected) has
+   * no edge leaving Connected. Initializer failures are swallowed, so InitializeSuccess fires and
+   * the FSM enters Active regardless.
+   *
+   * <p>Each reconnect establishes a brand new SecureChannel, so the Session the FSM is holding is
+   * no longer usable; the Server answers it with Bad_SecureChannelIdInvalid (Part 4 5.6.3).
+   */
+  @Test
+  public void testConnectionLostDuringInitializationIsNotMissed() throws Exception {
+    OpcUaServer server = TestServer.create().getServer();
+    server.startup().get();
+
+    // A keep-alive interval well beyond this test's own bounds: the keep-alive is the fallback that
+    // eventually notices the dead channel, and it would mask the transition being pinned here.
+    OpcUaClient client = TestClient.create(server, cfg -> cfg.setKeepAliveInterval(uint(60_000)));
+
+    var sessionInactive = new CountDownLatch(1);
+
+    client.addSessionActivityListener(
+        new SessionActivityListener() {
+          @Override
+          public void onSessionInactive(UaSession session) {
+            sessionInactive.countDown();
+          }
+        });
+
+    // Added last, so it runs after the built-in initializers: closes the channel and does not
+    // complete until the ChannelFsm has evaluated the Connected -> ReconnectWait edge and notified
+    // its listeners. That orders the drop strictly before the SDK registers its own listener,
+    // rather than relying on the race being won.
+    client.addSessionInitializer(
+        (c, session) -> {
+          ChannelFsm channelFsm = ((OpcTcpClientTransport) c.getTransport()).getChannelFsm();
+
+          var leftConnected = new CompletableFuture<Unit>();
+
+          channelFsm.addTransitionListener(
+              (from, to, via) -> {
+                if (from == com.digitalpetri.netty.fsm.State.Connected
+                    && to != com.digitalpetri.netty.fsm.State.Connected) {
+
+                  leftConnected.complete(Unit.VALUE);
+                }
+              });
+
+          channelFsm
+              .getChannel()
+              .whenComplete(
+                  (channel, ex) -> {
+                    if (channel != null) {
+                      channel.close();
+                    } else {
+                      leftConnected.completeExceptionally(ex);
+                    }
+                  });
+
+          // Hand the continuation to another thread so the rest of the establishment sequence does
+          // not run inline on the ChannelFsm's evaluation thread.
+          return leftConnected.thenApplyAsync(u -> u);
+        });
+
+    try {
+      client.connectAsync().get(30, TimeUnit.SECONDS);
+
+      assertTrue(
+          sessionInactive.await(10, TimeUnit.SECONDS),
+          "SessionFsm remained Active after the channel was lost during Session initialization");
     } finally {
       client.disconnect();
       server.shutdown().get();

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/session/StaleKeepAliveEpochTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/session/StaleKeepAliveEpochTest.java
@@ -1,0 +1,314 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.session;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.client.SessionActivityListener;
+import org.eclipse.milo.opcua.sdk.client.UaSession;
+import org.eclipse.milo.opcua.sdk.server.EndpointConfig;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.sdk.server.servicesets.AttributeServiceSet;
+import org.eclipse.milo.opcua.sdk.server.servicesets.impl.DefaultAttributeServiceSet;
+import org.eclipse.milo.opcua.sdk.test.TestClient;
+import org.eclipse.milo.opcua.sdk.test.TestServer;
+import org.eclipse.milo.opcua.stack.core.AttributeId;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.TimestampsToReturn;
+import org.eclipse.milo.opcua.stack.core.types.structured.HistoryReadRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.HistoryReadResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.HistoryUpdateRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.HistoryUpdateResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.ReadRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.ReadResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.ReadValueId;
+import org.eclipse.milo.opcua.stack.core.types.structured.WriteRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.WriteResponse;
+import org.eclipse.milo.opcua.stack.transport.server.ServiceRequestContext;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Which Session epoch a keep-alive is allowed to act on.
+ *
+ * <p>The keep-alive is a Read of Server_ServerStatus_State sent while the Session FSM is in {@code
+ * Active}, and its {@code whenComplete} decides — from a machine-wide failure count — whether the
+ * Session is still alive. Leaving {@code Active} cancels the timer that schedules new keep-alives,
+ * but a Read that has already been sent is not cancelled with it: the transport only fails pending
+ * requests when the channel errors or goes inactive, and the {@code Event.ServiceFault} route out
+ * of {@code Active} leaves the channel up. That request therefore outlives the epoch it was sent
+ * for, and re-activation (Part 4 §5.6.3) puts the FSM back in {@code Active} over the same channel
+ * with the request still parked at the Server.
+ *
+ * <p>When it finally completes it is answering a question about a Session epoch that is over, and
+ * the answer has already been superseded: the FSM saw the fault, reconnected, and the Server
+ * accepted the ActivateSession, which is proof the Session it now has is healthy. A callback that
+ * runs against whatever state the machine is in when it happens to complete, rather than the state
+ * it was sent in, spends the new epoch's keep-alive budget on the old epoch's observation and takes
+ * a Session down that nothing is wrong with.
+ *
+ * <p>Nothing here is timing-dependent: the Server holds the keep-alive Read until the test releases
+ * it, and the test does not release it until it has watched the Session go inactive and become
+ * active again.
+ */
+class StaleKeepAliveEpochTest {
+
+  /** How long to wait for something that must happen. */
+  private static final long AWAIT_TIMEOUT_MILLIS = 10_000;
+
+  /**
+   * The Session FSM waits one second in {@code ReactivatingWait} before its first re-activation
+   * attempt and doubles the wait on every failure; this window allows for several attempts.
+   */
+  private static final long RECONNECT_TIMEOUT_MILLIS = 30_000;
+
+  /**
+   * How long the re-activated Session is watched after the stale keep-alive is released. The stale
+   * callback runs as soon as the parked Read is answered and fires its event synchronously, so a
+   * Session that is going to be taken down by it is taken down in milliseconds; a longer window
+   * would not change an outcome.
+   */
+  private static final long STALL_WINDOW_MILLIS = 3_000;
+
+  /** Upper bound on how long the parked keep-alive is held, so nothing hangs indefinitely. */
+  private static final long GATE_TIMEOUT_MILLIS = 30_000;
+
+  /** Short enough that the first keep-alive is sent as soon as the Session is Active. */
+  private static final long KEEP_ALIVE_INTERVAL_MILLIS = 250;
+
+  /**
+   * Long enough that the parked keep-alive Read never times out on its own: the test decides when
+   * it completes, and it completes only once the next epoch is Active.
+   */
+  private static final long KEEP_ALIVE_TIMEOUT_MILLIS = 60_000;
+
+  private static final long REQUEST_TIMEOUT_MILLIS = 30_000;
+
+  /**
+   * A Node the Server answers Bad_SessionIdInvalid for, which is how the test provokes the {@code
+   * Event.ServiceFault} route out of {@code Active}. It is the only route that ends the epoch
+   * without taking the channel down, and therefore the only one that leaves an already-sent
+   * keep-alive Read pending.
+   */
+  private static final NodeId FAULT_TRIGGER = new NodeId(0, "SessionFaultTrigger");
+
+  /**
+   * A keep-alive that was sent on an epoch which has since ended must not be counted against the
+   * epoch that replaced it. The Server accepted the re-activation, so the Session the failure is
+   * charged to is one that has just been shown to work.
+   */
+  @Test
+  void keepAliveSentOnAPreviousEpochDoesNotFaultTheCurrentOne() throws Exception {
+    TestServer testServer = TestServer.create();
+    OpcUaServer server = testServer.getServer();
+
+    var attributeServiceSet = new GatingAttributeServiceSet(server);
+
+    for (EndpointConfig endpoint : server.getConfig().getEndpoints()) {
+      server.addServiceSet(endpoint.getPath(), attributeServiceSet);
+    }
+
+    server.startup().get();
+
+    OpcUaClient client =
+        TestClient.create(
+            server,
+            cfg ->
+                cfg.setRequestTimeout(uint(REQUEST_TIMEOUT_MILLIS))
+                    .setKeepAliveInterval(uint(KEEP_ALIVE_INTERVAL_MILLIS))
+                    .setKeepAliveTimeout(uint(KEEP_ALIVE_TIMEOUT_MILLIS))
+                    // One failed keep-alive is enough to end an epoch, so exactly one parked Read
+                    // decides the outcome. With the default of one the same defect needs two of
+                    // them and pins nothing further.
+                    .setKeepAliveFailuresAllowed(uint(0)));
+
+    var inactiveCount = new AtomicInteger(0);
+    var firstInactive = new CountDownLatch(1);
+    var secondInactive = new CountDownLatch(1);
+    var reactivated = new CountDownLatch(1);
+
+    try {
+      client.connect();
+
+      client.addSessionActivityListener(
+          new SessionActivityListener() {
+            @Override
+            public void onSessionInactive(UaSession session) {
+              if (inactiveCount.incrementAndGet() == 1) {
+                firstInactive.countDown();
+              } else {
+                secondInactive.countDown();
+              }
+            }
+
+            @Override
+            public void onSessionActive(UaSession session) {
+              if (firstInactive.getCount() == 0) {
+                reactivated.countDown();
+              }
+            }
+          });
+
+      attributeServiceSet.holdNextKeepAlive();
+
+      assertTrue(
+          attributeServiceSet.keepAliveHeld.await(AWAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS),
+          "precondition: no keep-alive Read reached the Server, so there is none in flight to"
+              + " outlive the epoch it was sent on");
+
+      // Ends the epoch without touching the channel, leaving the parked keep-alive Read pending.
+      client.readValuesAsync(0.0, TimestampsToReturn.Neither, List.of(FAULT_TRIGGER));
+
+      assertTrue(
+          firstInactive.await(RECONNECT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS),
+          "precondition: the Bad_SessionIdInvalid fault did not take the Session out of Active");
+      assertTrue(
+          reactivated.await(RECONNECT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS),
+          "precondition: the Session never became Active again, so there is no new epoch for the"
+              + " parked keep-alive to land in");
+
+      // Answer the keep-alive the way the Server would have if it had never come back: a failure,
+      // but a failure about the epoch that is already over and already recovered from.
+      attributeServiceSet.releaseKeepAlive();
+
+      assertFalse(
+          secondInactive.await(STALL_WINDOW_MILLIS, TimeUnit.MILLISECONDS),
+          "the re-activated Session was taken out of Active with nothing wrong with it: the"
+              + " keep-alive sent on the previous epoch completed against the machine-wide failure"
+              + " count of the current one and spent its whole keep-alive budget, even though the"
+              + " Server had just accepted the ActivateSession that established it");
+    } finally {
+      attributeServiceSet.releaseKeepAlive();
+      try {
+        client.disconnectAsync().get(AWAIT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+      } catch (TimeoutException ignored) {
+        // Shutting the Server down below is what releases a client that cannot complete its
+        // disconnect. Tolerated here so teardown does not mask the assertion above.
+      } finally {
+        server.shutdown().get(10, TimeUnit.SECONDS);
+      }
+    }
+  }
+
+  /**
+   * An {@link AttributeServiceSet} that can hold one keep-alive Read until the test releases it,
+   * and that answers {@link #FAULT_TRIGGER} with the Session fault the test uses to end an epoch.
+   * Everything else is answered normally, so the keep-alives of the next epoch succeed.
+   */
+  private static final class GatingAttributeServiceSet implements AttributeServiceSet {
+
+    private final AttributeServiceSet delegate;
+
+    private final AtomicBoolean holdNextKeepAlive = new AtomicBoolean(false);
+
+    /** Counted down when the keep-alive Read the test asked to have held reaches the Server. */
+    final CountDownLatch keepAliveHeld = new CountDownLatch(1);
+
+    /** Releases the held keep-alive Read. */
+    private final CountDownLatch keepAliveGate = new CountDownLatch(1);
+
+    GatingAttributeServiceSet(OpcUaServer server) {
+      this.delegate = new DefaultAttributeServiceSet(Objects.requireNonNull(server, "server"));
+    }
+
+    void holdNextKeepAlive() {
+      holdNextKeepAlive.set(true);
+    }
+
+    void releaseKeepAlive() {
+      keepAliveGate.countDown();
+    }
+
+    @Override
+    public ReadResponse onRead(ServiceRequestContext context, ReadRequest request)
+        throws UaException {
+
+      if (isFaultTrigger(request)) {
+        throw new UaException(StatusCodes.Bad_SessionIdInvalid);
+      }
+
+      if (isKeepAlive(request) && holdNextKeepAlive.compareAndSet(true, false)) {
+        keepAliveHeld.countDown();
+
+        await(keepAliveGate);
+
+        // The failure a keep-alive sees when the Server it was sent to has stopped answering.
+        throw new UaException(StatusCodes.Bad_Timeout);
+      }
+
+      return delegate.onRead(context, request);
+    }
+
+    @Override
+    public HistoryReadResponse onHistoryRead(
+        ServiceRequestContext context, HistoryReadRequest request) throws UaException {
+      return delegate.onHistoryRead(context, request);
+    }
+
+    @Override
+    public WriteResponse onWrite(ServiceRequestContext context, WriteRequest request)
+        throws UaException {
+      return delegate.onWrite(context, request);
+    }
+
+    @Override
+    public HistoryUpdateResponse onHistoryUpdate(
+        ServiceRequestContext context, HistoryUpdateRequest request) throws UaException {
+      return delegate.onHistoryUpdate(context, request);
+    }
+
+    private static boolean isKeepAlive(ReadRequest request) {
+      return isSingleValueReadOf(request, NodeIds.Server_ServerStatus_State);
+    }
+
+    private static boolean isFaultTrigger(ReadRequest request) {
+      return isSingleValueReadOf(request, FAULT_TRIGGER);
+    }
+
+    private static boolean isSingleValueReadOf(ReadRequest request, NodeId nodeId) {
+      ReadValueId[] nodesToRead = request.getNodesToRead();
+
+      return nodesToRead != null
+          && nodesToRead.length == 1
+          && nodeId.equals(nodesToRead[0].getNodeId())
+          && AttributeId.Value.uid().equals(nodesToRead[0].getAttributeId());
+    }
+  }
+
+  /**
+   * Suspend the calling Server dispatch thread until {@code gate} is released. Bounded, so a test
+   * that goes wrong fails rather than hangs; the Server dispatches every service request on its own
+   * executor, so only the thread handling this one request waits.
+   */
+  private static void await(CountDownLatch gate) throws UaException {
+    try {
+      if (!gate.await(GATE_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)) {
+        throw new UaException(StatusCodes.Bad_Timeout);
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
+    }
+  }
+}

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/session/TransferSubscriptionsNullResultsTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/session/TransferSubscriptionsNullResultsTest.java
@@ -1,0 +1,306 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.session;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.client.SessionActivityListener;
+import org.eclipse.milo.opcua.sdk.client.UaSession;
+import org.eclipse.milo.opcua.sdk.client.subscriptions.OpcUaSubscription;
+import org.eclipse.milo.opcua.sdk.server.EndpointConfig;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.sdk.test.DelegatingSessionServiceSet;
+import org.eclipse.milo.opcua.sdk.test.ScriptableSubscriptionServiceSet;
+import org.eclipse.milo.opcua.sdk.test.TestClient;
+import org.eclipse.milo.opcua.sdk.test.TestServer;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.structured.ActivateSessionRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.ActivateSessionResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.ResponseHeader;
+import org.eclipse.milo.opcua.stack.core.types.structured.TransferResult;
+import org.eclipse.milo.opcua.stack.core.types.structured.TransferSubscriptionsRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.TransferSubscriptionsResponse;
+import org.eclipse.milo.opcua.stack.transport.server.ServiceRequestContext;
+import org.junit.jupiter.api.Test;
+
+/**
+ * What {@code SessionFsmFactory.transferSubscriptions} does when its own response handling throws.
+ *
+ * <p>{@code transferSubscriptions} returns a {@code transferFuture} it completes from inside a
+ * {@code whenComplete} whose own result future is discarded. Anything thrown in that callback is
+ * therefore captured by a future nobody looks at, and {@code transferFuture} is never completed at
+ * all — which leaves the FSM parked in {@code Transferring} with no event pending and no timeout,
+ * so the Session never comes back and {@code closeSession()} is shelved forever.
+ *
+ * <p>{@code requireNonNull(tsr.getResults())} is the reachable throw site: Part 4 §5.14.7.2 defines
+ * results as the "list of results for the subscriptions to transfer", but a Server that answers
+ * Good with no results at all is a defect the client is the party that has to survive.
+ *
+ * <p>Pins that a transfer response the client cannot handle takes the FSM out of {@code
+ * Transferring} the way any other transfer failure does, rather than wedging it: the Server here
+ * answers the first TransferSubscriptions with Good and a null results array and every subsequent
+ * one normally, so a client that treats the first as a failure and starts over recovers, and only a
+ * wedged one never becomes Active again.
+ */
+class TransferSubscriptionsNullResultsTest {
+
+  /** How long to wait for something that must happen. */
+  private static final long AWAIT_TIMEOUT_MILLIS = 10_000;
+
+  /**
+   * How long to wait for a reconnect. The Session FSM waits one second in {@code ReactivatingWait}
+   * before its first re-activation attempt and another second in {@code CreatingWait} before
+   * creating a replacement Session, and doubles each wait on every failure — and this test spends
+   * two of those failures before it can succeed.
+   */
+  private static final long RECONNECT_TIMEOUT_MILLIS = 30_000;
+
+  /**
+   * Long enough that nothing times out on its own: no parked Publish request and no Session
+   * keep-alive. Every stall asserted against below is therefore the client's own doing.
+   */
+  private static final long REQUEST_TIMEOUT_MILLIS = 60_000;
+
+  @Test
+  void unhandleableTransferResponseDoesNotWedgeTransferring() throws Exception {
+    try (var fixture = new Fixture()) {
+      fixture.awaitPublishPipelineFull();
+      fixture.refuseNextReactivation();
+      fixture.faultSession();
+
+      assertTrue(
+          fixture.sessionInactive.await(RECONNECT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS),
+          "the scripted Bad_SessionIdInvalid Publish fault did not take the Session out of Active");
+
+      assertTrue(
+          fixture.awaitTrue(() -> fixture.transferCount() >= 1, AWAIT_TIMEOUT_MILLIS),
+          "precondition: the reconnect did not go through TransferSubscriptions, so this test is"
+              + " not exercising the transfer path at all");
+
+      assertTrue(
+          fixture.sessionReactivated.await(RECONNECT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS),
+          "the Session never became Active again: the throw out of the TransferSubscriptions"
+              + " response handling left transferFuture uncompleted, and the FSM parked in"
+              + " Transferring with nothing pending");
+    }
+  }
+
+  // region Fixture
+
+  /**
+   * A {@link ScriptableSubscriptionServiceSet} that answers the first TransferSubscriptions with a
+   * Good service result and no results at all, and every subsequent one with one Good result per
+   * requested SubscriptionId.
+   *
+   * <p>Publish is left to the script, i.e. parked, so the Server-side Subscription's own transfer
+   * state never participates in the test.
+   */
+  private static final class NullResultsSubscriptionServiceSet
+      extends ScriptableSubscriptionServiceSet {
+
+    private final AtomicInteger transferCount = new AtomicInteger(0);
+
+    NullResultsSubscriptionServiceSet(OpcUaServer server) {
+      super(server);
+    }
+
+    @Override
+    public TransferSubscriptionsResponse onTransferSubscriptions(
+        ServiceRequestContext context, TransferSubscriptionsRequest request) throws UaException {
+
+      boolean first = transferCount.getAndIncrement() == 0;
+
+      UInteger[] subscriptionIds = request.getSubscriptionIds();
+      int requested = subscriptionIds != null ? subscriptionIds.length : 0;
+
+      TransferResult[] results;
+      if (first) {
+        results = null;
+      } else {
+        results = new TransferResult[requested];
+        for (int i = 0; i < requested; i++) {
+          results[i] = new TransferResult(StatusCode.GOOD, null);
+        }
+      }
+
+      var responseHeader =
+          new ResponseHeader(
+              DateTime.now(),
+              request.getRequestHeader().getRequestHandle(),
+              StatusCode.GOOD,
+              null,
+              null,
+              null);
+
+      return new TransferSubscriptionsResponse(responseHeader, results, null);
+    }
+  }
+
+  /**
+   * A {@link DelegatingSessionServiceSet} that can refuse a single ActivateSession with a
+   * ServiceFault, which is what drives the Session FSM off the re-activation path and onto the
+   * create-a-new-Session-and-transfer path.
+   */
+  private static final class RefusingSessionServiceSet extends DelegatingSessionServiceSet {
+
+    private final AtomicBoolean refuseNext = new AtomicBoolean(false);
+
+    RefusingSessionServiceSet(OpcUaServer server) {
+      super(server);
+    }
+
+    @Override
+    public ActivateSessionResponse onActivateSession(
+        ServiceRequestContext context, ActivateSessionRequest request) throws UaException {
+
+      if (refuseNext.compareAndSet(true, false)) {
+        throw new UaException(StatusCodes.Bad_SessionIdInvalid);
+      }
+
+      return super.onActivateSession(context, request);
+    }
+  }
+
+  /**
+   * A running Server whose TransferSubscriptions and ActivateSession responses are scripted, and a
+   * connected client with one Subscription.
+   */
+  private static final class Fixture implements AutoCloseable {
+
+    private final CountDownLatch sessionInactive = new CountDownLatch(1);
+    private final CountDownLatch sessionReactivated = new CountDownLatch(1);
+
+    private final OpcUaServer server;
+    private final OpcUaClient client;
+    private final NullResultsSubscriptionServiceSet scriptable;
+    private final RefusingSessionServiceSet sessionServiceSet;
+
+    @SuppressWarnings("unused")
+    private final OpcUaSubscription subscription;
+
+    Fixture() throws Exception {
+      TestServer testServer = TestServer.create();
+      server = testServer.getServer();
+
+      scriptable = new NullResultsSubscriptionServiceSet(server);
+      sessionServiceSet = new RefusingSessionServiceSet(server);
+
+      for (EndpointConfig endpoint : server.getConfig().getEndpoints()) {
+        server.addServiceSet(endpoint.getPath(), scriptable);
+        server.addServiceSet(endpoint.getPath(), sessionServiceSet);
+      }
+
+      server.startup().get();
+
+      client =
+          TestClient.create(
+              server,
+              cfg ->
+                  cfg.setRequestTimeout(uint(REQUEST_TIMEOUT_MILLIS))
+                      // No Session keep-alive traffic: the only requests in flight during a test
+                      // are the ones it scripts.
+                      .setKeepAliveInterval(uint(REQUEST_TIMEOUT_MILLIS))
+                      .setMaxPendingPublishRequests(uint(1)));
+      client.connect();
+
+      client.addSessionActivityListener(
+          new SessionActivityListener() {
+            @Override
+            public void onSessionInactive(UaSession session) {
+              sessionInactive.countDown();
+            }
+
+            @Override
+            public void onSessionActive(UaSession session) {
+              if (sessionInactive.getCount() == 0) {
+                sessionReactivated.countDown();
+              }
+            }
+          });
+
+      subscription = new OpcUaSubscription(client);
+      subscription.create();
+    }
+
+    /**
+     * Wait until the client's single PublishRequest is parked at the Server, which is what {@link
+     * #faultSession()} answers.
+     */
+    void awaitPublishPipelineFull() throws Exception {
+      assertTrue(
+          awaitTrue(() -> scriptable.getParkedRequestCount() == 1, AWAIT_TIMEOUT_MILLIS),
+          "the client never filled its Publish pipeline, so there is no request to fault");
+    }
+
+    /**
+     * Refuse the next ActivateSession with a ServiceFault, which sends the Session FSM to {@code
+     * CreatingWait} and from there onto the create-a-new-Session-and-transfer path.
+     */
+    void refuseNextReactivation() {
+      sessionServiceSet.refuseNext.set(true);
+    }
+
+    /**
+     * Answer the one parked PublishRequest with a Bad_SessionIdInvalid ServiceFault, which {@code
+     * SessionFsmFactory}'s SessionFaultListener classifies as a Session error and turns into a
+     * reconnect.
+     */
+    void faultSession() {
+      scriptable.enqueueServiceFault(StatusCodes.Bad_SessionIdInvalid);
+    }
+
+    int transferCount() {
+      return scriptable.transferCount.get();
+    }
+
+    /** Polls {@code condition} until it holds or the timeout elapses. */
+    boolean awaitTrue(ThrowingBooleanSupplier condition, long timeoutMillis) throws Exception {
+      long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMillis);
+
+      while (System.nanoTime() < deadline) {
+        if (condition.get()) {
+          return true;
+        }
+        Thread.sleep(10);
+      }
+
+      return condition.get();
+    }
+
+    @Override
+    public void close() throws Exception {
+      scriptable.failParkedRequests(StatusCodes.Bad_NoSubscription);
+      try {
+        // Bounded: a wedged FSM shelves the CloseSession event forever.
+        client.disconnectAsync().get(5, TimeUnit.SECONDS);
+      } finally {
+        server.shutdown().get(10, TimeUnit.SECONDS);
+      }
+    }
+  }
+
+  @FunctionalInterface
+  private interface ThrowingBooleanSupplier {
+    boolean get() throws Exception;
+  }
+
+  // endregion
+}

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/session/TransferSubscriptionsNullResultsTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/session/TransferSubscriptionsNullResultsTest.java
@@ -29,13 +29,9 @@ import org.eclipse.milo.opcua.sdk.test.TestClient;
 import org.eclipse.milo.opcua.sdk.test.TestServer;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
-import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
-import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.structured.ActivateSessionRequest;
 import org.eclipse.milo.opcua.stack.core.types.structured.ActivateSessionResponse;
-import org.eclipse.milo.opcua.stack.core.types.structured.ResponseHeader;
-import org.eclipse.milo.opcua.stack.core.types.structured.TransferResult;
 import org.eclipse.milo.opcua.stack.core.types.structured.TransferSubscriptionsRequest;
 import org.eclipse.milo.opcua.stack.core.types.structured.TransferSubscriptionsResponse;
 import org.eclipse.milo.opcua.stack.transport.server.ServiceRequestContext;
@@ -56,9 +52,10 @@ import org.junit.jupiter.api.Test;
  *
  * <p>Pins that a transfer response the client cannot handle takes the FSM out of {@code
  * Transferring} the way any other transfer failure does, rather than wedging it: the Server here
- * answers the first TransferSubscriptions with Good and a null results array and every subsequent
- * one normally, so a client that treats the first as a failure and starts over recovers, and only a
- * wedged one never becomes Active again.
+ * carries out the first TransferSubscriptions but hands the Client a copy of the response with a
+ * null results array, and answers every subsequent one normally. A client that treats the first as
+ * a failure and starts over must preserve the transferred Subscription for the retry; only a wedged
+ * or destructive cleanup path fails to recover it.
  */
 class TransferSubscriptionsNullResultsTest {
 
@@ -80,7 +77,7 @@ class TransferSubscriptionsNullResultsTest {
   private static final long REQUEST_TIMEOUT_MILLIS = 60_000;
 
   @Test
-  void unhandleableTransferResponseDoesNotWedgeTransferring() throws Exception {
+  void unhandleableTransferResponseRetriesWithoutDeletingSubscription() throws Exception {
     try (var fixture = new Fixture()) {
       fixture.awaitPublishPipelineFull();
       fixture.refuseNextReactivation();
@@ -100,18 +97,27 @@ class TransferSubscriptionsNullResultsTest {
           "the Session never became Active again: the throw out of the TransferSubscriptions"
               + " response handling left transferFuture uncompleted, and the FSM parked in"
               + " Transferring with nothing pending");
+
+      assertTrue(
+          fixture.transferCount() >= 2,
+          "the Session became Active without retrying the unhandleable transfer response");
+
+      assertTrue(
+          fixture.subscriptionExistsOnServer(),
+          "automatic Session cleanup deleted the Subscription before the replacement Session"
+              + " could transfer it");
     }
   }
 
   // region Fixture
 
   /**
-   * A {@link ScriptableSubscriptionServiceSet} that answers the first TransferSubscriptions with a
-   * Good service result and no results at all, and every subsequent one with one Good result per
-   * requested SubscriptionId.
+   * A {@link ScriptableSubscriptionServiceSet} that performs the first TransferSubscriptions but
+   * replaces its results with {@code null} before returning it, and answers every subsequent one
+   * normally.
    *
-   * <p>Publish is left to the script, i.e. parked, so the Server-side Subscription's own transfer
-   * state never participates in the test.
+   * <p>Publish is left to the script, i.e. parked, so nothing else completes or removes the
+   * Server-side Subscription while the Session FSM retries.
    */
   private static final class NullResultsSubscriptionServiceSet
       extends ScriptableSubscriptionServiceSet {
@@ -128,29 +134,14 @@ class TransferSubscriptionsNullResultsTest {
 
       boolean first = transferCount.getAndIncrement() == 0;
 
-      UInteger[] subscriptionIds = request.getSubscriptionIds();
-      int requested = subscriptionIds != null ? subscriptionIds.length : 0;
+      TransferSubscriptionsResponse response = super.onTransferSubscriptions(context, request);
 
-      TransferResult[] results;
       if (first) {
-        results = null;
+        return new TransferSubscriptionsResponse(
+            response.getResponseHeader(), null, response.getDiagnosticInfos());
       } else {
-        results = new TransferResult[requested];
-        for (int i = 0; i < requested; i++) {
-          results[i] = new TransferResult(StatusCode.GOOD, null);
-        }
+        return response;
       }
-
-      var responseHeader =
-          new ResponseHeader(
-              DateTime.now(),
-              request.getRequestHeader().getRequestHandle(),
-              StatusCode.GOOD,
-              null,
-              null,
-              null);
-
-      return new TransferSubscriptionsResponse(responseHeader, results, null);
     }
   }
 
@@ -193,8 +184,8 @@ class TransferSubscriptionsNullResultsTest {
     private final NullResultsSubscriptionServiceSet scriptable;
     private final RefusingSessionServiceSet sessionServiceSet;
 
-    @SuppressWarnings("unused")
     private final OpcUaSubscription subscription;
+    private final UInteger subscriptionId;
 
     Fixture() throws Exception {
       TestServer testServer = TestServer.create();
@@ -238,6 +229,7 @@ class TransferSubscriptionsNullResultsTest {
 
       subscription = new OpcUaSubscription(client);
       subscription.create();
+      subscriptionId = subscription.getSubscriptionId().orElseThrow();
     }
 
     /**
@@ -269,6 +261,10 @@ class TransferSubscriptionsNullResultsTest {
 
     int transferCount() {
       return scriptable.transferCount.get();
+    }
+
+    boolean subscriptionExistsOnServer() {
+      return server.getSubscriptions().containsKey(subscriptionId);
     }
 
     /** Polls {@code condition} until it holds or the timeout elapses. */

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/session/TransferSubscriptionsResultBoundsTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/session/TransferSubscriptionsResultBoundsTest.java
@@ -1,0 +1,394 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.session;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.client.SessionActivityListener;
+import org.eclipse.milo.opcua.sdk.client.UaSession;
+import org.eclipse.milo.opcua.sdk.client.subscriptions.OpcUaSubscription;
+import org.eclipse.milo.opcua.sdk.server.EndpointConfig;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.sdk.test.DelegatingSessionServiceSet;
+import org.eclipse.milo.opcua.sdk.test.ScriptableSubscriptionServiceSet;
+import org.eclipse.milo.opcua.sdk.test.TestClient;
+import org.eclipse.milo.opcua.sdk.test.TestServer;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.structured.ActivateSessionRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.ActivateSessionResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.ResponseHeader;
+import org.eclipse.milo.opcua.stack.core.types.structured.TransferResult;
+import org.eclipse.milo.opcua.stack.core.types.structured.TransferSubscriptionsRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.TransferSubscriptionsResponse;
+import org.eclipse.milo.opcua.stack.transport.server.ServiceRequestContext;
+import org.junit.jupiter.api.Test;
+
+/**
+ * What {@code SessionFsmFactory.transferSubscriptions} does with a TransferSubscriptionsResponse
+ * carrying more TransferResults than the request carried SubscriptionIds.
+ *
+ * <p>Part 4 §5.14.7.2 defines results as the "list of results for the subscriptions to transfer",
+ * one per requested SubscriptionId, so a longer list is a Server defect — but the client is the
+ * party that has to survive it, and it is the only shape of that defect the client cannot detect
+ * before it indexes with it.
+ *
+ * <p>The loop that records availableSequenceNumbers has always been bounded by both the results and
+ * the requested ids ({@code SessionFsmFactory.transferSubscriptions}, {@code i < results.length &&
+ * i < subscriptionIdsArray.length}). The loop that reports failures was bounded only by {@code
+ * results.length} and indexed the unfiltered Subscription snapshot rather than the ids the request
+ * was built from ({@code subscriptions.get(i)}), so a surplus result indexed past the end of that
+ * snapshot. The IndexOutOfBoundsException escaped into the transport executor's task, where it
+ * killed the worker thread and abandoned every remaining notification in the loop.
+ *
+ * <p>Pins that: with one Subscription and a Server answering the transfer with two results, nothing
+ * may be thrown out of the transport executor, and the surplus result — which belongs to no
+ * Subscription the client asked about — must not be reported to one.
+ */
+class TransferSubscriptionsResultBoundsTest {
+
+  /** How long to wait for something that must happen. */
+  private static final long AWAIT_TIMEOUT_MILLIS = 10_000;
+
+  /**
+   * How long to wait for a reconnect. The Session FSM waits one second in {@code ReactivatingWait}
+   * before its first re-activation attempt and another second in {@code CreatingWait} before
+   * creating a replacement Session, and doubles each wait on every failure.
+   */
+  private static final long RECONNECT_TIMEOUT_MILLIS = 30_000;
+
+  /**
+   * How long the transport executor is given to run the task the transfer response dispatched. The
+   * task is submitted before the FSM leaves {@code Transferring}, so by the time the Session is
+   * {@code Active} again it has almost certainly already run; this is the margin, not the
+   * expectation.
+   */
+  private static final long SETTLE_TIMEOUT_MILLIS = 2_000;
+
+  /**
+   * Long enough that nothing times out on its own: no parked Publish request and no Session
+   * keep-alive. Every stall asserted against below is therefore the client's own doing.
+   */
+  private static final long REQUEST_TIMEOUT_MILLIS = 60_000;
+
+  @Test
+  void surplusTransferResultIsNotIndexedAgainstTheSubscriptionSnapshot() throws Exception {
+    try (var fixture = new Fixture()) {
+      fixture.awaitPublishPipelineFull();
+      fixture.refuseNextReactivation();
+      fixture.faultSession();
+      fixture.awaitReactivation();
+
+      assertTrue(
+          fixture.awaitTrue(() -> fixture.transferCount() >= 1, AWAIT_TIMEOUT_MILLIS),
+          "precondition: the reconnect did not go through TransferSubscriptions, so this test is"
+              + " not exercising the transfer path at all");
+
+      // Returns as soon as something is thrown, so only a client that survives the surplus result
+      // waits out the full timeout.
+      fixture.awaitTrue(() -> !fixture.uncaughtFailures().isEmpty(), SETTLE_TIMEOUT_MILLIS);
+
+      List<Throwable> failures = fixture.uncaughtFailures();
+
+      assertTrue(
+          failures.isEmpty(),
+          "a TransferResult the client has no SubscriptionId for was indexed against the"
+              + " Subscription snapshot: "
+              + failures.stream().map(Throwable::toString).toList());
+      assertEquals(
+          0,
+          fixture.transferFailedCount(),
+          "the surplus TransferResult corresponds to no Subscription the client asked to transfer,"
+              + " so no Subscription may be reset and reported as transfer-failed because of it");
+    }
+  }
+
+  // region Fixture
+
+  /**
+   * A {@link ScriptableSubscriptionServiceSet} that answers TransferSubscriptions with one Good
+   * result per requested SubscriptionId plus one surplus Bad result.
+   *
+   * <p>Publish is left to the script, i.e. parked, so the Server-side Subscription's own transfer
+   * state never participates in the test.
+   */
+  private static final class SurplusResultSubscriptionServiceSet
+      extends ScriptableSubscriptionServiceSet {
+
+    private final AtomicInteger transferCount = new AtomicInteger(0);
+
+    SurplusResultSubscriptionServiceSet(OpcUaServer server) {
+      super(server);
+    }
+
+    @Override
+    public TransferSubscriptionsResponse onTransferSubscriptions(
+        ServiceRequestContext context, TransferSubscriptionsRequest request) throws UaException {
+
+      transferCount.incrementAndGet();
+
+      UInteger[] subscriptionIds = request.getSubscriptionIds();
+      int requested = subscriptionIds != null ? subscriptionIds.length : 0;
+
+      var results = new TransferResult[requested + 1];
+      for (int i = 0; i < requested; i++) {
+        results[i] = new TransferResult(StatusCode.GOOD, null);
+      }
+      results[requested] =
+          new TransferResult(new StatusCode(StatusCodes.Bad_SubscriptionIdInvalid), null);
+
+      var responseHeader =
+          new ResponseHeader(
+              DateTime.now(),
+              request.getRequestHeader().getRequestHandle(),
+              StatusCode.GOOD,
+              null,
+              null,
+              null);
+
+      return new TransferSubscriptionsResponse(responseHeader, results, null);
+    }
+  }
+
+  /**
+   * A {@link DelegatingSessionServiceSet} that can refuse a single ActivateSession with a
+   * ServiceFault, which is what drives the Session FSM off the re-activation path and onto the
+   * create-a-new-Session-and-transfer path.
+   */
+  private static final class RefusingSessionServiceSet extends DelegatingSessionServiceSet {
+
+    private final AtomicBoolean refuseNext = new AtomicBoolean(false);
+
+    RefusingSessionServiceSet(OpcUaServer server) {
+      super(server);
+    }
+
+    @Override
+    public ActivateSessionResponse onActivateSession(
+        ServiceRequestContext context, ActivateSessionRequest request) throws UaException {
+
+      if (refuseNext.compareAndSet(true, false)) {
+        throw new UaException(StatusCodes.Bad_SessionIdInvalid);
+      }
+
+      return super.onActivateSession(context, request);
+    }
+  }
+
+  /**
+   * A running Server whose TransferSubscriptions and ActivateSession responses are scripted, and a
+   * connected client with one Subscription.
+   *
+   * <p>The client's transport executor is its own pool rather than {@code Stack.sharedExecutor()},
+   * so anything thrown out of a task the SDK dispatched onto it is attributable to this test
+   * instead of being logged and lost among the other tests sharing that pool.
+   */
+  private static final class Fixture implements AutoCloseable {
+
+    private final List<Throwable> uncaught = Collections.synchronizedList(new ArrayList<>());
+
+    private final AtomicInteger transferFailedCount = new AtomicInteger(0);
+
+    private final CountDownLatch sessionInactive = new CountDownLatch(1);
+    private final CountDownLatch sessionReactivated = new CountDownLatch(1);
+
+    private final ExecutorService executor;
+    private final OpcUaServer server;
+    private final OpcUaClient client;
+    private final SurplusResultSubscriptionServiceSet scriptable;
+    private final RefusingSessionServiceSet sessionServiceSet;
+
+    @SuppressWarnings("unused")
+    private final OpcUaSubscription subscription;
+
+    Fixture() throws Exception {
+      executor = recordingThreadPool(uncaught);
+
+      TestServer testServer = TestServer.create();
+      server = testServer.getServer();
+
+      scriptable = new SurplusResultSubscriptionServiceSet(server);
+      sessionServiceSet = new RefusingSessionServiceSet(server);
+
+      for (EndpointConfig endpoint : server.getConfig().getEndpoints()) {
+        server.addServiceSet(endpoint.getPath(), scriptable);
+        server.addServiceSet(endpoint.getPath(), sessionServiceSet);
+      }
+
+      server.startup().get();
+
+      client =
+          TestClient.create(
+              server,
+              transportConfig -> transportConfig.setExecutor(executor),
+              cfg ->
+                  cfg.setRequestTimeout(uint(REQUEST_TIMEOUT_MILLIS))
+                      // No Session keep-alive traffic: the only requests in flight during a test
+                      // are the ones it scripts.
+                      .setKeepAliveInterval(uint(REQUEST_TIMEOUT_MILLIS))
+                      .setMaxPendingPublishRequests(uint(1)));
+      client.connect();
+
+      client.addSessionActivityListener(
+          new SessionActivityListener() {
+            @Override
+            public void onSessionInactive(UaSession session) {
+              sessionInactive.countDown();
+            }
+
+            @Override
+            public void onSessionActive(UaSession session) {
+              if (sessionInactive.getCount() == 0) {
+                sessionReactivated.countDown();
+              }
+            }
+          });
+
+      subscription = new OpcUaSubscription(client);
+      subscription.setSubscriptionListener(
+          new OpcUaSubscription.SubscriptionListener() {
+            @Override
+            public void onTransferFailed(OpcUaSubscription s, StatusCode status) {
+              transferFailedCount.incrementAndGet();
+            }
+          });
+      subscription.create();
+    }
+
+    /**
+     * Wait until the client's single PublishRequest is parked at the Server, which is what {@link
+     * #faultSession()} answers.
+     */
+    void awaitPublishPipelineFull() throws Exception {
+      assertTrue(
+          awaitTrue(() -> scriptable.getParkedRequestCount() == 1, AWAIT_TIMEOUT_MILLIS),
+          "the client never filled its Publish pipeline, so there is no request to fault");
+    }
+
+    /**
+     * Refuse the next ActivateSession with a ServiceFault, which sends the Session FSM to {@code
+     * CreatingWait} and from there onto the create-a-new-Session-and-transfer path.
+     */
+    void refuseNextReactivation() {
+      sessionServiceSet.refuseNext.set(true);
+    }
+
+    /**
+     * Answer the one parked PublishRequest with a Bad_SessionIdInvalid ServiceFault, which {@code
+     * SessionFsmFactory}'s SessionFaultListener classifies as a Session error and turns into a
+     * reconnect.
+     */
+    void faultSession() {
+      scriptable.enqueueServiceFault(StatusCodes.Bad_SessionIdInvalid);
+    }
+
+    /** Wait for the Session to leave {@code Active} and come back to it. */
+    void awaitReactivation() throws Exception {
+      assertTrue(
+          sessionInactive.await(RECONNECT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS),
+          "the scripted Bad_SessionIdInvalid Publish fault did not take the Session out of Active");
+      assertTrue(
+          sessionReactivated.await(RECONNECT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS),
+          "the Session never became Active again");
+    }
+
+    int transferCount() {
+      return scriptable.transferCount.get();
+    }
+
+    int transferFailedCount() {
+      return transferFailedCount.get();
+    }
+
+    List<Throwable> uncaughtFailures() {
+      return List.copyOf(uncaught);
+    }
+
+    /** Polls {@code condition} until it holds or the timeout elapses. */
+    boolean awaitTrue(ThrowingBooleanSupplier condition, long timeoutMillis) throws Exception {
+      long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMillis);
+
+      while (System.nanoTime() < deadline) {
+        if (condition.get()) {
+          return true;
+        }
+        Thread.sleep(10);
+      }
+
+      return condition.get();
+    }
+
+    @Override
+    public void close() throws Exception {
+      scriptable.failParkedRequests(StatusCodes.Bad_NoSubscription);
+      try {
+        client.disconnectAsync().get(5, TimeUnit.SECONDS);
+      } finally {
+        try {
+          server.shutdown().get(10, TimeUnit.SECONDS);
+        } finally {
+          executor.shutdownNow();
+        }
+      }
+    }
+  }
+
+  @FunctionalInterface
+  private interface ThrowingBooleanSupplier {
+    boolean get() throws Exception;
+  }
+
+  /**
+   * The shape of {@code Stack.sharedExecutor()} — an unbounded cached pool of daemon threads — with
+   * an uncaught-exception handler that records instead of logging. {@code ThreadPoolExecutor}
+   * rethrows whatever a task passed to {@code execute} threw, so the handler sees it.
+   */
+  private static ExecutorService recordingThreadPool(List<Throwable> uncaught) {
+    return new ThreadPoolExecutor(
+        0,
+        Integer.MAX_VALUE,
+        60L,
+        TimeUnit.SECONDS,
+        new SynchronousQueue<>(),
+        recordingThreadFactory(uncaught));
+  }
+
+  private static ThreadFactory recordingThreadFactory(List<Throwable> uncaught) {
+    var counter = new AtomicInteger(0);
+
+    return runnable -> {
+      var thread = new Thread(runnable, "transfer-results-" + counter.incrementAndGet());
+      thread.setDaemon(true);
+      thread.setUncaughtExceptionHandler((t, ex) -> uncaught.add(ex));
+
+      return thread;
+    };
+  }
+
+  // endregion
+}

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/PublishCeilingRecoveryTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/PublishCeilingRecoveryTest.java
@@ -352,11 +352,11 @@ public class PublishCeilingRecoveryTest {
 
         // The intervals between probes, the first measured from the clamp. Geometric backoff makes
         // them grow, and the assertion is that the window ends with a longer wait than it began
-        // with. Strict step-by-step monotonicity is deliberately not asserted: a refusal and the
-        // delivery it is attributed to are two independently timed events, so which round trip a
-        // refusal is recorded against can jitter by one either way, and an inversion between
-        // adjacent intervals says nothing about the cooldown. The bound on the probe count above is
-        // what pins the guarantee; this pins its direction.
+        // with. The positions are the Server's own, recorded under its lock at the moment it
+        // refused, so they do not depend on when this thread next looked; strict step-by-step
+        // monotonicity is still not asserted, because the cooldown the client applies is its own
+        // count of round trips and need not agree with the Server's to the request. The bound on
+        // the probe count above is what pins the guarantee; this pins its direction.
         List<Integer> intervals = intervals(refusedAt);
 
         if (intervals.size() >= 2) {
@@ -445,6 +445,35 @@ public class PublishCeilingRecoveryTest {
   }
 
   /**
+   * Group refused requests into the probes that provoked them.
+   *
+   * <p>One probe can cost the Server more than one refusal. A refused request returns to the client
+   * like any other, and the client replaces it; that replacement meets the same full queue and is
+   * refused in its turn. The two are one question asked once, and under load they straddle a round
+   * trip, so counting refusals rather than probes reports a probe that never happened and an
+   * interval of one round trip that no cooldown would allow.
+   *
+   * <p>Refusals within {@link #QUIET_PREFIX_DELIVERIES} round trips of the probe that opened the
+   * run are therefore folded into it. That is not a tolerance: this class already requires the
+   * cooldown to be longer than that many round trips — it is what {@link
+   * ImmediateResponseToTheFault} pins — so two refusals that close together cannot be two probes.
+   *
+   * @param refusals the round trip each refused request was refused at, in order.
+   * @return the round trip each probe was refused at, in order.
+   */
+  private static List<Integer> coalesceProbes(List<Integer> refusals) {
+    var probes = new ArrayList<Integer>();
+
+    for (int at : refusals) {
+      if (probes.isEmpty() || at - probes.get(probes.size() - 1) > QUIET_PREFIX_DELIVERIES) {
+        probes.add(at);
+      }
+    }
+
+    return probes;
+  }
+
+  /**
    * A {@link ScriptableSubscriptionServiceSet} that also models a Server which will not queue more
    * than a fixed number of PublishRequests for a Session: one that would take its queue past the
    * cap is answered Bad_TooManyPublishRequests, which is what Part 4 §5.14.5.1 has a Server do when
@@ -479,6 +508,24 @@ public class PublishCeilingRecoveryTest {
     /** Publish requests refused for exceeding the cap. Guarded by {@link #lock}. */
     private int rejections = 0;
 
+    /**
+     * Successful Publish round trips answered so far, which is the unit the client's probe cooldown
+     * is counted in. Advanced by {@link #noteDelivery()} immediately before each answer is
+     * enqueued. Guarded by {@link #lock}.
+     */
+    private int deliveries = 0;
+
+    /**
+     * The value of {@link #deliveries} at the moment each refusal was decided, in order. Recorded
+     * here, by the thread that refuses, rather than inferred by the test from when it next happens
+     * to sample {@link #rejections}: a probe and the round trip that provoked it are separately
+     * timed, so a test that samples after a fixed window attributes a probe that arrives late to
+     * the following round trip and every interval after it shifts.
+     *
+     * <p>Guarded by {@link #lock}.
+     */
+    private final List<Integer> refusedAtDelivery = new ArrayList<>();
+
     private volatile int cap;
 
     CappingSubscriptionServiceSet(OpcUaServer server, int cap) {
@@ -504,6 +551,44 @@ public class PublishCeilingRecoveryTest {
       lock.lock();
       try {
         return rejections;
+      } finally {
+        lock.unlock();
+      }
+    }
+
+    /**
+     * Count one successful Publish round trip. Called immediately before the answer that makes it
+     * one, so that a refusal provoked by that answer is recorded against it.
+     */
+    void noteDelivery() {
+      lock.lock();
+      try {
+        deliveries++;
+      } finally {
+        lock.unlock();
+      }
+    }
+
+    /**
+     * @return the successful Publish round trip each refused request was refused at, in order. One
+     *     probe can appear here more than once; see {@link #coalesceProbes(List)}.
+     */
+    List<Integer> getRefusalDeliveries() {
+      lock.lock();
+      try {
+        return List.copyOf(refusedAtDelivery);
+      } finally {
+        lock.unlock();
+      }
+    }
+
+    /**
+     * @return the number of successful Publish round trips answered so far.
+     */
+    int getDeliveryCount() {
+      lock.lock();
+      try {
+        return deliveries;
       } finally {
         lock.unlock();
       }
@@ -563,6 +648,7 @@ public class PublishCeilingRecoveryTest {
 
         if (getParkedRequestCount() >= cap) {
           rejections++;
+          refusedAtDelivery.add(deliveries);
 
           return CompletableFuture.failedFuture(
               new UaException(StatusCodes.Bad_TooManyPublishRequests));
@@ -710,6 +796,10 @@ public class PublishCeilingRecoveryTest {
 
       int arrivals = scriptable.getArrivalCount();
 
+      // Before the answer, not after: the probe it provokes can arrive while this call is still
+      // returning, and it must be charged to this round trip rather than to the one before it.
+      scriptable.noteDelivery();
+
       scriptable.enqueueKeepAlive(notifiedSubscriptionId(), KEEP_ALIVE_SEQUENCE_NUMBER);
 
       assertTrue(
@@ -740,27 +830,22 @@ public class PublishCeilingRecoveryTest {
     /**
      * Deliver {@code count} keep-alives, one at a time, watching for the Server refusing one.
      *
-     * @return the number of successful Publish round trips that had been delivered when each
-     *     refused request was observed, in order. Each entry is a probe: an extra PublishRequest
-     *     the client sent to find out whether the Server would now queue one more.
+     * @return the successful Publish round trip at which each probe was refused, in order. Each
+     *     entry is a probe: an extra PublishRequest the client sent to find out whether the Server
+     *     would now queue one more.
      */
     List<Integer> deliverAndRecordRefusals(int count) throws Exception {
-      var refusedAt = new ArrayList<Integer>();
-      int rejections = scriptable.getRejectionCount();
+      int before = scriptable.getRefusalDeliveries().size();
+      int origin = scriptable.getDeliveryCount();
 
       for (int delivered = 1; delivered <= count; delivered++) {
         deliverOneKeepAlive();
-
-        int total = scriptable.getRejectionCount();
-
-        for (int i = rejections; i < total; i++) {
-          refusedAt.add(delivered);
-        }
-
-        rejections = total;
       }
 
-      return refusedAt;
+      // Positions are the Server's own, recorded under its lock at the moment it refused, and are
+      // re-based on the round trip this window started at so that they read as offsets into it.
+      return coalesceProbes(
+          scriptable.getRefusalDeliveries().stream().skip(before).map(at -> at - origin).toList());
     }
 
     /**

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsm.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsm.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.atomic.AtomicLong;
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
 import org.eclipse.milo.opcua.sdk.client.OpcUaSession;
 import org.eclipse.milo.opcua.sdk.client.SessionActivityListener;
@@ -146,8 +147,16 @@ public class SessionFsm {
   static final FsmContext.Key<SessionFuture> KEY_SESSION_FUTURE =
       new FsmContext.Key<>("sessionFuture", SessionFuture.class);
 
-  static final FsmContext.Key<Long> KEY_KEEP_ALIVE_FAILURE_COUNT =
-      new FsmContext.Key<>("keepAliveFailureCount", Long.class);
+  /**
+   * The number of consecutive keep-alive failures observed during the current Session epoch.
+   *
+   * <p>A new instance is created on every entry to {@link State#Active}, and the value it holds
+   * identifies the epoch it belongs to: a keep-alive that was sent on a previous epoch captures
+   * that epoch's instance and can tell, when it eventually completes, that it is no longer the
+   * current one.
+   */
+  static final FsmContext.Key<AtomicLong> KEY_KEEP_ALIVE_FAILURE_COUNT =
+      new FsmContext.Key<>("keepAliveFailureCount", AtomicLong.class);
 
   static final FsmContext.Key<ScheduledFuture> KEY_KEEP_ALIVE_SCHEDULED_FUTURE =
       new FsmContext.Key<>("keepAliveScheduledFuture", ScheduledFuture.class);

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsm.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsm.java
@@ -20,6 +20,7 @@ import java.util.concurrent.ScheduledFuture;
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
 import org.eclipse.milo.opcua.sdk.client.OpcUaSession;
 import org.eclipse.milo.opcua.sdk.client.SessionActivityListener;
+import org.eclipse.milo.opcua.stack.core.types.structured.CreateSessionResponse;
 import org.eclipse.milo.opcua.stack.core.util.Unit;
 
 public class SessionFsm {
@@ -129,6 +130,18 @@ public class SessionFsm {
 
   static final FsmContext.Key<OpcUaSession> KEY_SESSION =
       new FsmContext.Key<>("session", OpcUaSession.class);
+
+  /**
+   * The response to the CreateSession request for a Session that exists on the Server but has not
+   * been established yet, i.e. it is not reachable via {@link #KEY_SESSION} because the FSM has not
+   * reached {@link State#Active}.
+   *
+   * <p>Set on entry to {@link State#Activating} and removed on entry to {@link State#Active}. If
+   * establishment fails before then the Session is closed on the Server rather than left to expire
+   * on its own when the Session timeout elapses.
+   */
+  static final FsmContext.Key<CreateSessionResponse> KEY_PENDING_SESSION =
+      new FsmContext.Key<>("pendingSession", CreateSessionResponse.class);
 
   static final FsmContext.Key<SessionFuture> KEY_SESSION_FUTURE =
       new FsmContext.Key<>("sessionFuture", SessionFuture.class);

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmFactory.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmFactory.java
@@ -107,6 +107,13 @@ public class SessionFsmFactory {
 
   private static final int MAX_WAIT_SECONDS = 16;
 
+  /**
+   * Lower bound, in milliseconds, on the keep-alive interval derived from a revised session
+   * timeout, so that a Server revising the timeout down to a very small value can't turn the
+   * keep-alive into a flood of requests.
+   */
+  private static final long MIN_KEEP_ALIVE_INTERVAL = 1000L;
+
   private SessionFsmFactory() {}
 
   public static SessionFsm newSessionFsm(OpcUaClient client) {
@@ -615,7 +622,32 @@ public class SessionFsmFactory {
               // reset the wait time
               KEY_WAIT_TIME.remove(ctx);
 
-              long keepAliveInterval = client.getConfig().getKeepAliveInterval().longValue();
+              // The Server is free to revise the requested session timeout downwards, and it
+              // terminates the Session if the Client issues no request within the revised
+              // interval (Part 4 §5.7.2.2). Keep-alives scheduled from the configured interval
+              // alone would let the Session expire between them, so bound the interval at half
+              // the revised timeout, leaving room for one keep-alive to be missed. The clamp only
+              // ever lowers the interval; a configured value that is already safe is untouched.
+              long configuredInterval = client.getConfig().getKeepAliveInterval().longValue();
+              long revisedTimeout = event.session.getSessionTimeout().longValue();
+
+              long keepAliveInterval =
+                  Math.min(
+                      configuredInterval, Math.max(MIN_KEEP_ALIVE_INTERVAL, revisedTimeout / 2));
+
+              if (keepAliveInterval != configuredInterval) {
+                try (MDCCloseable ignoredInstanceId = putInstanceId(ctx);
+                    MDCCloseable ignoredSessionId = putSessionId(event.session)) {
+
+                  LOGGER.warn(
+                      "Server revised the session timeout to {}ms; the configured keep-alive"
+                          + " interval of {}ms leaves too little margin before the Session"
+                          + " expires, using {}ms instead.",
+                      revisedTimeout,
+                      configuredInterval,
+                      keepAliveInterval);
+                }
+              }
 
               // A new counter instance per epoch, so a keep-alive sent on a previous epoch can
               // recognize that the one it captured is no longer the current one.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmFactory.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmFactory.java
@@ -39,7 +39,6 @@ import java.security.KeyPair;
 import java.security.PrivateKey;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
@@ -1447,26 +1446,26 @@ public class SessionFsmFactory {
       return completedFuture(Unit.VALUE);
     }
 
-    CompletableFuture<Unit> transferFuture = new CompletableFuture<>();
+    // Pair each Subscription with its SubscriptionId once, up front. A concurrent reset() removes a
+    // Subscription from the client before clearing its id, so the id is an unsynchronized read that
+    // can disappear between the snapshot above and the request below; deriving the ids separately
+    // would leave the results indexed against a list the request was not built from, shifting every
+    // position at or after a dropped Subscription.
+    record Transferable(OpcUaSubscription subscription, UInteger subscriptionId) {}
 
-    // A Subscription can be reset() concurrently, clearing its id, so the ids sent and the
-    // Subscriptions they came from are captured together: the TransferResults are indexed
-    // against the ids the request carried, and pairing them back through a list whose shape
-    // can since have changed would apply a result to the wrong Subscription.
-    var transferable = new ArrayList<OpcUaSubscription>(subscriptions.size());
-    var subscriptionIds = new ArrayList<UInteger>(subscriptions.size());
+    List<Transferable> transferable =
+        subscriptions.stream()
+            .flatMap(s -> s.getSubscriptionId().map(id -> new Transferable(s, id)).stream())
+            .toList();
 
-    for (OpcUaSubscription subscription : subscriptions) {
-      subscription
-          .getSubscriptionId()
-          .ifPresent(
-              id -> {
-                transferable.add(subscription);
-                subscriptionIds.add(id);
-              });
+    if (transferable.isEmpty()) {
+      return completedFuture(Unit.VALUE);
     }
 
-    UInteger[] subscriptionIdsArray = subscriptionIds.toArray(new UInteger[0]);
+    CompletableFuture<Unit> transferFuture = new CompletableFuture<>();
+
+    UInteger[] subscriptionIdsArray =
+        transferable.stream().map(Transferable::subscriptionId).toArray(UInteger[]::new);
 
     TransferSubscriptionsRequest request =
         new TransferSubscriptionsRequest(
@@ -1496,13 +1495,14 @@ public class SessionFsmFactory {
 
                   if (LOGGER.isDebugEnabled()) {
                     try {
+                      Stream<UInteger> subscriptionIds = Stream.of(subscriptionIdsArray);
                       Stream<StatusCode> statusCodes =
                           Stream.of(results).map(TransferResult::getStatusCode);
 
                       //noinspection UnstableApiUsage
                       String[] ss =
                           Streams.zip(
-                                  subscriptionIds.stream(),
+                                  subscriptionIds,
                                   statusCodes,
                                   (i, s) -> {
                                     assert s != null;
@@ -1541,12 +1541,15 @@ public class SessionFsmFactory {
                   }
                 }
 
+                // Bounded by the requested Subscriptions as well: Part 4 §5.14.7.2 defines results
+                // as one per requested SubscriptionId, but a Server returning a longer list must
+                // not reach past the end of them.
                 for (int i = 0; i < results.length && i < transferable.size(); i++) {
                   TransferResult result = results[i];
 
                   if (!result.getStatusCode().isGood()) {
                     handleTransferFailure(
-                        ctx, session, transferable.get(i), result.getStatusCode());
+                        ctx, session, transferable.get(i).subscription(), result.getStatusCode());
                   }
                 }
 

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmFactory.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmFactory.java
@@ -1063,6 +1063,35 @@ public class SessionFsmFactory {
                   .orElse(false);
             });
 
+    // Neither retrying the reactivation nor creating a new Session can succeed while the transport
+    // is disconnected for good, and both routes retry indefinitely, so this has to be evaluated
+    // before the escalation to CreatingWait below.
+    Predicate<Event> isReactivateSessionFailureTerminal =
+        isReactivateSessionFailure.and(e -> isTransportDisconnectedForGood(client));
+
+    fb.when(State.Reactivating)
+        .on(isReactivateSessionFailureTerminal)
+        .transitionTo(State.Inactive)
+        .executeFirst(
+            ctx -> {
+              KEY_WAIT_TIME.remove(ctx);
+
+              Event.ReactivateSessionFailure e = (Event.ReactivateSessionFailure) ctx.event();
+
+              OpcUaSession session = KEY_SESSION.remove(ctx);
+
+              try (MDCCloseable ignoredInstanceId = putInstanceId(ctx)) {
+                LOGGER.warn(
+                    "Transport is disconnected and will not reconnect on its own; abandoning"
+                        + " Session {}.",
+                    session != null ? session.getSessionId() : null);
+              }
+
+              // The Session can't be closed on the Server without a channel to send the request
+              // over; it is left to expire when the Session timeout elapses (Part 4 §5.6.2).
+              handleFailureToOpenSession(client, ctx, e.failure);
+            });
+
     fb.when(State.Reactivating)
         .on(isReactivateSessionFailureFatal)
         .transitionTo(State.CreatingWait)
@@ -1144,6 +1173,29 @@ public class SessionFsmFactory {
     fb.onInternalTransition(State.Reactivating)
         .via(Event.CloseSession.class)
         .execute(ctx -> ctx.shelveEvent(ctx.event()));
+  }
+
+  /**
+   * Check whether the transport is disconnected in a way that nothing will undo on its own.
+   *
+   * <p>The ChannelFsm is configured persistent, so a channel that drops unexpectedly is reconnected
+   * without any help from the Session. {@code NotConnected} is the exception: it is reached only
+   * when the application deliberately disconnects the transport, its only outbound edge is an
+   * explicit Connect, and every request attempted from it fails immediately. A Session has nothing
+   * left to reactivate over until the application connects again.
+   *
+   * @param client the {@link OpcUaClient} the Session belongs to.
+   * @return {@code true} if the transport is disconnected and will not reconnect on its own.
+   */
+  private static boolean isTransportDisconnectedForGood(OpcUaClient client) {
+    OpcClientTransport transport = client.getTransport();
+
+    if (transport instanceof OpcTcpClientTransport tcpClientTransport) {
+      return tcpClientTransport.getChannelFsm().getState()
+          == com.digitalpetri.netty.fsm.State.NotConnected;
+    } else {
+      return false;
+    }
   }
 
   private static void handleGetSessionEvent(ActionContext<State, Event> ctx) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmFactory.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmFactory.java
@@ -1106,11 +1106,12 @@ public class SessionFsmFactory {
               // Reactivation is being abandoned in favor of creating a new Session. The old one may
               // still exist on the Server (the fault might have been e.g.
               // Bad_IdentityTokenRejected rather than Bad_SessionIdInvalid), so close it
-              // best-effort; a fault in response to this is expected and ignored.
+              // best-effort without deleting its Subscriptions: the replacement Session will try
+              // to transfer them. A fault in response to this is expected and ignored.
               OpcUaSession session = KEY_SESSION.remove(ctx);
 
               if (session != null) {
-                closeSession(ctx, client, session);
+                abandonSession(ctx, client, session);
               }
             });
 
@@ -1239,30 +1240,50 @@ public class SessionFsmFactory {
 
     // If CreateSession already succeeded the Session exists on the Server, and a new one is about
     // to be created in its place. Close it best-effort so the Server isn't left holding an orphan
-    // until the Session timeout expires; failure to close changes nothing about the outcome here.
+    // until the Session timeout expires, but preserve any Subscriptions already transferred to it
+    // so the replacement Session can recover them. Failure to close changes nothing about the
+    // outcome here.
     CreateSessionResponse pendingSession = KEY_PENDING_SESSION.remove(ctx);
 
     if (pendingSession != null) {
-      closeSession(
-          ctx, client, pendingSession.getSessionId(), pendingSession.getAuthenticationToken());
+      abandonSession(ctx, client, pendingSession);
     }
   }
 
   private static CompletableFuture<Unit> closeSession(
       FsmContext<State, Event> ctx, OpcUaClient client, OpcUaSession session) {
 
-    return closeSession(ctx, client, session.getSessionId(), session.getAuthenticationToken());
+    return closeSession(
+        ctx, client, session.getSessionId(), session.getAuthenticationToken(), true);
+  }
+
+  private static CompletableFuture<Unit> abandonSession(
+      FsmContext<State, Event> ctx, OpcUaClient client, OpcUaSession session) {
+
+    return closeSession(
+        ctx, client, session.getSessionId(), session.getAuthenticationToken(), false);
+  }
+
+  private static CompletableFuture<Unit> abandonSession(
+      FsmContext<State, Event> ctx, OpcUaClient client, CreateSessionResponse session) {
+
+    return closeSession(
+        ctx, client, session.getSessionId(), session.getAuthenticationToken(), false);
   }
 
   private static CompletableFuture<Unit> closeSession(
-      FsmContext<State, Event> ctx, OpcUaClient client, NodeId sessionId, NodeId authToken) {
+      FsmContext<State, Event> ctx,
+      OpcUaClient client,
+      NodeId sessionId,
+      NodeId authToken,
+      boolean deleteSubscriptions) {
 
     try {
       CompletableFuture<Unit> closeFuture = new CompletableFuture<>();
 
       RequestHeader requestHeader = client.newRequestHeader(authToken, uint(5000));
 
-      CloseSessionRequest request = new CloseSessionRequest(requestHeader, true);
+      CloseSessionRequest request = new CloseSessionRequest(requestHeader, deleteSubscriptions);
 
       try (MDCCloseable ignoredInstanceId = putInstanceId(ctx);
           MDCCloseable ignoredSessionId = putSessionId(sessionId)) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmFactory.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmFactory.java
@@ -616,7 +616,10 @@ public class SessionFsmFactory {
               KEY_WAIT_TIME.remove(ctx);
 
               long keepAliveInterval = client.getConfig().getKeepAliveInterval().longValue();
-              KEY_KEEP_ALIVE_FAILURE_COUNT.set(ctx, 0L);
+
+              // A new counter instance per epoch, so a keep-alive sent on a previous epoch can
+              // recognize that the one it captured is no longer the current one.
+              KEY_KEEP_ALIVE_FAILURE_COUNT.set(ctx, new AtomicLong(0L));
 
               ScheduledFuture<?> scheduledFuture =
                   client
@@ -753,9 +756,25 @@ public class SessionFsmFactory {
             ctx -> {
               Event.KeepAlive event = (Event.KeepAlive) ctx.event();
 
+              // Capture the counter belonging to the epoch this keep-alive is sent on. Leaving
+              // Active cancels the scheduling of new keep-alives but does not cancel one that has
+              // already been sent, and the Event.ServiceFault route leaves Active without taking
+              // the channel down, so the request below can still be pending when the Session is
+              // re-activated (Part 4 §5.6.3) and complete against a later epoch.
+              AtomicLong failureCount = KEY_KEEP_ALIVE_FAILURE_COUNT.get(ctx);
+
               sendKeepAlive(client, event.session)
                   .whenComplete(
                       (response, ex) -> {
+                        if (ctx.currentState() != State.Active
+                            || KEY_SESSION.get(ctx) != event.session
+                            || KEY_KEEP_ALIVE_FAILURE_COUNT.get(ctx) != failureCount) {
+
+                          // The epoch this keep-alive was sent on is over; whatever it observed is
+                          // no longer relevant to the Session the FSM has now.
+                          return;
+                        }
+
                         if (response != null) {
                           DataValue[] results = response.getResults();
 
@@ -772,17 +791,9 @@ public class SessionFsmFactory {
                             }
                           }
 
-                          KEY_KEEP_ALIVE_FAILURE_COUNT.set(ctx, 0L);
+                          failureCount.set(0L);
                         } else {
-                          Long keepAliveFailureCount = KEY_KEEP_ALIVE_FAILURE_COUNT.get(ctx);
-
-                          if (keepAliveFailureCount == null) {
-                            keepAliveFailureCount = 1L;
-                          } else {
-                            keepAliveFailureCount += 1L;
-                          }
-
-                          KEY_KEEP_ALIVE_FAILURE_COUNT.set(ctx, keepAliveFailureCount);
+                          long keepAliveFailureCount = failureCount.incrementAndGet();
 
                           long keepAliveFailuresAllowed =
                               client.getConfig().getKeepAliveFailuresAllowed().longValue();

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmFactory.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmFactory.java
@@ -1095,157 +1095,165 @@ public class SessionFsmFactory {
   private static CompletableFuture<Unit> closeSession(
       FsmContext<State, Event> ctx, OpcUaClient client, OpcUaSession session) {
 
-    CompletableFuture<Unit> closeFuture = new CompletableFuture<>();
+    try {
+      CompletableFuture<Unit> closeFuture = new CompletableFuture<>();
 
-    RequestHeader requestHeader =
-        client.newRequestHeader(session.getAuthenticationToken(), uint(5000));
+      RequestHeader requestHeader =
+          client.newRequestHeader(session.getAuthenticationToken(), uint(5000));
 
-    CloseSessionRequest request = new CloseSessionRequest(requestHeader, true);
+      CloseSessionRequest request = new CloseSessionRequest(requestHeader, true);
 
-    try (MDCCloseable ignoredInstanceId = putInstanceId(ctx);
-        MDCCloseable ignoredSessionId = putSessionId(session)) {
+      try (MDCCloseable ignoredInstanceId = putInstanceId(ctx);
+          MDCCloseable ignoredSessionId = putSessionId(session)) {
 
-      LOGGER.debug("Sending CloseSessionRequest...");
+        LOGGER.debug("Sending CloseSessionRequest...");
+      }
+
+      client
+          .getTransport()
+          .sendRequestMessage(request)
+          .whenCompleteAsync(
+              (csr, ex2) -> closeFuture.complete(Unit.VALUE),
+              client.getTransport().getConfig().getExecutor());
+
+      return closeFuture;
+    } catch (Exception ex) {
+      return failedFuture(ex);
     }
-
-    client
-        .getTransport()
-        .sendRequestMessage(request)
-        .whenCompleteAsync(
-            (csr, ex2) -> closeFuture.complete(Unit.VALUE),
-            client.getTransport().getConfig().getExecutor());
-
-    return closeFuture;
   }
 
   @SuppressWarnings("Duplicates")
   private static CompletableFuture<CreateSessionResponse> createSession(
       FsmContext<State, Event> ctx, OpcUaClient client) {
 
-    EndpointDescription endpoint = client.getConfig().getEndpoint();
+    try {
+      EndpointDescription endpoint = client.getConfig().getEndpoint();
 
-    String gatewayServerUri = endpoint.getServer().getGatewayServerUri();
+      String gatewayServerUri = endpoint.getServer().getGatewayServerUri();
 
-    String serverUri;
-    if (gatewayServerUri != null && !gatewayServerUri.isEmpty()) {
-      serverUri = endpoint.getServer().getApplicationUri();
-    } else {
-      serverUri = null;
-    }
+      String serverUri;
+      if (gatewayServerUri != null && !gatewayServerUri.isEmpty()) {
+        serverUri = endpoint.getServer().getApplicationUri();
+      } else {
+        serverUri = null;
+      }
 
-    ByteString clientNonce = NonceUtil.generateNonce(32);
+      ByteString clientNonce = NonceUtil.generateNonce(32);
 
-    ByteString clientCertificate =
-        client
-            .getConfig()
-            .getCertificate()
-            .map(
-                c -> {
-                  try {
-                    return ByteString.of(c.getEncoded());
-                  } catch (CertificateEncodingException e) {
-                    return ByteString.NULL_VALUE;
+      ByteString clientCertificate =
+          client
+              .getConfig()
+              .getCertificate()
+              .map(
+                  c -> {
+                    try {
+                      return ByteString.of(c.getEncoded());
+                    } catch (CertificateEncodingException e) {
+                      return ByteString.NULL_VALUE;
+                    }
+                  })
+              .orElse(ByteString.NULL_VALUE);
+
+      ApplicationDescription clientDescription =
+          new ApplicationDescription(
+              client.getConfig().getApplicationUri(),
+              client.getConfig().getProductUri(),
+              client.getConfig().getApplicationName(),
+              ApplicationType.Client,
+              null,
+              null,
+              null);
+
+      CreateSessionRequest request =
+          new CreateSessionRequest(
+              client.newRequestHeader(),
+              clientDescription,
+              serverUri,
+              client.getConfig().getEndpoint().getEndpointUrl(),
+              client.getConfig().getSessionName().get(),
+              clientNonce,
+              clientCertificate,
+              client.getConfig().getSessionTimeout().doubleValue(),
+              client.getConfig().getMaxResponseMessageSize());
+
+      try (MDCCloseable ignored = putInstanceId(ctx)) {
+
+        LOGGER.debug("Sending CreateSessionRequest...");
+      }
+
+      return client
+          .getTransport()
+          .sendRequestMessage(request)
+          .thenApply(CreateSessionResponse.class::cast)
+          .thenCompose(
+              response -> {
+                try {
+                  SecurityPolicy securityPolicy =
+                      SecurityPolicy.fromUri(endpoint.getSecurityPolicyUri());
+
+                  if (securityPolicy != SecurityPolicy.None) {
+                    if (response.getServerCertificate().isNullOrEmpty()) {
+                      throw new UaException(
+                          StatusCodes.Bad_SecurityChecksFailed,
+                          "Certificate missing from CreateSessionResponse");
+                    }
+
+                    List<X509Certificate> serverCertificateChain =
+                        CertificateUtil.decodeCertificates(
+                            response.getServerCertificate().bytesOrEmpty());
+
+                    X509Certificate serverCertificate = serverCertificateChain.get(0);
+
+                    X509Certificate certificateFromEndpoint =
+                        CertificateUtil.decodeCertificate(
+                            endpoint.getServerCertificate().bytesOrEmpty());
+
+                    if (!serverCertificate.equals(certificateFromEndpoint)) {
+                      throw new UaException(
+                          StatusCodes.Bad_SecurityChecksFailed,
+                          "Certificate from CreateSessionResponse did not "
+                              + "match certificate from EndpointDescription!");
+                    }
+
+                    client
+                        .getConfig()
+                        .getCertificateValidator()
+                        .validateCertificateChain(
+                            serverCertificateChain,
+                            endpoint.getServer().getApplicationUri(),
+                            new String[] {EndpointUtil.getHost(endpoint.getEndpointUrl())});
+
+                    SignatureData serverSignature = response.getServerSignature();
+
+                    byte[] dataBytes =
+                        Bytes.concat(clientCertificate.bytesOrEmpty(), clientNonce.bytesOrEmpty());
+
+                    byte[] signatureBytes = serverSignature.getSignature().bytesOrEmpty();
+
+                    SignatureUtil.verify(
+                        SecurityAlgorithm.fromUri(serverSignature.getAlgorithm()),
+                        serverCertificate,
+                        dataBytes,
+                        signatureBytes);
                   }
-                })
-            .orElse(ByteString.NULL_VALUE);
 
-    ApplicationDescription clientDescription =
-        new ApplicationDescription(
-            client.getConfig().getApplicationUri(),
-            client.getConfig().getProductUri(),
-            client.getConfig().getApplicationName(),
-            ApplicationType.Client,
-            null,
-            null,
-            null);
-
-    CreateSessionRequest request =
-        new CreateSessionRequest(
-            client.newRequestHeader(),
-            clientDescription,
-            serverUri,
-            client.getConfig().getEndpoint().getEndpointUrl(),
-            client.getConfig().getSessionName().get(),
-            clientNonce,
-            clientCertificate,
-            client.getConfig().getSessionTimeout().doubleValue(),
-            client.getConfig().getMaxResponseMessageSize());
-
-    try (MDCCloseable ignored = putInstanceId(ctx)) {
-
-      LOGGER.debug("Sending CreateSessionRequest...");
-    }
-
-    return client
-        .getTransport()
-        .sendRequestMessage(request)
-        .thenApply(CreateSessionResponse.class::cast)
-        .thenCompose(
-            response -> {
-              try {
-                SecurityPolicy securityPolicy =
-                    SecurityPolicy.fromUri(endpoint.getSecurityPolicyUri());
-
-                if (securityPolicy != SecurityPolicy.None) {
-                  if (response.getServerCertificate().isNullOrEmpty()) {
-                    throw new UaException(
-                        StatusCodes.Bad_SecurityChecksFailed,
-                        "Certificate missing from CreateSessionResponse");
+                  if (client.getConfig().isSessionEndpointValidationEnabled()) {
+                    validateSessionEndpoints(
+                        endpoint.getTransportProfileUri(),
+                        client.getConfig().getDiscoveryEndpoints(),
+                        List.of(
+                            Objects.requireNonNullElse(
+                                response.getServerEndpoints(), new EndpointDescription[0])));
                   }
 
-                  List<X509Certificate> serverCertificateChain =
-                      CertificateUtil.decodeCertificates(
-                          response.getServerCertificate().bytesOrEmpty());
-
-                  X509Certificate serverCertificate = serverCertificateChain.get(0);
-
-                  X509Certificate certificateFromEndpoint =
-                      CertificateUtil.decodeCertificate(
-                          endpoint.getServerCertificate().bytesOrEmpty());
-
-                  if (!serverCertificate.equals(certificateFromEndpoint)) {
-                    throw new UaException(
-                        StatusCodes.Bad_SecurityChecksFailed,
-                        "Certificate from CreateSessionResponse did not "
-                            + "match certificate from EndpointDescription!");
-                  }
-
-                  client
-                      .getConfig()
-                      .getCertificateValidator()
-                      .validateCertificateChain(
-                          serverCertificateChain,
-                          endpoint.getServer().getApplicationUri(),
-                          new String[] {EndpointUtil.getHost(endpoint.getEndpointUrl())});
-
-                  SignatureData serverSignature = response.getServerSignature();
-
-                  byte[] dataBytes =
-                      Bytes.concat(clientCertificate.bytesOrEmpty(), clientNonce.bytesOrEmpty());
-
-                  byte[] signatureBytes = serverSignature.getSignature().bytesOrEmpty();
-
-                  SignatureUtil.verify(
-                      SecurityAlgorithm.fromUri(serverSignature.getAlgorithm()),
-                      serverCertificate,
-                      dataBytes,
-                      signatureBytes);
+                  return completedFuture(response);
+                } catch (UaException e) {
+                  return failedFuture(e);
                 }
-
-                if (client.getConfig().isSessionEndpointValidationEnabled()) {
-                  validateSessionEndpoints(
-                      endpoint.getTransportProfileUri(),
-                      client.getConfig().getDiscoveryEndpoints(),
-                      List.of(
-                          Objects.requireNonNullElse(
-                              response.getServerEndpoints(), new EndpointDescription[0])));
-                }
-
-                return completedFuture(response);
-              } catch (UaException e) {
-                return failedFuture(e);
-              }
-            });
+              });
+    } catch (Exception ex) {
+      return failedFuture(ex);
+    }
   }
 
   /**
@@ -1594,6 +1602,15 @@ public class SessionFsmFactory {
                   transferFuture.completeExceptionally(ex);
                 }
               }
+            })
+        // The whenComplete above has its own result future discarded, so a response its handling
+        // can't make sense of - e.g. a Good response carrying no results at all - would otherwise
+        // leave transferFuture uncompleted and the FSM parked in Transferring with no event
+        // pending and no timeout. A no-op when the callback completed transferFuture itself.
+        .exceptionally(
+            ex -> {
+              transferFuture.completeExceptionally(ex);
+              return null;
             });
 
     return transferFuture;

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmFactory.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmFactory.java
@@ -114,6 +114,19 @@ public class SessionFsmFactory {
    */
   private static final long MIN_KEEP_ALIVE_INTERVAL = 1000L;
 
+  /**
+   * StatusCodes that mean the Server no longer has a usable Session for us, i.e. the Session it
+   * would have to be reactivated against is gone or was never activated.
+   */
+  private static final Predicate<StatusCode> SESSION_ERROR =
+      statusCode -> {
+        long status = statusCode.value();
+
+        return status == StatusCodes.Bad_SessionClosed
+            || status == StatusCodes.Bad_SessionIdInvalid
+            || status == StatusCodes.Bad_SessionNotActivated;
+      };
+
   private SessionFsmFactory() {}
 
   public static SessionFsm newSessionFsm(OpcUaClient client) {
@@ -1031,18 +1044,27 @@ public class SessionFsmFactory {
   private static void configureReactivatingState(FsmBuilder<State, Event> fb, OpcUaClient client) {
     Predicate<Event> isReactivateSessionFailure = e -> e instanceof Event.ReactivateSessionFailure;
 
-    Predicate<Event> isReactivateSessionFailureServiceFault =
+    // Part 4 §6.7: a Client shall create a new Session if ActivateSession fails. Escalate on the
+    // StatusCode rather than the exception type so that a Server reporting a definitive
+    // session-level error with a channel-level Error message instead of an application-level
+    // ServiceFault - the same defective behavior guarded against on the transfer path below -
+    // escalates as well. Failures that carry no such StatusCode, e.g. Bad_Timeout or
+    // Bad_ConnectionClosed, are connectivity problems; Part 4 §5.7.2.1 says to keep trying to
+    // reactivate over a new connection, so those stay on the ReactivatingWait retry loop.
+    Predicate<Event> isReactivateSessionFailureFatal =
         isReactivateSessionFailure.and(
             e -> {
               Event.ReactivateSessionFailure event = (Event.ReactivateSessionFailure) e;
               return UaException.extract(event.failure)
-                  .map(ex -> ex instanceof UaServiceFaultException)
+                  .map(
+                      ex ->
+                          ex instanceof UaServiceFaultException
+                              || SESSION_ERROR.test(ex.getStatusCode()))
                   .orElse(false);
             });
 
-    // If reactivating fails due to a ServiceFault, move to CreatingWait
     fb.when(State.Reactivating)
-        .on(isReactivateSessionFailureServiceFault)
+        .on(isReactivateSessionFailureFatal)
         .transitionTo(State.CreatingWait)
         .executeFirst(
             ctx -> {
@@ -1831,15 +1853,6 @@ public class SessionFsmFactory {
   }
 
   private static class SessionFaultListener implements ServiceFaultListener {
-
-    private static final Predicate<StatusCode> SESSION_ERROR =
-        statusCode -> {
-          long status = statusCode.value();
-
-          return status == StatusCodes.Bad_SessionClosed
-              || status == StatusCodes.Bad_SessionIdInvalid
-              || status == StatusCodes.Bad_SessionNotActivated;
-        };
 
     private static final Predicate<StatusCode> SECURE_CHANNEL_ERROR =
         statusCode -> {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmFactory.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmFactory.java
@@ -670,6 +670,17 @@ public class SessionFsmFactory {
 
                 channelFsm.addTransitionListener(listener);
                 KEY_CHANNEL_FSM_TRANSITION_LISTENER.set(ctx, listener);
+
+                // ChannelFsm notifies its listeners synchronously while evaluating a transition,
+                // so a connection loss that occurred while the Session was being created,
+                // activated, or initialized was dispatched before the listener above existed and
+                // will never be delivered to it: the reconnect cycle leaves and re-enters
+                // Connected without another transition originating from Connected. Synthesize the
+                // missed event rather than leaving the Session bound to a secure channel that no
+                // longer exists.
+                if (channelFsm.getState() != com.digitalpetri.netty.fsm.State.Connected) {
+                  ctx.fireEvent(new Event.ConnectionLost());
+                }
               }
 
               client

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmFactory.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmFactory.java
@@ -16,6 +16,7 @@ import static org.eclipse.milo.opcua.sdk.client.session.SessionFsm.KEY_CHANNEL_F
 import static org.eclipse.milo.opcua.sdk.client.session.SessionFsm.KEY_CLOSE_FUTURE;
 import static org.eclipse.milo.opcua.sdk.client.session.SessionFsm.KEY_KEEP_ALIVE_FAILURE_COUNT;
 import static org.eclipse.milo.opcua.sdk.client.session.SessionFsm.KEY_KEEP_ALIVE_SCHEDULED_FUTURE;
+import static org.eclipse.milo.opcua.sdk.client.session.SessionFsm.KEY_PENDING_SESSION;
 import static org.eclipse.milo.opcua.sdk.client.session.SessionFsm.KEY_SESSION;
 import static org.eclipse.milo.opcua.sdk.client.session.SessionFsm.KEY_SESSION_ACTIVITY_LISTENERS;
 import static org.eclipse.milo.opcua.sdk.client.session.SessionFsm.KEY_SESSION_FUTURE;
@@ -384,6 +385,10 @@ public class SessionFsmFactory {
             ctx -> {
               Event.CreateSessionSuccess event = (Event.CreateSessionSuccess) ctx.event();
 
+              // The Session now exists on the Server; remember it so it can be closed if the
+              // remainder of the establishment sequence fails.
+              KEY_PENDING_SESSION.set(ctx, event.response);
+
               activateSession(ctx, client, event.response)
                   .whenComplete(
                       (session, ex) -> {
@@ -626,6 +631,9 @@ public class SessionFsmFactory {
               KEY_KEEP_ALIVE_SCHEDULED_FUTURE.set(ctx, scheduledFuture);
 
               KEY_SESSION.set(ctx, event.session);
+
+              // The Session is established; it's reachable via KEY_SESSION from here on.
+              KEY_PENDING_SESSION.remove(ctx);
 
               SessionFuture sessionFuture = KEY_SESSION_FUTURE.get(ctx);
 
@@ -989,6 +997,16 @@ public class SessionFsmFactory {
               Event.ReactivateSessionFailure e = (Event.ReactivateSessionFailure) ctx.event();
 
               handleFailureToOpenSession(client, ctx, e.failure);
+
+              // Reactivation is being abandoned in favor of creating a new Session. The old one may
+              // still exist on the Server (the fault might have been e.g.
+              // Bad_IdentityTokenRejected rather than Bad_SessionIdInvalid), so close it
+              // best-effort; a fault in response to this is expected and ignored.
+              OpcUaSession session = KEY_SESSION.remove(ctx);
+
+              if (session != null) {
+                closeSession(ctx, client, session);
+              }
             });
 
     // If reactivating fails for any other reason, move back to ReactivatingWait and keep trying to
@@ -1090,21 +1108,36 @@ public class SessionFsmFactory {
           .getExecutor()
           .execute(() -> sessionFuture.future.completeExceptionally(failure));
     }
+
+    // If CreateSession already succeeded the Session exists on the Server, and a new one is about
+    // to be created in its place. Close it best-effort so the Server isn't left holding an orphan
+    // until the Session timeout expires; failure to close changes nothing about the outcome here.
+    CreateSessionResponse pendingSession = KEY_PENDING_SESSION.remove(ctx);
+
+    if (pendingSession != null) {
+      closeSession(
+          ctx, client, pendingSession.getSessionId(), pendingSession.getAuthenticationToken());
+    }
   }
 
   private static CompletableFuture<Unit> closeSession(
       FsmContext<State, Event> ctx, OpcUaClient client, OpcUaSession session) {
 
+    return closeSession(ctx, client, session.getSessionId(), session.getAuthenticationToken());
+  }
+
+  private static CompletableFuture<Unit> closeSession(
+      FsmContext<State, Event> ctx, OpcUaClient client, NodeId sessionId, NodeId authToken) {
+
     try {
       CompletableFuture<Unit> closeFuture = new CompletableFuture<>();
 
-      RequestHeader requestHeader =
-          client.newRequestHeader(session.getAuthenticationToken(), uint(5000));
+      RequestHeader requestHeader = client.newRequestHeader(authToken, uint(5000));
 
       CloseSessionRequest request = new CloseSessionRequest(requestHeader, true);
 
       try (MDCCloseable ignoredInstanceId = putInstanceId(ctx);
-          MDCCloseable ignoredSessionId = putSessionId(session)) {
+          MDCCloseable ignoredSessionId = putSessionId(sessionId)) {
 
         LOGGER.debug("Sending CloseSessionRequest...");
       }


### PR DESCRIPTION
## Summary

Corrects client-side Session establishment, reactivation, keep-alive accounting, and teardown in `SessionFsm` and `SessionFsmFactory`, under entry actions that throw, a Server that revises the Session timeout below the configured keep-alive interval, a channel lost before the client is watching for it, a definitive session-level status delivered as a channel-level Error, and a transport deliberately disconnected out from under an Active Session.

This began as a review of the two files. Twelve findings were raised; each was verified against the source and against the `strict-machine` and `netty-channel-fsm` sources before anything was changed. Eight were real and are fixed here, every one with a regression test that fails without the fix. The other four did not survive verification and are deliberately not addressed.

## FSM totality

`StrictMachine` sets the next state before it runs the matching transition actions, and it catches and merely logs whatever those actions throw. An entry action that throws before attaching the `whenComplete` that fires the corresponding Success/Failure event therefore leaves the FSM parked in the new state with no event pending, and no Session state has a timeout to kick it out again. `CloseSession` is shelved rather than acted on in `Creating`, `Activating`, `Transferring`, `Initializing` and `Reactivating`, and a shelved event's future completes only when a later transition drains the shelf, so a wedge takes `disconnect()` with it: `disconnectAsync()` has an `exceptionally` but no timeout, and a future that never completes is not an exceptional one.

`activateSession` and `reactivateSession` were already total for this reason. `createSession` and `closeSession` now are too. `createSession` had two synchronous throw sites reachable before the request is sent — `endpoint.getServer().getGatewayServerUri()` NPEs when the configured `EndpointDescription` carries no server, and `getSessionName().get()` invokes a user-supplied `Supplier` outside any guard — and its body is now wrapped the way the other two already wrap theirs, routing the original `Throwable` into the existing `whenComplete` and on to `CreatingWait` as any other CreateSession failure would.

`Transferring` was exposed by a different mechanism: `transferSubscriptions` returns `transferFuture` but completes it from inside a `whenComplete` whose own result future is discarded, so anything the callback throws is captured by a future nobody observes. The reachable throw is `requireNonNull(tsr.getResults())` against a Server answering Good with no Results array. An `exceptionally` on that discarded chain now guarantees `transferFuture` is always completed.

## Sessions abandoned on the Server

`CloseSessionRequest` was built in one place, whose only caller was the `Closing` entry action — and that action reads `KEY_SESSION`, a context key written only on entry to `Active`. Once CreateSession had succeeded, every establishment failure that followed dropped straight back to `CreatingWait` via `handleFailureToOpenSession`, which did nothing but fail the pending Session future. The `Activating`, `Transferring` and `Initializing` failure edges all abandoned a Session that exists on the Server with no way left to name it, since the failure events carry only a `Throwable`. The Server reaps such a Session only when its timeout elapses; nothing ties Session lifetime to the SecureChannel, and a rejected ActivateSession leaves the entry in `createdSessions`. With a 120s default revised timeout and the `CreatingWait` backoff capped at 16s, a persistent ActivateSession failure — wrong credentials, an untrusted X.509 identity — keeps a rolling set of roughly eight orphans alive indefinitely.

`KEY_PENDING_SESSION` now names the state the FSM had no word for: a Session that exists on the Server but is not yet reachable via `KEY_SESSION`. It holds the `CreateSessionResponse`, is set on the `Creating --CreateSessionSuccess--> Activating` edge where both the sessionId and the authentication token are in hand, and is removed on entry to `Active` beside `KEY_SESSION.set()`, so exactly one of the two keys ever refers to a live Session. `handleFailureToOpenSession` removes it and, when it is non-null, sends a best-effort CloseSession — one hook covering all three edges, and a no-op on the edges where nothing is pending. The `Reactivating --ReactivateSessionFailure--> CreatingWait` edge gets a close of its own, since what it abandons is the old Session rather than a pending one.

Both of these closes are new, and both send `deleteSubscriptions` false, so an abandoned Session's Subscriptions survive for the replacement Session's `TransferSubscriptions` to recover; an `abandonSession` overload names that intent beside `closeSession`. The `Closing` entry action — the explicit client-shutdown path, and the only CloseSession the base branch ever sent — still closes with deletion and is otherwise untouched.

## Reactivation

`Reactivating` had one edge to `CreatingWait`, guarded by a predicate asking whether `UaException.extract(failure)` produced a `UaServiceFaultException`. Every other `ReactivateSessionFailure` took the catch-all edge back to `ReactivatingWait`, where the wait doubles and saturates at 16s. That made the decision to abandon a Session turn on how the Server chose to frame its answer rather than on what the answer said. A Server replying to ActivateSession with a channel-level Error message produces a plain `UaException` carrying the same StatusCode — `InboundUascResponseHandler` builds it and `failAndClearPending` completes the in-flight ActivateSession with it — so `Bad_SessionIdInvalid`, `Bad_SessionClosed` and `Bad_SessionNotActivated` delivered that way never escalated, and the client re-sent ActivateSession every lap for a Session the Server had already said it no longer has. Part 4 §6.7 requires a new Session when ActivateSession fails, and that obligation does not depend on the message type the status arrived in.

The guard now keys on the StatusCode as well as the exception class. The `SESSION_ERROR` predicate naming the three definitive session-level statuses is hoisted out of `SessionFaultListener` to a top-level constant with its contents unchanged. Failures carrying no such status — `Bad_Timeout` or `Bad_ConnectionClosed` from a request timer or a dropped channel — are connectivity problems and deliberately keep the indefinite `ReactivatingWait` retry: Part 4 §5.7.2.1 has the client establish a new connection and call ActivateSession again, and dropping to CreateSession while the channel is merely down throws away a Session whose Subscriptions could still be transferred. Behavior against a conformant Server, Milo's own included, is unchanged.

Milo builds its ChannelFsm with `setLazy(false)` and `setPersistent(true)`, so a channel that drops unexpectedly reconnects without the Session doing anything. There is exactly one state that does not self-heal: `NotConnected`, reachable only through an explicit Disconnect, whose sole outbound edge is Connect and whose `GetChannel` completes immediately with a plain `Exception("not connected")`. An application calling `getTransport().disconnect()` while a Session is Active parks the transport somewhere nothing will move it from, and the Session did not notice — it left `Active` for `ReactivatingWait` either at once via the transition listener or one keep-alive interval later, and every reactivation attempt then failed with a bare `Exception` that carries no StatusCode and is not a `UaException`, so no escalation predicate could match. The FSM cycled `ReactivatingWait` ⇄ `Reactivating` at the 16s cap for the life of the client with every caller blocked in `getSession()` left hanging.

`Reactivating` now has a terminal edge to `Inactive`, guarded by the ordinary reactivation-failure predicate plus a check that the transport is an `OpcTcpClientTransport` whose ChannelFsm reads `NotConnected` — false for any other transport, so websocket and https behavior is untouched. The edge clears the wait time so a later Session starts from a fresh backoff, drops `KEY_SESSION`, logs one warning, and calls `handleFailureToOpenSession` so pending futures fail with the "not connected" cause instead of waiting forever. Leaving the FSM in `Inactive` keeps both exits open: the existing `onTransitionTo(Inactive)` action drains the shelf, so a `disconnect()` whose CloseSession was shelved still completes, and `Inactive --OpenSession--> Creating` means a subsequent `connect()` builds a fresh Session. The new edge is declared before the escalation to `CreatingWait` because `StrictMachine` takes the first matching transition, and escalating over a dead transport would only relocate the identical endless loop.

## Keep-alive

The `Event.KeepAlive` internal transition captured the machine-wide `ActionContext`, and its `whenComplete` read-modify-wrote a single machine-wide failure count with nothing tying the completion back to the Session epoch the Read was sent on. Leaving `Active` cancels the scheduled future, which stops new keep-alives but does not cancel one already sent, and the `Active --ServiceFault--> ReactivatingWait` edge never takes the channel down, so `failAndClearPending` never drains it. The Read stayed parked in the transport across the whole reactivation cycle and, when it finally failed, incremented the *new* epoch's count. With the default `keepAliveFailuresAllowed` of 1 that spends an interval of the new epoch's budget on an observation about a Session that is already gone; with two such stale failures it fires `Event.KeepAliveFailure` outright and closes a still-healthy channel on a Session the Server had just accepted an ActivateSession for. The read-modify-write was also non-atomic — a get under the read lock and a set under the write lock — so completions racing on the shared executor could lose an increment.

The count is now a per-epoch `AtomicLong` installed on entry to `Active`, so the instance itself identifies the epoch. The action captures that instance before sending, and the callback returns before touching shared state if the current state is not `Active`, if `KEY_SESSION` no longer holds the event's session, or if the key no longer holds the captured instance. The last check is load-bearing: on the ServiceFault route the session and the channel are the same and the next epoch is `Active` again, so only the per-epoch instance separates them.

The `RevisedSessionTimeout` the Server answers CreateSession with was stored on the `OpcUaSession` and exposed as `UaSession.getSessionTimeout()`, but nothing in sdk-client read it back. The keep-alive was scheduled straight from `OpcUaClientConfig.getKeepAliveInterval()`, so the one mechanism that keeps an otherwise idle Session alive was driven entirely by a number the client picked and never reconciled with the number the Server granted. Part 4 §5.7.2.2 makes that number binding. When the configured interval lands at or above the revised timeout the Session dies between keep-alives, and the recovery machinery hides it: the `Bad_SessionIdInvalid` on the next keep-alive becomes `Event.ServiceFault`, a new Session is created and activated, and all of it is at DEBUG — the WARN needs the failure count to exceed `keepAliveFailuresAllowed` and the ServiceFault edge pre-empts it. The backoff does not escalate either, since the wait time is cleared on entry to `Active`, so the client churns `Active → ReactivatingWait → Creating → Active` for as long as it stays connected, with fresh Subscription transfers each lap and nothing in the log saying why.

The interval is now derived from the Session actually established: the configured value is bounded at half the revised timeout, with a 1000 ms floor on the derived value so a Server revising to something very small cannot turn the keep-alive into a request flood. Half leaves room for exactly one keep-alive round trip to be lost before the Session expires, the same tolerance `keepAliveFailuresAllowed` already assumes. The outer `Math.min` means the clamp only ever lowers the interval, so it can only send more keep-alives than before, never fewer, and cannot break a configuration that was already working. A WARN naming all three numbers is emitted only when the clamp changes the value, once per Session epoch. With Milo defaults nothing changes at all.

## Connection loss during establishment

The `ChannelFsm.TransitionListener` that turns a secure channel drop into `Event.ConnectionLost` is constructed and registered inside the `Initializing --> Active` transition action, and it reacts only to the edge leaving `Connected`. netty-channel-fsm dispatches listeners synchronously over the snapshot taken while the event is being evaluated, so a `Connected --> ReconnectWait` edge evaluated before the listener was added is lost permanently: the rest of the reconnect cycle contains no further transition originating from `Connected`, and that is the only shape a drop takes for a non-lazy persistent FSM. The listener is also removed on every `Active --> non-Active` transition, so nothing is watching the channel while the Session is being established.

The window is wide rather than a narrow race. `runSequentially` wraps each initializer with `.exceptionally(ex -> Unit.VALUE)`, so a request failed with `Bad_ConnectionClosed` is swallowed and `Event.InitializeSuccess` fires anyway; the ChannelFsm learns of the loss from a pipeline handler on the netty thread, whereas the SessionFsm can only enqueue `InitializeSuccess` after the failed request's callback runs on the transport executor, so the ChannelFsm edge is evaluated first essentially every time. The result is a SessionFsm parked in `Active` holding a Session bound to a secure channel that no longer exists, with no `onSessionInactive` reported and application requests failing until the first request on the new channel draws `Bad_SecureChannelIdInvalid`. That fallback makes this delayed recovery rather than a permanently dead Session, but the delay is a keep-alive interval plus reconnect backoff, and it is paid in failed requests.

The action now re-reads `channelFsm.getState()` immediately after `addTransitionListener` and, if the ChannelFsm is no longer `Connected`, fires `Event.ConnectionLost` itself. The Session can only have been created and activated over a Connected channel, so a non-Connected state at that point means the channel was lost after the Session was established. The synthesized event is evaluated after the transition into `Active` completes, so it is consumed by the `Active --> ReactivatingWait` edge; a later duplicate from the listener is harmless, since `ConnectionLost` is consumed only in `Active`.

If the drop and the subsequent reconnect both complete before the action runs, the ChannelFsm is back in `Connected` and the state check cannot see it. Recognizing that would mean recording which channel instance the Session was bound to and comparing identities, a larger change than this is scoped for; that case remains covered by the `Bad_SecureChannelIdInvalid` path.

## TransferSubscriptions indexing

#1823 independently fixed the misindexing this branch was originally written for, capturing the ids sent and the Subscriptions they came from in one pass and bounding both result loops against that aligned list. The two fixes conflicted, and the pairing is kept here in record form rather than as two parallel `ArrayList`s: the failure mode both address is a pairing that has silently shifted, and a single list of `(subscription, id)` cannot shift against itself, whereas two lists have to be maintained in lockstep to stay aligned. The ids array is derived from that list, so the request and the results are indexed against the same thing by construction, and the debug-logging zip streams that same array rather than deriving the ids from the snapshot a third time — which was a third independently racy read. The failure loop keeps #1823's double bound and its synchronous `handleTransferFailure` cleanup.

What is new beyond #1823 is the early return on the filtered list: a snapshot of entirely id-less Subscriptions previously still sent a `TransferSubscriptionsRequest` carrying no SubscriptionIds.

## Behavior changes

- **The keep-alive interval is bounded by the revised Session timeout** — half of it, with a 1000 ms floor, and a WARN when the clamp changes the configured value. The clamp only ever lowers the interval. `getSessionTimeout()` keeps its current meaning as the raw revised value, and the configured value is not mutated.
- **A Session abandoned during establishment, or abandoned in favor of a replacement, is closed on the Server** rather than left to expire on its Session timeout. Both closes send `deleteSubscriptions` false, so the abandoned Session's Subscriptions remain transferable. The explicit client-shutdown close is unchanged and still deletes.
- **Reactivation escalates on the StatusCode**, so a definitive session-level status delivered as a channel-level Error now creates a new Session instead of retrying indefinitely.
- **Reactivation over a deliberately disconnected transport ends in `Inactive`** and fails pending `getSession()`/`openSession()` futures with the "not connected" cause, instead of cycling forever. A subsequent `connect()` builds a fresh Session.
- **A synchronous throw from `createSession` completes the caller's `openSession()` future** with that cause rather than wedging the FSM.
- **No `TransferSubscriptions` request is sent when no Subscription in the snapshot holds an id.**

🤖 Originally generated with [Claude Code](https://claude.com/claude-code); updated after subsequent code review.
