### PR TITLE
Update Maven dependencies (2026-07-27)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
     <maven-failsafe-plugin.version>3.5.6</maven-failsafe-plugin.version>
     <maven-gpg-plugin.version>3.2.8</maven-gpg-plugin.version>
     <maven-install-plugin.version>3.1.4</maven-install-plugin.version>
-    <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>
+    <maven-jar-plugin.version>3.5.1</maven-jar-plugin.version>
     <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
     <maven-release-plugin.version>3.3.1</maven-release-plugin.version>
     <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
@@ -96,7 +96,7 @@
     <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
     <spotless-maven-plugin.version>3.8.0</spotless-maven-plugin.version>
     <versions-maven-plugin.version>2.21.0</versions-maven-plugin.version>
-    <flatten-maven-plugin.version>1.7.3</flatten-maven-plugin.version>
+    <flatten-maven-plugin.version>1.8.0</flatten-maven-plugin.version>
 
     <!-- Test Dependency Versions -->
     <junit.version>6.1.2</junit.version>


### PR DESCRIPTION
## Summary

Updated stable Maven build plugin versions reported by the Maven Versions Plugin:

| Plugin | Old | New |
|---|---:|---:|
| `org.apache.maven.plugins:maven-jar-plugin` | `3.5.0` | `3.5.1` |
| `org.codehaus.mojo:flatten-maven-plugin` | `1.7.3` | `1.8.0` |

No dependency updates were reported.

## Skipped prerelease/non-stable suggestions

None. The repository's `versions-maven-plugin` rule set filtered prerelease-style versions and preserved configured compatibility pins, including Netty `< 4.2.0` and Checkstyle `< 13.0.0`.

## Verification

Report-only checks:

- `mise exec -- mvn versions:display-dependency-updates` - passed; no dependency updates reported (`/tmp/maven_dependency_updates.log`)
- `mise exec -- mvn versions:display-plugin-updates` - passed; reported the two plugin updates above (`/tmp/maven_plugin_updates.log`)

Verification checks:

- `mise exec -- mvn -q dependency:resolve` - initially failed on a clean `origin/main` baseline and this branch because fresh worktrees lacked locally installed reactor SNAPSHOT artifacts (`milo-guava-dependencies`, then `milo-stack-core`).
- `mise exec -- mvn -q install -DskipTests` - passed as a local reactor SNAPSHOT recovery step (`/tmp/maven_install_20260727101312.log`)
- `mise exec -- mvn -q dependency:resolve` - passed after reactor install (`/tmp/maven_dependency_resolve_20260727101452.log`)
- `mise exec -- mvn -q spotless:apply` - passed (`/tmp/maven_spotless_apply_20260727101503.log`)
- `mise exec -- mvn -q clean compile` - passed (`/tmp/maven_clean_compile_20260727101509.log`)
- `mise exec -- mvn -q clean verify` - passed (`/tmp/maven_clean_verify_20260727101529.log`)

## Review

Codex subagent review returned `APPROVED` for the POM-only plugin updates.
