### PR TITLE
Improve binary serialization performance

### DIFF
--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryDecoder.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryDecoder.java
@@ -22,7 +22,6 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
@@ -62,7 +61,15 @@ public class OpcUaBinaryDecoder implements UaDecoder {
   private int currentByte = 0;
   private int bitsRemaining = 0;
 
-  private final AtomicInteger depth = new AtomicInteger(0);
+  /**
+   * Nesting level of the decode in progress, used to bound recursion.
+   *
+   * <p>Not synchronized, and does not need to be: a decoder instance is confined to one thread at a
+   * time, the same way the mutable {@link #buffer} field is. {@code SerializationQueue} shares an
+   * instance behind a task queue that serializes decodes, and the client and server UASC handlers
+   * each own a channel-confined instance.
+   */
+  private int depth = 0;
 
   private final EncodingContext context;
 
@@ -235,13 +242,13 @@ public class OpcUaBinaryDecoder implements UaDecoder {
   }
 
   public DiagnosticInfo decodeDiagnosticInfo() throws UaSerializationException {
-    if (depth.get() >= context.getEncodingLimits().getMaxRecursionDepth()) {
+    if (depth >= context.getEncodingLimits().getMaxRecursionDepth()) {
       throw new UaSerializationException(
           StatusCodes.Bad_EncodingLimitsExceeded,
           "max recursion depth exceeded: " + context.getEncodingLimits().getMaxRecursionDepth());
     }
 
-    depth.incrementAndGet();
+    depth++;
     try {
       int mask = buffer.readByte();
 
@@ -267,7 +274,7 @@ public class OpcUaBinaryDecoder implements UaDecoder {
             innerDiagnosticInfo);
       }
     } finally {
-      depth.decrementAndGet();
+      depth--;
     }
   }
 
@@ -384,13 +391,13 @@ public class OpcUaBinaryDecoder implements UaDecoder {
   }
 
   public Variant decodeVariant() throws UaSerializationException {
-    if (depth.get() >= context.getEncodingLimits().getMaxRecursionDepth()) {
+    if (depth >= context.getEncodingLimits().getMaxRecursionDepth()) {
       throw new UaSerializationException(
           StatusCodes.Bad_EncodingLimitsExceeded,
           "max recursion depth exceeded: " + context.getEncodingLimits().getMaxRecursionDepth());
     }
 
-    depth.incrementAndGet();
+    depth++;
     try {
       int encodingMask = buffer.readByte();
 
@@ -441,7 +448,7 @@ public class OpcUaBinaryDecoder implements UaDecoder {
         }
       }
     } finally {
-      depth.decrementAndGet();
+      depth--;
     }
   }
 

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryDecoder.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryDecoder.java
@@ -81,7 +81,7 @@ public class OpcUaBinaryDecoder implements UaDecoder {
   }
 
   public <T> T[] decodeArray(Supplier<T> read, Class<T> clazz) throws UaSerializationException {
-    int length = decodeInt32();
+    int length = buffer.readIntLE();
 
     if (length == -1) {
       return null;
@@ -184,7 +184,7 @@ public class OpcUaBinaryDecoder implements UaDecoder {
   }
 
   public ByteString decodeByteString() throws UaSerializationException {
-    int length = decodeInt32();
+    int length = buffer.readIntLE();
 
     if (length == -1) {
       return ByteString.NULL_VALUE;
@@ -248,10 +248,10 @@ public class OpcUaBinaryDecoder implements UaDecoder {
       if (mask == 0) {
         return null;
       } else {
-        int symbolicId = ((mask & 0x01) == 0x01) ? decodeInt32() : -1;
-        int namespaceUri = ((mask & 0x02) == 0x02) ? decodeInt32() : -1;
-        int localizedText = ((mask & 0x04) == 0x04) ? decodeInt32() : -1;
-        int locale = ((mask & 0x08) == 0x08) ? decodeInt32() : -1;
+        int symbolicId = ((mask & 0x01) == 0x01) ? buffer.readIntLE() : -1;
+        int namespaceUri = ((mask & 0x02) == 0x02) ? buffer.readIntLE() : -1;
+        int localizedText = ((mask & 0x04) == 0x04) ? buffer.readIntLE() : -1;
+        int locale = ((mask & 0x08) == 0x08) ? buffer.readIntLE() : -1;
         String additionalInfo = ((mask & 0x10) == 0x10) ? decodeString() : null;
         StatusCode innerStatusCode = ((mask & 0x20) == 0x20) ? decodeStatusCode() : null;
         DiagnosticInfo innerDiagnosticInfo =
@@ -402,7 +402,7 @@ public class OpcUaBinaryDecoder implements UaDecoder {
         boolean arrayEncoded = (encodingMask & 0x80) == 0x80;
 
         if (arrayEncoded) {
-          int length = decodeInt32();
+          int length = buffer.readIntLE();
 
           if (length == -1) {
             return new Variant(null);
@@ -447,7 +447,7 @@ public class OpcUaBinaryDecoder implements UaDecoder {
 
   @Nullable
   private String decodeLengthPrefixedString(Charset charset) {
-    int length = decodeInt32();
+    int length = buffer.readIntLE();
 
     if (length == -1) {
       return null;
@@ -483,7 +483,7 @@ public class OpcUaBinaryDecoder implements UaDecoder {
   }
 
   private int[] decodeDimensions() {
-    int length = decodeInt32();
+    int length = buffer.readIntLE();
 
     if (length == -1) {
       return new int[0];
@@ -492,7 +492,7 @@ public class OpcUaBinaryDecoder implements UaDecoder {
 
       int[] is = new int[length];
       for (int i = 0; i < length; i++) {
-        is[i] = decodeInt32();
+        is[i] = buffer.readIntLE();
       }
       return is;
     }
@@ -910,7 +910,7 @@ public class OpcUaBinaryDecoder implements UaDecoder {
 
   @Override
   public Boolean[] decodeBooleanArray(String field) throws UaSerializationException {
-    int length = decodeInt32();
+    int length = buffer.readIntLE();
 
     if (length == -1) {
       return null;
@@ -927,7 +927,7 @@ public class OpcUaBinaryDecoder implements UaDecoder {
 
   @Override
   public Byte[] decodeSByteArray(String field) throws UaSerializationException {
-    int length = decodeInt32();
+    int length = buffer.readIntLE();
 
     if (length == -1) {
       return null;
@@ -944,7 +944,7 @@ public class OpcUaBinaryDecoder implements UaDecoder {
 
   @Override
   public Short[] decodeInt16Array(String field) throws UaSerializationException {
-    int length = decodeInt32();
+    int length = buffer.readIntLE();
 
     if (length == -1) {
       return null;
@@ -961,7 +961,7 @@ public class OpcUaBinaryDecoder implements UaDecoder {
 
   @Override
   public Integer[] decodeInt32Array(String field) throws UaSerializationException {
-    int length = decodeInt32();
+    int length = buffer.readIntLE();
 
     if (length == -1) {
       return null;
@@ -978,7 +978,7 @@ public class OpcUaBinaryDecoder implements UaDecoder {
 
   @Override
   public Long[] decodeInt64Array(String field) throws UaSerializationException {
-    int length = decodeInt32();
+    int length = buffer.readIntLE();
 
     if (length == -1) {
       return null;
@@ -995,7 +995,7 @@ public class OpcUaBinaryDecoder implements UaDecoder {
 
   @Override
   public UByte[] decodeByteArray(String field) throws UaSerializationException {
-    int length = decodeInt32();
+    int length = buffer.readIntLE();
 
     if (length == -1) {
       return null;
@@ -1012,7 +1012,7 @@ public class OpcUaBinaryDecoder implements UaDecoder {
 
   @Override
   public UShort[] decodeUInt16Array(String field) throws UaSerializationException {
-    int length = decodeInt32();
+    int length = buffer.readIntLE();
 
     if (length == -1) {
       return null;
@@ -1029,7 +1029,7 @@ public class OpcUaBinaryDecoder implements UaDecoder {
 
   @Override
   public UInteger[] decodeUInt32Array(String field) throws UaSerializationException {
-    int length = decodeInt32();
+    int length = buffer.readIntLE();
 
     if (length == -1) {
       return null;
@@ -1046,7 +1046,7 @@ public class OpcUaBinaryDecoder implements UaDecoder {
 
   @Override
   public ULong[] decodeUInt64Array(String field) throws UaSerializationException {
-    int length = decodeInt32();
+    int length = buffer.readIntLE();
 
     if (length == -1) {
       return null;
@@ -1063,7 +1063,7 @@ public class OpcUaBinaryDecoder implements UaDecoder {
 
   @Override
   public Float[] decodeFloatArray(String field) throws UaSerializationException {
-    int length = decodeInt32();
+    int length = buffer.readIntLE();
 
     if (length == -1) {
       return null;
@@ -1080,7 +1080,7 @@ public class OpcUaBinaryDecoder implements UaDecoder {
 
   @Override
   public Double[] decodeDoubleArray(String field) throws UaSerializationException {
-    int length = decodeInt32();
+    int length = buffer.readIntLE();
 
     if (length == -1) {
       return null;
@@ -1097,7 +1097,7 @@ public class OpcUaBinaryDecoder implements UaDecoder {
 
   @Override
   public String[] decodeStringArray(String field) throws UaSerializationException {
-    int length = decodeInt32();
+    int length = buffer.readIntLE();
 
     if (length == -1) {
       return null;
@@ -1114,7 +1114,7 @@ public class OpcUaBinaryDecoder implements UaDecoder {
 
   @Override
   public DateTime[] decodeDateTimeArray(String field) throws UaSerializationException {
-    int length = decodeInt32();
+    int length = buffer.readIntLE();
 
     if (length == -1) {
       return null;
@@ -1131,7 +1131,7 @@ public class OpcUaBinaryDecoder implements UaDecoder {
 
   @Override
   public UUID[] decodeGuidArray(String field) throws UaSerializationException {
-    int length = decodeInt32();
+    int length = buffer.readIntLE();
 
     if (length == -1) {
       return null;
@@ -1148,7 +1148,7 @@ public class OpcUaBinaryDecoder implements UaDecoder {
 
   @Override
   public ByteString[] decodeByteStringArray(String field) throws UaSerializationException {
-    int length = decodeInt32();
+    int length = buffer.readIntLE();
 
     if (length == -1) {
       return null;
@@ -1165,7 +1165,7 @@ public class OpcUaBinaryDecoder implements UaDecoder {
 
   @Override
   public XmlElement[] decodeXmlElementArray(String field) throws UaSerializationException {
-    int length = decodeInt32();
+    int length = buffer.readIntLE();
 
     if (length == -1) {
       return null;
@@ -1182,7 +1182,7 @@ public class OpcUaBinaryDecoder implements UaDecoder {
 
   @Override
   public NodeId[] decodeNodeIdArray(String field) throws UaSerializationException {
-    int length = decodeInt32();
+    int length = buffer.readIntLE();
 
     if (length == -1) {
       return null;
@@ -1199,7 +1199,7 @@ public class OpcUaBinaryDecoder implements UaDecoder {
 
   @Override
   public ExpandedNodeId[] decodeExpandedNodeIdArray(String field) throws UaSerializationException {
-    int length = decodeInt32();
+    int length = buffer.readIntLE();
 
     if (length == -1) {
       return null;
@@ -1216,7 +1216,7 @@ public class OpcUaBinaryDecoder implements UaDecoder {
 
   @Override
   public StatusCode[] decodeStatusCodeArray(String field) throws UaSerializationException {
-    int length = decodeInt32();
+    int length = buffer.readIntLE();
 
     if (length == -1) {
       return null;
@@ -1233,7 +1233,7 @@ public class OpcUaBinaryDecoder implements UaDecoder {
 
   @Override
   public QualifiedName[] decodeQualifiedNameArray(String field) throws UaSerializationException {
-    int length = decodeInt32();
+    int length = buffer.readIntLE();
 
     if (length == -1) {
       return null;
@@ -1250,7 +1250,7 @@ public class OpcUaBinaryDecoder implements UaDecoder {
 
   @Override
   public LocalizedText[] decodeLocalizedTextArray(String field) throws UaSerializationException {
-    int length = decodeInt32();
+    int length = buffer.readIntLE();
 
     if (length == -1) {
       return null;
@@ -1268,7 +1268,7 @@ public class OpcUaBinaryDecoder implements UaDecoder {
   @Override
   public ExtensionObject[] decodeExtensionObjectArray(String field)
       throws UaSerializationException {
-    int length = decodeInt32();
+    int length = buffer.readIntLE();
 
     if (length == -1) {
       return null;
@@ -1285,7 +1285,7 @@ public class OpcUaBinaryDecoder implements UaDecoder {
 
   @Override
   public DataValue[] decodeDataValueArray(String field) throws UaSerializationException {
-    int length = decodeInt32();
+    int length = buffer.readIntLE();
 
     if (length == -1) {
       return null;
@@ -1302,7 +1302,7 @@ public class OpcUaBinaryDecoder implements UaDecoder {
 
   @Override
   public Variant[] decodeVariantArray(String field) throws UaSerializationException {
-    int length = decodeInt32();
+    int length = buffer.readIntLE();
 
     if (length == -1) {
       return null;
@@ -1319,7 +1319,7 @@ public class OpcUaBinaryDecoder implements UaDecoder {
 
   @Override
   public DiagnosticInfo[] decodeDiagnosticInfoArray(String field) throws UaSerializationException {
-    int length = decodeInt32();
+    int length = buffer.readIntLE();
 
     if (length == -1) {
       return null;
@@ -1343,7 +1343,7 @@ public class OpcUaBinaryDecoder implements UaDecoder {
   public UaStructuredType @Nullable [] decodeStructArray(String field, NodeId dataTypeId)
       throws UaSerializationException {
 
-    int length = decodeInt32();
+    int length = buffer.readIntLE();
 
     if (length == -1) {
       return null;
@@ -1436,7 +1436,7 @@ public class OpcUaBinaryDecoder implements UaDecoder {
   private <T> T[] decodeArray(String field, Function<String, T> decoder, Class<T> clazz)
       throws UaSerializationException {
 
-    int length = decodeInt32();
+    int length = buffer.readIntLE();
 
     if (length == -1) {
       return null;
@@ -1511,7 +1511,7 @@ public class OpcUaBinaryDecoder implements UaDecoder {
   }
 
   private int @Nullable [] decodeMatrixDimensions() {
-    int length = decodeInt32(null);
+    int length = buffer.readIntLE();
 
     if (length == -1) {
       return null;
@@ -1520,7 +1520,7 @@ public class OpcUaBinaryDecoder implements UaDecoder {
 
       int[] dimensions = new int[length];
       for (int i = 0; i < length; i++) {
-        dimensions[i] = decodeInt32(null);
+        dimensions[i] = buffer.readIntLE();
       }
 
       return dimensions;

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryDecoder.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryDecoder.java
@@ -402,7 +402,6 @@ public class OpcUaBinaryDecoder implements UaDecoder {
         boolean arrayEncoded = (encodingMask & 0x80) == 0x80;
 
         if (arrayEncoded) {
-          Class<?> backingClass = OpcUaDataType.getBackingClass(typeId);
           int length = decodeInt32();
 
           if (length == -1) {
@@ -410,14 +409,7 @@ public class OpcUaBinaryDecoder implements UaDecoder {
           } else {
             checkArrayLength(length);
 
-            // TODO speed this up by switching on BuiltinDataType instead of using reflection
-            Object flatArray = Array.newInstance(backingClass, length);
-
-            for (int i = 0; i < length; i++) {
-              Object element = decodeBuiltinType(typeId);
-
-              Array.set(flatArray, i, element);
-            }
+            Object flatArray = decodeBuiltinTypeArray(typeId, length);
 
             int[] dimensions = dimensionsEncoded ? decodeDimensions() : new int[] {length};
 
@@ -533,6 +525,203 @@ public class OpcUaBinaryDecoder implements UaDecoder {
       case 23 -> decodeDataValue();
       case 24 -> decodeVariant();
       case 25 -> decodeDiagnosticInfo();
+      default ->
+          throw new UaSerializationException(
+              StatusCodes.Bad_DecodingError, "unknown builtin type: " + typeId);
+    };
+  }
+
+  /**
+   * Decode {@code length} elements of the builtin type identified by {@code typeId} into a new
+   * array.
+   *
+   * <p>The component type of the returned array is the builtin type's backing class, i.e. the same
+   * {@link Class} that {@link OpcUaDataType#getBackingClass(int)} reports for {@code typeId}.
+   * Callers rely on this: {@link Matrix} and {@link Variant} both derive their DataType from the
+   * component type, including when the array is empty.
+   *
+   * @param typeId the id of the builtin type to decode.
+   * @param length the number of elements to decode.
+   * @return an array of {@code length} decoded elements.
+   * @throws UaSerializationException if {@code typeId} is not a builtin type id.
+   */
+  private Object decodeBuiltinTypeArray(int typeId, int length) throws UaSerializationException {
+    return switch (typeId) {
+      case 1 -> {
+        Boolean[] values = new Boolean[length];
+        for (int i = 0; i < length; i++) {
+          values[i] = decodeBoolean();
+        }
+        yield values;
+      }
+      case 2 -> {
+        Byte[] values = new Byte[length];
+        for (int i = 0; i < length; i++) {
+          values[i] = decodeSByte();
+        }
+        yield values;
+      }
+      case 3 -> {
+        UByte[] values = new UByte[length];
+        for (int i = 0; i < length; i++) {
+          values[i] = decodeByte();
+        }
+        yield values;
+      }
+      case 4 -> {
+        Short[] values = new Short[length];
+        for (int i = 0; i < length; i++) {
+          values[i] = decodeInt16();
+        }
+        yield values;
+      }
+      case 5 -> {
+        UShort[] values = new UShort[length];
+        for (int i = 0; i < length; i++) {
+          values[i] = decodeUInt16();
+        }
+        yield values;
+      }
+      case 6 -> {
+        Integer[] values = new Integer[length];
+        for (int i = 0; i < length; i++) {
+          values[i] = decodeInt32();
+        }
+        yield values;
+      }
+      case 7 -> {
+        UInteger[] values = new UInteger[length];
+        for (int i = 0; i < length; i++) {
+          values[i] = decodeUInt32();
+        }
+        yield values;
+      }
+      case 8 -> {
+        Long[] values = new Long[length];
+        for (int i = 0; i < length; i++) {
+          values[i] = decodeInt64();
+        }
+        yield values;
+      }
+      case 9 -> {
+        ULong[] values = new ULong[length];
+        for (int i = 0; i < length; i++) {
+          values[i] = decodeUInt64();
+        }
+        yield values;
+      }
+      case 10 -> {
+        Float[] values = new Float[length];
+        for (int i = 0; i < length; i++) {
+          values[i] = decodeFloat();
+        }
+        yield values;
+      }
+      case 11 -> {
+        Double[] values = new Double[length];
+        for (int i = 0; i < length; i++) {
+          values[i] = decodeDouble();
+        }
+        yield values;
+      }
+      case 12 -> {
+        String[] values = new String[length];
+        for (int i = 0; i < length; i++) {
+          values[i] = decodeString();
+        }
+        yield values;
+      }
+      case 13 -> {
+        DateTime[] values = new DateTime[length];
+        for (int i = 0; i < length; i++) {
+          values[i] = decodeDateTime();
+        }
+        yield values;
+      }
+      case 14 -> {
+        UUID[] values = new UUID[length];
+        for (int i = 0; i < length; i++) {
+          values[i] = decodeGuid();
+        }
+        yield values;
+      }
+      case 15 -> {
+        ByteString[] values = new ByteString[length];
+        for (int i = 0; i < length; i++) {
+          values[i] = decodeByteString();
+        }
+        yield values;
+      }
+      case 16 -> {
+        XmlElement[] values = new XmlElement[length];
+        for (int i = 0; i < length; i++) {
+          values[i] = decodeXmlElement();
+        }
+        yield values;
+      }
+      case 17 -> {
+        NodeId[] values = new NodeId[length];
+        for (int i = 0; i < length; i++) {
+          values[i] = decodeNodeId();
+        }
+        yield values;
+      }
+      case 18 -> {
+        ExpandedNodeId[] values = new ExpandedNodeId[length];
+        for (int i = 0; i < length; i++) {
+          values[i] = decodeExpandedNodeId();
+        }
+        yield values;
+      }
+      case 19 -> {
+        StatusCode[] values = new StatusCode[length];
+        for (int i = 0; i < length; i++) {
+          values[i] = decodeStatusCode();
+        }
+        yield values;
+      }
+      case 20 -> {
+        QualifiedName[] values = new QualifiedName[length];
+        for (int i = 0; i < length; i++) {
+          values[i] = decodeQualifiedName();
+        }
+        yield values;
+      }
+      case 21 -> {
+        LocalizedText[] values = new LocalizedText[length];
+        for (int i = 0; i < length; i++) {
+          values[i] = decodeLocalizedText();
+        }
+        yield values;
+      }
+      case 22 -> {
+        ExtensionObject[] values = new ExtensionObject[length];
+        for (int i = 0; i < length; i++) {
+          values[i] = decodeExtensionObject();
+        }
+        yield values;
+      }
+      case 23 -> {
+        DataValue[] values = new DataValue[length];
+        for (int i = 0; i < length; i++) {
+          values[i] = decodeDataValue();
+        }
+        yield values;
+      }
+      case 24 -> {
+        Variant[] values = new Variant[length];
+        for (int i = 0; i < length; i++) {
+          values[i] = decodeVariant();
+        }
+        yield values;
+      }
+      case 25 -> {
+        DiagnosticInfo[] values = new DiagnosticInfo[length];
+        for (int i = 0; i < length; i++) {
+          values[i] = decodeDiagnosticInfo();
+        }
+        yield values;
+      }
       default ->
           throw new UaSerializationException(
               StatusCodes.Bad_DecodingError, "unknown builtin type: " + typeId);
@@ -1275,15 +1464,7 @@ public class OpcUaBinaryDecoder implements UaDecoder {
 
     int length = calculateMatrixLength(dimensions);
 
-    // TODO speed this up by switching on BuiltinDataType instead of using reflection
-    Class<?> backingClass = dataType.getBackingClass();
-    Object flatArray = Array.newInstance(backingClass, length);
-
-    for (int i = 0; i < length; i++) {
-      Object element = decodeBuiltinType(dataType.getTypeId());
-
-      Array.set(flatArray, i, element);
-    }
+    Object flatArray = decodeBuiltinTypeArray(dataType.getTypeId(), length);
 
     return new Matrix(flatArray, dimensions, dataType);
   }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryDecoder.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryDecoder.java
@@ -376,7 +376,7 @@ public class OpcUaBinaryDecoder implements UaDecoder {
   }
 
   public StatusCode decodeStatusCode() throws UaSerializationException {
-    return new StatusCode(decodeUInt32());
+    return new StatusCode(buffer.readUnsignedIntLE());
   }
 
   public String decodeString() throws UaSerializationException {

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryDecoder.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryDecoder.java
@@ -1357,16 +1357,13 @@ public class OpcUaBinaryDecoder implements UaDecoder {
             StatusCodes.Bad_DecodingError, "no codec registered: " + dataTypeId);
       }
 
-      Class<?> clazz = codec.getType();
-      Object array = Array.newInstance(clazz, length);
+      UaStructuredType[] array = (UaStructuredType[]) Array.newInstance(codec.getType(), length);
 
       for (int i = 0; i < length; i++) {
-        Object value = codec.decode(context, this);
-
-        Array.set(array, i, value);
+        array[i] = codec.decode(context, this);
       }
 
-      return (UaStructuredType[]) array;
+      return array;
     }
   }
 
@@ -1489,13 +1486,10 @@ public class OpcUaBinaryDecoder implements UaDecoder {
           StatusCodes.Bad_DecodingError, "no codec registered: " + dataTypeId);
     }
 
-    Class<?> clazz = codec.getType();
-    Object flatArray = Array.newInstance(clazz, length);
+    UaStructuredType[] flatArray = (UaStructuredType[]) Array.newInstance(codec.getType(), length);
 
     for (int i = 0; i < length; i++) {
-      Object value = codec.decode(context, this);
-
-      Array.set(flatArray, i, value);
+      flatArray[i] = codec.decode(context, this);
     }
 
     return new Matrix(flatArray, dimensions, OpcUaDataType.ExtensionObject, dataTypeId.expanded());

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryDecoder.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryDecoder.java
@@ -1493,7 +1493,9 @@ public class OpcUaBinaryDecoder implements UaDecoder {
           StatusCodes.Bad_DecodingError, "no codec registered: " + dataTypeId);
     }
 
-    UaStructuredType[] flatArray = (UaStructuredType[]) Array.newInstance(codec.getType(), length);
+    // Kept as Object[]: DataTypeCodec.getType() is unbounded, so generic codecs may report a
+    // component type that is not a UaStructuredType (the encoder supports such matrices too).
+    Object[] flatArray = (Object[]) Array.newInstance(codec.getType(), length);
 
     for (int i = 0; i < length; i++) {
       flatArray[i] = codec.decode(context, this);

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryEncoder.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryEncoder.java
@@ -1420,15 +1420,10 @@ public class OpcUaBinaryEncoder implements UaEncoder {
       int length = Array.getLength(elements);
       assert length == Arrays.stream(dimensions).reduce(1, (left, right) -> left * right);
 
-      if (elements instanceof UaEnumeratedType[] values) {
-        for (int i = 0; i < length; i++) {
-          encodeEnum(null, values[i]);
-        }
-      } else {
-        // Generic codecs build their matrices as Object[], which is not a UaEnumeratedType[].
-        for (int i = 0; i < length; i++) {
-          encodeEnum(null, (UaEnumeratedType) Array.get(elements, i));
-        }
+      // Object[] covers both UaEnumeratedType[] and the Object[] built by generic codecs.
+      Object[] values = (Object[]) elements;
+      for (int i = 0; i < length; i++) {
+        encodeEnum(null, (UaEnumeratedType) values[i]);
       }
     }
   }
@@ -1458,15 +1453,10 @@ public class OpcUaBinaryEncoder implements UaEncoder {
       int length = Array.getLength(elements);
       assert length == Arrays.stream(dimensions).reduce(1, (left, right) -> left * right);
 
-      if (elements instanceof UaStructuredType[] values) {
-        for (int i = 0; i < length; i++) {
-          encodeStruct(null, values[i], dataTypeId);
-        }
-      } else {
-        // Generic codecs build their matrices as Object[], which is not a UaStructuredType[].
-        for (int i = 0; i < length; i++) {
-          encodeStruct(null, (UaStructuredType) Array.get(elements, i), dataTypeId);
-        }
+      // Object[] covers both UaStructuredType[] and the Object[] built by generic codecs.
+      Object[] values = (Object[]) elements;
+      for (int i = 0; i < length; i++) {
+        encodeStruct(null, (UaStructuredType) values[i], dataTypeId);
       }
     }
   }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryEncoder.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryEncoder.java
@@ -634,10 +634,14 @@ public class OpcUaBinaryEncoder implements UaEncoder {
           int length = Array.getLength(value);
           buffer.writeIntLE(length);
 
-          for (int i = 0; i < length; i++) {
-            Object o = Array.get(value, i);
+          if (isPlainBuiltinArray(typeId, value)) {
+            encodeBuiltinTypeArray(typeId, value, length);
+          } else {
+            for (int i = 0; i < length; i++) {
+              Object o = Array.get(value, i);
 
-            encodeValue(o, typeId, structure, enumeration, optionSet);
+              encodeValue(o, typeId, structure, enumeration, optionSet);
+            }
           }
         } else {
           int[] dimensions = ((Matrix) value).getDimensions();
@@ -648,10 +652,14 @@ public class OpcUaBinaryEncoder implements UaEncoder {
           int length = Array.getLength(elements);
           buffer.writeIntLE(length);
 
-          for (int i = 0; i < length; i++) {
-            Object o = Array.get(elements, i);
+          if (isPlainBuiltinArray(typeId, elements)) {
+            encodeBuiltinTypeArray(typeId, elements, length);
+          } else {
+            for (int i = 0; i < length; i++) {
+              Object o = Array.get(elements, i);
 
-            encodeValue(o, typeId, structure, enumeration, optionSet);
+              encodeValue(o, typeId, structure, enumeration, optionSet);
+            }
           }
 
           encodeInt32(dimensions.length);
@@ -766,6 +774,176 @@ public class OpcUaBinaryEncoder implements UaEncoder {
       default:
         throw new UaSerializationException(
             StatusCodes.Bad_EncodingError, "unknown builtin type: " + typeId);
+    }
+  }
+
+  /**
+   * Test whether {@code array} holds the builtin type identified by {@code typeId} directly, in
+   * either its boxed or its primitive representation.
+   *
+   * <p>False for arrays that need per-element conversion before encoding: arrays of {@link
+   * UaStructuredType}, {@link UaEnumeratedType}, or {@link OptionSetUInteger}, and arrays typed as
+   * a supertype or subtype of the builtin's backing class.
+   *
+   * @param typeId the id of the builtin type being encoded.
+   * @param array the array to test.
+   * @return {@code true} if {@link #encodeBuiltinTypeArray} can encode {@code array}.
+   */
+  private static boolean isPlainBuiltinArray(int typeId, Object array) {
+    Class<?> componentType = array.getClass().getComponentType();
+
+    return componentType != null
+        && (componentType == OpcUaDataType.getBackingClass(typeId)
+            || componentType == OpcUaDataType.getPrimitiveBackingClass(typeId));
+  }
+
+  /**
+   * Encode the first {@code length} elements of {@code array} as the builtin type identified by
+   * {@code typeId}.
+   *
+   * <p>Only valid when {@link #isPlainBuiltinArray} holds for {@code typeId} and {@code array}; the
+   * casts below rely on it. Both representations of a builtin type are accepted, e.g. Int32 values
+   * may arrive as {@code Integer[]} or as {@code int[]}.
+   *
+   * @param typeId the id of the builtin type to encode.
+   * @param array the array holding the elements to encode.
+   * @param length the number of elements to encode.
+   */
+  private void encodeBuiltinTypeArray(int typeId, Object array, int length)
+      throws UaSerializationException {
+
+    switch (typeId) {
+      case 1 -> {
+        if (array instanceof boolean[] values) {
+          for (int i = 0; i < length; i++) buffer.writeBoolean(values[i]);
+        } else {
+          Boolean[] values = (Boolean[]) array;
+          for (int i = 0; i < length; i++) encodeBoolean(values[i]);
+        }
+      }
+      case 2 -> {
+        if (array instanceof byte[] values) {
+          for (int i = 0; i < length; i++) buffer.writeByte(values[i]);
+        } else {
+          Byte[] values = (Byte[]) array;
+          for (int i = 0; i < length; i++) encodeSByte(values[i]);
+        }
+      }
+      case 3 -> {
+        UByte[] values = (UByte[]) array;
+        for (int i = 0; i < length; i++) encodeByte(values[i]);
+      }
+      case 4 -> {
+        if (array instanceof short[] values) {
+          for (int i = 0; i < length; i++) buffer.writeShortLE(values[i]);
+        } else {
+          Short[] values = (Short[]) array;
+          for (int i = 0; i < length; i++) encodeInt16(values[i]);
+        }
+      }
+      case 5 -> {
+        UShort[] values = (UShort[]) array;
+        for (int i = 0; i < length; i++) encodeUInt16(values[i]);
+      }
+      case 6 -> {
+        if (array instanceof int[] values) {
+          for (int i = 0; i < length; i++) buffer.writeIntLE(values[i]);
+        } else {
+          Integer[] values = (Integer[]) array;
+          for (int i = 0; i < length; i++) encodeInt32(values[i]);
+        }
+      }
+      case 7 -> {
+        UInteger[] values = (UInteger[]) array;
+        for (int i = 0; i < length; i++) encodeUInt32(values[i]);
+      }
+      case 8 -> {
+        if (array instanceof long[] values) {
+          for (int i = 0; i < length; i++) buffer.writeLongLE(values[i]);
+        } else {
+          Long[] values = (Long[]) array;
+          for (int i = 0; i < length; i++) encodeInt64(values[i]);
+        }
+      }
+      case 9 -> {
+        ULong[] values = (ULong[]) array;
+        for (int i = 0; i < length; i++) encodeUInt64(values[i]);
+      }
+      case 10 -> {
+        if (array instanceof float[] values) {
+          for (int i = 0; i < length; i++) buffer.writeFloatLE(values[i]);
+        } else {
+          Float[] values = (Float[]) array;
+          for (int i = 0; i < length; i++) encodeFloat(values[i]);
+        }
+      }
+      case 11 -> {
+        if (array instanceof double[] values) {
+          for (int i = 0; i < length; i++) buffer.writeDoubleLE(values[i]);
+        } else {
+          Double[] values = (Double[]) array;
+          for (int i = 0; i < length; i++) encodeDouble(values[i]);
+        }
+      }
+      case 12 -> {
+        String[] values = (String[]) array;
+        for (int i = 0; i < length; i++) encodeString(values[i]);
+      }
+      case 13 -> {
+        DateTime[] values = (DateTime[]) array;
+        for (int i = 0; i < length; i++) encodeDateTime(values[i]);
+      }
+      case 14 -> {
+        UUID[] values = (UUID[]) array;
+        for (int i = 0; i < length; i++) encodeGuid(values[i]);
+      }
+      case 15 -> {
+        ByteString[] values = (ByteString[]) array;
+        for (int i = 0; i < length; i++) encodeByteString(values[i]);
+      }
+      case 16 -> {
+        XmlElement[] values = (XmlElement[]) array;
+        for (int i = 0; i < length; i++) encodeXmlElement(values[i]);
+      }
+      case 17 -> {
+        NodeId[] values = (NodeId[]) array;
+        for (int i = 0; i < length; i++) encodeNodeId(values[i]);
+      }
+      case 18 -> {
+        ExpandedNodeId[] values = (ExpandedNodeId[]) array;
+        for (int i = 0; i < length; i++) encodeExpandedNodeId(values[i]);
+      }
+      case 19 -> {
+        StatusCode[] values = (StatusCode[]) array;
+        for (int i = 0; i < length; i++) encodeStatusCode(values[i]);
+      }
+      case 20 -> {
+        QualifiedName[] values = (QualifiedName[]) array;
+        for (int i = 0; i < length; i++) encodeQualifiedName(values[i]);
+      }
+      case 21 -> {
+        LocalizedText[] values = (LocalizedText[]) array;
+        for (int i = 0; i < length; i++) encodeLocalizedText(values[i]);
+      }
+      case 22 -> {
+        ExtensionObject[] values = (ExtensionObject[]) array;
+        for (int i = 0; i < length; i++) encodeExtensionObject(values[i]);
+      }
+      case 23 -> {
+        DataValue[] values = (DataValue[]) array;
+        for (int i = 0; i < length; i++) encodeDataValue(values[i]);
+      }
+      case 24 -> {
+        Variant[] values = (Variant[]) array;
+        for (int i = 0; i < length; i++) encodeVariant(values[i]);
+      }
+      case 25 -> {
+        DiagnosticInfo[] values = (DiagnosticInfo[]) array;
+        for (int i = 0; i < length; i++) encodeDiagnosticInfo(values[i]);
+      }
+      default ->
+          throw new UaSerializationException(
+              StatusCodes.Bad_EncodingError, "unknown builtin type: " + typeId);
     }
   }
 
@@ -1202,15 +1380,19 @@ public class OpcUaBinaryEncoder implements UaEncoder {
       int typeId =
           value.getDataType().orElseThrow().getTypeId(); // won't throw, we checked for null
 
-      for (int i = 0; i < length; i++) {
-        Object o = Array.get(elements, i);
+      if (isPlainBuiltinArray(typeId, elements)) {
+        encodeBuiltinTypeArray(typeId, elements, length);
+      } else {
+        for (int i = 0; i < length; i++) {
+          Object o = Array.get(elements, i);
 
-        encodeValue(
-            o,
-            typeId,
-            o instanceof UaStructuredType,
-            o instanceof UaEnumeratedType,
-            o instanceof OptionSetUInteger);
+          encodeValue(
+              o,
+              typeId,
+              o instanceof UaStructuredType,
+              o instanceof UaEnumeratedType,
+              o instanceof OptionSetUInteger);
+        }
       }
     }
   }
@@ -1238,10 +1420,15 @@ public class OpcUaBinaryEncoder implements UaEncoder {
       int length = Array.getLength(elements);
       assert length == Arrays.stream(dimensions).reduce(1, (left, right) -> left * right);
 
-      for (int i = 0; i < length; i++) {
-        Object o = Array.get(elements, i);
-
-        encodeEnum(null, (UaEnumeratedType) o);
+      if (elements instanceof UaEnumeratedType[] values) {
+        for (int i = 0; i < length; i++) {
+          encodeEnum(null, values[i]);
+        }
+      } else {
+        // Generic codecs build their matrices as Object[], which is not a UaEnumeratedType[].
+        for (int i = 0; i < length; i++) {
+          encodeEnum(null, (UaEnumeratedType) Array.get(elements, i));
+        }
       }
     }
   }
@@ -1271,10 +1458,15 @@ public class OpcUaBinaryEncoder implements UaEncoder {
       int length = Array.getLength(elements);
       assert length == Arrays.stream(dimensions).reduce(1, (left, right) -> left * right);
 
-      for (int i = 0; i < length; i++) {
-        Object o = Array.get(elements, i);
-
-        encodeStruct(null, (UaStructuredType) o, dataTypeId);
+      if (elements instanceof UaStructuredType[] values) {
+        for (int i = 0; i < length; i++) {
+          encodeStruct(null, values[i], dataTypeId);
+        }
+      } else {
+        // Generic codecs build their matrices as Object[], which is not a UaStructuredType[].
+        for (int i = 0; i < length; i++) {
+          encodeStruct(null, (UaStructuredType) Array.get(elements, i), dataTypeId);
+        }
       }
     }
   }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/unsigned/UInteger.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/unsigned/UInteger.java
@@ -57,54 +57,15 @@ public final class UInteger extends UNumber implements Comparable<UInteger> {
   private final long value;
 
   /**
-   * Figure out the size of the precache.
-   *
-   * @return The parsed value of the system property {@link #PRECACHE_PROPERTY} or {@link
-   *     #DEFAULT_PRECACHE_SIZE} if the property is not set, not a number or retrieving results in a
-   *     {@link SecurityException}. If the parsed value is zero or negative no cache will be
-   *     created. If the value is larger than {@link Integer#MAX_VALUE} then Integer#MAX_VALUE will
-   *     be used.
-   */
-  private static int getPrecacheSize() {
-    String prop = null;
-    long propParsed;
-
-    try {
-      prop = System.getProperty(PRECACHE_PROPERTY);
-    } catch (SecurityException e) {
-      // security manager stopped us so use default
-      // FIXME: should we log this somewhere?
-      return DEFAULT_PRECACHE_SIZE;
-    }
-    if (prop == null) return DEFAULT_PRECACHE_SIZE;
-    if (prop.length() <= 0) {
-      // empty value
-      // FIXME: should we log this somewhere?
-      return DEFAULT_PRECACHE_SIZE;
-    }
-    try {
-      propParsed = Long.parseLong(prop);
-    } catch (NumberFormatException e) {
-      // not a valid number
-      // FIXME: should we log this somewhere?
-      return DEFAULT_PRECACHE_SIZE;
-    }
-    // treat negative value as no cache...
-    if (propParsed < 0) return 0;
-    if (propParsed > Integer.MAX_VALUE) {
-      // FIXME: should we log this somewhere?
-      return Integer.MAX_VALUE;
-    }
-    return (int) propParsed;
-  }
-
-  /**
    * Generate a cached value for initial unsigned integer values.
    *
-   * @return Array of cached values for UInteger
+   * <p>The cache size is read from the system property {@link #PRECACHE_PROPERTY}, defaulting to
+   * {@link #DEFAULT_PRECACHE_SIZE} and capped at {@link Integer#MAX_VALUE}.
+   *
+   * @return array of cached values for UInteger, or null if caching is disabled.
    */
   private static UInteger[] mkValues() {
-    int precacheSize = getPrecacheSize();
+    int precacheSize = getPrecacheSize(PRECACHE_PROPERTY, DEFAULT_PRECACHE_SIZE, Integer.MAX_VALUE);
     UInteger[] ret;
 
     if (precacheSize <= 0) return null;

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/unsigned/UNumber.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/unsigned/UNumber.java
@@ -29,4 +29,36 @@ public abstract class UNumber extends Number {
   public BigInteger toBigInteger() {
     return new BigInteger(toString());
   }
+
+  /**
+   * Figure out the size of a value precache from a system property.
+   *
+   * @param propertyName the name of the system property holding the requested size.
+   * @param defaultSize the size to use if the property is not set, empty, not a number, or cannot
+   *     be read.
+   * @param maxSize the maximum size the parsed value is capped at.
+   * @return the precache size; if the parsed value is zero or negative no cache should be created.
+   */
+  static int getPrecacheSize(String propertyName, int defaultSize, long maxSize) {
+    String prop;
+    long propParsed;
+
+    try {
+      prop = System.getProperty(propertyName);
+    } catch (SecurityException e) {
+      // security manager stopped us so use default
+      return defaultSize;
+    }
+    if (prop == null) return defaultSize;
+    if (prop.isEmpty()) return defaultSize;
+    try {
+      propParsed = Long.parseLong(prop);
+    } catch (NumberFormatException e) {
+      // not a valid number
+      return defaultSize;
+    }
+    // treat negative value as no cache...
+    if (propParsed < 0) return 0;
+    return (int) Math.min(propParsed, maxSize);
+  }
 }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/unsigned/UShort.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/unsigned/UShort.java
@@ -10,6 +10,7 @@
 
 package org.eclipse.milo.opcua.stack.core.types.builtin.unsigned;
 
+import java.io.InvalidObjectException;
 import java.io.ObjectStreamException;
 import org.jspecify.annotations.NonNull;
 
@@ -187,11 +188,14 @@ public final class UShort extends UNumber implements Comparable<UShort> {
   /**
    * Replace version read through deserialization with cached version.
    *
-   * @return cached instance of this object's value if one exists, otherwise this object
+   * @return cached instance of this object's value if one exists, otherwise this object.
+   * @throws InvalidObjectException if the deserialized value is out of range.
    */
   private Object readResolve() throws ObjectStreamException {
     // the value read could be invalid so check it
-    rangeCheck();
+    if (value < MIN_VALUE || value > MAX_VALUE) {
+      throw new InvalidObjectException("Value is out of range : " + value);
+    }
 
     UShort cached = getCached(value);
 

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/unsigned/UShort.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/unsigned/UShort.java
@@ -10,6 +10,7 @@
 
 package org.eclipse.milo.opcua.stack.core.types.builtin.unsigned;
 
+import java.io.ObjectStreamException;
 import org.jspecify.annotations.NonNull;
 
 /**
@@ -20,8 +21,24 @@ import org.jspecify.annotations.NonNull;
  */
 public final class UShort extends UNumber implements Comparable<UShort> {
 
+  private static final Class<UShort> CLASS = UShort.class;
+  private static final String CLASS_NAME = CLASS.getName();
+
+  /** System property name for the property to set the size of the pre-cache. */
+  private static final String PRECACHE_PROPERTY = CLASS_NAME + ".precacheSize";
+
+  /** Default size for the value cache. */
+  private static final int DEFAULT_PRECACHE_SIZE = 256;
+
   /** Generated UID */
   private static final long serialVersionUID = -6821055240959745390L;
+
+  /**
+   * Cached values.
+   *
+   * <p>Declared before {@link #MIN} and {@link #MAX} so that their initializers can use the cache.
+   */
+  private static final UShort[] VALUES = mkValues();
 
   /** A constant holding the minimum value an <code>unsigned short</code> can have, 0. */
   public static final int MIN_VALUE = 0x0000;
@@ -44,13 +61,72 @@ public final class UShort extends UNumber implements Comparable<UShort> {
   private final int value;
 
   /**
+   * Figure out the size of the precache.
+   *
+   * @return The parsed value of the system property {@link #PRECACHE_PROPERTY} or {@link
+   *     #DEFAULT_PRECACHE_SIZE} if the property is not set, not a number or retrieving results in a
+   *     {@link SecurityException}. If the parsed value is zero or negative no cache will be
+   *     created. The value is capped at {@link #MAX_VALUE}+1, the number of distinct <code>
+   *     unsigned short
+   *     </code> values.
+   */
+  private static int getPrecacheSize() {
+    String prop;
+    long propParsed;
+
+    try {
+      prop = System.getProperty(PRECACHE_PROPERTY);
+    } catch (SecurityException e) {
+      // security manager stopped us so use default
+      return DEFAULT_PRECACHE_SIZE;
+    }
+    if (prop == null) return DEFAULT_PRECACHE_SIZE;
+    if (prop.isEmpty()) return DEFAULT_PRECACHE_SIZE;
+    try {
+      propParsed = Long.parseLong(prop);
+    } catch (NumberFormatException e) {
+      // not a valid number
+      return DEFAULT_PRECACHE_SIZE;
+    }
+    // treat negative value as no cache...
+    if (propParsed < 0) return 0;
+    return (int) Math.min(propParsed, MAX_VALUE + 1L);
+  }
+
+  /**
+   * Generate a cached value for initial unsigned short values.
+   *
+   * @return Array of cached values for UShort, or null if caching is disabled.
+   */
+  private static UShort[] mkValues() {
+    int precacheSize = getPrecacheSize();
+
+    if (precacheSize <= 0) return null;
+
+    UShort[] ret = new UShort[precacheSize];
+    for (int i = 0; i < precacheSize; i++) ret[i] = new UShort(i);
+    return ret;
+  }
+
+  /**
+   * Retrieve a cached value.
+   *
+   * @param value Cached value to retrieve
+   * @return Cached value if one exists. Null otherwise.
+   */
+  private static UShort getCached(int value) {
+    if (VALUES != null && value >= 0 && value < VALUES.length) return VALUES[value];
+    return null;
+  }
+
+  /**
    * Create an <code>unsigned short</code>
    *
    * @throws NumberFormatException If <code>value</code> does not contain a parsable <code>
    *     unsigned short</code>.
    */
   public static UShort valueOf(String value) throws NumberFormatException {
-    return new UShort(value);
+    return valueOf(Integer.parseInt(value));
   }
 
   /**
@@ -58,7 +134,11 @@ public final class UShort extends UNumber implements Comparable<UShort> {
    * (short) -1</code> becomes <code>(ushort) 65535</code>
    */
   public static UShort valueOf(short value) {
-    return new UShort(value);
+    int masked = value & MAX_VALUE;
+
+    UShort cached = getCached(masked);
+
+    return cached != null ? cached : new UShort(masked);
   }
 
   /**
@@ -68,7 +148,10 @@ public final class UShort extends UNumber implements Comparable<UShort> {
    *     unsigned short</code>
    */
   public static UShort valueOf(int value) throws NumberFormatException {
-    return new UShort(value);
+    UShort cached = getCached(value);
+
+    // out-of-range values are never cached, so new UShort(int) still range checks them
+    return cached != null ? cached : new UShort(value);
   }
 
   /**
@@ -81,7 +164,7 @@ public final class UShort extends UNumber implements Comparable<UShort> {
     if (value < MIN_VALUE || value > MAX_VALUE) {
       throw new NumberFormatException("Value is out of range : " + value);
     }
-    return new UShort((int) value);
+    return valueOf((int) value);
   }
 
   /**
@@ -95,29 +178,24 @@ public final class UShort extends UNumber implements Comparable<UShort> {
     rangeCheck();
   }
 
-  /**
-   * Create an <code>unsigned short</code> by masking it with <code>0xFFFF</code> i.e. <code>
-   * (short) -1</code> becomes <code>(ushort) 65535</code>
-   */
-  private UShort(short value) {
-    this.value = value & MAX_VALUE;
-  }
-
-  /**
-   * Create an <code>unsigned short</code>
-   *
-   * @throws NumberFormatException If <code>value</code> does not contain a parsable <code>
-   *     unsigned short</code>.
-   */
-  private UShort(String value) throws NumberFormatException {
-    this.value = Integer.parseInt(value);
-    rangeCheck();
-  }
-
   private void rangeCheck() throws NumberFormatException {
     if (value < MIN_VALUE || value > MAX_VALUE) {
       throw new NumberFormatException("Value is out of range : " + value);
     }
+  }
+
+  /**
+   * Replace version read through deserialization with cached version.
+   *
+   * @return cached instance of this object's value if one exists, otherwise this object
+   */
+  private Object readResolve() throws ObjectStreamException {
+    // the value read could be invalid so check it
+    rangeCheck();
+
+    UShort cached = getCached(value);
+
+    return cached != null ? cached : this;
   }
 
   @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/unsigned/UShort.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/unsigned/UShort.java
@@ -62,45 +62,16 @@ public final class UShort extends UNumber implements Comparable<UShort> {
   private final int value;
 
   /**
-   * Figure out the size of the precache.
-   *
-   * @return The parsed value of the system property {@link #PRECACHE_PROPERTY} or {@link
-   *     #DEFAULT_PRECACHE_SIZE} if the property is not set, not a number or retrieving results in a
-   *     {@link SecurityException}. If the parsed value is zero or negative no cache will be
-   *     created. The value is capped at {@link #MAX_VALUE}+1, the number of distinct <code>
-   *     unsigned short
-   *     </code> values.
-   */
-  private static int getPrecacheSize() {
-    String prop;
-    long propParsed;
-
-    try {
-      prop = System.getProperty(PRECACHE_PROPERTY);
-    } catch (SecurityException e) {
-      // security manager stopped us so use default
-      return DEFAULT_PRECACHE_SIZE;
-    }
-    if (prop == null) return DEFAULT_PRECACHE_SIZE;
-    if (prop.isEmpty()) return DEFAULT_PRECACHE_SIZE;
-    try {
-      propParsed = Long.parseLong(prop);
-    } catch (NumberFormatException e) {
-      // not a valid number
-      return DEFAULT_PRECACHE_SIZE;
-    }
-    // treat negative value as no cache...
-    if (propParsed < 0) return 0;
-    return (int) Math.min(propParsed, MAX_VALUE + 1L);
-  }
-
-  /**
    * Generate a cached value for initial unsigned short values.
    *
-   * @return Array of cached values for UShort, or null if caching is disabled.
+   * <p>The cache size is read from the system property {@link #PRECACHE_PROPERTY}, defaulting to
+   * {@link #DEFAULT_PRECACHE_SIZE} and capped at {@link #MAX_VALUE}+1, the number of distinct
+   * <code>unsigned short</code> values.
+   *
+   * @return array of cached values for UShort, or null if caching is disabled.
    */
   private static UShort[] mkValues() {
-    int precacheSize = getPrecacheSize();
+    int precacheSize = getPrecacheSize(PRECACHE_PROPERTY, DEFAULT_PRECACHE_SIZE, MAX_VALUE + 1L);
 
     if (precacheSize <= 0) return null;
 
@@ -112,8 +83,8 @@ public final class UShort extends UNumber implements Comparable<UShort> {
   /**
    * Retrieve a cached value.
    *
-   * @param value Cached value to retrieve
-   * @return Cached value if one exists. Null otherwise.
+   * @param value the value to retrieve a cached instance of.
+   * @return cached value if one exists, null otherwise.
    */
   private static UShort getCached(int value) {
     if (VALUES != null && value >= 0 && value < VALUES.length) return VALUES[value];

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryDecoderTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryDecoderTest.java
@@ -12,18 +12,25 @@ package org.eclipse.milo.opcua.stack.core.encoding.binary;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import java.lang.reflect.Array;
 import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaSerializationException;
 import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DiagnosticInfo;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Matrix;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.structured.XVType;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class OpcUaBinaryDecoderTest {
 
@@ -262,5 +269,86 @@ public class OpcUaBinaryDecoderTest {
             new OpcUaBinaryDecoder(DefaultEncodingContext.INSTANCE)
                 .setBuffer(buffer)
                 .decodeVariant());
+  }
+
+  // The component type of a decoded array is not an implementation detail: Variant.getDataType()
+  // and Matrix both derive the DataType from it. An empty array is the case that matters most,
+  // because there is no element to fall back on, so a wrong component type silently changes the
+  // DataType a Variant reports rather than producing a visible ClassCastException.
+  @ParameterizedTest
+  @EnumSource(OpcUaDataType.class)
+  void decodeVariantEmptyArrayUsesBackingClassAsComponentType(OpcUaDataType dataType) {
+    ByteBuf buffer = Unpooled.buffer();
+    buffer.writeByte(dataType.getTypeId() | 0x80);
+    buffer.writeIntLE(0);
+
+    Variant variant =
+        new OpcUaBinaryDecoder(DefaultEncodingContext.INSTANCE).setBuffer(buffer).decodeVariant();
+
+    Object value = variant.value();
+    assertNotNull(value);
+    assertEquals(dataType.getBackingClass(), value.getClass().getComponentType());
+  }
+
+  // Same contract as above, reached through decodeMatrix rather than decodeVariant.
+  @ParameterizedTest
+  @EnumSource(OpcUaDataType.class)
+  void decodeMatrixEmptyUsesBackingClassAsComponentType(OpcUaDataType dataType) {
+    ByteBuf buffer = Unpooled.buffer();
+    buffer.writeIntLE(2);
+    buffer.writeIntLE(0);
+    buffer.writeIntLE(2);
+
+    Matrix matrix =
+        new OpcUaBinaryDecoder(DefaultEncodingContext.INSTANCE)
+            .setBuffer(buffer)
+            .decodeMatrix(null, dataType);
+
+    Object elements = matrix.getElements();
+    assertNotNull(elements);
+    assertEquals(dataType.getBackingClass(), elements.getClass().getComponentType());
+  }
+
+  // A builtin type id outside 1..25 in an array-encoded Variant is malformed input from a peer.
+  // It must surface as Bad_DecodingError; it previously escaped the codec as a NullPointerException
+  // from Array.newInstance(null, length).
+  @ParameterizedTest
+  @ValueSource(ints = {0, 26, 63})
+  void decodeVariantRejectsUnknownArrayTypeId(int typeId) {
+    ByteBuf buffer = Unpooled.buffer();
+    buffer.writeByte(typeId | 0x80);
+    buffer.writeIntLE(1);
+    buffer.writeIntLE(0);
+
+    UaSerializationException ex =
+        assertThrows(
+            UaSerializationException.class,
+            () ->
+                new OpcUaBinaryDecoder(DefaultEncodingContext.INSTANCE)
+                    .setBuffer(buffer)
+                    .decodeVariant());
+
+    assertEquals(new StatusCode(StatusCodes.Bad_DecodingError), ex.getStatusCode());
+  }
+
+  // DiagnosticInfo is the one builtin type that cannot legally appear in a Variant, so it has no
+  // round-trip coverage in VariantSerializationTest. Decode it from raw bytes instead, to prove the
+  // array path dispatches to decodeDiagnosticInfo and not to some other element decoder.
+  @Test
+  void decodeVariantDiagnosticInfoArrayDispatchesToDiagnosticInfoDecoder() {
+    ByteBuf buffer = Unpooled.buffer();
+    buffer.writeByte(OpcUaDataType.DiagnosticInfo.getTypeId() | 0x80);
+    buffer.writeIntLE(1);
+    buffer.writeByte(0x01); // SymbolicId present
+    buffer.writeIntLE(7);
+
+    Variant variant =
+        new OpcUaBinaryDecoder(DefaultEncodingContext.INSTANCE).setBuffer(buffer).decodeVariant();
+
+    DiagnosticInfo[] values = (DiagnosticInfo[]) variant.value();
+    assertNotNull(values);
+    assertEquals(1, values.length);
+    assertEquals(7, values[0].symbolicId());
+    assertEquals(0, buffer.readableBytes(), "element decoder consumed the wrong number of bytes");
   }
 }

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryEncoderTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryEncoderTest.java
@@ -11,6 +11,7 @@
 package org.eclipse.milo.opcua.stack.core.encoding.binary;
 
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ubyte;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -141,6 +142,46 @@ public class OpcUaBinaryEncoderTest {
     Matrix decodedMatrix = decoder.decodeMatrix(null, OpcUaDataType.Int32);
 
     assertEquals(matrix, decodedMatrix.transform(v -> ApplicationType.from((Integer) v)));
+  }
+
+  // Generic codecs (JsonStructCodec, the DTD codecs) build matrix elements as Object[]. Object[] is
+  // not assignable to UaEnumeratedType[], so the encoder must not assume the concrete array type.
+  @Test
+  void encodeEnumMatrixBackedByObjectArray() {
+    Matrix matrix =
+        new Matrix(
+            new Object[] {ApplicationType.Server, ApplicationType.Client},
+            new int[] {1, 2},
+            OpcUaDataType.Int32);
+
+    encoder.encodeEnumMatrix(null, matrix);
+
+    var decoder = new OpcUaBinaryDecoder(DefaultEncodingContext.INSTANCE).setBuffer(buffer);
+    Matrix decodedMatrix = decoder.decodeMatrix(null, OpcUaDataType.Int32);
+
+    assertArrayEquals(
+        new Integer[] {ApplicationType.Server.getValue(), ApplicationType.Client.getValue()},
+        (Integer[]) decodedMatrix.getElements());
+  }
+
+  // As above, for UaStructuredType[].
+  @Test
+  void encodeStructMatrixBackedByObjectArray() throws Exception {
+    XVType xv1 = new XVType(1.0, 2.0f);
+    XVType xv2 = new XVType(3.0, 4.0f);
+
+    Matrix matrix =
+        new Matrix(new Object[] {xv1, xv2}, new int[] {1, 2}, OpcUaDataType.ExtensionObject);
+
+    NodeId dataTypeId =
+        XVType.TYPE_ID.toNodeIdOrThrow(DefaultEncodingContext.INSTANCE.getNamespaceTable());
+
+    encoder.encodeStructMatrix(null, matrix, dataTypeId);
+
+    var decoder = new OpcUaBinaryDecoder(DefaultEncodingContext.INSTANCE).setBuffer(buffer);
+    Matrix decodedMatrix = decoder.decodeStructMatrix(null, dataTypeId);
+
+    assertArrayEquals(new XVType[] {xv1, xv2}, (XVType[]) decodedMatrix.getElements());
   }
 
   @Test

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/binary/VariantSerializationTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/binary/VariantSerializationTest.java
@@ -10,19 +10,37 @@
 
 package org.eclipse.milo.opcua.stack.core.encoding.binary;
 
+import static java.util.Objects.requireNonNull;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ubyte;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ulong;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import java.util.UUID;
 import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Matrix;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.builtin.XmlElement;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.ULong;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
 import org.eclipse.milo.opcua.stack.core.types.structured.ServiceCounterDataType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -96,6 +114,70 @@ public class VariantSerializationTest extends BinarySerializationFixture {
     Variant decoded = reader.decodeVariant();
 
     assertEquals(expected, decoded);
+  }
+
+  public static Object[][] getBuiltinArrayVariants() {
+    return new Object[][] {
+      {new Variant(new Boolean[] {true, false})},
+      {new Variant(new Byte[] {(byte) -1, (byte) 2})},
+      {new Variant(new UByte[] {ubyte(1), ubyte(255)})},
+      {new Variant(new Short[] {(short) -1, (short) 2})},
+      {new Variant(new UShort[] {ushort(1), ushort(65535)})},
+      {new Variant(new Integer[] {-1, 2})},
+      {new Variant(new UInteger[] {uint(1), uint(4294967295L)})},
+      {new Variant(new Long[] {-1L, 2L})},
+      {new Variant(new ULong[] {ulong(1), ulong(2)})},
+      {new Variant(new Float[] {-1.5f, 2.5f})},
+      {new Variant(new Double[] {-1.5d, 2.5d})},
+      {new Variant(new String[] {"a", null})},
+      {new Variant(new DateTime[] {new DateTime(1L), new DateTime(2L)})},
+      {
+        new Variant(
+            new UUID[] {
+              UUID.fromString("00000000-0000-0000-0000-000000000001"),
+              UUID.fromString("0f0e0d0c-0b0a-0908-0706-050403020100")
+            })
+      },
+      {new Variant(new ByteString[] {ByteString.of(new byte[] {1, 2}), ByteString.NULL_VALUE})},
+      {new Variant(new XmlElement[] {new XmlElement("<a/>"), new XmlElement("<b/>")})},
+      {new Variant(new NodeId[] {new NodeId(0, 1), new NodeId(2, "s")})},
+      {
+        new Variant(
+            new ExpandedNodeId[] {new NodeId(0, 1).expanded(), new NodeId(2, "s").expanded()})
+      },
+      {
+        new Variant(
+            new StatusCode[] {StatusCode.GOOD, new StatusCode(StatusCodes.Bad_InternalError)})
+      },
+      {new Variant(new QualifiedName[] {new QualifiedName(0, "a"), new QualifiedName(2, "b")})},
+      {new Variant(new LocalizedText[] {LocalizedText.english("a"), new LocalizedText("b")})},
+      {
+        new Variant(
+            new ExtensionObject[] {
+              ExtensionObject.of(ByteString.of(new byte[] {1, 2}), new NodeId(0, 1))
+            })
+      },
+      {
+        new Variant(
+            new DataValue[] {new DataValue(new Variant(1)), new DataValue(new Variant("x"))})
+      }
+    };
+  }
+
+  // Exercises one switch case per builtin type in the decoder's array path. The component-type
+  // assertion catches a case that allocates the wrong array type; the equality assertion catches a
+  // case that allocates the right array but calls the wrong element decoder (e.g. Int32 for Int16),
+  // which the empty-array coverage in OpcUaBinaryDecoderTest cannot see.
+  @ParameterizedTest
+  @MethodSource("getBuiltinArrayVariants")
+  public void builtinArrayVariantRoundTripPreservesValuesAndComponentType(Variant variant) {
+    writer.encodeVariant(variant);
+    Variant decoded = reader.decodeVariant();
+
+    assertEquals(variant, decoded);
+    assertEquals(
+        requireNonNull(variant.value()).getClass().getComponentType(),
+        requireNonNull(decoded.value()).getClass().getComponentType());
   }
 
   @Test

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/binary/VariantSerializationTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/binary/VariantSerializationTest.java
@@ -91,6 +91,14 @@ public class VariantSerializationTest extends BinarySerializationFixture {
 
   public static Object[][] getPrimitiveArrayVariants() {
     return new Object[][] {
+      {new Variant(new boolean[] {true, false}), new Variant(new Boolean[] {true, false})},
+      {
+        new Variant(new byte[] {(byte) -1, (byte) 2}), new Variant(new Byte[] {(byte) -1, (byte) 2})
+      },
+      {
+        new Variant(new short[] {(short) -1, (short) 2}),
+        new Variant(new Short[] {(short) -1, (short) 2})
+      },
       {new Variant(new int[] {0, 1, 2, 3}), new Variant(new Integer[] {0, 1, 2, 3})},
       {
         new Variant(Matrix.ofInt32(new int[][] {{0, 1}, {2, 3}})),
@@ -100,7 +108,9 @@ public class VariantSerializationTest extends BinarySerializationFixture {
       {
         new Variant(Matrix.ofInt64(new long[][] {{0L, 1L}, {2L, 3L}})),
         new Variant(Matrix.ofInt64(new Long[][] {{0L, 1L}, {2L, 3L}}))
-      }
+      },
+      {new Variant(new float[] {-1.5f, 2.5f}), new Variant(new Float[] {-1.5f, 2.5f})},
+      {new Variant(new double[] {-1.5d, 2.5d}), new Variant(new Double[] {-1.5d, 2.5d})}
     };
   }
 

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/types/builtin/unsigned/UShortTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/types/builtin/unsigned/UShortTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.core.types.builtin.unsigned;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class UShortTest {
+
+  // Namespace indexes are UShorts and are almost always small, so the low values are allocated
+  // constantly during decoding. Sharing instances is the whole point of the cache.
+  @ParameterizedTest
+  @ValueSource(ints = {0, 1, 255})
+  void valueOfSharesInstancesWithinTheCachedRange(int value) {
+    assertSame(UShort.valueOf(value), UShort.valueOf(value));
+    assertSame(UShort.valueOf(value), UShort.valueOf((long) value));
+    assertSame(UShort.valueOf(value), UShort.valueOf((short) value));
+  }
+
+  // The cache is initialized before MIN, so MIN must be the shared zero instance rather than a
+  // separate one. Reordering the static fields would silently break that.
+  @Test
+  void minIsTheCachedZeroInstance() {
+    assertSame(UShort.valueOf(0), UShort.MIN);
+  }
+
+  // Values beyond the cache are still correct, just not shared; equality must stay value-based.
+  @Test
+  void valueOfOutsideTheCachedRangeStillComparesByValue() {
+    UShort a = UShort.valueOf(4096);
+    UShort b = UShort.valueOf(4096);
+
+    assertNotSame(a, b);
+    assertEquals(a, b);
+    assertEquals(a.hashCode(), b.hashCode());
+  }
+
+  // valueOf(short) masks rather than range checks, so (short) -1 is 65535 and not an error.
+  @Test
+  void valueOfShortMasksNegativeValues() {
+    assertEquals(UShort.MAX_VALUE, UShort.valueOf((short) -1).intValue());
+    assertEquals(UShort.MAX, UShort.valueOf((short) -1));
+  }
+
+  @Test
+  void valueOfRejectsValuesOutsideUnsignedShortRange() {
+    assertThrows(NumberFormatException.class, () -> UShort.valueOf(-1));
+    assertThrows(NumberFormatException.class, () -> UShort.valueOf(UShort.MAX_VALUE + 1));
+    assertThrows(NumberFormatException.class, () -> UShort.valueOf(-1L));
+    assertThrows(NumberFormatException.class, () -> UShort.valueOf(UShort.MAX_VALUE + 1L));
+    assertThrows(NumberFormatException.class, () -> UShort.valueOf("65536"));
+    assertThrows(NumberFormatException.class, () -> UShort.valueOf("not a number"));
+  }
+
+  @Test
+  void valueOfStringParsesInRangeValues() {
+    assertEquals(UShort.MIN, UShort.valueOf("0"));
+    assertEquals(UShort.MAX, UShort.valueOf("65535"));
+  }
+
+  // readResolve keeps deserialization from smuggling in a duplicate of a cached value, which would
+  // make reference comparisons behave differently depending on how the instance was obtained.
+  @Test
+  void deserializationResolvesToTheCachedInstance() throws Exception {
+    UShort original = UShort.valueOf(7);
+
+    var bytes = new ByteArrayOutputStream();
+    try (var out = new ObjectOutputStream(bytes)) {
+      out.writeObject(original);
+    }
+
+    Object restored;
+    try (var in = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+      restored = in.readObject();
+    }
+
+    assertSame(original, restored);
+  }
+}


### PR DESCRIPTION
## Summary

Removes reflection and boxing from the hot paths of the binary encoder and decoder, and caches low unsigned values:

- Decode and encode builtin arrays with typed per-element loops instead of reflective `Array.get`/`Array.set`
- Store decoded structs without reflection
- Read internal int fields (length prefixes, dimensions, DiagnosticInfo) directly from the buffer without boxing
- Decode StatusCode without an intermediate UInteger
- Track recursion depth with a plain int instead of an AtomicInteger
- Cache low UShort values (configurable via system property, mirroring UInteger)

Follow-up fixes and cleanups from review of the branch:

- Restore struct matrix decoding for generic codecs (regression from the reflection removal: an unbounded `DataTypeCodec.getType()` is not necessarily a `UaStructuredType` subtype)
- Throw `InvalidObjectException` from `UShort.readResolve` instead of an undeclared `NumberFormatException`
- Collapse duplicated enum/struct matrix encoding loops
- Share precache size parsing between UShort and UInteger

## Testing

`spotless:check` and the full `stack-core` test suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)