### PR TITLE
Fix Condition method dispatch on type nodes

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/methods/ManagedAddressSpaceMethodDispatchTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/methods/ManagedAddressSpaceMethodDispatchTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.methods;
+
+import static java.util.Objects.requireNonNull;
+import static org.eclipse.milo.opcua.stack.core.StatusCodes.Bad_MethodInvalid;
+import static org.eclipse.milo.opcua.stack.core.StatusCodes.Bad_NodeIdInvalid;
+import static org.eclipse.milo.opcua.stack.core.StatusCodes.Bad_SubscriptionIdInvalid;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import org.eclipse.milo.opcua.sdk.test.AbstractClientServerTest;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.structured.CallMethodRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.CallMethodResult;
+import org.eclipse.milo.opcua.stack.core.types.structured.CallResponse;
+import org.junit.jupiter.api.Test;
+
+public class ManagedAddressSpaceMethodDispatchTest extends AbstractClientServerTest {
+
+  @Test
+  void addCommentCannotBeInvokedOnConditionType() throws UaException {
+    assertModelledConditionMethodCannotBeInvokedOnTypeNode(
+        NodeIds.ConditionType, NodeIds.ConditionType_AddComment);
+  }
+
+  @Test
+  void acknowledgeCannotBeInvokedOnAcknowledgeableConditionType() throws UaException {
+    assertModelledConditionMethodCannotBeInvokedOnTypeNode(
+        NodeIds.AcknowledgeableConditionType, NodeIds.AcknowledgeableConditionType_Acknowledge);
+  }
+
+  @Test
+  void inheritedConditionMethodCannotBeInvokedOnConditionSubtype() throws UaException {
+    assertModelledConditionMethodCannotBeInvokedOnTypeNode(
+        NodeIds.AlarmConditionType, NodeIds.ConditionType_AddComment);
+  }
+
+  private void assertModelledConditionMethodCannotBeInvokedOnTypeNode(
+      NodeId objectTypeId, NodeId methodId) throws UaException {
+
+    var request = new CallMethodRequest(objectTypeId, methodId, new Variant[0]);
+
+    CallMethodResult result = call(request);
+
+    assertEquals(StatusCode.of(Bad_NodeIdInvalid), result.getStatusCode());
+  }
+
+  @Test
+  void unrelatedModelledMethodOnObjectTypeReturnsBadMethodInvalid() throws UaException {
+    var request =
+        new CallMethodRequest(
+            NodeIds.ServerType, NodeIds.ServerType_GetMonitoredItems, new Variant[0]);
+
+    CallMethodResult result = call(request);
+
+    assertEquals(StatusCode.of(Bad_MethodInvalid), result.getStatusCode());
+  }
+
+  @Test
+  void unmodelledObjectTypeMethodRemainsCallable() throws UaException {
+    var request =
+        new CallMethodRequest(
+            NodeIds.ConditionType,
+            NodeIds.ConditionType_ConditionRefresh,
+            new Variant[] {new Variant(UInteger.valueOf(0))});
+
+    CallMethodResult result = call(request);
+
+    assertEquals(StatusCode.of(Bad_SubscriptionIdInvalid), result.getStatusCode());
+  }
+
+  @Test
+  void objectInstanceMethodRemainsCallable() throws UaException {
+    var request =
+        new CallMethodRequest(
+            NodeIds.ObjectsFolder, newNodeId("sqrt(x)"), new Variant[] {new Variant(16.0)});
+
+    CallMethodResult result = call(request);
+
+    assertEquals(StatusCode.GOOD, result.getStatusCode());
+    assertEquals(new Variant(4.0), requireNonNull(result.getOutputArguments())[0]);
+  }
+
+  private CallMethodResult call(CallMethodRequest request) throws UaException {
+    CallResponse response = client.call(List.of(request));
+
+    return requireNonNull(response.getResults())[0];
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/ManagedAddressSpace.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/ManagedAddressSpace.java
@@ -10,6 +10,9 @@
 
 package org.eclipse.milo.opcua.sdk.server;
 
+import static org.eclipse.milo.opcua.sdk.core.Reference.COMPONENT_OF_PREDICATE;
+import static org.eclipse.milo.opcua.sdk.core.Reference.ORDERED_COMPONENT_OF_PREDICATE;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Semaphore;
@@ -23,6 +26,7 @@ import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectTypeNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaServerNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.factories.NodeFactory;
 import org.eclipse.milo.opcua.stack.core.AttributeId;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
@@ -278,6 +282,13 @@ public abstract class ManagedAddressSpace implements AddressSpace {
             .getNode(objectId)
             .orElseThrow(() -> new UaException(StatusCodes.Bad_NodeIdUnknown));
 
+    // ObjectTypes are valid targets for type-level Methods, so they cannot be rejected
+    // unconditionally. Validate modelled Methods before consulting ConditionManager; otherwise an
+    // instance Method called on its type node could reach a handler and return an unrelated error.
+    if (node instanceof UaObjectTypeNode objectTypeNode) {
+      validateObjectTypeMethodCall(objectTypeNode, methodId);
+    }
+
     MethodInvocationHandler conditionHandler =
         server.getConditionManager().findMethodInvocationHandler(objectId, methodId).orElse(null);
     if (conditionHandler != null) {
@@ -301,5 +312,54 @@ public abstract class ManagedAddressSpace implements AddressSpace {
     } else {
       throw new UaException(StatusCodes.Bad_MethodInvalid);
     }
+  }
+
+  /*
+   * Part 4 §5.12.2 permits an ObjectType as ObjectId only when the Method has no ModellingRule. A
+   * Method with a ModellingRule is an InstanceDeclaration, for which generic Call processing
+   * returns Bad_MethodInvalid. Part 9 §§5.5.6 and 5.7.3 specialize that result to Bad_NodeIdInvalid
+   * when a Condition instance Method such as AddComment or Acknowledge is called on a Condition
+   * type node.
+   */
+  private void validateObjectTypeMethodCall(UaObjectTypeNode objectTypeNode, NodeId methodId)
+      throws UaException {
+
+    UaNode requestedNode = server.getAddressSpaceManager().getManagedNode(methodId).orElse(null);
+
+    if (requestedNode instanceof UaMethodNode requestedMethod
+        && requestedMethod.getModellingRuleNode().isPresent()) {
+
+      long statusCode =
+          isConditionType(objectTypeNode.getNodeId()) && isConditionInstanceMethod(requestedMethod)
+              ? StatusCodes.Bad_NodeIdInvalid
+              : StatusCodes.Bad_MethodInvalid;
+
+      throw new UaException(statusCode);
+    }
+  }
+
+  /*
+   * Derive Condition ownership from the Method's inverse ComponentOf reference instead of keeping
+   * a list of Method NodeIds. This also covers inherited and vendor-defined Methods declared by a
+   * subtype of ConditionType.
+   */
+  private boolean isConditionInstanceMethod(UaMethodNode methodNode) {
+    return methodNode.getReferences().stream()
+        .filter(COMPONENT_OF_PREDICATE.or(ORDERED_COMPONENT_OF_PREDICATE))
+        .flatMap(
+            reference ->
+                server
+                    .getAddressSpaceManager()
+                    .getManagedNode(reference.getTargetNodeId())
+                    .stream())
+        .filter(UaObjectTypeNode.class::isInstance)
+        .map(UaObjectTypeNode.class::cast)
+        .anyMatch(typeNode -> isConditionType(typeNode.getNodeId()));
+  }
+
+  private boolean isConditionType(NodeId typeId) {
+    // TypeTree.isSubtypeOf() does not consider a type to be a subtype of itself.
+    return NodeIds.ConditionType.equals(typeId)
+        || server.getObjectTypeTree().isSubtypeOf(typeId, NodeIds.ConditionType);
   }
 }


### PR DESCRIPTION
## Summary

- reject modelled instance Methods before dispatch when the Call `ObjectId` is an `ObjectType`
- return the Part 9-required `Bad_NodeIdInvalid` for Condition instance Methods called on Condition type nodes
- preserve valid unmodelled type-level Methods, generic `Bad_MethodInvalid` behavior, and ordinary object-instance calls
- add focused integration coverage for Condition and non-Condition dispatch paths

## Root cause

`ManagedAddressSpace` allowed `UaObjectTypeNode` targets to reach normal Method and `ConditionManager` handler resolution. As a result, Acknowledge returned `Bad_MethodInvalid` and AddComment reached its default handler and returned `Bad_NotImplemented` when invoked on Condition type nodes.

Part 4 permits ObjectType calls for Methods without a ModellingRule, so rejecting every ObjectType target would also break legitimate type-level Methods such as `ConditionRefresh`. Part 9 specifically requires `Bad_NodeIdInvalid` when Condition instance Methods such as AddComment or Acknowledge are invoked on a Condition type node.

The fix classifies modelled Methods before handler lookup. Condition ownership is derived structurally from inverse `HasComponent`/`HasOrderedComponent` references and the ConditionType hierarchy rather than from a hard-coded list of Method NodeIds.

## Verification

- focused integration tests: 6 passed, 0 failed, 0 skipped
- `mise exec -- mvn -q spotless:apply`
- `mise exec -- mvn -q clean compile`
- unchanged demo server built against isolated fixed Milo `1.2.0-SNAPSHOT` artifacts
- OPC UA CTT 1.05.513 focused cases passed on all five dedicated fixtures:
  - A & C Acknowledge / `Err_008.js`
  - A & C Comment / `Err_003.js`
- full A & C Acknowledge, Comment, and Alarm units plus the combined three-unit selection completed with no target failures

CTT returned raw/normalized exit 1 because of setup warnings. Comment-only skips were for unavailable fixture scenarios; there were no manual results. The `QueryFirst`/`QueryNext` not-supported entries were after-test cleanup diagnostics, not target failures.
