### PR TITLE
Fix Variant encoding and decoding edge cases

### DIFF
--- a/opc-ua-stack/encoding-json/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoder.java
+++ b/opc-ua-stack/encoding-json/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoder.java
@@ -897,6 +897,11 @@ public class OpcUaJsonEncoder implements UaEncoder, AutoCloseable {
       typeId = OpcUaDataType.getBuiltinTypeId(valueClass);
     }
 
+    if (typeId == -1) {
+      throw new UaSerializationException(
+          StatusCodes.Bad_EncodingError, "not a built-in type: " + valueClass.getName());
+    }
+
     if (value.getClass().isArray()) {
       jsonWriter.beginObject();
 

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/OpcUaDataType.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/OpcUaDataType.java
@@ -114,10 +114,13 @@ public enum OpcUaDataType {
 
   /**
    * @param backingClass the backing {@link Class} of the builtin type.
-   * @return the id of the builtin type backed by {@code backingClass}.
+   * @return the id of the builtin type backed by {@code backingClass}, or {@code -1} if {@code
+   *     backingClass} does not back a builtin type.
    */
   public static int getBuiltinTypeId(Class<?> backingClass) {
-    return BACKING_CLASSES_BY_ID.inverse().get(maybeTransformClass(backingClass));
+    Integer typeId = BACKING_CLASSES_BY_ID.inverse().get(maybeTransformClass(backingClass));
+
+    return typeId != null ? typeId : -1;
   }
 
   /**

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryDecoder.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryDecoder.java
@@ -412,6 +412,10 @@ public class OpcUaBinaryDecoder implements UaDecoder {
           int length = buffer.readIntLE();
 
           if (length == -1) {
+            if (dimensionsEncoded) {
+              // consume ArrayDimensions so the read position stays aligned
+              decodeDimensions();
+            }
             return new Variant(null);
           } else {
             checkArrayLength(length);

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryEncoder.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryEncoder.java
@@ -54,7 +54,6 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.IdType;
 import org.eclipse.milo.opcua.stack.core.util.ArrayUtil;
 import org.jspecify.annotations.NonNull;
-import org.slf4j.LoggerFactory;
 
 public class OpcUaBinaryEncoder implements UaEncoder {
 
@@ -622,9 +621,8 @@ public class OpcUaBinaryEncoder implements UaEncoder {
       int typeId = OpcUaDataType.getBuiltinTypeId(valueClass);
 
       if (typeId == -1) {
-        LoggerFactory.getLogger(getClass())
-            .warn(
-                "Not a built-in type: value={}, valueClass={}", value, valueClass, new Exception());
+        throw new UaSerializationException(
+            StatusCodes.Bad_EncodingError, "not a built-in type: " + valueClass.getName());
       }
 
       if (value.getClass().isArray() || value instanceof Matrix) {

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryEncoder.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryEncoder.java
@@ -42,6 +42,10 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Matrix;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.OptionSetUI16;
+import org.eclipse.milo.opcua.stack.core.types.builtin.OptionSetUI32;
+import org.eclipse.milo.opcua.stack.core.types.builtin.OptionSetUI64;
+import org.eclipse.milo.opcua.stack.core.types.builtin.OptionSetUI8;
 import org.eclipse.milo.opcua.stack.core.types.builtin.OptionSetUInteger;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
@@ -613,8 +617,10 @@ public class OpcUaBinaryEncoder implements UaEncoder {
         valueClass = Integer.class;
         enumeration = true;
       } else if (OptionSetUInteger.class.isAssignableFrom(valueClass)) {
-        assert value instanceof OptionSetUInteger<?>;
-        valueClass = ((OptionSetUInteger<?>) value).getValue().getClass();
+        // Derived from the element class rather than from value, which for an array or a Matrix is
+        // the container and not an OptionSetUInteger. This also resolves empty arrays, where there
+        // is no element to inspect.
+        valueClass = optionSetBackingClass(valueClass);
         optionSet = true;
       }
 
@@ -951,6 +957,28 @@ public class OpcUaBinaryEncoder implements UaEncoder {
     } else {
       return o.getClass();
     }
+  }
+
+  /**
+   * Resolve the unsigned integer class an {@link OptionSetUInteger} is encoded as.
+   *
+   * <p>Derived from the class hierarchy rather than from an instance so that arrays, Matrices, and
+   * empty arrays all resolve without an element to inspect.
+   *
+   * @param optionSetClass the {@link OptionSetUInteger} subclass.
+   * @return the backing class the option set is encoded as.
+   * @throws UaSerializationException if {@code optionSetClass} has no OptionSetUI8/16/32/64
+   *     ancestor.
+   */
+  private static Class<?> optionSetBackingClass(Class<?> optionSetClass) {
+    if (OptionSetUI8.class.isAssignableFrom(optionSetClass)) return UByte.class;
+    if (OptionSetUI16.class.isAssignableFrom(optionSetClass)) return UShort.class;
+    if (OptionSetUI32.class.isAssignableFrom(optionSetClass)) return UInteger.class;
+    if (OptionSetUI64.class.isAssignableFrom(optionSetClass)) return ULong.class;
+
+    throw new UaSerializationException(
+        StatusCodes.Bad_EncodingError,
+        "no OptionSetUI8/16/32/64 ancestor for " + optionSetClass.getName());
   }
 
   private void encodeLengthPrefixedString(String value, Charset charset)

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/OpcUaDataTypeTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/OpcUaDataTypeTest.java
@@ -50,6 +50,23 @@ class OpcUaDataTypeTest {
         clazz.getSimpleName() + " should be recognized as a built-in type");
   }
 
+  // Callers branch on a -1 sentinel (Variant.getDataTypeId, OpcUaBinaryEncoder.encodeVariant), so
+  // an unknown class must return -1 rather than throwing on an unboxed null.
+  @Test
+  void getBuiltinTypeIdReturnsMinusOneForNonBuiltinClass() {
+    assertEquals(-1, OpcUaDataType.getBuiltinTypeId(Object.class));
+    assertEquals(-1, OpcUaDataType.getBuiltinTypeId(java.util.List.class));
+  }
+
+  @ParameterizedTest
+  @MethodSource("allBackingClasses")
+  void getBuiltinTypeIdResolvesBackingClasses(Class<?> clazz) {
+    assertNotEquals(
+        -1,
+        OpcUaDataType.getBuiltinTypeId(clazz),
+        clazz.getSimpleName() + " should resolve to a built-in type id");
+  }
+
   private static Stream<Class<?>> allBackingClasses() {
     return Stream.concat(standardBackingClasses(), extensionObjectSubtypeBackingClasses());
   }

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryDecoderTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryDecoderTest.java
@@ -95,6 +95,26 @@ public class OpcUaBinaryDecoderTest {
   }
 
   @Test
+  void decodeVariantNullArrayConsumesDimensions() {
+    ByteBuf buffer = Unpooled.buffer();
+
+    // Int32 | array | dimensions, ArrayLength -1 (null array), then an ArrayDimensions field
+    buffer.writeByte(6 | 0x80 | 0x40);
+    buffer.writeIntLE(-1);
+    buffer.writeIntLE(2);
+    buffer.writeIntLE(2);
+    buffer.writeIntLE(3);
+    // a subsequent field, decoded correctly only if ArrayDimensions was consumed
+    buffer.writeIntLE(42);
+
+    OpcUaBinaryDecoder decoder =
+        new OpcUaBinaryDecoder(DefaultEncodingContext.INSTANCE).setBuffer(buffer);
+
+    assertEquals(new Variant(null), decoder.decodeVariant());
+    assertEquals(42, decoder.decodeInt32());
+  }
+
+  @Test
   void decodeMatrixRejectsNegativeDimensionCount() {
     ByteBuf buffer = Unpooled.buffer();
     buffer.writeIntLE(-2);

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryEncoderTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryEncoderTest.java
@@ -13,12 +13,14 @@ package org.eclipse.milo.opcua.stack.core.encoding.binary;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ubyte;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaSerializationException;
 import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
 import org.eclipse.milo.opcua.stack.core.types.builtin.*;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
@@ -182,6 +184,17 @@ public class OpcUaBinaryEncoderTest {
     Matrix decodedMatrix = decoder.decodeStructMatrix(null, dataTypeId);
 
     assertArrayEquals(new XVType[] {xv1, xv2}, (XVType[]) decodedMatrix.getElements());
+  }
+
+  // A Variant holding something that is not a builtin type cannot be encoded. Report it rather than
+  // writing a bogus encoding mask that the peer will reject as a framing error.
+  @Test
+  void encodeVariantOfNonBuiltinTypeReportsEncodingError() {
+    UaSerializationException ex =
+        assertThrows(
+            UaSerializationException.class, () -> encoder.encodeVariant(new Variant(new Object())));
+
+    assertEquals(new StatusCode(StatusCodes.Bad_EncodingError), ex.getStatusCode());
   }
 
   @Test

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryEncoderTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryEncoderTest.java
@@ -186,6 +186,48 @@ public class OpcUaBinaryEncoderTest {
     assertArrayEquals(new XVType[] {xv1, xv2}, (XVType[]) decodedMatrix.getElements());
   }
 
+  // An OptionSet's builtin type must be derived from the element class, not by casting the value
+  // itself: for an array or a Matrix the value is the container, not an OptionSetUInteger.
+  @Test
+  void encodeVariantOfOptionSetArray() {
+    AccessLevelType[] values = {
+      AccessLevelType.of(AccessLevelType.Field.CurrentRead),
+      AccessLevelType.of(AccessLevelType.Field.CurrentWrite)
+    };
+
+    encoder.encodeVariant(new Variant(values));
+
+    var decoder = new OpcUaBinaryDecoder(DefaultEncodingContext.INSTANCE).setBuffer(buffer);
+    Variant decoded = decoder.decodeVariant();
+
+    // OptionSets go on the wire as their backing UInteger, so they come back as UByte here.
+    assertArrayEquals(
+        new UByte[] {(UByte) values[0].getValue(), (UByte) values[1].getValue()},
+        (UByte[]) decoded.value());
+  }
+
+  // As above, reached through the Matrix branch of encodeVariant.
+  @Test
+  void encodeVariantOfOptionSetMatrix() {
+    AccessLevelType[][] values = {
+      {
+        AccessLevelType.of(AccessLevelType.Field.CurrentRead),
+        AccessLevelType.of(AccessLevelType.Field.CurrentWrite)
+      }
+    };
+
+    encoder.encodeVariant(new Variant(Matrix.ofOptionSetUI(values)));
+
+    var decoder = new OpcUaBinaryDecoder(DefaultEncodingContext.INSTANCE).setBuffer(buffer);
+    Variant decoded = decoder.decodeVariant();
+
+    Matrix decodedMatrix = (Matrix) decoded.value();
+    assertArrayEquals(new int[] {1, 2}, decodedMatrix.getDimensions());
+    assertArrayEquals(
+        new UByte[] {(UByte) values[0][0].getValue(), (UByte) values[0][1].getValue()},
+        (UByte[]) decodedMatrix.getElements());
+  }
+
   // A Variant holding something that is not a builtin type cannot be encoded. Report it rather than
   // writing a bogus encoding mask that the peer will reject as a framing error.
   @Test


### PR DESCRIPTION
## Summary

Stacked on #1829. One commit per fix, consolidating the fixes that were floating on individual `fix/*` branches:

- **Return -1 from getBuiltinTypeId for non-builtin classes** — the BiMap lookup NPE'd on unboxing for a non-builtin class, making the `-1` guards in `Variant.getDataTypeId` and `encodeVariant` dead code. `encodeVariant` now throws `Bad_EncodingError` instead of writing a corrupt encoding mask, and `OpcUaJsonEncoder` gets the same guard.
- **Fix OptionSet arrays and matrices in Variants** — `encodeVariant` picked an OptionSet's builtin type by casting the value to `OptionSetUInteger`, which only holds for scalars; a Variant carrying an array or Matrix of option sets failed with ClassCastException (or AssertionError with assertions enabled). The type is now derived from the element class, as the JSON and XML encoders already do.
- **Consume ArrayDimensions when a Variant array is null** — `decodeVariant` returned early on a -1 array length without reading the ArrayDimensions field when the dimensions bit was set, desynchronizing every subsequent read in the message.

## Testing

`spotless:check` and the `stack-core` + `encoding-json` test suites pass, including new regression tests for each fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)