### PR TITLE
Add server lifecycle participants

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServer.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServer.java
@@ -18,6 +18,7 @@ import java.net.InetSocketAddress;
 import java.security.KeyPair;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedHashSet;
@@ -30,7 +31,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import org.eclipse.milo.opcua.sdk.core.typetree.DataTypeTree;
 import org.eclipse.milo.opcua.sdk.core.typetree.ObjectTypeTree;
@@ -125,6 +125,14 @@ import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Hosts the address space, services, and transports for an OPC UA server application.
+ *
+ * <p>The standard address space is initialized during construction. Application components that
+ * must start after that initialization but before the server becomes externally visible can be
+ * registered with {@link #addLifecycleParticipant(Lifecycle)} before calling {@link #startup()}.
+ * The server then owns their lifecycle through startup rollback or terminal shutdown.
+ */
 public class OpcUaServer extends AbstractServiceHandler {
 
   public static final String SDK_VERSION = ManifestUtil.read("X-SDK-Version").orElse("dev");
@@ -190,14 +198,18 @@ public class OpcUaServer extends AbstractServiceHandler {
 
   private final Map<TransportProfile, OpcServerTransport> transports = new ConcurrentHashMap<>();
 
-  /**
-   * Shared shutdown result for the terminal server shutdown.
-   *
-   * <p>Shutdown tears down diagnostics and namespace state that cannot be safely torn down twice,
-   * so concurrent callers must observe the same operation instead of each running teardown logic.
-   */
-  private final AtomicReference<CompletableFuture<OpcUaServer>> shutdownFuture =
-      new AtomicReference<>();
+  // lifecycleState, startupFuture, and shutdownFuture are guarded by lifecycleLock.
+  // lifecycleParticipants is mutated under the lock and only while state is NEW, so the startup
+  // thread may iterate it unlocked once the state leaves NEW and registration is closed.
+  // startedParticipants is confined to the thread executing startup; teardown reads it only after
+  // startupFuture completes, which orders the accesses.
+  private final Object lifecycleLock = new Object();
+  private final List<Lifecycle> lifecycleParticipants = new ArrayList<>();
+  private final List<Lifecycle> startedParticipants = new ArrayList<>();
+
+  private ServerLifecycleState lifecycleState = ServerLifecycleState.NEW;
+  private @Nullable CompletableFuture<OpcUaServer> startupFuture;
+  private @Nullable CompletableFuture<OpcUaServer> shutdownFuture;
 
   private final EventBus eventBus = new EventBus("server");
   private final EventFactory eventFactory = new EventFactory(this);
@@ -358,83 +370,204 @@ public class OpcUaServer extends AbstractServiceHandler {
     accessController = new DefaultAccessController(this);
   }
 
+  /**
+   * Start this server and make its configured endpoints externally visible.
+   *
+   * <p>Registered lifecycle participants are started synchronously in registration order after the
+   * standard address space and event facilities are available, but before the first passive
+   * transport bind or reverse-connect attempt. If startup fails, each participant whose {@link
+   * Lifecycle#startup()} call completed normally is shut down in reverse order before this future
+   * fails.
+   *
+   * <p>Startup is single-flight. Concurrent or subsequent calls return the same future. Once
+   * startup begins, the server is terminal: a failed or shut-down server cannot be started again.
+   *
+   * <p>A {@link #shutdown()} requested before endpoints are bound abandons startup and fails this
+   * future; a later request lets startup complete and then tears the server down.
+   *
+   * @return a future completed with this server when startup succeeds.
+   */
   public CompletableFuture<OpcUaServer> startup() {
-    try {
-      // Reject ambiguous endpoint configurations before binding anything: two Session-capable
-      // endpoints mapping to the same wire-observable selection key cannot be told apart at
-      // OpenSecureChannel time, so runtime selection would depend on collection ordering.
-      getEndpointSelectionIndex().validate();
-    } catch (UaException e) {
-      return CompletableFuture.failedFuture(e);
+    CompletableFuture<OpcUaServer> future;
+
+    synchronized (lifecycleLock) {
+      if (startupFuture != null) {
+        return startupFuture;
+      }
+      if (lifecycleState != ServerLifecycleState.NEW) {
+        startupFuture =
+            CompletableFuture.failedFuture(
+                new IllegalStateException("cannot start server when state=" + lifecycleState));
+        return startupFuture;
+      }
+
+      lifecycleState = ServerLifecycleState.STARTING;
+      startupFuture = future = new CompletableFuture<>();
     }
+
+    try {
+      startupInternal();
+
+      synchronized (lifecycleLock) {
+        // A shutdown requested late in startup leaves state at SHUTTING_DOWN; startup still
+        // succeeded, and the shutdown chained on this future performs the teardown.
+        if (lifecycleState == ServerLifecycleState.STARTING) {
+          lifecycleState = ServerLifecycleState.RUNNING;
+        }
+      }
+
+      future.complete(this);
+    } catch (Throwable t) {
+      rollbackStartup(t);
+
+      synchronized (lifecycleLock) {
+        if (lifecycleState == ServerLifecycleState.STARTING) {
+          lifecycleState = ServerLifecycleState.STARTUP_FAILED;
+        }
+      }
+
+      future.completeExceptionally(t);
+    }
+
+    return future;
+  }
+
+  private void startupInternal() throws UaException {
+    // Reject ambiguous endpoint configurations before binding anything: two Session-capable
+    // endpoints mapping to the same wire-observable selection key cannot be told apart at
+    // OpenSecureChannel time, so runtime selection would depend on collection ordering.
+    getEndpointSelectionIndex().validate();
 
     eventFactory.startup();
     eventInstantiator.startup();
 
-    getResolvedEndpoints().stream()
-        .sorted(Comparator.comparing(e -> e.endpointConfig().getTransportProfile()))
-        .forEach(
-            resolvedEndpoint -> {
-              EndpointConfig endpoint = resolvedEndpoint.endpointConfig();
-
-              logger.info(
-                  "Binding endpoint {} to {}:{} [{}/{}]",
-                  endpoint.getEndpointUrl(),
-                  endpoint.getBindAddress(),
-                  endpoint.getBindPort(),
-                  endpoint.getSecurityPolicy(),
-                  endpoint.getSecurityMode());
-
-              TransportProfile transportProfile = endpoint.getTransportProfile();
-
-              OpcServerTransport transport = getOrCreateTransport(transportProfile);
-
-              if (transport != null) {
-                try {
-                  var bindAddress =
-                      new InetSocketAddress(endpoint.getBindAddress(), endpoint.getBindPort());
-                  transport.bind(applicationContext, bindAddress);
-
-                  transports.put(transportProfile, transport);
-
-                  boundEndpoints.add(endpoint);
-                } catch (Exception e) {
-                  logger.warn(
-                      "Failed to bind endpoint {} to {}:{} [{}/{}]",
-                      endpoint.getEndpointUrl(),
-                      endpoint.getBindAddress(),
-                      endpoint.getBindPort(),
-                      endpoint.getSecurityPolicy(),
-                      endpoint.getSecurityMode(),
-                      e);
-                }
-              } else {
-                logger.warn("No OpcServerTransport for TransportProfile: {}", transportProfile);
-              }
-            });
-
-    try {
-      // Validate after binding so the reverse-connect transport lookup finds the bound transport
-      // without having to create one as a side effect.
-      reverseConnectTargetManager.validateTargets();
-    } catch (Throwable t) {
-      rollbackStartup();
-      return CompletableFuture.failedFuture(t);
+    // Participants run application code that may request shutdown re-entrantly. Honor such a
+    // request between participants, and once more before the server becomes externally visible.
+    for (Lifecycle participant : lifecycleParticipants) {
+      abortStartupIfShutdownRequested();
+      participant.startup();
+      startedParticipants.add(participant);
     }
+    abortStartupIfShutdownRequested();
 
-    try {
-      reverseConnectTargetManager.startup();
-    } catch (Throwable t) {
-      rollbackStartup();
-      return CompletableFuture.failedFuture(t);
-    }
+    bindEndpoints();
+
+    // Startup validates targets internally; it runs after binding so the reverse-connect transport
+    // lookup finds the bound transport without having to create one as a side effect.
+    reverseConnectTargetManager.startup();
 
     if (boundEndpoints.isEmpty() && !reverseConnectTargetManager.hasSchedulableTargets()) {
-      rollbackStartup();
-      return CompletableFuture.failedFuture(
-          new UaException(StatusCodes.Bad_ConfigurationError, "No endpoints bound"));
-    } else {
-      return CompletableFuture.completedFuture(this);
+      throw new UaException(StatusCodes.Bad_ConfigurationError, "No endpoints bound");
+    }
+  }
+
+  private void bindEndpoints() {
+    List<ResolvedEndpoint> endpoints =
+        getResolvedEndpoints().stream()
+            .sorted(Comparator.comparing(e -> e.endpointConfig().getTransportProfile()))
+            .toList();
+
+    for (ResolvedEndpoint resolvedEndpoint : endpoints) {
+      EndpointConfig endpoint = resolvedEndpoint.endpointConfig();
+
+      logger.info(
+          "Binding endpoint {} to {}:{} [{}/{}]",
+          endpoint.getEndpointUrl(),
+          endpoint.getBindAddress(),
+          endpoint.getBindPort(),
+          endpoint.getSecurityPolicy(),
+          endpoint.getSecurityMode());
+
+      TransportProfile transportProfile = endpoint.getTransportProfile();
+      OpcServerTransport transport = getOrCreateTransport(transportProfile);
+
+      if (transport != null) {
+        try {
+          var bindAddress =
+              new InetSocketAddress(endpoint.getBindAddress(), endpoint.getBindPort());
+          transport.bind(applicationContext, bindAddress);
+
+          boundEndpoints.add(endpoint);
+        } catch (Exception e) {
+          logger.warn(
+              "Failed to bind endpoint {} to {}:{} [{}/{}]",
+              endpoint.getEndpointUrl(),
+              endpoint.getBindAddress(),
+              endpoint.getBindPort(),
+              endpoint.getSecurityPolicy(),
+              endpoint.getSecurityMode(),
+              e);
+        }
+      } else {
+        logger.warn("No OpcServerTransport for TransportProfile: {}", transportProfile);
+      }
+    }
+  }
+
+  private void abortStartupIfShutdownRequested() {
+    synchronized (lifecycleLock) {
+      if (lifecycleState != ServerLifecycleState.STARTING) {
+        throw new IllegalStateException("server shutdown requested during startup");
+      }
+    }
+  }
+
+  /**
+   * Register a server-owned lifecycle participant.
+   *
+   * <p>The participant is started during {@link #startup()} after core server facilities and the
+   * standard address space are ready, but before an endpoint can accept connections. If its startup
+   * completes normally, it is shut down exactly once during startup rollback or terminal server
+   * shutdown, in reverse registration order and while the standard address space still exists.
+   *
+   * <p>Registration transfers exclusive lifecycle ownership to this server: the caller must not
+   * invoke the participant's lifecycle methods unless it first removes the participant. The same
+   * instance cannot be registered more than once. Concurrent registrations are ordered by the order
+   * in which they acquire the server's lifecycle lock.
+   *
+   * <p>Participant callbacks run synchronously as part of a server startup or shutdown. A
+   * participant may initiate a server shutdown from its startup callback, but it must not block
+   * waiting for the enclosing server lifecycle operation to complete.
+   *
+   * @param participant the lifecycle participant whose startup and shutdown this server will own.
+   * @throws IllegalArgumentException if the same participant instance is already registered.
+   * @throws IllegalStateException if startup or shutdown has begun.
+   */
+  public void addLifecycleParticipant(Lifecycle participant) {
+    Objects.requireNonNull(participant, "participant");
+
+    synchronized (lifecycleLock) {
+      requireLifecycleRegistrationOpen();
+      if (lifecycleParticipants.stream().anyMatch(p -> p == participant)) {
+        throw new IllegalArgumentException("lifecycle participant is already registered");
+      }
+      lifecycleParticipants.add(participant);
+    }
+  }
+
+  /**
+   * Remove a lifecycle participant before the server startup begins.
+   *
+   * <p>A successful removal returns lifecycle ownership to the caller; this server will not invoke
+   * the participant. Removal is matched by object identity, not {@link Object#equals(Object)}.
+   *
+   * @param participant the lifecycle participant instance to remove.
+   * @return {@code true} if the participant was registered and removed.
+   * @throws IllegalStateException if startup or shutdown has begun.
+   */
+  public boolean removeLifecycleParticipant(Lifecycle participant) {
+    Objects.requireNonNull(participant, "participant");
+
+    synchronized (lifecycleLock) {
+      requireLifecycleRegistrationOpen();
+      return lifecycleParticipants.removeIf(p -> p == participant);
+    }
+  }
+
+  private void requireLifecycleRegistrationOpen() {
+    if (lifecycleState != ServerLifecycleState.NEW) {
+      throw new IllegalStateException(
+          "lifecycle participants cannot be changed when server state=" + lifecycleState);
     }
   }
 
@@ -442,81 +575,196 @@ public class OpcUaServer extends AbstractServiceHandler {
    * Stop accepting new sessions and tear down the server runtime.
    *
    * <p>This method is the synchronization point for server shutdown. The first caller performs the
-   * shutdown sequence: reject new sessions, unbind transports, drain session listener work, close
-   * sessions, then shut down namespaces, diagnostics, events, and subscriptions. Concurrent callers
-   * receive the same {@link CompletableFuture} so namespace and diagnostics lifecycle code is only
-   * run once.
+   * shutdown sequence: reject new sessions, stop reverse-connect activity, unbind passive
+   * transports, drain session listener work, close sessions, stop successfully started lifecycle
+   * participants in reverse registration order, then tear down the remaining namespaces,
+   * diagnostics, events, and subscriptions. Concurrent callers receive the same {@link
+   * CompletableFuture} so terminal lifecycle code is only run once.
    *
-   * <p>If shutdown is requested from a session listener callback, the shutdown path avoids waiting
-   * on the callback that is currently executing. When another caller is already waiting for
-   * listener quiescence, this method returns a completed future for that callback and the outer
-   * shutdown caller continues the real teardown after the callback returns.
+   * <p>Every started participant is given one shutdown attempt even if another participant fails.
+   * The first shutdown failure completes the returned future exceptionally; later cleanup failures
+   * are attached to it as suppressed exceptions. Calling shutdown before startup does not start or
+   * stop registered participants.
+   *
+   * <p>If shutdown is requested from a session listener callback, this method never returns a
+   * future whose completion requires that callback to return first. When the teardown runs on
+   * another thread — chained behind an in-flight startup, or already driven by an earlier caller —
+   * the callback receives an already-completed future; when the callback itself is the first caller
+   * after startup has completed, the teardown runs inline without waiting for listener quiescence.
    *
    * @return a future completed when the server shutdown sequence has finished.
    */
   public CompletableFuture<OpcUaServer> shutdown() {
     sessionManager.beginShutdown();
 
-    CompletableFuture<OpcUaServer> newShutdownFuture = new CompletableFuture<>();
-    if (!shutdownFuture.compareAndSet(null, newShutdownFuture)) {
-      CompletableFuture<OpcUaServer> existingShutdownFuture = shutdownFuture.get();
-      if (sessionManager.isSessionListenerCallback() && !existingShutdownFuture.isDone()) {
-        // The active shutdown is waiting for this callback to return; joining it here would
-        // deadlock the listener queue.
-        return CompletableFuture.completedFuture(this);
-      } else {
-        return existingShutdownFuture;
+    CompletableFuture<OpcUaServer> newShutdownFuture;
+    CompletableFuture<OpcUaServer> startupToAwait;
+
+    synchronized (lifecycleLock) {
+      if (shutdownFuture != null) {
+        if (sessionManager.isSessionListenerCallback() && !shutdownFuture.isDone()) {
+          // The active shutdown is waiting for this callback to return; joining it here would
+          // deadlock the listener queue.
+          return CompletableFuture.completedFuture(this);
+        }
+        return shutdownFuture;
       }
+
+      shutdownFuture = newShutdownFuture = new CompletableFuture<>();
+      startupToAwait = startupFuture;
+      lifecycleState = ServerLifecycleState.SHUTTING_DOWN;
     }
 
-    try {
-      shutdownInternal();
-      newShutdownFuture.complete(this);
-    } catch (Exception e) {
-      newShutdownFuture.completeExceptionally(e);
+    if (startupToAwait != null && !startupToAwait.isDone()) {
+      startupToAwait.whenComplete((server, failure) -> performShutdown(newShutdownFuture));
+
+      if (sessionManager.isSessionListenerCallback()) {
+        // The deferred teardown runs on the startup thread and waits for listener quiescence;
+        // handing this callback the real future would let it block the very drain it must return
+        // from.
+        return CompletableFuture.completedFuture(this);
+      }
+    } else {
+      performShutdown(newShutdownFuture);
     }
 
     return newShutdownFuture;
   }
 
-  private void shutdownInternal() {
-    reverseConnectTargetManager.shutdown();
+  private void performShutdown(CompletableFuture<OpcUaServer> future) {
+    Throwable failure = shutdownInternal();
 
-    unbindTransports();
+    synchronized (lifecycleLock) {
+      lifecycleState = ServerLifecycleState.SHUTDOWN;
+    }
 
-    conditionManager.shutdown();
-
-    sessionManager.shutdown();
-
-    serverNamespace.shutdown();
-    opcUaNamespace.shutdown();
-
-    eventInstantiator.shutdown();
-    eventFactory.shutdown();
-
-    subscriptions.values().forEach(Subscription::deleteSubscription);
+    if (failure == null) {
+      future.complete(this);
+    } else {
+      future.completeExceptionally(failure);
+    }
   }
 
-  private void rollbackStartup() {
-    reverseConnectTargetManager.shutdown();
-    unbindTransports();
-    eventInstantiator.shutdown();
-    eventFactory.shutdown();
+  private @Nullable Throwable shutdownInternal() {
+    var failures = new FailureAccumulator();
+
+    failures.run(reverseConnectTargetManager::shutdown);
+    unbindTransports(failures);
+    failures.run(sessionManager::shutdown);
+
+    // Participants may depend on the standard namespaces and event facilities, so stop them after
+    // external visibility and sessions are quiesced but before any core address-space teardown.
+    stopStartedParticipants(failures);
+
+    failures.run(conditionManager::shutdown);
+    failures.run(serverNamespace::shutdown);
+    failures.run(opcUaNamespace::shutdown);
+    stopEventServices(failures);
+
+    for (Subscription subscription : subscriptions.values()) {
+      failures.run(subscription::deleteSubscription);
+    }
+
+    return failures.failure();
   }
 
-  private void unbindTransports() {
-    transports
-        .values()
-        .forEach(
-            transport -> {
-              try {
-                transport.unbind();
-              } catch (Exception e) {
-                logger.warn("Error unbinding transport", e);
-              }
-            });
+  /**
+   * Undo the externally visible effects of a failed startup.
+   *
+   * <p>Cleanup failures are attached to {@code startupFailure} as suppressed exceptions.
+   */
+  private void rollbackStartup(Throwable startupFailure) {
+    sessionManager.beginShutdown();
+
+    var failures = new FailureAccumulator(startupFailure);
+    failures.run(reverseConnectTargetManager::shutdown);
+    unbindTransports(failures);
+    failures.run(sessionManager::shutdown);
+    stopStartedParticipants(failures);
+    stopEventServices(failures);
+  }
+
+  private void stopStartedParticipants(FailureAccumulator failures) {
+    List<Lifecycle> participants = new ArrayList<>(startedParticipants);
+    startedParticipants.clear();
+
+    Collections.reverse(participants);
+    participants.forEach(participant -> failures.run(participant::shutdown));
+  }
+
+  private void stopEventServices(FailureAccumulator failures) {
+    // AbstractLifecycle rejects shutdown when never started, so guard the path where shutdown is
+    // requested before startup ever ran. Repeat shutdown of a started lifecycle is a no-op.
+    if (eventInstantiator.isRunning()) {
+      failures.run(eventInstantiator::shutdown);
+    }
+    if (eventFactory.isRunning()) {
+      failures.run(eventFactory::shutdown);
+    }
+  }
+
+  private void unbindTransports(FailureAccumulator failures) {
+    for (OpcServerTransport transport : transports.values()) {
+      try {
+        transport.unbind();
+      } catch (Throwable t) {
+        // Unbind failures never fail a normal shutdown; log them, and when an earlier failure is
+        // primary keep them attached as suppressed diagnostic context.
+        logger.warn("Error unbinding transport", t);
+        failures.suppress(t);
+      }
+    }
+
     transports.clear();
     boundEndpoints.clear();
+  }
+
+  /**
+   * Accumulates failures from a best-effort teardown sequence: the first failure becomes the
+   * primary, and later failures are attached to it as suppressed exceptions.
+   */
+  private static final class FailureAccumulator {
+
+    private @Nullable Throwable failure;
+
+    FailureAccumulator() {}
+
+    FailureAccumulator(@Nullable Throwable failure) {
+      this.failure = failure;
+    }
+
+    /** Run {@code step}, capturing anything it throws. */
+    void run(Runnable step) {
+      try {
+        step.run();
+      } catch (Throwable t) {
+        if (failure == null) {
+          failure = t;
+        } else {
+          suppress(t);
+        }
+      }
+    }
+
+    /** Attach {@code t} to the primary failure, if one exists, without promoting it. */
+    void suppress(Throwable t) {
+      if (failure != null && failure != t) {
+        failure.addSuppressed(t);
+      }
+    }
+
+    @Nullable Throwable failure() {
+      return failure;
+    }
+  }
+
+  private enum ServerLifecycleState {
+    NEW,
+    STARTING,
+    RUNNING,
+    STARTUP_FAILED,
+    SHUTTING_DOWN,
+    SHUTDOWN
   }
 
   public OpcUaServerConfig getConfig() {
@@ -912,7 +1160,7 @@ public class OpcUaServer extends AbstractServiceHandler {
    *
    * <p>The returned list is populated during {@link #startup()} and cleared by {@link #shutdown()}
    * (and on a failed startup that rolls back). Callers querying after shutdown observe an empty
-   * list. A subsequent successful {@link #startup()} repopulates the list.
+   * list; server instances are terminal and cannot be restarted.
    *
    * @return the {@link EndpointConfig}s that are currently bound, or an empty list when the server
    *     is not running.

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/SessionManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/SessionManager.java
@@ -741,8 +741,13 @@ public class SessionManager {
         });
   }
 
-  /** Run listener dispatch with re-entrant shutdown detection enabled for the current thread. */
-  private void withSessionListenerCallback(Runnable notification) {
+  /**
+   * Run listener dispatch with re-entrant shutdown detection enabled for the current thread.
+   *
+   * <p>Package-private so tests can run code with {@link #isSessionListenerCallback()} reporting
+   * {@code true} without racing a real client connection.
+   */
+  void withSessionListenerCallback(Runnable notification) {
     Boolean previous = sessionListenerCallback.get();
     sessionListenerCallback.set(true);
     try {

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/package-info.java
@@ -28,6 +28,17 @@
  * or certificate request cannot be served by the current runtime are omitted from discovery
  * advertisements.
  *
+ * <h2>Lifecycle extensions</h2>
+ *
+ * <p>{@link org.eclipse.milo.opcua.sdk.server.OpcUaServer#addLifecycleParticipant(
+ * org.eclipse.milo.opcua.sdk.server.Lifecycle)} transfers lifecycle ownership of an application
+ * component to the server before startup. The server starts these participants in registration
+ * order after its standard namespaces and event facilities are available, then exposes passive and
+ * reverse-connect endpoints. Startup rollback and terminal shutdown stop only successfully started
+ * participants, in reverse order. On normal shutdown, transports and sessions are quiesced first;
+ * participant shutdown therefore runs without external server visibility but before the standard
+ * address space and event facilities are torn down.
+ *
  * <h2>Runtime boundaries</h2>
  *
  * <p>The SDK server package coordinates high-level server configuration and lifecycle. Certificate

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/OpcUaServerLifecycleParticipantTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/OpcUaServerLifecycleParticipantTest.java
@@ -1,0 +1,535 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.security.DefaultCertificateManager;
+import org.eclipse.milo.opcua.stack.core.security.MemoryCertificateQuarantine;
+import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.MessageSecurityMode;
+import org.eclipse.milo.opcua.stack.transport.server.OpcServerTransport;
+import org.eclipse.milo.opcua.stack.transport.server.ServerApplicationContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class OpcUaServerLifecycleParticipantTest {
+
+  private final List<OpcUaServer> servers = new ArrayList<>();
+
+  @AfterEach
+  void tearDown() throws Exception {
+    // Teardown is a real assertion: any server still on this list must shut down cleanly. Tests
+    // that deliberately fail shutdown assert on the failure themselves and then remove the server.
+    for (OpcUaServer server : servers) {
+      server.shutdown().get(5, TimeUnit.SECONDS);
+    }
+  }
+
+  // The participant seam exists specifically to finish application initialization before a
+  // transport can expose the server.
+  @Test
+  void participantStartupCompletesBeforeTransportBind() throws Exception {
+    AtomicBoolean participantStarted = new AtomicBoolean();
+    RecordingTransport transport = new RecordingTransport();
+    transport.onBind = () -> assertTrue(participantStarted.get());
+    OpcUaServer server = newServer(transport);
+
+    server.addLifecycleParticipant(
+        participant(
+            () -> {
+              assertTrue(server.getEventInstantiator().isRunning());
+              assertTrue(
+                  server
+                      .getAddressSpaceManager()
+                      .isRegistered(server.getOpcUaNamespace().getNodeManager()));
+              participantStarted.set(true);
+            },
+            () -> {}));
+
+    server.startup().get(5, TimeUnit.SECONDS);
+
+    assertTrue(transport.bound);
+  }
+
+  @Test
+  void participantsStartInRegistrationOrder() throws Exception {
+    List<String> events = new ArrayList<>();
+    OpcUaServer server = newServer(new RecordingTransport());
+    server.addLifecycleParticipant(participant(() -> events.add("start-a"), () -> {}));
+    server.addLifecycleParticipant(participant(() -> events.add("start-b"), () -> {}));
+    server.addLifecycleParticipant(participant(() -> events.add("start-c"), () -> {}));
+
+    server.startup().get(5, TimeUnit.SECONDS);
+
+    assertEquals(List.of("start-a", "start-b", "start-c"), events);
+  }
+
+  // Shutdown must remove external visibility before application components release address-space
+  // state, and reverse ordering lets dependent participants unwind safely.
+  @Test
+  void shutdownUnbindsTransportThenStopsParticipantsInReverseOrder() throws Exception {
+    List<String> events = new ArrayList<>();
+    RecordingTransport transport = new RecordingTransport(events);
+    OpcUaServer server = newServer(transport);
+    server.addLifecycleParticipant(
+        participant(
+            () -> {},
+            () -> {
+              assertTrue(
+                  server
+                      .getAddressSpaceManager()
+                      .isRegistered(server.getOpcUaNamespace().getNodeManager()));
+              events.add("stop-a");
+            }));
+    server.addLifecycleParticipant(
+        participant(
+            () -> {},
+            () -> {
+              assertTrue(
+                  server
+                      .getAddressSpaceManager()
+                      .isRegistered(server.getOpcUaNamespace().getNodeManager()));
+              events.add("stop-b");
+            }));
+
+    server.startup().get(5, TimeUnit.SECONDS);
+    events.clear();
+    server.shutdown().get(5, TimeUnit.SECONDS);
+
+    assertEquals(List.of("unbind", "stop-b", "stop-a"), events);
+  }
+
+  @Test
+  void participantStartupFailureRollsBackOnlySuccessfulParticipants() throws Exception {
+    List<String> events = new ArrayList<>();
+    RuntimeException startupFailure = new RuntimeException("start-b");
+    RecordingTransport transport = new RecordingTransport(events);
+    OpcUaServer server = newServer(transport);
+    server.addLifecycleParticipant(
+        participant(() -> events.add("start-a"), () -> events.add("stop-a")));
+    server.addLifecycleParticipant(
+        participant(
+            () -> {
+              events.add("start-b");
+              throw startupFailure;
+            },
+            () -> events.add("stop-b")));
+    server.addLifecycleParticipant(
+        participant(() -> events.add("start-c"), () -> events.add("stop-c")));
+
+    ExecutionException ex =
+        assertThrows(ExecutionException.class, () -> server.startup().get(5, TimeUnit.SECONDS));
+
+    assertSame(startupFailure, ex.getCause());
+    assertEquals(List.of("start-a", "start-b", "stop-a"), events);
+    assertFalse(transport.bound);
+
+    server.shutdown().get(5, TimeUnit.SECONDS);
+    assertEquals(List.of("start-a", "start-b", "stop-a"), events);
+  }
+
+  @Test
+  void transportStartupFailureRollsBackStartedParticipants() throws Exception {
+    List<String> events = new ArrayList<>();
+    RecordingTransport transport = new RecordingTransport(events);
+    transport.bindFailure = new Exception("bind");
+    OpcUaServer server = newServer(transport);
+    server.addLifecycleParticipant(
+        participant(() -> events.add("participant-start"), () -> events.add("participant-stop")));
+
+    ExecutionException ex =
+        assertThrows(ExecutionException.class, () -> server.startup().get(5, TimeUnit.SECONDS));
+
+    UaException cause = assertInstanceOf(UaException.class, ex.getCause());
+    assertEquals(StatusCodes.Bad_ConfigurationError, cause.getStatusCode().value());
+    assertEquals(List.of("participant-start", "bind", "unbind", "participant-stop"), events);
+  }
+
+  // The startup exception is the actionable failure; rollback exceptions remain available without
+  // preventing later participants from being cleaned up.
+  @Test
+  void startupRollbackPreservesPrimaryFailureAndSuppressesCleanupFailures() {
+    RuntimeException cleanupA = new RuntimeException("cleanup-a");
+    RuntimeException cleanupB = new RuntimeException("cleanup-b");
+    RuntimeException startupFailure = new RuntimeException("start-c");
+    List<String> events = new ArrayList<>();
+    OpcUaServer server = newServer(new RecordingTransport());
+    server.addLifecycleParticipant(
+        participant(
+            () -> events.add("start-a"),
+            () -> {
+              events.add("stop-a");
+              throw cleanupA;
+            }));
+    server.addLifecycleParticipant(
+        participant(
+            () -> events.add("start-b"),
+            () -> {
+              events.add("stop-b");
+              throw cleanupB;
+            }));
+    server.addLifecycleParticipant(
+        participant(
+            () -> {
+              throw startupFailure;
+            },
+            () -> {}));
+
+    ExecutionException ex =
+        assertThrows(ExecutionException.class, () -> server.startup().get(5, TimeUnit.SECONDS));
+
+    assertSame(startupFailure, ex.getCause());
+    assertEquals(List.of(cleanupB, cleanupA), List.of(startupFailure.getSuppressed()));
+    assertEquals(List.of("start-a", "start-b", "stop-b", "stop-a"), events);
+  }
+
+  @Test
+  void shutdownAttemptsEveryParticipantAndAggregatesFailures() throws Exception {
+    RuntimeException cleanupA = new RuntimeException("cleanup-a");
+    RuntimeException cleanupB = new RuntimeException("cleanup-b");
+    List<String> events = new ArrayList<>();
+    OpcUaServer server = newServer(new RecordingTransport());
+    server.addLifecycleParticipant(
+        participant(
+            () -> {},
+            () -> {
+              events.add("stop-a");
+              throw cleanupA;
+            }));
+    server.addLifecycleParticipant(
+        participant(
+            () -> {},
+            () -> {
+              events.add("stop-b");
+              throw cleanupB;
+            }));
+    server.startup().get(5, TimeUnit.SECONDS);
+
+    ExecutionException ex =
+        assertThrows(ExecutionException.class, () -> server.shutdown().get(5, TimeUnit.SECONDS));
+
+    assertSame(cleanupB, ex.getCause());
+    assertEquals(List.of(cleanupA), List.of(cleanupB.getSuppressed()));
+    assertEquals(List.of("stop-b", "stop-a"), events);
+
+    // Shutdown ran every teardown step and its single-flight future is permanently failed; remove
+    // the server so tearDown stays a strict success assertion for every other test.
+    servers.remove(server);
+  }
+
+  @Test
+  void registrationAndRemovalAreRejectedOnceStartupBegins() throws Exception {
+    CountDownLatch startupEntered = new CountDownLatch(1);
+    CountDownLatch releaseStartup = new CountDownLatch(1);
+    Lifecycle blockingParticipant =
+        participant(
+            () -> {
+              startupEntered.countDown();
+              await(releaseStartup);
+            },
+            () -> {});
+    Lifecycle lateParticipant = participant(() -> {}, () -> {});
+    OpcUaServer server = newServer(new RecordingTransport());
+    server.addLifecycleParticipant(blockingParticipant);
+
+    //noinspection resource
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    try {
+      Future<CompletableFuture<OpcUaServer>> firstStartup = executor.submit(server::startup);
+      assertTrue(startupEntered.await(5, TimeUnit.SECONDS));
+
+      assertThrows(
+          IllegalStateException.class, () -> server.addLifecycleParticipant(lateParticipant));
+      assertThrows(
+          IllegalStateException.class,
+          () -> server.removeLifecycleParticipant(blockingParticipant));
+
+      releaseStartup.countDown();
+      firstStartup.get(5, TimeUnit.SECONDS).get(5, TimeUnit.SECONDS);
+
+      assertThrows(
+          IllegalStateException.class, () -> server.addLifecycleParticipant(lateParticipant));
+      assertThrows(
+          IllegalStateException.class,
+          () -> server.removeLifecycleParticipant(blockingParticipant));
+    } finally {
+      releaseStartup.countDown();
+      executor.shutdownNow();
+    }
+  }
+
+  @Test
+  void removalBeforeStartupReturnsOwnershipToCaller() throws Exception {
+    AtomicInteger starts = new AtomicInteger();
+    AtomicInteger stops = new AtomicInteger();
+    Lifecycle participant = participant(starts::incrementAndGet, stops::incrementAndGet);
+    OpcUaServer server = newServer(new RecordingTransport());
+    server.addLifecycleParticipant(participant);
+
+    assertThrows(IllegalArgumentException.class, () -> server.addLifecycleParticipant(participant));
+    assertTrue(server.removeLifecycleParticipant(participant));
+    assertFalse(server.removeLifecycleParticipant(participant));
+
+    server.startup().get(5, TimeUnit.SECONDS);
+    server.shutdown().get(5, TimeUnit.SECONDS);
+
+    assertEquals(0, starts.get());
+    assertEquals(0, stops.get());
+  }
+
+  // A concurrent caller must observe the in-progress operation rather than starting participants a
+  // second time.
+  @Test
+  void concurrentStartupCallsShareOneFutureAndStartParticipantsOnce() throws Exception {
+    CountDownLatch startupEntered = new CountDownLatch(1);
+    CountDownLatch releaseStartup = new CountDownLatch(1);
+    AtomicInteger starts = new AtomicInteger();
+    OpcUaServer server = newServer(new RecordingTransport());
+    server.addLifecycleParticipant(
+        participant(
+            () -> {
+              starts.incrementAndGet();
+              startupEntered.countDown();
+              await(releaseStartup);
+            },
+            () -> {}));
+
+    //noinspection resource
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    try {
+      Future<CompletableFuture<OpcUaServer>> firstCall = executor.submit(server::startup);
+      assertTrue(startupEntered.await(5, TimeUnit.SECONDS));
+
+      CompletableFuture<OpcUaServer> concurrentCall = server.startup();
+      releaseStartup.countDown();
+      CompletableFuture<OpcUaServer> originalCall = firstCall.get(5, TimeUnit.SECONDS);
+
+      assertSame(originalCall, concurrentCall);
+      assertEquals(server, concurrentCall.get(5, TimeUnit.SECONDS));
+      assertEquals(1, starts.get());
+    } finally {
+      releaseStartup.countDown();
+      executor.shutdownNow();
+    }
+  }
+
+  @Test
+  void shutdownBeforeStartupDoesNotInvokeParticipantsAndPreventsLaterStartup() throws Exception {
+    AtomicInteger starts = new AtomicInteger();
+    AtomicInteger stops = new AtomicInteger();
+    OpcUaServer server = newServer(new RecordingTransport());
+    server.addLifecycleParticipant(participant(starts::incrementAndGet, stops::incrementAndGet));
+
+    server.shutdown().get(5, TimeUnit.SECONDS);
+
+    ExecutionException ex =
+        assertThrows(ExecutionException.class, () -> server.startup().get(5, TimeUnit.SECONDS));
+    assertInstanceOf(IllegalStateException.class, ex.getCause());
+    assertEquals(0, starts.get());
+    assertEquals(0, stops.get());
+    assertThrows(
+        IllegalStateException.class,
+        () -> server.addLifecycleParticipant(participant(() -> {}, () -> {})));
+  }
+
+  @Test
+  void shutdownDuringStartupRollsBackParticipantsBeforeBinding() throws Exception {
+    CountDownLatch startupEntered = new CountDownLatch(1);
+    CountDownLatch releaseStartup = new CountDownLatch(1);
+    List<String> events = new ArrayList<>();
+    RecordingTransport transport = new RecordingTransport(events);
+    OpcUaServer server = newServer(transport);
+    server.addLifecycleParticipant(
+        participant(() -> events.add("start-a"), () -> events.add("stop-a")));
+    server.addLifecycleParticipant(
+        participant(
+            () -> {
+              events.add("start-b");
+              startupEntered.countDown();
+              await(releaseStartup);
+            },
+            () -> events.add("stop-b")));
+
+    //noinspection resource
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    try {
+      Future<CompletableFuture<OpcUaServer>> startupCall = executor.submit(server::startup);
+      assertTrue(startupEntered.await(5, TimeUnit.SECONDS));
+
+      CompletableFuture<OpcUaServer> shutdown = server.shutdown();
+      releaseStartup.countDown();
+
+      ExecutionException startupFailure =
+          assertThrows(
+              ExecutionException.class,
+              () -> startupCall.get(5, TimeUnit.SECONDS).get(5, TimeUnit.SECONDS));
+      assertInstanceOf(IllegalStateException.class, startupFailure.getCause());
+      assertEquals(server, shutdown.get(5, TimeUnit.SECONDS));
+      assertEquals(List.of("start-a", "start-b", "stop-b", "stop-a"), events);
+      assertFalse(transport.bound);
+    } finally {
+      releaseStartup.countDown();
+      executor.shutdownNow();
+    }
+  }
+
+  // A session listener that is the first shutdown caller while startup is still in flight must not
+  // receive the real shutdown future: the deferred teardown later drains the listener queue from
+  // the startup thread, so a callback blocked on that future would deadlock the drain.
+  @Test
+  void shutdownFromSessionListenerCallbackDuringStartupReturnsCompletedFuture() throws Exception {
+    CountDownLatch startupEntered = new CountDownLatch(1);
+    CountDownLatch releaseStartup = new CountDownLatch(1);
+    OpcUaServer server = newServer(new RecordingTransport());
+    server.addLifecycleParticipant(
+        participant(
+            () -> {
+              startupEntered.countDown();
+              await(releaseStartup);
+            },
+            () -> {}));
+
+    //noinspection resource
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    try {
+      Future<CompletableFuture<OpcUaServer>> startupCall = executor.submit(server::startup);
+      assertTrue(startupEntered.await(5, TimeUnit.SECONDS));
+
+      List<CompletableFuture<OpcUaServer>> callbackResult = new ArrayList<>();
+      server
+          .getSessionManager()
+          .withSessionListenerCallback(() -> callbackResult.add(server.shutdown()));
+
+      assertTrue(
+          callbackResult.get(0).isDone(),
+          "a listener callback must not receive a future it can block the listener drain on");
+
+      releaseStartup.countDown();
+      ExecutionException startupFailure =
+          assertThrows(
+              ExecutionException.class,
+              () -> startupCall.get(5, TimeUnit.SECONDS).get(5, TimeUnit.SECONDS));
+      assertInstanceOf(IllegalStateException.class, startupFailure.getCause());
+
+      // The real single-flight future, observed from outside the callback, still completes.
+      server.shutdown().get(5, TimeUnit.SECONDS);
+    } finally {
+      releaseStartup.countDown();
+      executor.shutdownNow();
+    }
+  }
+
+  private OpcUaServer newServer(RecordingTransport transport) {
+    EndpointConfig endpoint =
+        EndpointConfig.newBuilder()
+            .setBindAddress("127.0.0.1")
+            .setBindPort(4840)
+            .setHostname("localhost")
+            .setPath("/milo")
+            .setSecurityPolicy(SecurityPolicy.None)
+            .setSecurityMode(MessageSecurityMode.None)
+            .addTokenPolicy(OpcUaServerConfig.USER_TOKEN_POLICY_ANONYMOUS)
+            .build();
+
+    OpcUaServerConfig config =
+        OpcUaServerConfig.builder()
+            .setApplicationUri("urn:eclipse:milo:test:server")
+            .setApplicationName(LocalizedText.english("test server"))
+            .setProductUri("urn:eclipse:milo:test")
+            .setCertificateManager(new DefaultCertificateManager(new MemoryCertificateQuarantine()))
+            .setEndpoints(Set.of(endpoint))
+            .build();
+
+    OpcUaServer server = new OpcUaServer(config, transportProfile -> transport);
+    servers.add(server);
+    return server;
+  }
+
+  private static Lifecycle participant(Runnable startup, Runnable shutdown) {
+    return new Lifecycle() {
+      @Override
+      public void startup() {
+        startup.run();
+      }
+
+      @Override
+      public void shutdown() {
+        shutdown.run();
+      }
+    };
+  }
+
+  private static void await(CountDownLatch latch) {
+    try {
+      if (!latch.await(5, TimeUnit.SECONDS)) {
+        throw new AssertionError("timed out waiting for latch");
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new AssertionError("interrupted waiting for latch", e);
+    }
+  }
+
+  private static final class RecordingTransport implements OpcServerTransport {
+
+    private final List<String> events;
+    private boolean bound;
+    private Runnable onBind = () -> {};
+    private Exception bindFailure;
+
+    private RecordingTransport() {
+      this(new ArrayList<>());
+    }
+
+    private RecordingTransport(List<String> events) {
+      this.events = events;
+    }
+
+    @Override
+    public void bind(ServerApplicationContext applicationContext, InetSocketAddress bindAddress)
+        throws Exception {
+      events.add("bind");
+      onBind.run();
+      if (bindFailure != null) {
+        throw bindFailure;
+      }
+      bound = true;
+    }
+
+    @Override
+    public void unbind() {
+      events.add("unbind");
+      bound = false;
+    }
+  }
+}


### PR DESCRIPTION
OpcUaServer currently has no supported lifecycle phase for application components that need the standard address space and core event facilities to be ready before any endpoint becomes visible. Components such as AliasManager and application namespaces must otherwise start either too early or after clients can already connect.

This adds a server-owned lifecycle participant API. Registered Lifecycle instances start in order after core initialization and before passive transport binding or reverse-connect startup. The server stops them in reverse order after removing external visibility, rolls back started participants when startup fails, and preserves cleanup failures without replacing the primary failure.

The existing Lifecycle and AbstractLifecycle APIs remain unchanged.
