### PR TITLE
Add app-driven limit alarm state APIs

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/conditions/AppDrivenLimitAlarmStateTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/conditions/AppDrivenLimitAlarmStateTest.java
@@ -1,0 +1,1075 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.conditions;
+
+import static java.util.Objects.requireNonNull;
+import static org.eclipse.milo.opcua.sdk.test.EventTestSupport.conditionNameFilter;
+import static org.eclipse.milo.opcua.sdk.test.EventTestSupport.localizedTextOf;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ubyte;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.AbstractSet;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.eclipse.milo.opcua.sdk.client.subscriptions.OpcUaSubscription;
+import org.eclipse.milo.opcua.sdk.core.Reference;
+import org.eclipse.milo.opcua.sdk.server.model.objects.NonExclusiveLimitAlarmTypeNode;
+import org.eclipse.milo.opcua.sdk.server.model.objects.ShelvedStateMachineTypeNode;
+import org.eclipse.milo.opcua.sdk.server.model.variables.TwoStateVariableTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNodeContext;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectNode;
+import org.eclipse.milo.opcua.sdk.test.AbstractClientServerTest;
+import org.eclipse.milo.opcua.sdk.test.EventTestSupport;
+import org.eclipse.milo.opcua.sdk.test.TestNamespace;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.structured.CallMethodRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.CallMethodResult;
+import org.eclipse.milo.opcua.stack.core.types.structured.CallResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.EventFilter;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Client-visible coverage for application-computed non-exclusive limit-alarm states: atomic tuple
+ * replacement, caller-selected presentation, acknowledgement and timing rules, validation, and
+ * interaction with the standard Condition lifecycle.
+ */
+// Fields below are assigned in configureTestNamespace(), which the nullability inspection does not
+// model.
+@SuppressWarnings("NotNullFieldNotInitialized")
+public class AppDrivenLimitAlarmStateTest extends AbstractClientServerTest {
+
+  private static final int BASE_SEVERITY = 100;
+  private static final int HIGH_HIGH_SEVERITY = 800;
+  private static final int HIGH_SEVERITY = 600;
+  private static final int LOW_SEVERITY = 500;
+  private static final int LOW_LOW_SEVERITY = 700;
+
+  private UaNodeContext nodeContext;
+  private UaObjectNode source;
+
+  @Override
+  protected void configureTestNamespace(TestNamespace namespace) {
+    namespace.configure(
+        (context, nodeManager) -> {
+          nodeContext = context;
+
+          source =
+              new UaObjectNode(
+                  context,
+                  newNodeId("AppDrivenLimitAlarmStateTest/Source"),
+                  newQualifiedName("AppDrivenLimitAlarmStateTest/Source"),
+                  LocalizedText.english("AppDrivenLimitAlarmStateTest/Source"),
+                  LocalizedText.NULL_VALUE,
+                  uint(0),
+                  uint(0),
+                  ubyte(0));
+
+          source.addReference(
+              new Reference(
+                  source.getNodeId(),
+                  NodeIds.HasTypeDefinition,
+                  NodeIds.BaseObjectType.expanded(),
+                  true));
+          source.addReference(
+              new Reference(
+                  source.getNodeId(),
+                  NodeIds.HasComponent,
+                  NodeIds.ObjectsFolder.expanded(),
+                  Reference.Direction.INVERSE));
+
+          nodeManager.addNode(source);
+        });
+  }
+
+  @Nested
+  class StateApplication {
+
+    // Caller-computed compound states must not inherit the scalar evaluator's excursion order.
+    @Test
+    void callerSelectedEffectiveStateDrivesOneCoherentCrossSideEvent() throws Exception {
+      NonExclusiveLimitAlarm alarm = createNonExclusiveAlarm("CrossSideSelection", false);
+      var subscription = new OpcUaSubscription(client);
+      subscription.create();
+
+      try {
+        EventFilter filter =
+            conditionNameFilter(
+                "CrossSideSelection",
+                EventTestSupport.eventField(NodeIds.BaseEventType, "Message"),
+                EventTestSupport.eventField(NodeIds.BaseEventType, "Severity"),
+                EventTestSupport.eventField(NodeIds.AlarmConditionType, "ActiveState", "Id"),
+                EventTestSupport.eventField(
+                    NodeIds.AlarmConditionType, "ActiveState", "EffectiveDisplayName"),
+                EventTestSupport.eventField(
+                    NodeIds.NonExclusiveLimitAlarmType, "HighHighState", "Id"),
+                EventTestSupport.eventField(NodeIds.NonExclusiveLimitAlarmType, "HighState", "Id"),
+                EventTestSupport.eventField(NodeIds.NonExclusiveLimitAlarmType, "LowState", "Id"),
+                EventTestSupport.eventField(
+                    NodeIds.NonExclusiveLimitAlarmType, "LowLowState", "Id"));
+
+        List<Variant[]> events =
+            EventTestSupport.monitorEvents(subscription, NodeIds.Server, filter);
+
+        alarm.setLimitStates(
+            EnumSet.of(ExclusiveLimitState.HIGH, ExclusiveLimitState.LOW), ExclusiveLimitState.LOW);
+
+        Variant[] event =
+            EventTestSupport.awaitEvent(
+                events,
+                "cross-side state with caller-selected Low presentation",
+                fields ->
+                    "Active/Low".equals(messageOf(fields))
+                        && ushort(LOW_SEVERITY).equals(fields[1].value()));
+
+        assertEquals(Boolean.TRUE, event[2].value());
+        assertEquals("Active/Low", localizedTextOf(event[3]));
+        assertEquals(Boolean.FALSE, event[4].value());
+        assertEquals(Boolean.TRUE, event[5].value());
+        assertEquals(Boolean.TRUE, event[6].value());
+        assertEquals(Boolean.FALSE, event[7].value());
+        assertOnlyEvents(events, "cross-side reduced-state transition", event);
+
+        assertActiveStates(alarm, EnumSet.of(ExclusiveLimitState.HIGH, ExclusiveLimitState.LOW));
+        assertEquals(ExclusiveLimitState.LOW, alarm.getEffectiveLimitState());
+        assertEquals("Active/Low", effectiveDisplayName(alarm));
+        assertEquals(ushort(LOW_SEVERITY), alarm.getNode().getSeverity());
+        assertTrue(alarm.isActive());
+      } finally {
+        subscription.delete();
+      }
+    }
+
+    // Full replacement prevents consumers from observing transient delta-update combinations.
+    @Test
+    void replacementClearsOmittedStatesWithOneSharedTransitionTime() throws Exception {
+      NonExclusiveLimitAlarm alarm = createNonExclusiveAlarm("FullReplacement", false);
+      var subscription = new OpcUaSubscription(client);
+      subscription.create();
+
+      try {
+        EventFilter filter =
+            conditionNameFilter(
+                "FullReplacement",
+                EventTestSupport.eventField(NodeIds.BaseEventType, "Message"),
+                EventTestSupport.eventField(
+                    NodeIds.NonExclusiveLimitAlarmType, "HighHighState", "Id"),
+                EventTestSupport.eventField(NodeIds.NonExclusiveLimitAlarmType, "HighState", "Id"),
+                EventTestSupport.eventField(NodeIds.NonExclusiveLimitAlarmType, "LowState", "Id"),
+                EventTestSupport.eventField(
+                    NodeIds.NonExclusiveLimitAlarmType, "LowLowState", "Id"),
+                EventTestSupport.eventField(NodeIds.BaseEventType, "Time"),
+                EventTestSupport.eventField(
+                    NodeIds.NonExclusiveLimitAlarmType, "HighHighState", "TransitionTime"),
+                EventTestSupport.eventField(
+                    NodeIds.NonExclusiveLimitAlarmType, "HighState", "TransitionTime"),
+                EventTestSupport.eventField(
+                    NodeIds.NonExclusiveLimitAlarmType, "LowState", "TransitionTime"),
+                EventTestSupport.eventField(
+                    NodeIds.NonExclusiveLimitAlarmType, "LowLowState", "TransitionTime"),
+                EventTestSupport.eventField(
+                    NodeIds.AlarmConditionType, "ActiveState", "TransitionTime"),
+                EventTestSupport.eventField(
+                    NodeIds.AlarmConditionType, "ActiveState", "EffectiveTransitionTime"));
+
+        List<Variant[]> events =
+            EventTestSupport.monitorEvents(subscription, NodeIds.Server, filter);
+
+        alarm.setLimitStates(
+            EnumSet.allOf(ExclusiveLimitState.class), ExclusiveLimitState.HIGH_HIGH);
+        Variant[] allStates =
+            EventTestSupport.awaitEvent(
+                events,
+                "all limit states active",
+                fields -> "Active/HighHigh".equals(messageOf(fields)));
+
+        DateTime highTime = (DateTime) allStates[7].value();
+        DateTime lowTime = (DateTime) allStates[8].value();
+        DateTime activeTime = (DateTime) allStates[10].value();
+
+        alarm.setLimitStates(
+            EnumSet.of(ExclusiveLimitState.HIGH, ExclusiveLimitState.LOW), ExclusiveLimitState.LOW);
+
+        Variant[] replacement =
+            EventTestSupport.awaitEvent(
+                events,
+                "omitted outer states cleared in the Low-selected replacement",
+                fields ->
+                    "Active/Low".equals(messageOf(fields))
+                        && Boolean.FALSE.equals(fields[1].value())
+                        && Boolean.TRUE.equals(fields[2].value())
+                        && Boolean.TRUE.equals(fields[3].value())
+                        && Boolean.FALSE.equals(fields[4].value()));
+
+        DateTime eventTime = (DateTime) replacement[5].value();
+        assertEquals(eventTime, replacement[6].value(), "HighHigh cleared at event time");
+        assertEquals(highTime, replacement[7].value(), "High remained active without transition");
+        assertEquals(lowTime, replacement[8].value(), "Low remained active without transition");
+        assertEquals(eventTime, replacement[9].value(), "LowLow cleared at event time");
+        assertEquals(activeTime, replacement[10].value(), "Active stayed true");
+        assertEquals(
+            eventTime,
+            replacement[11].value(),
+            "membership change advances EffectiveTransitionTime");
+        assertOnlyEvents(events, "complete-set replacement", allStates, replacement);
+      } finally {
+        subscription.delete();
+      }
+    }
+
+    @Test
+    void callerMutationAfterNormalizationCannotChangeTheAppliedDefensiveSnapshot()
+        throws Exception {
+      NonExclusiveLimitAlarm alarm = createNonExclusiveAlarm("DefensiveCopy", false);
+      var traversalComplete = new CountDownLatch(1);
+      var callerStates =
+          new TraversalSignallingSet(
+              EnumSet.of(ExclusiveLimitState.HIGH, ExclusiveLimitState.LOW), traversalComplete);
+      var setter = new AtomicReference<@Nullable Future<?>>();
+      ExecutorService executor = Executors.newSingleThreadExecutor();
+
+      try {
+        // Hold the mutation boundary while the worker defensively normalizes the caller's set.
+        alarm.runLocked(
+            () -> {
+              setter.set(
+                  executor.submit(
+                      () -> alarm.setLimitStates(callerStates, ExclusiveLimitState.LOW)));
+
+              assertTrue(
+                  traversalComplete.await(5, TimeUnit.SECONDS),
+                  "setter did not finish traversing its input set");
+              assertFalse(
+                  requireNonNull(setter.get()).isDone(),
+                  "setter must still be waiting on the held lock");
+
+              callerStates.clear();
+              callerStates.add(ExclusiveLimitState.HIGH_HIGH);
+            });
+
+        requireNonNull(setter.get()).get(5, TimeUnit.SECONDS);
+      } finally {
+        executor.shutdownNow();
+        assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
+      }
+
+      assertActiveStates(alarm, EnumSet.of(ExclusiveLimitState.HIGH, ExclusiveLimitState.LOW));
+      assertEquals(ExclusiveLimitState.LOW, alarm.getEffectiveLimitState());
+    }
+
+    @Test
+    void scalarEvaluationReassertsItsMembershipPolicyAndClearResetsEffectiveReadback()
+        throws Exception {
+      NonExclusiveLimitAlarm alarm = createNonExclusiveAlarm("ScalarReassertion", false);
+      alarm.setLimitStates(
+          EnumSet.of(ExclusiveLimitState.HIGH, ExclusiveLimitState.LOW), ExclusiveLimitState.LOW);
+
+      alarm.evaluate(96.0);
+
+      assertActiveStates(
+          alarm, EnumSet.of(ExclusiveLimitState.HIGH_HIGH, ExclusiveLimitState.HIGH));
+      assertEquals(ExclusiveLimitState.HIGH_HIGH, alarm.getEffectiveLimitState());
+      assertEquals("Active/HighHigh", message(alarm));
+      assertEquals("Active/HighHigh", effectiveDisplayName(alarm));
+      assertEquals(ushort(HIGH_HIGH_SEVERITY), alarm.getNode().getSeverity());
+
+      alarm.setActive(false);
+
+      assertActiveStates(alarm, Set.of());
+      assertNull(alarm.getEffectiveLimitState());
+      assertFalse(alarm.isActive());
+    }
+
+    // Scalar precedence must run even when evaluation does not change any modeled limit bit.
+    @Test
+    void scalarEvaluationReselectsItsFixedPolicyWhenMembershipAlreadyMatches() throws Exception {
+      NonExclusiveLimitAlarm alarm = createNonExclusiveAlarm("ScalarReselection", false);
+      Set<ExclusiveLimitState> scalarMembership =
+          EnumSet.of(ExclusiveLimitState.HIGH_HIGH, ExclusiveLimitState.HIGH);
+      alarm.setLimitStates(scalarMembership, ExclusiveLimitState.HIGH);
+
+      ByteString directEventId = alarm.currentBranch().getLastEventId();
+      DateTime effectiveTime = activeState(alarm).getEffectiveTransitionTime();
+      DateTime highHighTime = stateNode(alarm, ExclusiveLimitState.HIGH_HIGH).getTransitionTime();
+      DateTime highTime = stateNode(alarm, ExclusiveLimitState.HIGH).getTransitionTime();
+
+      alarm.evaluate(96.0);
+
+      ByteString scalarEventId = alarm.currentBranch().getLastEventId();
+      assertActiveStates(alarm, scalarMembership);
+      assertEquals(ExclusiveLimitState.HIGH_HIGH, alarm.getEffectiveLimitState());
+      assertEquals("Active/HighHigh", message(alarm));
+      assertEquals(ushort(HIGH_HIGH_SEVERITY), alarm.getNode().getSeverity());
+      assertNotEquals(directEventId, scalarEventId);
+      assertFalse(alarm.currentBranch().isAcknowledgeable(directEventId));
+      assertTrue(alarm.currentBranch().isAcknowledgeable(scalarEventId));
+      assertEquals(effectiveTime, activeState(alarm).getEffectiveTransitionTime());
+      assertEquals(
+          highHighTime, stateNode(alarm, ExclusiveLimitState.HIGH_HIGH).getTransitionTime());
+      assertEquals(highTime, stateNode(alarm, ExclusiveLimitState.HIGH).getTransitionTime());
+    }
+
+    @Test
+    void scalarSeverityCorrectionPreservesTheComputedReducedStateAndAcknowledgement()
+        throws Exception {
+      NonExclusiveLimitAlarm alarm = createNonExclusiveAlarm("ScalarSeverityCorrection", false);
+      alarm.evaluate(96.0);
+      acknowledge(alarm);
+
+      TwoStateVariableTypeNode ackedState = requireNonNull(alarm.getNode().getAckedStateNode());
+      DateTime ackedTime = ackedState.getTransitionTime();
+      DateTime effectiveTime = activeState(alarm).getEffectiveTransitionTime();
+      ByteString acknowledgedEventId = alarm.currentBranch().getLastEventId();
+
+      alarm.getNode().setSeverityHighHigh(ushort(HIGH_HIGH_SEVERITY + 1));
+      alarm.evaluate(96.0);
+
+      assertActiveStates(
+          alarm, EnumSet.of(ExclusiveLimitState.HIGH_HIGH, ExclusiveLimitState.HIGH));
+      assertEquals(ExclusiveLimitState.HIGH_HIGH, alarm.getEffectiveLimitState());
+      assertEquals(ushort(HIGH_HIGH_SEVERITY + 1), alarm.getNode().getSeverity());
+      assertEquals(ushort(HIGH_HIGH_SEVERITY), alarm.getNode().getLastSeverity());
+      assertTrue(alarm.isAcked());
+      assertEquals(ackedTime, ackedState.getTransitionTime());
+      assertEquals(effectiveTime, activeState(alarm).getEffectiveTransitionTime());
+      assertNotEquals(acknowledgedEventId, alarm.currentBranch().getLastEventId());
+    }
+  }
+
+  @Nested
+  class Validation {
+
+    // Invalid input must not lazily expire shelving before reporting the caller error.
+    @Test
+    @SuppressWarnings("DataFlowIssue")
+    void invalidTuplesFailBeforeAnyStateOrShelvingMutation() throws Exception {
+      NonExclusiveLimitAlarm alarm = createNonExclusiveAlarm("InvalidTuples", true);
+      alarm.setLimitStates(Set.of(ExclusiveLimitState.LOW), ExclusiveLimitState.LOW);
+      makeShelvingExpiryDue(alarm);
+
+      ByteString eventId = alarm.currentBranch().getLastEventId();
+      DateTime eventTime = alarm.currentBranch().getLastEventTime();
+      DateTime activeTime = activeState(alarm).getTransitionTime();
+      DateTime lowTime = stateNode(alarm, ExclusiveLimitState.LOW).getTransitionTime();
+
+      assertThrows(NullPointerException.class, () -> alarm.setLimitStates(null, null));
+
+      var nullMember = new HashSet<ExclusiveLimitState>();
+      nullMember.add(ExclusiveLimitState.LOW);
+      nullMember.add(null);
+      assertThrows(
+          NullPointerException.class,
+          () -> alarm.setLimitStates(nullMember, ExclusiveLimitState.LOW));
+
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> alarm.setLimitStates(Set.of(), ExclusiveLimitState.LOW));
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> alarm.setLimitStates(Set.of(ExclusiveLimitState.LOW), null));
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> alarm.setLimitStates(Set.of(ExclusiveLimitState.HIGH), ExclusiveLimitState.LOW));
+
+      assertActiveStates(alarm, Set.of(ExclusiveLimitState.LOW));
+      assertEquals(ExclusiveLimitState.LOW, alarm.getEffectiveLimitState());
+      assertEquals(eventId, alarm.currentBranch().getLastEventId());
+      assertEquals(eventTime, alarm.currentBranch().getLastEventTime());
+      assertEquals(activeTime, activeState(alarm).getTransitionTime());
+      assertEquals(lowTime, stateNode(alarm, ExclusiveLimitState.LOW).getTransitionTime());
+      assertEquals("TimedShelved", shelvingStateName(alarm));
+    }
+
+    @Test
+    void missingStateNodeAndMissingLimitPropertyAreRejectedIndependently() throws Exception {
+      NonExclusiveLimitAlarm missingState =
+          createPartiallyLoadedAlarm("MissingStateNode", true, true);
+      NonExclusiveLimitAlarm missingLimit =
+          createPartiallyLoadedAlarm("MissingLimitProperty", false, true);
+
+      assertUnsupportedStateRejectedBeforeShelvingTouch(missingState);
+      assertUnsupportedStateRejectedBeforeShelvingTouch(missingLimit);
+    }
+  }
+
+  @Nested
+  class AcknowledgementAndTiming {
+
+    // Configuration correction is observable, but it is not a new alarm state needing ack.
+    @Test
+    void identicalTupleIsSilentAndSeverityCorrectionDoesNotRenewAcknowledgement() throws Exception {
+      NonExclusiveLimitAlarm alarm = createNonExclusiveAlarm("SeverityCorrection", false);
+      Set<ExclusiveLimitState> states =
+          EnumSet.of(ExclusiveLimitState.HIGH, ExclusiveLimitState.LOW);
+
+      alarm.setLimitStates(states, ExclusiveLimitState.LOW);
+      acknowledge(alarm);
+
+      TwoStateVariableTypeNode ackedState = alarm.getNode().getAckedStateNode();
+      DateTime ackedTime = requireNonNull(ackedState).getTransitionTime();
+      ByteString acknowledgedEventId = alarm.currentBranch().getLastEventId();
+      DateTime acknowledgedEventTime = alarm.currentBranch().getLastEventTime();
+
+      var subscription = new OpcUaSubscription(client);
+      subscription.create();
+
+      try {
+        EventFilter filter =
+            conditionNameFilter(
+                "SeverityCorrection",
+                EventTestSupport.eventField(NodeIds.BaseEventType, "Message"),
+                EventTestSupport.eventField(NodeIds.BaseEventType, "Severity"),
+                EventTestSupport.eventField(NodeIds.ConditionType, "LastSeverity"),
+                EventTestSupport.eventField(
+                    NodeIds.AcknowledgeableConditionType, "AckedState", "Id"));
+        List<Variant[]> events =
+            EventTestSupport.monitorEvents(subscription, NodeIds.Server, filter);
+
+        alarm.setLimitStates(states, ExclusiveLimitState.LOW);
+
+        assertEquals(acknowledgedEventId, alarm.currentBranch().getLastEventId());
+        assertEquals(acknowledgedEventTime, alarm.currentBranch().getLastEventTime());
+        EventTestSupport.assertNoEvent(events, "exact tuple no-op", fields -> true);
+
+        alarm.getNode().setSeverityLow(ushort(LOW_SEVERITY + 1));
+        alarm.setLimitStates(states, ExclusiveLimitState.LOW);
+
+        Variant[] correction =
+            EventTestSupport.awaitEvent(
+                events,
+                "selected Low Severity correction",
+                fields -> ushort(LOW_SEVERITY + 1).equals(fields[1].value()));
+
+        assertEquals("Active/Low", messageOf(correction));
+        assertEquals(ushort(LOW_SEVERITY), correction[2].value());
+        assertEquals(Boolean.TRUE, correction[3].value());
+        assertTrue(alarm.isAcked());
+        assertEquals(ackedTime, ackedState.getTransitionTime());
+        assertNotEquals(acknowledgedEventId, alarm.currentBranch().getLastEventId());
+        assertOnlyEvents(events, "selected Severity correction", correction);
+      } finally {
+        subscription.delete();
+      }
+    }
+
+    // Selecting a different primary state is semantic, but no modeled substate entered or left.
+    @Test
+    void effectiveReselectionRenewsAckWithoutChangingModeledTransitionTimes() throws Exception {
+      NonExclusiveLimitAlarm alarm = createNonExclusiveAlarm("EffectiveReselection", false);
+      Set<ExclusiveLimitState> states =
+          EnumSet.of(ExclusiveLimitState.HIGH, ExclusiveLimitState.LOW);
+      alarm.setLimitStates(states, ExclusiveLimitState.HIGH);
+
+      TwoStateVariableTypeNode activeState = activeState(alarm);
+      TwoStateVariableTypeNode ackedState = requireNonNull(alarm.getNode().getAckedStateNode());
+      DateTime activeTime = activeState.getTransitionTime();
+      DateTime sentinel = new DateTime(1L);
+      activeState.setEffectiveTransitionTime(sentinel);
+      DateTime highTime = stateNode(alarm, ExclusiveLimitState.HIGH).getTransitionTime();
+      DateTime lowTime = stateNode(alarm, ExclusiveLimitState.LOW).getTransitionTime();
+      DateTime ackedTime = ackedState.getTransitionTime();
+      ByteString firstEventId = alarm.currentBranch().getLastEventId();
+
+      var subscription = new OpcUaSubscription(client);
+      subscription.create();
+
+      try {
+        EventFilter filter =
+            conditionNameFilter(
+                "EffectiveReselection",
+                EventTestSupport.eventField(NodeIds.BaseEventType, "Message"),
+                EventTestSupport.eventField(NodeIds.BaseEventType, "Severity"),
+                EventTestSupport.eventField(
+                    NodeIds.AlarmConditionType, "ActiveState", "EffectiveDisplayName"),
+                EventTestSupport.eventField(
+                    NodeIds.AcknowledgeableConditionType, "AckedState", "Id"));
+        List<Variant[]> events =
+            EventTestSupport.monitorEvents(subscription, NodeIds.Server, filter);
+
+        alarm.setLimitStates(states, ExclusiveLimitState.LOW);
+
+        Variant[] reselection =
+            EventTestSupport.awaitEvent(
+                events,
+                "same-membership Low reselection",
+                fields -> "Active/Low".equals(messageOf(fields)));
+
+        ByteString secondEventId = alarm.currentBranch().getLastEventId();
+        assertEquals(ushort(LOW_SEVERITY), reselection[1].value());
+        assertEquals("Active/Low", localizedTextOf(reselection[2]));
+        assertEquals(Boolean.FALSE, reselection[3].value());
+        assertEquals(ExclusiveLimitState.LOW, alarm.getEffectiveLimitState());
+        assertNotEquals(firstEventId, secondEventId);
+        assertFalse(alarm.currentBranch().isAcknowledgeable(firstEventId));
+        assertTrue(alarm.currentBranch().isAcknowledgeable(secondEventId));
+        assertEquals(ackedTime, ackedState.getTransitionTime());
+        assertEquals(activeTime, activeState.getTransitionTime());
+        assertEquals(sentinel, activeState.getEffectiveTransitionTime());
+        assertEquals(highTime, stateNode(alarm, ExclusiveLimitState.HIGH).getTransitionTime());
+        assertEquals(lowTime, stateNode(alarm, ExclusiveLimitState.LOW).getTransitionTime());
+        assertOnlyEvents(events, "effective-state reselection", reselection);
+      } finally {
+        subscription.delete();
+      }
+    }
+
+    // Part 9 allows a server to renew the acknowledgement obligation for a changed alarm state.
+    @Test
+    void membershipChangeRenewsAckAndAdvancesOnlyMembershipTiming() throws Exception {
+      NonExclusiveLimitAlarm alarm = createNonExclusiveAlarm("MembershipRenewal", false);
+      alarm.setLimitStates(Set.of(ExclusiveLimitState.HIGH), ExclusiveLimitState.HIGH);
+
+      TwoStateVariableTypeNode activeState = activeState(alarm);
+      TwoStateVariableTypeNode ackedState = requireNonNull(alarm.getNode().getAckedStateNode());
+      DateTime activeTime = activeState.getTransitionTime();
+      DateTime sentinel = new DateTime(1L);
+      activeState.setEffectiveTransitionTime(sentinel);
+      DateTime highTime = stateNode(alarm, ExclusiveLimitState.HIGH).getTransitionTime();
+      DateTime ackedTime = ackedState.getTransitionTime();
+      ByteString firstEventId = alarm.currentBranch().getLastEventId();
+
+      alarm.setLimitStates(
+          EnumSet.of(ExclusiveLimitState.HIGH, ExclusiveLimitState.LOW), ExclusiveLimitState.HIGH);
+
+      ByteString secondEventId = alarm.currentBranch().getLastEventId();
+      DateTime lowTime = stateNode(alarm, ExclusiveLimitState.LOW).getTransitionTime();
+
+      assertNotEquals(firstEventId, secondEventId);
+      assertFalse(alarm.currentBranch().isAcknowledgeable(firstEventId));
+      assertTrue(alarm.currentBranch().isAcknowledgeable(secondEventId));
+      assertFalse(alarm.isAcked());
+      assertEquals(ackedTime, ackedState.getTransitionTime());
+      assertEquals(activeTime, activeState.getTransitionTime());
+      assertEquals(highTime, stateNode(alarm, ExclusiveLimitState.HIGH).getTransitionTime());
+      assertNotEquals(sentinel, activeState.getEffectiveTransitionTime());
+      assertEquals(lowTime, activeState.getEffectiveTransitionTime());
+    }
+
+    @Test
+    void createdLimitAlarmsExposeInitializedEffectiveTransitionTime() throws Exception {
+      NonExclusiveLimitAlarm nonExclusive =
+          createNonExclusiveAlarm("InitializedEffectiveTime", false);
+      ExclusiveLimitAlarm exclusive = createExclusiveAlarm("ExclusiveEffectiveTime");
+
+      TwoStateVariableTypeNode nonExclusiveActive = activeState(nonExclusive);
+      TwoStateVariableTypeNode exclusiveActive = activeState(exclusive);
+
+      assertNotNull(nonExclusiveActive.getEffectiveTransitionTimeNode());
+      assertNotNull(nonExclusiveActive.getEffectiveTransitionTime());
+      assertEquals(
+          nonExclusiveActive.getTransitionTime(), nonExclusiveActive.getEffectiveTransitionTime());
+      assertNotNull(exclusiveActive.getEffectiveTransitionTimeNode());
+      assertNotNull(exclusiveActive.getEffectiveTransitionTime());
+      assertEquals(
+          exclusiveActive.getTransitionTime(), exclusiveActive.getEffectiveTransitionTime());
+
+      exclusive.setLimitState(ExclusiveLimitState.HIGH);
+      DateTime sentinel = new DateTime(1L);
+      exclusiveActive.setEffectiveTransitionTime(sentinel);
+      exclusive.setLimitState(ExclusiveLimitState.HIGH_HIGH);
+
+      assertNotEquals(sentinel, exclusiveActive.getEffectiveTransitionTime());
+    }
+  }
+
+  @Nested
+  class ConditionLifecycle {
+
+    @Test
+    void clearRetainBehaviorTracksTheOutstandingAcknowledgement() throws Exception {
+      NonExclusiveLimitAlarm alarm = createNonExclusiveAlarm("RetainLifecycle", false);
+
+      alarm.setLimitStates(Set.of(ExclusiveLimitState.HIGH), ExclusiveLimitState.HIGH);
+      alarm.setLimitStates(Set.of(), null);
+
+      assertFalse(alarm.isActive());
+      assertFalse(alarm.isAcked());
+      assertTrue(alarm.isRetained(), "inactive but unacknowledged state must remain retained");
+      acknowledge(alarm);
+      assertFalse(alarm.isRetained(), "acknowledging the inactive state retracts Retain");
+
+      alarm.setLimitStates(Set.of(ExclusiveLimitState.LOW), ExclusiveLimitState.LOW);
+      acknowledge(alarm);
+
+      assertTrue(alarm.isActive());
+      assertTrue(alarm.isAcked());
+      assertTrue(alarm.isRetained());
+
+      alarm.setLimitStates(Set.of(), null);
+
+      assertFalse(alarm.isActive());
+      assertTrue(alarm.isAcked());
+      assertFalse(alarm.isRetained(), "inactive and acknowledged state retracts immediately");
+      assertNull(alarm.getEffectiveLimitState());
+    }
+
+    // Disabled Conditions keep processing internal alarm state for a coherent re-enable event.
+    @Test
+    void disabledApplicationSurvivesEnableReassertion() throws Exception {
+      NonExclusiveLimitAlarm alarm = createNonExclusiveAlarm("DisabledApplication", false);
+      assertGood(call(alarm.getConditionId(), NodeIds.ConditionType_Disable));
+      ByteString disabledEventId = alarm.currentBranch().getLastEventId();
+
+      alarm.setLimitStates(
+          EnumSet.of(ExclusiveLimitState.HIGH, ExclusiveLimitState.LOW), ExclusiveLimitState.LOW);
+
+      assertTrue(alarm.isActive());
+      assertActiveStates(alarm, EnumSet.of(ExclusiveLimitState.HIGH, ExclusiveLimitState.LOW));
+      assertEquals(ExclusiveLimitState.LOW, alarm.getEffectiveLimitState());
+      assertFalse(alarm.isRetained());
+      assertEquals(disabledEventId, alarm.currentBranch().getLastEventId());
+
+      var subscription = new OpcUaSubscription(client);
+      subscription.create();
+
+      try {
+        EventFilter filter =
+            conditionNameFilter(
+                "DisabledApplication",
+                EventTestSupport.eventField(NodeIds.BaseEventType, "Message"),
+                EventTestSupport.eventField(NodeIds.AlarmConditionType, "ActiveState", "Id"),
+                EventTestSupport.eventField(
+                    NodeIds.AlarmConditionType, "ActiveState", "EffectiveDisplayName"),
+                EventTestSupport.eventField(NodeIds.NonExclusiveLimitAlarmType, "HighState", "Id"),
+                EventTestSupport.eventField(NodeIds.NonExclusiveLimitAlarmType, "LowState", "Id"));
+        List<Variant[]> events =
+            EventTestSupport.monitorEvents(subscription, NodeIds.Server, filter);
+
+        assertGood(call(alarm.getConditionId(), NodeIds.ConditionType_Enable));
+
+        Variant[] enabled =
+            EventTestSupport.awaitEvent(
+                events,
+                "enabled Condition reasserts the silently applied tuple",
+                fields -> "Enabled".equals(messageOf(fields)));
+
+        assertEquals(Boolean.TRUE, enabled[1].value());
+        assertEquals("Active/Low", localizedTextOf(enabled[2]));
+        assertEquals(Boolean.TRUE, enabled[3].value());
+        assertEquals(Boolean.TRUE, enabled[4].value());
+        assertTrue(alarm.isRetained());
+        assertOnlyEvents(events, "enable reassertion", enabled);
+      } finally {
+        subscription.delete();
+      }
+    }
+
+    // A valid no-op is still a shelving touch, so a lost expiry timer cannot pin suppression.
+    @Test
+    void identicalTupleAppliesDueLazyShelvingExpiryBeforeNoOpDetection() throws Exception {
+      NonExclusiveLimitAlarm alarm = createNonExclusiveAlarm("LazyShelving", true);
+      Set<ExclusiveLimitState> states = Set.of(ExclusiveLimitState.HIGH);
+      alarm.setLimitStates(states, ExclusiveLimitState.HIGH);
+      makeShelvingExpiryDue(alarm);
+      ByteString shelvedEventId = alarm.currentBranch().getLastEventId();
+
+      var subscription = new OpcUaSubscription(client);
+      subscription.create();
+
+      try {
+        EventFilter filter =
+            conditionNameFilter(
+                "LazyShelving", EventTestSupport.eventField(NodeIds.BaseEventType, "Message"));
+        List<Variant[]> events =
+            EventTestSupport.monitorEvents(subscription, NodeIds.Server, filter);
+
+        alarm.setLimitStates(states, ExclusiveLimitState.HIGH);
+
+        Variant[] unshelved =
+            EventTestSupport.awaitEvent(
+                events,
+                "due lazy shelving expiry",
+                fields -> "Unshelved".equals(messageOf(fields)));
+
+        assertEquals("Unshelved", shelvingStateName(alarm));
+        assertEquals(Boolean.FALSE, alarm.getNode().getSuppressedOrShelved());
+        assertActiveStates(alarm, states);
+        assertEquals(ExclusiveLimitState.HIGH, alarm.getEffectiveLimitState());
+        assertNotEquals(shelvedEventId, alarm.currentBranch().getLastEventId());
+        assertOnlyEvents(events, "lazy shelving expiry", unshelved);
+      } finally {
+        subscription.delete();
+      }
+    }
+
+    @Test
+    void clearingReleasesOneShotShelvingButPreservesTimedShelving() throws Exception {
+      NonExclusiveLimitAlarm alarm = createNonExclusiveAlarm("ShelvingModes", true);
+      alarm.setLimitStates(Set.of(ExclusiveLimitState.HIGH), ExclusiveLimitState.HIGH);
+
+      ShelvedStateMachineTypeNode shelving = requireNonNull(alarm.getShelvingState());
+      assertGood(
+          call(
+              shelving.getNodeId(),
+              requireNonNull(shelving.getOneShotShelveMethodNode()).getNodeId()));
+      assertEquals("OneShotShelved", shelvingStateName(alarm));
+
+      alarm.setLimitStates(Set.of(), null);
+      assertEquals("Unshelved", shelvingStateName(alarm));
+
+      alarm.setLimitStates(Set.of(ExclusiveLimitState.LOW), ExclusiveLimitState.LOW);
+      assertGood(
+          call(
+              shelving.getNodeId(),
+              requireNonNull(shelving.getTimedShelveMethodNode()).getNodeId(),
+              new Variant(30_000.0)));
+
+      alarm.setLimitStates(Set.of(), null);
+
+      assertEquals("TimedShelved", shelvingStateName(alarm));
+      assertEquals(Boolean.TRUE, alarm.getNode().getSuppressedOrShelved());
+      assertFalse(alarm.isActive());
+      assertNull(alarm.getEffectiveLimitState());
+    }
+  }
+
+  @Nested
+  class LoadedStateCompatibility {
+
+    @Test
+    void firstSetterRepairsIncoherentActiveButSeedsCoherentLegacySelectionAsNoOp()
+        throws Exception {
+      NonExclusiveLimitAlarm incoherent = createLoadedAlarm("IncoherentLoaded", false);
+      NonExclusiveLimitAlarm coherent = createLoadedAlarm("CoherentLoaded", true);
+
+      var subscription = new OpcUaSubscription(client);
+      subscription.create();
+
+      try {
+        EventFilter incoherentFilter =
+            conditionNameFilter(
+                "IncoherentLoaded",
+                EventTestSupport.eventField(NodeIds.BaseEventType, "Message"),
+                EventTestSupport.eventField(NodeIds.AlarmConditionType, "ActiveState", "Id"),
+                EventTestSupport.eventField(NodeIds.NonExclusiveLimitAlarmType, "HighState", "Id"));
+        List<Variant[]> incoherentEvents =
+            EventTestSupport.monitorEvents(subscription, NodeIds.Server, incoherentFilter);
+
+        EventFilter coherentFilter =
+            conditionNameFilter(
+                "CoherentLoaded", EventTestSupport.eventField(NodeIds.BaseEventType, "Message"));
+        List<Variant[]> coherentEvents =
+            EventTestSupport.monitorEvents(subscription, NodeIds.Server, coherentFilter);
+
+        ByteString coherentEventId = coherent.currentBranch().getLastEventId();
+        DateTime coherentEventTime = coherent.currentBranch().getLastEventTime();
+
+        incoherent.setLimitStates(Set.of(ExclusiveLimitState.HIGH), ExclusiveLimitState.HIGH);
+        coherent.setLimitStates(Set.of(ExclusiveLimitState.HIGH), ExclusiveLimitState.HIGH);
+
+        Variant[] repaired =
+            EventTestSupport.awaitEvent(
+                incoherentEvents,
+                "loaded High bit repairs false ActiveState",
+                fields ->
+                    "Active/High".equals(messageOf(fields))
+                        && Boolean.TRUE.equals(fields[1].value())
+                        && Boolean.TRUE.equals(fields[2].value()));
+
+        assertNotNull(repaired);
+        assertTrue(incoherent.isActive());
+        assertEquals(ExclusiveLimitState.HIGH, incoherent.getEffectiveLimitState());
+        assertOnlyEvents(incoherentEvents, "loaded ActiveState repair", repaired);
+
+        EventTestSupport.assertNoEvent(coherentEvents, "coherent first setter", fields -> true);
+        assertTrue(coherent.isActive());
+        assertEquals(ExclusiveLimitState.HIGH, coherent.getEffectiveLimitState());
+        assertEquals(coherentEventId, coherent.currentBranch().getLastEventId());
+        assertEquals(coherentEventTime, coherent.currentBranch().getLastEventTime());
+      } finally {
+        subscription.delete();
+      }
+    }
+  }
+
+  private NonExclusiveLimitAlarm createNonExclusiveAlarm(String name, boolean shelving)
+      throws UaException {
+    NonExclusiveLimitAlarm alarm = buildNonExclusiveAlarm(name, shelving);
+    server.getConditionManager().register(alarm);
+    return alarm;
+  }
+
+  private NonExclusiveLimitAlarm buildNonExclusiveAlarm(String name, boolean shelving)
+      throws UaException {
+    return NonExclusiveLimitAlarm.create(
+        nodeContext,
+        builder -> {
+          builder
+              .nodeId(newNodeId("AppDrivenLimitAlarmStateTest/" + name))
+              .browseName(newQualifiedName(name))
+              .conditionSource(source)
+              .severity(ushort(BASE_SEVERITY))
+              .highHighLimit(95.0, ushort(HIGH_HIGH_SEVERITY))
+              .highLimit(90.0, ushort(HIGH_SEVERITY))
+              .lowLimit(10.0, ushort(LOW_SEVERITY))
+              .lowLowLimit(5.0, ushort(LOW_LOW_SEVERITY));
+
+          if (shelving) {
+            builder.withShelving(Duration.ofMinutes(1));
+          }
+        });
+  }
+
+  private ExclusiveLimitAlarm createExclusiveAlarm(String name) throws UaException {
+    ExclusiveLimitAlarm alarm =
+        ExclusiveLimitAlarm.create(
+            nodeContext,
+            builder ->
+                builder
+                    .nodeId(newNodeId("AppDrivenLimitAlarmStateTest/" + name))
+                    .browseName(newQualifiedName(name))
+                    .conditionSource(source)
+                    .highHighLimit(95.0)
+                    .highLimit(90.0));
+    server.getConditionManager().register(alarm);
+    return alarm;
+  }
+
+  private NonExclusiveLimitAlarm createPartiallyLoadedAlarm(
+      String name, boolean deleteStateNode, boolean shelving) throws Exception {
+    NonExclusiveLimitAlarm created = buildNonExclusiveAlarm(name, shelving);
+    NonExclusiveLimitAlarmTypeNode node = created.getNode();
+
+    if (deleteStateNode) {
+      requireNonNull(node.getHighStateNode()).delete();
+      assertNull(node.getHighStateNode());
+      assertNotNull(node.getHighLimitNode());
+    } else {
+      requireNonNull(node.getHighLimitNode()).delete();
+      assertNotNull(node.getHighStateNode());
+      assertNull(node.getHighLimitNode());
+    }
+
+    NonExclusiveLimitAlarm attached =
+        NonExclusiveLimitAlarm.attach(node, options -> options.conditionSource(source));
+    server.getConditionManager().register(attached);
+    return attached;
+  }
+
+  private NonExclusiveLimitAlarm createLoadedAlarm(String name, boolean coherent) throws Exception {
+    NonExclusiveLimitAlarm created = buildNonExclusiveAlarm(name, false);
+    created.setLimitStates(Set.of(ExclusiveLimitState.HIGH), ExclusiveLimitState.HIGH);
+
+    if (!coherent) {
+      TwoStateVariableTypeNode activeState = activeState(created);
+      activeState.setId(false);
+      activeState.setValue(new DataValue(new Variant(LocalizedText.english("Inactive"))));
+    }
+
+    NonExclusiveLimitAlarm attached =
+        NonExclusiveLimitAlarm.attach(
+            created.getNode(), options -> options.conditionSource(source));
+    server.getConditionManager().register(attached);
+    return attached;
+  }
+
+  private void assertUnsupportedStateRejectedBeforeShelvingTouch(NonExclusiveLimitAlarm alarm)
+      throws Exception {
+    alarm.setLimitStates(Set.of(ExclusiveLimitState.LOW), ExclusiveLimitState.LOW);
+    makeShelvingExpiryDue(alarm);
+
+    ByteString eventId = alarm.currentBranch().getLastEventId();
+    DateTime eventTime = alarm.currentBranch().getLastEventTime();
+    DateTime activeTime = activeState(alarm).getTransitionTime();
+    DateTime lowTime = stateNode(alarm, ExclusiveLimitState.LOW).getTransitionTime();
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> alarm.setLimitStates(Set.of(ExclusiveLimitState.HIGH), ExclusiveLimitState.HIGH));
+
+    assertActiveStates(alarm, Set.of(ExclusiveLimitState.LOW));
+    assertEquals(ExclusiveLimitState.LOW, alarm.getEffectiveLimitState());
+    assertEquals(eventId, alarm.currentBranch().getLastEventId());
+    assertEquals(eventTime, alarm.currentBranch().getLastEventTime());
+    assertEquals(activeTime, activeState(alarm).getTransitionTime());
+    assertEquals(lowTime, stateNode(alarm, ExclusiveLimitState.LOW).getTransitionTime());
+    assertEquals("TimedShelved", shelvingStateName(alarm));
+  }
+
+  private void makeShelvingExpiryDue(NonExclusiveLimitAlarm alarm) throws Exception {
+    ShelvedStateMachineTypeNode shelving = requireNonNull(alarm.getShelvingState());
+    assertGood(
+        call(
+            shelving.getNodeId(),
+            requireNonNull(shelving.getTimedShelveMethodNode()).getNodeId(),
+            new Variant(30_000.0)));
+
+    ShelvingRuntime runtime = requireNonNull(alarm.getShelvingRuntime());
+    runtime.setExpiryTimerSuppressedForTesting(true);
+    runtime.makeExpiryDueForTesting();
+  }
+
+  private void acknowledge(NonExclusiveLimitAlarm alarm) throws Exception {
+    CallMethodResult result =
+        call(
+            alarm.getConditionId(),
+            NodeIds.AcknowledgeableConditionType_Acknowledge,
+            new Variant(alarm.currentBranch().getLastEventId()),
+            new Variant(LocalizedText.NULL_VALUE));
+    assertGood(result);
+  }
+
+  private CallMethodResult call(NodeId objectId, NodeId methodId, Variant... inputs)
+      throws Exception {
+    CallResponse response = client.call(List.of(new CallMethodRequest(objectId, methodId, inputs)));
+    return requireNonNull(response.getResults())[0];
+  }
+
+  private static void assertGood(CallMethodResult result) {
+    assertTrue(requireNonNull(result.getStatusCode()).isGood());
+  }
+
+  private static void assertOnlyEvents(
+      List<Variant[]> events, String description, Variant[]... expectedEvents)
+      throws InterruptedException {
+    for (Variant[] expectedEvent : expectedEvents) {
+      assertTrue(events.remove(expectedEvent), "expected event was not collected: " + description);
+    }
+    EventTestSupport.assertNoEvent(events, "additional " + description, fields -> true);
+  }
+
+  private static TwoStateVariableTypeNode activeState(LimitAlarm alarm) {
+    return requireNonNull(alarm.getNode().getActiveStateNode());
+  }
+
+  private static TwoStateVariableTypeNode stateNode(
+      NonExclusiveLimitAlarm alarm, ExclusiveLimitState state) {
+    TwoStateVariableTypeNode node =
+        switch (state) {
+          case HIGH_HIGH -> alarm.getNode().getHighHighStateNode();
+          case HIGH -> alarm.getNode().getHighStateNode();
+          case LOW -> alarm.getNode().getLowStateNode();
+          case LOW_LOW -> alarm.getNode().getLowLowStateNode();
+        };
+    return requireNonNull(node);
+  }
+
+  private static void assertActiveStates(
+      NonExclusiveLimitAlarm alarm, Set<ExclusiveLimitState> expected) {
+    for (ExclusiveLimitState state : ExclusiveLimitState.values()) {
+      assertEquals(
+          expected.contains(state), alarm.isLimitActive(state), state.stateName() + " membership");
+    }
+  }
+
+  private static String shelvingStateName(NonExclusiveLimitAlarm alarm) {
+    LocalizedText currentState =
+        requireNonNull(requireNonNull(alarm.getShelvingState()).getCurrentState());
+    return requireNonNull(currentState.text());
+  }
+
+  private static String effectiveDisplayName(NonExclusiveLimitAlarm alarm) {
+    LocalizedText displayName = requireNonNull(activeState(alarm).getEffectiveDisplayName());
+    return requireNonNull(displayName.text());
+  }
+
+  private static String message(NonExclusiveLimitAlarm alarm) {
+    LocalizedText message = requireNonNull(alarm.getNode().getMessage());
+    return requireNonNull(message.text());
+  }
+
+  private static @Nullable String messageOf(Variant[] eventFields) {
+    return localizedTextOf(eventFields[0]);
+  }
+
+  /** A mutable caller set that signals once a defensive-copy traversal has captured its values. */
+  private static final class TraversalSignallingSet extends AbstractSet<ExclusiveLimitState> {
+
+    private final Set<ExclusiveLimitState> delegate;
+    private final CountDownLatch traversalComplete;
+
+    private TraversalSignallingSet(
+        Set<ExclusiveLimitState> delegate, CountDownLatch traversalComplete) {
+      this.delegate = delegate;
+      this.traversalComplete = traversalComplete;
+    }
+
+    @Override
+    public Iterator<ExclusiveLimitState> iterator() {
+      Iterator<ExclusiveLimitState> iterator = delegate.iterator();
+
+      return new Iterator<>() {
+        @Override
+        public boolean hasNext() {
+          boolean hasNext = iterator.hasNext();
+          if (!hasNext) {
+            traversalComplete.countDown();
+          }
+          return hasNext;
+        }
+
+        @Override
+        public ExclusiveLimitState next() {
+          ExclusiveLimitState next = iterator.next();
+          if (!iterator.hasNext()) {
+            traversalComplete.countDown();
+          }
+          return next;
+        }
+      };
+    }
+
+    @Override
+    public int size() {
+      return delegate.size();
+    }
+
+    @Override
+    public boolean add(ExclusiveLimitState state) {
+      return delegate.add(state);
+    }
+
+    @Override
+    public void clear() {
+      delegate.clear();
+    }
+
+    @Override
+    public Object[] toArray() {
+      Object[] snapshot = delegate.toArray();
+      traversalComplete.countDown();
+      return snapshot;
+    }
+
+    @Override
+    public <T> T[] toArray(T[] array) {
+      T[] snapshot = delegate.toArray(array);
+      traversalComplete.countDown();
+      return snapshot;
+    }
+  }
+}

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/conditions/ConditionAttachAdoptTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/conditions/ConditionAttachAdoptTest.java
@@ -16,6 +16,8 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -36,13 +38,17 @@ import org.eclipse.milo.opcua.sdk.server.methods.MethodInvocationHandler;
 import org.eclipse.milo.opcua.sdk.server.model.objects.AcknowledgeableConditionTypeNode;
 import org.eclipse.milo.opcua.sdk.server.model.objects.AlarmConditionTypeNode;
 import org.eclipse.milo.opcua.sdk.server.model.objects.ExclusiveLimitAlarmTypeNode;
+import org.eclipse.milo.opcua.sdk.server.model.objects.NonExclusiveLimitAlarmTypeNode;
 import org.eclipse.milo.opcua.sdk.server.model.variables.FiniteStateVariableTypeNode;
 import org.eclipse.milo.opcua.sdk.server.model.variables.FiniteTransitionVariableTypeNode;
+import org.eclipse.milo.opcua.sdk.server.model.variables.PropertyTypeNode;
 import org.eclipse.milo.opcua.sdk.server.model.variables.TwoStateVariableTypeNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaMethodNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectTypeNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.instantiation.BrowsePath;
 import org.eclipse.milo.opcua.sdk.server.nodes.instantiation.InstantiationRequest;
 import org.eclipse.milo.opcua.sdk.server.nodes.instantiation.MethodInstantiation;
 import org.eclipse.milo.opcua.sdk.test.AbstractClientServerTest;
@@ -407,6 +413,131 @@ public class ConditionAttachAdoptTest extends AbstractClientServerTest {
     assertNull(((ExclusiveLimitAlarmTypeNode) genericBehavior.getNode()).getHighLimit());
   }
 
+  // Part 9 leaves compound-input reduction to the application. Attaching stock behavior to a
+  // vendor subtype must keep that subtype's model intact while applying the standard alarm state.
+  @Test
+  void attachedVendorSubtypePreservesIdentityAndCustomMembersDuringAppDrivenTransition()
+      throws Exception {
+    VendorLimitFixture fixture = vendorLimitFixture("VendorArrayLimitAlarm");
+    NonExclusiveLimitAlarmTypeNode loadedNode = fixture.node();
+    assertEquals(NonExclusiveLimitAlarmTypeNode.class, loadedNode.getClass());
+    TwoStateVariableTypeNode highState = requireNonNull(loadedNode.getHighStateNode());
+    TwoStateVariableTypeNode lowState = requireNonNull(loadedNode.getLowStateNode());
+    TwoStateVariableTypeNode activeState = requireNonNull(loadedNode.getActiveStateNode());
+    PropertyTypeNode effectiveDisplayName =
+        requireNonNull(activeState.getEffectiveDisplayNameNode());
+    PropertyTypeNode effectiveTransitionTime =
+        requireNonNull(activeState.getEffectiveTransitionTimeNode());
+
+    NonExclusiveLimitAlarm attached = NonExclusiveLimitAlarm.attach(loadedNode);
+    attached.setLimitStates(
+        Set.of(ExclusiveLimitState.HIGH, ExclusiveLimitState.LOW), ExclusiveLimitState.LOW);
+
+    assertSame(loadedNode, attached.getNode());
+    assertEquals(loadedNode.getNodeId(), attached.getConditionId());
+    assertTrue(
+        loadedNode.getReferences().stream()
+            .anyMatch(
+                reference ->
+                    reference.isForward()
+                        && NodeIds.HasTypeDefinition.equals(reference.getReferenceTypeId())
+                        && fixture.typeId().expanded().equals(reference.getTargetNodeId())));
+    assertEquals(fixture.typeId(), loadedNode.getEventType());
+    assertSame(
+        fixture.vendorMember(),
+        testNamespace.getNodeManager().getNode(fixture.vendorMember().getNodeId()).orElseThrow());
+    assertTrue(
+        loadedNode.getReferences().stream()
+            .anyMatch(
+                reference ->
+                    reference.isForward()
+                        && NodeIds.HasComponent.equals(reference.getReferenceTypeId())
+                        && fixture
+                            .vendorMember()
+                            .getNodeId()
+                            .expanded()
+                            .equals(reference.getTargetNodeId())));
+    assertEquals(uint(0x5A), requireNonNull(fixture.vendorMember().getValue().value().value()));
+
+    assertSame(highState, loadedNode.getHighStateNode());
+    assertSame(lowState, loadedNode.getLowStateNode());
+    assertSame(effectiveDisplayName, activeState.getEffectiveDisplayNameNode());
+    assertSame(effectiveTransitionTime, activeState.getEffectiveTransitionTimeNode());
+    assertTrue(attached.isLimitActive(ExclusiveLimitState.HIGH));
+    assertTrue(attached.isLimitActive(ExclusiveLimitState.LOW));
+    assertTrue(attached.isActive());
+    assertEquals(ExclusiveLimitState.LOW, attached.getEffectiveLimitState());
+    assertEquals(LocalizedText.english("Active/Low"), activeState.getEffectiveDisplayName());
+    assertNotNull(activeState.getEffectiveTransitionTime());
+  }
+
+  // EffectiveTransitionTime is Optional in the information model. Attach is observational and
+  // must not turn a complete loaded instance into a different address-space shape.
+  @Test
+  void attachLeavesMissingEffectiveTransitionTimeAbsentDuringTransition() throws Exception {
+    NonExclusiveLimitAlarm loaded = createNonExclusiveAlarm("AttachWithoutEffectiveTime");
+    TwoStateVariableTypeNode activeState = requireNonNull(loaded.getNode().getActiveStateNode());
+    requireNonNull(activeState.getEffectiveTransitionTimeNode()).delete();
+
+    NonExclusiveLimitAlarm attached = NonExclusiveLimitAlarm.attach(loaded.getNode());
+    assertNull(activeState.getEffectiveTransitionTimeNode());
+
+    attached.setLimitStates(Set.of(ExclusiveLimitState.HIGH), ExclusiveLimitState.HIGH);
+
+    assertTrue(attached.isActive());
+    assertTrue(attached.isLimitActive(ExclusiveLimitState.HIGH));
+    assertNull(activeState.getEffectiveTransitionTimeNode());
+  }
+
+  // Adoption completes the standard limit-alarm shape so later substate changes expose the
+  // effective timestamp for the most recent modeled-state transition.
+  @Test
+  void adoptionAddsAndInitializesMissingEffectiveTransitionTime() throws Exception {
+    NonExclusiveLimitAlarm loaded = createNonExclusiveAlarm("AdoptWithoutEffectiveTime");
+    TwoStateVariableTypeNode activeState = requireNonNull(loaded.getNode().getActiveStateNode());
+    UaNode deletedEffectiveTime = requireNonNull(activeState.getEffectiveTransitionTimeNode());
+    deletedEffectiveTime.delete();
+
+    NonExclusiveLimitAlarm completed =
+        NonExclusiveLimitAlarm.adopt(
+            testNamespace.getNodeContext(), loaded.getConditionId(), builder -> {});
+
+    TwoStateVariableTypeNode completedActiveState =
+        requireNonNull(completed.getNode().getActiveStateNode());
+    PropertyTypeNode effectiveTime =
+        requireNonNull(completedActiveState.getEffectiveTransitionTimeNode());
+    assertNotSame(deletedEffectiveTime, effectiveTime);
+    assertEquals(
+        completedActiveState.getTransitionTime(),
+        completedActiveState.getEffectiveTransitionTime());
+  }
+
+  // A persisted EffectiveTransitionTime is historical state, not a builder default. Adoption must
+  // reuse it and subsequent modeled-state transitions must update that same Property node.
+  @Test
+  void adoptionPreservesAndUpdatesExistingEffectiveTransitionTimeNode() throws Exception {
+    NonExclusiveLimitAlarm loaded = createNonExclusiveAlarm("AdoptWithEffectiveTime");
+    TwoStateVariableTypeNode activeState = requireNonNull(loaded.getNode().getActiveStateNode());
+    PropertyTypeNode loadedEffectiveTime =
+        requireNonNull(activeState.getEffectiveTransitionTimeNode());
+    DateTime persistedTime = new DateTime(1234L);
+    activeState.setEffectiveTransitionTime(persistedTime);
+
+    NonExclusiveLimitAlarm adopted =
+        NonExclusiveLimitAlarm.adopt(
+            testNamespace.getNodeContext(), loaded.getConditionId(), builder -> {});
+
+    TwoStateVariableTypeNode adoptedActiveState =
+        requireNonNull(adopted.getNode().getActiveStateNode());
+    assertSame(loadedEffectiveTime, adoptedActiveState.getEffectiveTransitionTimeNode());
+    assertEquals(persistedTime, adoptedActiveState.getEffectiveTransitionTime());
+
+    adopted.setLimitStates(Set.of(ExclusiveLimitState.HIGH), ExclusiveLimitState.HIGH);
+
+    assertSame(loadedEffectiveTime, adoptedActiveState.getEffectiveTransitionTimeNode());
+    assertNotEquals(persistedTime, adoptedActiveState.getEffectiveTransitionTime());
+  }
+
   @Test
   void severityOnlyAdoptionUsesStoredLimitWithoutReplacingIt() throws Exception {
     ExclusiveLimitAlarm loaded =
@@ -727,7 +858,7 @@ public class ConditionAttachAdoptTest extends AbstractClientServerTest {
         requireNonNull(node.getQualityNode())
             .getFilterChain()
             .readAttribute(null, requireNonNull(node.getQualityNode()), AttributeId.Value);
-    assertTrue(quality instanceof DataValue);
+    assertInstanceOf(DataValue.class, quality);
 
     NodeId shelvingStateId = requireNonNull(replacement.getShelvingState()).getNodeId();
     CallMethodResult unshelve = call(shelvingStateId, NodeIds.ShelvedStateMachineType_Unshelve);
@@ -880,6 +1011,124 @@ public class ConditionAttachAdoptTest extends AbstractClientServerTest {
     assertEquals(Boolean.FALSE, normalized.getNode().getSuppressedOrShelved());
     assertEquals(eventId, normalized.getNode().getEventId());
   }
+
+  private VendorLimitFixture vendorLimitFixture(String name) throws UaException {
+    var context = testNamespace.getNodeContext();
+    var nodeManager = testNamespace.getNodeManager();
+    NodeId typeId = newNodeId("ConditionAttachAdoptTest/" + name + "Type");
+    UaObjectTypeNode typeNode =
+        new UaObjectTypeNode(
+            context,
+            typeId,
+            newQualifiedName(name + "Type"),
+            LocalizedText.english(name + "Type"),
+            LocalizedText.NULL_VALUE,
+            uint(0),
+            uint(0),
+            false);
+    typeNode.addReference(
+        new Reference(
+            typeId, NodeIds.HasSubtype, NodeIds.NonExclusiveLimitAlarmType.expanded(), false));
+    nodeManager.addNode(typeNode);
+
+    QualifiedName vendorMemberName = newQualifiedName("ReductionMask");
+    UaVariableNode vendorDeclaration =
+        new UaVariableNode(
+            context,
+            newNodeId("ConditionAttachAdoptTest/" + name + "Type/ReductionMask"),
+            vendorMemberName,
+            LocalizedText.english("ReductionMask"),
+            LocalizedText.NULL_VALUE,
+            uint(0),
+            uint(0));
+    vendorDeclaration.setDataType(NodeIds.UInt32);
+    vendorDeclaration.setValue(new DataValue(new Variant(uint(0))));
+    vendorDeclaration.addReference(
+        new Reference(
+            vendorDeclaration.getNodeId(),
+            NodeIds.HasTypeDefinition,
+            NodeIds.BaseDataVariableType.expanded(),
+            true));
+    vendorDeclaration.addReference(
+        new Reference(
+            vendorDeclaration.getNodeId(),
+            NodeIds.HasModellingRule,
+            NodeIds.ModellingRule_Mandatory.expanded(),
+            true));
+    nodeManager.addNode(vendorDeclaration);
+    typeNode.addReference(
+        new Reference(
+            typeId, NodeIds.HasComponent, vendorDeclaration.getNodeId().expanded(), true));
+
+    BrowsePath vendorMemberPath = BrowsePath.of(vendorMemberName);
+    BrowsePath activeEffectiveDisplayName =
+        BrowsePath.of(
+            new QualifiedName(0, "ActiveState"), new QualifiedName(0, "EffectiveDisplayName"));
+    BrowsePath activeEffectiveTransitionTime =
+        BrowsePath.of(
+            new QualifiedName(0, "ActiveState"), new QualifiedName(0, "EffectiveTransitionTime"));
+    Set<String> includedOptionalNames =
+        Set.of(
+            "TransitionTime",
+            "SupportsFilteredRetain",
+            "HighLimit",
+            "HighState",
+            "LowLimit",
+            "LowState");
+    NodeId rootId = newNodeId("ConditionAttachAdoptTest/" + name);
+    NodeId vendorMemberId = newNodeId("ConditionAttachAdoptTest/" + name + "/ReductionMask");
+
+    NonExclusiveLimitAlarmTypeNode node =
+        server
+            .getNodeInstantiator()
+            .instantiate(
+                InstantiationRequest.of(NonExclusiveLimitAlarmTypeNode.class, typeId)
+                    .nodeId(rootId)
+                    .browseName(newQualifiedName(name))
+                    .displayName(LocalizedText.english(name))
+                    .target(nodeManager)
+                    .assignNodeId(vendorMemberPath, vendorMemberId)
+                    .includeOptionals(
+                        declaration -> {
+                          String browseName = declaration.browseName().name();
+                          return includedOptionalNames.contains(browseName)
+                              || activeEffectiveDisplayName.equals(declaration.browsePath())
+                              || activeEffectiveTransitionTime.equals(declaration.browsePath());
+                        })
+                    .build())
+            .root();
+
+    DateTime time = DateTime.now();
+    initializeRawCondition(node, typeId, ByteString.NULL_VALUE, time);
+    node.setInputNode(NodeId.NULL_VALUE);
+    node.setSuppressedOrShelved(false);
+    node.setHighLimit(10.0);
+    node.setLowLimit(0.0);
+    setTwoState(requireNonNull(node.getActiveStateNode()), false, "Inactive", time);
+    setTwoState(requireNonNull(node.getHighStateNode()), false, "High inactive", time);
+    setTwoState(requireNonNull(node.getLowStateNode()), false, "Low inactive", time);
+
+    UaVariableNode vendorMember =
+        (UaVariableNode) nodeManager.getNode(vendorMemberId).orElseThrow();
+    vendorMember.setValue(new DataValue(new Variant(uint(0x5A))));
+
+    return new VendorLimitFixture(typeId, node, vendorMember);
+  }
+
+  private NonExclusiveLimitAlarm createNonExclusiveAlarm(String name) throws UaException {
+    return NonExclusiveLimitAlarm.create(
+        testNamespace.getNodeContext(),
+        builder ->
+            builder
+                .nodeId(newNodeId("ConditionAttachAdoptTest/" + name))
+                .browseName(newQualifiedName(name))
+                .severity(ushort(500))
+                .highLimit(10.0)
+                .lowLimit(0.0));
+  }
+
+  private record VendorLimitFixture(
+      NodeId typeId, NonExclusiveLimitAlarmTypeNode node, UaVariableNode vendorMember) {}
 
   private AcknowledgeableConditionTypeNode rawAcknowledgeable(
       String name,

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/conditions/ConditionSnapshotTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/conditions/ConditionSnapshotTest.java
@@ -16,6 +16,7 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -30,6 +31,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.eclipse.milo.opcua.sdk.client.subscriptions.OpcUaSubscription;
 import org.eclipse.milo.opcua.sdk.core.Reference;
+import org.eclipse.milo.opcua.sdk.server.model.variables.TwoStateVariableTypeNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaNodeContext;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectNode;
 import org.eclipse.milo.opcua.sdk.test.AbstractClientServerTest;
@@ -39,38 +41,34 @@ import org.eclipse.milo.opcua.stack.core.AttributeId;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
-import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
-import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
-import org.eclipse.milo.opcua.stack.core.types.enumerated.FilterOperator;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
 import org.eclipse.milo.opcua.stack.core.types.structured.CallMethodRequest;
 import org.eclipse.milo.opcua.stack.core.types.structured.CallMethodResult;
 import org.eclipse.milo.opcua.stack.core.types.structured.CallResponse;
-import org.eclipse.milo.opcua.stack.core.types.structured.ContentFilter;
-import org.eclipse.milo.opcua.stack.core.types.structured.ContentFilterElement;
 import org.eclipse.milo.opcua.stack.core.types.structured.EventFilter;
-import org.eclipse.milo.opcua.stack.core.types.structured.LiteralOperand;
 import org.eclipse.milo.opcua.stack.core.types.structured.SimpleAttributeOperand;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 /**
- * Client-visible tests for the WP7 snapshot/restore contract (Part 9 §4.12): a captured
- * active/shelved limit alarm round-trips onto a fresh instance whose restored branch replays via
- * ConditionRefresh with the original EventId/Time and accepts that EventId for Acknowledge; restore
- * is silent and rejected once the Condition is live; absent snapshot fields take the §4.12 recovery
- * defaults; and a shelve deadline that passed during downtime unshelves on first touch.
+ * Client-visible tests for the snapshot/restore contract (Part 9 §4.12): a captured active/shelved
+ * limit alarm round-trips onto a fresh instance whose restored branch replays via ConditionRefresh
+ * with the original EventId/Time and accepts that EventId for Acknowledge; restore is silent and
+ * rejected once the Condition is live; absent snapshot fields take the §4.12 recovery defaults; and
+ * a shelve deadline that passed during downtime unshelves on first touch.
  *
  * <p>Also covered: a Retained recovery branch with no captured event identity mints an
  * acknowledgeable EventId at first refresh replay (which seals the pre-live restore window),
- * repeated restore replaces rather than accumulates subtype state, and capture under concurrent
- * load always observes one lock-consistent whole-state combination.
+ * repeated restore replaces rather than accumulates subtype state, caller-selected non-exclusive
+ * effective states survive restart without changing acknowledgement or timing metadata, and capture
+ * under concurrent load always observes one lock-consistent whole-state combination.
  */
 public class ConditionSnapshotTest extends AbstractClientServerTest {
 
@@ -175,6 +173,7 @@ public class ConditionSnapshotTest extends AbstractClientServerTest {
       assertEquals(Boolean.FALSE, trunk.acked());
       assertEquals(Boolean.TRUE, trunk.active());
       assertEquals(Set.of(ExclusiveLimitState.HIGH), trunk.activeLimits());
+      assertEquals(ExclusiveLimitState.HIGH, trunk.effectiveLimitState());
       assertTrue(trunk.retained());
       assertEquals(originalEventId, trunk.lastEventId());
       assertEquals(originalEventTime, trunk.lastEventTime());
@@ -238,6 +237,373 @@ public class ConditionSnapshotTest extends AbstractClientServerTest {
     }
   }
 
+  // A caller-selected effective state is part of the reduced alarm state; losing it on restart
+  // would silently change the alarm's classification, severity, and operator-facing text.
+  @Test
+  void callerSelectedNonExclusiveEffectiveStateRoundTripsWithoutChangingBranchIdentity()
+      throws Exception {
+
+    NonExclusiveLimitAlarm original = createCrossSideAlarm("EffectiveOriginal");
+    original.setLimitStates(
+        Set.of(ExclusiveLimitState.HIGH, ExclusiveLimitState.LOW), ExclusiveLimitState.LOW);
+
+    ConditionSnapshot snapshot = original.captureSnapshot();
+    ConditionSnapshot.BranchSnapshot captured = snapshot.trunk().orElseThrow();
+    ByteString capturedEventId = requireNonNull(captured.lastEventId());
+    DateTime capturedEventTime = requireNonNull(captured.lastEventTime());
+
+    assertEquals(
+        Set.of(ExclusiveLimitState.HIGH, ExclusiveLimitState.LOW), captured.activeLimits());
+    assertEquals(ExclusiveLimitState.LOW, captured.effectiveLimitState());
+    assertTrue(capturedEventId.isNotNull());
+
+    NonExclusiveLimitAlarm restored = createCrossSideAlarm("EffectiveRestored");
+    var subscription = new OpcUaSubscription(client);
+    subscription.create();
+    try {
+      List<Variant[]> events =
+          EventTestSupport.monitorEvents(
+              subscription, NodeIds.Server, conditionNameFilter("EffectiveRestored"));
+
+      restored.restoreSnapshot(snapshot);
+
+      EventTestSupport.assertNoEvent(events, "event generated by non-exclusive restore", e -> true);
+    } finally {
+      subscription.delete();
+    }
+
+    assertTrue(restored.isActive());
+    assertTrue(restored.isLimitActive(ExclusiveLimitState.HIGH));
+    assertTrue(restored.isLimitActive(ExclusiveLimitState.LOW));
+    assertEquals(ExclusiveLimitState.LOW, restored.getEffectiveLimitState());
+    assertEquals(LocalizedText.english("Active/Low"), restored.getNode().getMessage());
+    assertEquals(
+        LocalizedText.english("Active/Low"),
+        requireNonNull(restored.getNode().getActiveStateNode()).getEffectiveDisplayName());
+    assertEquals(ushort(300), restored.getNode().getSeverity());
+    assertEquals(ushort(100), restored.getNode().getLastSeverity());
+    assertTrue(restored.isRetained());
+    assertEquals(capturedEventId, restored.currentBranch().getLastEventId());
+    assertEquals(capturedEventTime, restored.currentBranch().getLastEventTime());
+    assertTrue(restored.currentBranch().isAcknowledgeable(capturedEventId));
+
+    ConditionSnapshot.BranchSnapshot recaptured = restored.captureSnapshot().trunk().orElseThrow();
+    assertEquals(captured.activeLimits(), recaptured.activeLimits());
+    assertEquals(captured.effectiveLimitState(), recaptured.effectiveLimitState());
+    assertEquals(captured.retained(), recaptured.retained());
+    assertEquals(captured.eventIdWindow(), recaptured.eventIdWindow());
+    assertEquals(capturedEventId, recaptured.lastEventId());
+    assertEquals(capturedEventTime, recaptured.lastEventTime());
+  }
+
+  // Snapshots persisted before selector metadata existed carry no effective state; scalar
+  // precedence is the compatibility rule that keeps their restored presentation deterministic.
+  @Test
+  void absentEffectiveStateRestoresThroughScalarFallback() throws Exception {
+    ConditionSnapshot.BranchSnapshot legacyBranch =
+        new ConditionSnapshot.BranchSnapshot(
+            null,
+            false,
+            true,
+            true,
+            Set.of(ExclusiveLimitState.HIGH, ExclusiveLimitState.LOW),
+            null,
+            true,
+            null,
+            null,
+            List.of());
+    assertNull(legacyBranch.effectiveLimitState());
+
+    ConditionSnapshot snapshot =
+        new ConditionSnapshot(true, null, null, null, null, null, null, List.of(legacyBranch));
+    NonExclusiveLimitAlarm restored = createCrossSideAlarm("LegacyEffectiveFallback");
+
+    restored.restoreSnapshot(snapshot);
+
+    assertTrue(restored.isActive());
+    assertTrue(restored.isLimitActive(ExclusiveLimitState.HIGH));
+    assertTrue(restored.isLimitActive(ExclusiveLimitState.LOW));
+    assertEquals(ExclusiveLimitState.HIGH, restored.getEffectiveLimitState());
+    assertEquals(LocalizedText.english("Active/High"), restored.getNode().getMessage());
+    assertEquals(
+        LocalizedText.english("Active/High"),
+        requireNonNull(restored.getNode().getActiveStateNode()).getEffectiveDisplayName());
+    assertEquals(ushort(700), restored.getNode().getSeverity());
+  }
+
+  // Construction must stay total: a selector that drifted outside the captured membership (e.g.
+  // limit-state nodes written directly while behavior state lagged) normalizes to absent so the
+  // snapshot restores through the scalar fallback instead of capture failing.
+  @Test
+  void branchSnapshotNormalizesEffectiveStateOutsideActiveLimits() {
+    ConditionSnapshot.BranchSnapshot branch =
+        new ConditionSnapshot.BranchSnapshot(
+            null,
+            false,
+            true,
+            true,
+            Set.of(ExclusiveLimitState.HIGH),
+            ExclusiveLimitState.LOW,
+            true,
+            null,
+            null,
+            List.of());
+
+    assertNull(branch.effectiveLimitState());
+  }
+
+  // A destination can legitimately implement fewer optional limit members than the source; it
+  // must restore the representable subset and choose an effective state from that subset.
+  @Test
+  void restoreDiscardsUnsupportedLimitsAndFallsBackWithinSupportedSet() throws Exception {
+    ConditionSnapshot snapshot =
+        activeLimitSnapshot(
+            Set.of(ExclusiveLimitState.HIGH, ExclusiveLimitState.LOW),
+            ExclusiveLimitState.LOW,
+            null,
+            null);
+    NonExclusiveLimitAlarm restored =
+        NonExclusiveLimitAlarm.create(
+            nodeContext,
+            b ->
+                b.nodeId(newNodeId("ConditionSnapshotTest/SupportedSubset"))
+                    .browseName(newQualifiedName("SupportedSubset"))
+                    .conditionSource(source)
+                    .severity(ushort(100))
+                    .highLimit(90.0, ushort(700)));
+
+    restored.restoreSnapshot(snapshot);
+
+    assertTrue(restored.isActive());
+    assertTrue(restored.isLimitActive(ExclusiveLimitState.HIGH));
+    assertFalse(restored.isLimitActive(ExclusiveLimitState.LOW));
+    assertEquals(ExclusiveLimitState.HIGH, restored.getEffectiveLimitState());
+    assertEquals(LocalizedText.english("Active/High"), restored.getNode().getMessage());
+    assertEquals(ushort(700), restored.getNode().getSeverity());
+  }
+
+  // The restored Active flag must describe a real modeled substate; an unsupported captured state
+  // cannot leave Active true with no representable limit state beneath it.
+  @Test
+  void restoreNormalizesActiveFalseWhenNoCapturedLimitIsRepresentable() throws Exception {
+    ConditionSnapshot snapshot =
+        activeLimitSnapshot(Set.of(ExclusiveLimitState.LOW), ExclusiveLimitState.LOW, null, null);
+    NonExclusiveLimitAlarm restored =
+        NonExclusiveLimitAlarm.create(
+            nodeContext,
+            b ->
+                b.nodeId(newNodeId("ConditionSnapshotTest/NoSupportedState"))
+                    .browseName(newQualifiedName("NoSupportedState"))
+                    .conditionSource(source)
+                    .severity(ushort(100))
+                    .highLimit(90.0, ushort(700)));
+    TwoStateVariableTypeNode activeState = requireNonNull(restored.getNode().getActiveStateNode());
+    assertNotNull(activeState.getEffectiveTransitionTimeNode());
+    activeState.setEffectiveTransitionTime(DateTime.MIN_VALUE);
+    assertEquals(DateTime.MIN_VALUE, activeState.getEffectiveTransitionTime());
+
+    restored.restoreSnapshot(snapshot);
+
+    assertFalse(restored.isActive());
+    assertFalse(restored.isLimitActive(ExclusiveLimitState.HIGH));
+    assertFalse(restored.isLimitActive(ExclusiveLimitState.LOW));
+    assertNull(restored.getEffectiveLimitState());
+    assertEquals(LocalizedText.english("Inactive"), restored.getNode().getMessage());
+    assertEquals(
+        LocalizedText.english("Inactive"),
+        requireNonNull(restored.getNode().getActiveStateNode()).getEffectiveDisplayName());
+    assertEquals(ushort(100), restored.getNode().getSeverity());
+    assertEquals(DateTime.MIN_VALUE, activeState.getEffectiveTransitionTime());
+  }
+
+  // Severity and LastSeverity describe captured event history, so destination limit configuration
+  // must not rewrite them while reconstructing the current reduced state.
+  @Test
+  void capturedSeverityAndLastSeverityTakePrecedenceDuringRestore() throws Exception {
+    ConditionSnapshot snapshot =
+        activeLimitSnapshot(
+            Set.of(ExclusiveLimitState.HIGH, ExclusiveLimitState.LOW),
+            ExclusiveLimitState.LOW,
+            ushort(777),
+            ushort(444));
+    NonExclusiveLimitAlarm restored = createCrossSideAlarm("CapturedSeverity");
+
+    restored.restoreSnapshot(snapshot);
+
+    assertEquals(ExclusiveLimitState.LOW, restored.getEffectiveLimitState());
+    assertEquals(ushort(777), restored.getNode().getSeverity());
+    assertEquals(ushort(444), restored.getNode().getLastSeverity());
+  }
+
+  // When old or partial snapshots omit Severity, restore must derive the current presentation
+  // without manufacturing a LastSeverity transition that never occurred.
+  @Test
+  void absentSeverityDerivesFromEffectiveStateWithoutInventingLastSeverity() throws Exception {
+    ConditionSnapshot snapshot =
+        activeLimitSnapshot(
+            Set.of(ExclusiveLimitState.HIGH, ExclusiveLimitState.LOW),
+            ExclusiveLimitState.LOW,
+            null,
+            null);
+    NonExclusiveLimitAlarm restored = createCrossSideAlarm("DerivedSeverity");
+    UShort initialLastSeverity = restored.getNode().getLastSeverity();
+
+    restored.restoreSnapshot(snapshot);
+
+    assertEquals(ushort(300), restored.getNode().getSeverity());
+    assertEquals(initialLastSeverity, restored.getNode().getLastSeverity());
+  }
+
+  // Silent restore may reconstruct modeled membership but must leave the captured operator
+  // obligation, accepted EventIds, and shelving state exactly as persisted.
+  @Test
+  void restoredMembershipAdvancesEffectiveTimeWithoutChangingRecoveryMetadata() throws Exception {
+    NonExclusiveLimitAlarm restored =
+        NonExclusiveLimitAlarm.create(
+            nodeContext,
+            b ->
+                b.nodeId(newNodeId("ConditionSnapshotTest/RestoreMetadata"))
+                    .browseName(newQualifiedName("RestoreMetadata"))
+                    .conditionSource(source)
+                    .severity(ushort(100))
+                    .withShelving()
+                    .highLimit(90.0, ushort(700))
+                    .lowLimit(10.0, ushort(300)));
+
+    TwoStateVariableTypeNode activeState = requireNonNull(restored.getNode().getActiveStateNode());
+    assertNotNull(activeState.getEffectiveTransitionTimeNode());
+    activeState.setEffectiveTransitionTime(DateTime.MIN_VALUE);
+    assertEquals(DateTime.MIN_VALUE, activeState.getEffectiveTransitionTime());
+
+    ByteString eventId =
+        ByteString.of(new byte[] {16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1});
+    DateTime eventTime = DateTime.now();
+    ConditionSnapshot.AcceptedEventId acceptedEventId =
+        new ConditionSnapshot.AcceptedEventId(eventId, false, true, true, true);
+    ConditionSnapshot snapshot =
+        new ConditionSnapshot(
+            true,
+            null,
+            null,
+            null,
+            null,
+            null,
+            new ConditionSnapshot.ShelvingSnapshot(ShelvedState.ONE_SHOT_SHELVED, null),
+            List.of(
+                new ConditionSnapshot.BranchSnapshot(
+                    null,
+                    false,
+                    true,
+                    true,
+                    Set.of(ExclusiveLimitState.HIGH, ExclusiveLimitState.LOW),
+                    ExclusiveLimitState.HIGH,
+                    true,
+                    eventId,
+                    eventTime,
+                    List.of(acceptedEventId))));
+
+    restored.restoreSnapshot(snapshot);
+
+    DateTime restoredEffectiveTime = requireNonNull(activeState.getEffectiveTransitionTime());
+    assertNotEquals(DateTime.MIN_VALUE, restoredEffectiveTime);
+    assertEquals(restoredEffectiveTime, activeState.getTransitionTime());
+    assertEquals(
+        restoredEffectiveTime,
+        requireNonNull(restored.getNode().getHighStateNode()).getTransitionTime());
+    assertEquals(
+        restoredEffectiveTime,
+        requireNonNull(restored.getNode().getLowStateNode()).getTransitionTime());
+    assertTrue(restored.isActive());
+    assertTrue(restored.isLimitActive(ExclusiveLimitState.HIGH));
+    assertTrue(restored.isLimitActive(ExclusiveLimitState.LOW));
+    assertEquals(ExclusiveLimitState.HIGH, restored.getEffectiveLimitState());
+    assertFalse(restored.isAcked());
+    assertTrue(restored.currentBranch().isAcknowledgeable(eventId));
+    assertEquals(eventId, restored.currentBranch().getLastEventId());
+    assertEquals(eventTime, restored.currentBranch().getLastEventTime());
+    assertEquals("OneShotShelved", currentStateText(restored));
+    assertEquals(Boolean.TRUE, restored.getNode().getSuppressedOrShelved());
+
+    ConditionSnapshot recaptured = restored.captureSnapshot();
+    assertEquals(snapshot.shelving(), recaptured.shelving());
+    assertEquals(List.of(acceptedEventId), recaptured.trunk().orElseThrow().eventIdWindow());
+  }
+
+  // ActiveState.TransitionTime tracks only the Active boolean, while its EffectiveTransitionTime
+  // must still reveal an active-to-active change in modeled limit membership.
+  @Test
+  void activeToActiveMembershipRestoreAdvancesOnlyEffectiveTransitionTime() throws Exception {
+    NonExclusiveLimitAlarm restored = createCrossSideAlarm("RepeatedMembership");
+    restored.restoreSnapshot(
+        activeLimitSnapshot(
+            Set.of(ExclusiveLimitState.HIGH, ExclusiveLimitState.LOW),
+            ExclusiveLimitState.HIGH,
+            null,
+            null));
+
+    TwoStateVariableTypeNode activeState = requireNonNull(restored.getNode().getActiveStateNode());
+    TwoStateVariableTypeNode highState = requireNonNull(restored.getNode().getHighStateNode());
+    TwoStateVariableTypeNode lowState = requireNonNull(restored.getNode().getLowStateNode());
+    DateTime activeTransitionTime = requireNonNull(activeState.getTransitionTime());
+    DateTime highTransitionTime = requireNonNull(highState.getTransitionTime());
+    activeState.setEffectiveTransitionTime(DateTime.MIN_VALUE);
+    assertEquals(DateTime.MIN_VALUE, activeState.getEffectiveTransitionTime());
+
+    restored.restoreSnapshot(
+        activeLimitSnapshot(
+            Set.of(ExclusiveLimitState.HIGH), ExclusiveLimitState.HIGH, null, null));
+
+    DateTime membershipTime = requireNonNull(activeState.getEffectiveTransitionTime());
+    assertNotEquals(DateTime.MIN_VALUE, membershipTime);
+    assertEquals(activeTransitionTime, activeState.getTransitionTime());
+    assertEquals(highTransitionTime, highState.getTransitionTime());
+    assertEquals(membershipTime, lowState.getTransitionTime());
+    assertTrue(restored.isActive());
+    assertTrue(restored.isLimitActive(ExclusiveLimitState.HIGH));
+    assertFalse(restored.isLimitActive(ExclusiveLimitState.LOW));
+  }
+
+  // Reselecting an effective state changes classification but enters no modeled substate, so a
+  // repeated pre-live restore must replace the selector without advancing EffectiveTransitionTime.
+  @Test
+  void repeatedSelectorRestoreReplacesSelectionWithoutAdvancingEffectiveTime() throws Exception {
+    NonExclusiveLimitAlarm restored = createCrossSideAlarm("RepeatedEffectiveSelection");
+    ConditionSnapshot highEffective =
+        activeLimitSnapshot(
+            Set.of(ExclusiveLimitState.HIGH, ExclusiveLimitState.LOW),
+            ExclusiveLimitState.HIGH,
+            null,
+            null);
+    ConditionSnapshot lowEffective =
+        activeLimitSnapshot(
+            Set.of(ExclusiveLimitState.HIGH, ExclusiveLimitState.LOW),
+            ExclusiveLimitState.LOW,
+            null,
+            null);
+
+    restored.restoreSnapshot(highEffective);
+    DateTime membershipTime =
+        requireNonNull(
+            requireNonNull(restored.getNode().getActiveStateNode()).getEffectiveTransitionTime());
+
+    restored.restoreSnapshot(lowEffective);
+
+    assertEquals(ExclusiveLimitState.LOW, restored.getEffectiveLimitState());
+    assertEquals(LocalizedText.english("Active/Low"), restored.getNode().getMessage());
+    assertEquals(
+        LocalizedText.english("Active/Low"),
+        requireNonNull(restored.getNode().getActiveStateNode()).getEffectiveDisplayName());
+    assertEquals(ushort(300), restored.getNode().getSeverity());
+    assertEquals(
+        membershipTime,
+        requireNonNull(restored.getNode().getActiveStateNode()).getEffectiveTransitionTime());
+
+    // Repeated restore remains a pre-live facility; using the public state API seals the window.
+    restored.setLimitStates(
+        Set.of(ExclusiveLimitState.HIGH, ExclusiveLimitState.LOW), ExclusiveLimitState.HIGH);
+    assertThrows(IllegalStateException.class, () -> restored.restoreSnapshot(lowEffective));
+  }
+
   @Test
   void restoreIsSilentAndRejectedOnceTheConditionIsLive() throws Exception {
     AlarmCondition alarm =
@@ -280,6 +646,7 @@ public class ConditionSnapshotTest extends AbstractClientServerTest {
                       false,
                       false,
                       Set.of(),
+                      null,
                       true,
                       preCaptureEventId,
                       preCaptureEventTime,
@@ -461,6 +828,7 @@ public class ConditionSnapshotTest extends AbstractClientServerTest {
                     .withShelving(Duration.ofMillis((long) MAX_TIME_SHELVED_MILLIS))
                     .highLimit(90.0)
                     .highHighLimit(95.0));
+    UShort configuredSeverity = alarm.getNode().getSeverity();
 
     ByteString eventId =
         ByteString.of(new byte[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16});
@@ -483,6 +851,7 @@ public class ConditionSnapshotTest extends AbstractClientServerTest {
                     false,
                     true,
                     Set.of(ExclusiveLimitState.HIGH),
+                    null,
                     true,
                     eventId,
                     DateTime.now(),
@@ -493,14 +862,19 @@ public class ConditionSnapshotTest extends AbstractClientServerTest {
     alarm.restoreSnapshot(rich);
     assertTrue(alarm.isActive());
     assertEquals(ExclusiveLimitState.HIGH, alarm.getLimitState());
+    assertEquals(LocalizedText.english("Active/High"), alarm.getNode().getMessage());
+    assertEquals(ushort(500), alarm.getNode().getSeverity());
     assertEquals("TimedShelved", currentStateText(alarm));
     assertTrue(requireNonNull(alarm.getShelvingRuntime()).hasExpiryTimerForTesting());
 
     // A later restore replaces every level of state: the empty snapshot's recovery defaults win
-    // over the previous restore's shelving, limit machine, active state, and event identity.
+    // over the previous restore's presentation, shelving, limit machine, active state, and event
+    // identity.
     alarm.restoreSnapshot(ConditionSnapshot.empty());
     assertFalse(alarm.isActive());
     assertNull(alarm.getLimitState());
+    assertEquals(LocalizedText.english("Inactive"), alarm.getNode().getMessage());
+    assertEquals(configuredSeverity, alarm.getNode().getSeverity());
     assertEquals("Unshelved", currentStateText(alarm));
     assertEquals(Boolean.FALSE, alarm.getNode().getSuppressedOrShelved());
     assertFalse(requireNonNull(alarm.getShelvingRuntime()).hasExpiryTimerForTesting());
@@ -533,6 +907,7 @@ public class ConditionSnapshotTest extends AbstractClientServerTest {
                     false,
                     true,
                     Set.of(ExclusiveLimitState.HIGH, ExclusiveLimitState.HIGH_HIGH),
+                    null,
                     true,
                     null,
                     null,
@@ -542,12 +917,16 @@ public class ConditionSnapshotTest extends AbstractClientServerTest {
     assertTrue(nonExclusive.isActive());
     assertTrue(nonExclusive.isLimitActive(ExclusiveLimitState.HIGH));
     assertTrue(nonExclusive.isLimitActive(ExclusiveLimitState.HIGH_HIGH));
+    assertEquals(ExclusiveLimitState.HIGH_HIGH, nonExclusive.getEffectiveLimitState());
+    assertEquals(LocalizedText.english("Active/HighHigh"), nonExclusive.getNode().getMessage());
 
     // Limits the next snapshot omits go inactive rather than lingering violated.
     nonExclusive.restoreSnapshot(ConditionSnapshot.empty());
     assertFalse(nonExclusive.isActive());
     assertFalse(nonExclusive.isLimitActive(ExclusiveLimitState.HIGH));
     assertFalse(nonExclusive.isLimitActive(ExclusiveLimitState.HIGH_HIGH));
+    assertNull(nonExclusive.getEffectiveLimitState());
+    assertEquals(LocalizedText.english("Inactive"), nonExclusive.getNode().getMessage());
   }
 
   @Test
@@ -691,10 +1070,52 @@ public class ConditionSnapshotTest extends AbstractClientServerTest {
         restored.currentBranch().getLastEventId());
   }
 
+  private NonExclusiveLimitAlarm createCrossSideAlarm(String name) throws UaException {
+    return NonExclusiveLimitAlarm.create(
+        nodeContext,
+        b ->
+            b.nodeId(newNodeId("ConditionSnapshotTest/" + name))
+                .browseName(newQualifiedName(name))
+                .conditionName(name)
+                .conditionSource(source)
+                .severity(ushort(100))
+                .highLimit(90.0, ushort(700))
+                .lowLimit(10.0, ushort(300)));
+  }
+
+  private static ConditionSnapshot activeLimitSnapshot(
+      Set<ExclusiveLimitState> activeLimits,
+      ExclusiveLimitState effectiveLimitState,
+      @Nullable UShort severity,
+      @Nullable UShort lastSeverity) {
+
+    return new ConditionSnapshot(
+        true,
+        severity,
+        lastSeverity,
+        null,
+        null,
+        null,
+        null,
+        List.of(
+            new ConditionSnapshot.BranchSnapshot(
+                null,
+                false,
+                true,
+                true,
+                activeLimits,
+                effectiveLimitState,
+                true,
+                null,
+                null,
+                List.of())));
+  }
+
   /**
    * Assert {@code snapshot} is one legal whole-state combination of an enabled exclusive limit
-   * alarm without ConfirmedState: active iff exactly one violated limit, Retain follows the {@code
-   * ¬acked ∨ active} formula, and an issued last EventId is within the accepted window.
+   * alarm without ConfirmedState: active iff exactly one violated limit and that limit is
+   * effective, Retain follows the {@code ¬acked ∨ active} formula, and an issued last EventId is
+   * within the accepted window.
    */
   private static void assertSnapshotCoherent(ConditionSnapshot snapshot) {
     ConditionSnapshot.BranchSnapshot trunk = snapshot.trunk().orElseThrow();
@@ -704,6 +1125,14 @@ public class ConditionSnapshotTest extends AbstractClientServerTest {
         active,
         trunk.activeLimits().size() == 1,
         () -> "active=" + active + " but activeLimits=" + trunk.activeLimits());
+    assertEquals(
+        active ? trunk.activeLimits().iterator().next() : null,
+        trunk.effectiveLimitState(),
+        () ->
+            "effectiveLimitState="
+                + trunk.effectiveLimitState()
+                + " but activeLimits="
+                + trunk.activeLimits());
 
     boolean acked = Boolean.TRUE.equals(trunk.acked());
     assertEquals(
@@ -755,22 +1184,7 @@ public class ConditionSnapshotTest extends AbstractClientServerTest {
 
   /** Like {@link #severityFilter()}, but matching on ConditionName equality instead. */
   private static EventFilter conditionNameFilter(String conditionName) {
-    var whereClause =
-        new ContentFilter(
-            new ContentFilterElement[] {
-              new ContentFilterElement(
-                  FilterOperator.Equals,
-                  new ExtensionObject[] {
-                    ExtensionObject.encode(
-                        DefaultEncodingContext.INSTANCE,
-                        EventTestSupport.eventField(NodeIds.ConditionType, "ConditionName")),
-                    ExtensionObject.encode(
-                        DefaultEncodingContext.INSTANCE,
-                        new LiteralOperand(new Variant(conditionName)))
-                  })
-            });
-
-    return new EventFilter(selectClauses(), whereClause);
+    return EventTestSupport.conditionNameFilter(conditionName, selectClauses());
   }
 
   private static SimpleAttributeOperand[] selectClauses() {

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/conditions/DiscreteAlarmTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/conditions/DiscreteAlarmTest.java
@@ -11,6 +11,7 @@
 package org.eclipse.milo.opcua.sdk.server.conditions;
 
 import static java.util.Objects.requireNonNull;
+import static org.eclipse.milo.opcua.sdk.test.EventTestSupport.conditionNameFilter;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ubyte;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -30,23 +31,16 @@ import org.eclipse.milo.opcua.sdk.test.EventTestSupport;
 import org.eclipse.milo.opcua.sdk.test.TestNamespace;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
 import org.eclipse.milo.opcua.stack.core.UaException;
-import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
-import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
-import org.eclipse.milo.opcua.stack.core.types.enumerated.FilterOperator;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.TimestampsToReturn;
 import org.eclipse.milo.opcua.stack.core.types.structured.CallMethodRequest;
 import org.eclipse.milo.opcua.stack.core.types.structured.CallMethodResult;
 import org.eclipse.milo.opcua.stack.core.types.structured.CallResponse;
-import org.eclipse.milo.opcua.stack.core.types.structured.ContentFilter;
-import org.eclipse.milo.opcua.stack.core.types.structured.ContentFilterElement;
 import org.eclipse.milo.opcua.stack.core.types.structured.EventFilter;
-import org.eclipse.milo.opcua.stack.core.types.structured.LiteralOperand;
-import org.eclipse.milo.opcua.stack.core.types.structured.SimpleAttributeOperand;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -294,33 +288,8 @@ public class DiscreteAlarmTest extends AbstractClientServerTest {
     return requireNonNull(response.getResults())[0];
   }
 
-  /**
-   * Create an {@link EventFilter} with the given select clauses, matching only events whose
-   * ConditionName equals {@code conditionName} — scoping each test to its own alarm's events.
-   */
-  private static EventFilter conditionNameFilter(
-      String conditionName, SimpleAttributeOperand... selectClauses) {
-
-    var whereClause =
-        new ContentFilter(
-            new ContentFilterElement[] {
-              new ContentFilterElement(
-                  FilterOperator.Equals,
-                  new ExtensionObject[] {
-                    ExtensionObject.encode(
-                        DefaultEncodingContext.INSTANCE,
-                        EventTestSupport.eventField(NodeIds.ConditionType, "ConditionName")),
-                    ExtensionObject.encode(
-                        DefaultEncodingContext.INSTANCE,
-                        new LiteralOperand(new Variant(conditionName)))
-                  })
-            });
-
-    return new EventFilter(selectClauses, whereClause);
-  }
-
   private static @Nullable String messageOf(Variant[] eventFields) {
-    return eventFields[0].value() instanceof LocalizedText text ? text.text() : null;
+    return EventTestSupport.localizedTextOf(eventFields[0]);
   }
 
   private static boolean ackedIdOf(Variant[] eventFields) {

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/conditions/LimitAlarmTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/conditions/LimitAlarmTest.java
@@ -11,6 +11,8 @@
 package org.eclipse.milo.opcua.sdk.server.conditions;
 
 import static java.util.Objects.requireNonNull;
+import static org.eclipse.milo.opcua.sdk.test.EventTestSupport.conditionNameFilter;
+import static org.eclipse.milo.opcua.sdk.test.EventTestSupport.localizedTextOf;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ubyte;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
@@ -40,27 +42,20 @@ import org.eclipse.milo.opcua.sdk.test.EventTestSupport;
 import org.eclipse.milo.opcua.sdk.test.TestNamespace;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
 import org.eclipse.milo.opcua.stack.core.UaException;
-import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
-import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.BrowseDirection;
-import org.eclipse.milo.opcua.stack.core.types.enumerated.FilterOperator;
 import org.eclipse.milo.opcua.stack.core.types.structured.CallMethodRequest;
 import org.eclipse.milo.opcua.stack.core.types.structured.CallMethodResult;
 import org.eclipse.milo.opcua.stack.core.types.structured.CallResponse;
-import org.eclipse.milo.opcua.stack.core.types.structured.ContentFilter;
-import org.eclipse.milo.opcua.stack.core.types.structured.ContentFilterElement;
 import org.eclipse.milo.opcua.stack.core.types.structured.EUInformation;
 import org.eclipse.milo.opcua.stack.core.types.structured.EventFilter;
-import org.eclipse.milo.opcua.stack.core.types.structured.LiteralOperand;
 import org.eclipse.milo.opcua.stack.core.types.structured.ReferenceDescription;
-import org.eclipse.milo.opcua.stack.core.types.structured.SimpleAttributeOperand;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
@@ -817,6 +812,202 @@ public class LimitAlarmTest extends AbstractClientServerTest {
     assertTrue(currentState.getId().isNull());
   }
 
+  @Test
+  void setLimitStateActivatesAndNullClearsWithOneCoherentEventEach() throws Exception {
+    appDrivenAlarm.setLimitState(null);
+
+    var subscription = new OpcUaSubscription(client);
+    subscription.create();
+
+    try {
+      EventFilter eventFilter =
+          conditionNameFilter(
+              "AppDriven",
+              EventTestSupport.eventField(NodeIds.BaseEventType, "Message"),
+              EventTestSupport.eventField(NodeIds.AlarmConditionType, "ActiveState", "Id"),
+              EventTestSupport.eventField(
+                  NodeIds.ExclusiveLimitAlarmType, "LimitState", "CurrentState"));
+
+      List<Variant[]> events =
+          EventTestSupport.monitorEvents(subscription, NodeIds.Server, eventFilter);
+
+      // Part 9 §5.2 requires the ActiveState and its limit substate to be reported together.
+      appDrivenAlarm.setLimitState(ExclusiveLimitState.HIGH);
+
+      Variant[] active =
+          EventTestSupport.awaitEvent(
+              events, "app-driven High activation", e -> "Active/High".equals(messageOf(e)));
+      assertEquals(Boolean.TRUE, active[1].value());
+      assertEquals("High", localizedTextOf(active[2]));
+      assertTrue(appDrivenAlarm.isActive());
+      assertEquals(ExclusiveLimitState.HIGH, appDrivenAlarm.getLimitState());
+
+      appDrivenAlarm.setLimitState(null);
+
+      Variant[] inactive =
+          EventTestSupport.awaitEvent(
+              events, "app-driven clear", e -> "Inactive".equals(messageOf(e)));
+      assertEquals(Boolean.FALSE, inactive[1].value());
+      assertNull(localizedTextOf(inactive[2]));
+      assertFalse(appDrivenAlarm.isActive());
+      assertNull(appDrivenAlarm.getLimitState());
+      assertTrue(
+          appDrivenAlarm.getNode().getLimitStateNode().getCurrentStateNode().getId().isNull());
+
+      assertTrue(events.remove(active), "activation event was not collected");
+      assertTrue(events.remove(inactive), "deactivation event was not collected");
+      EventTestSupport.assertNoEvent(
+          events, "additional reduced-state transition event", e -> true);
+    } finally {
+      subscription.delete();
+      appDrivenAlarm.setLimitState(null);
+    }
+  }
+
+  @Test
+  void unconfiguredLimitStateIsRejectedBeforeAnyAlarmOrShelvingMutation() throws Exception {
+    resetShelvedExclusiveAlarm();
+    try {
+      shelvedExclusiveAlarm.setLimitState(ExclusiveLimitState.HIGH);
+      makeShelvingExpiryDue(shelvedExclusiveAlarm);
+
+      ExclusiveLimitStateMachineTypeNode limitStateNode =
+          shelvedExclusiveAlarm.getNode().getLimitStateNode();
+      TwoStateVariableTypeNode activeStateNode =
+          shelvedExclusiveAlarm.getNode().getActiveStateNode();
+      ShelvedStateMachineTypeNode shelvingState =
+          requireNonNull(shelvedExclusiveAlarm.getShelvingState());
+
+      ByteString eventId = shelvedExclusiveAlarm.currentBranch().getLastEventId();
+      DateTime eventTime = shelvedExclusiveAlarm.currentBranch().getLastEventTime();
+      DateTime conditionTime = shelvedExclusiveAlarm.getNode().getTime();
+      DateTime activeTransitionTime = activeStateNode.getTransitionTime();
+      DateTime limitTransitionTime =
+          requireNonNull(limitStateNode.getLastTransitionNode()).getTransitionTime();
+      DateTime shelvingTransitionTime =
+          requireNonNull(shelvingState.getLastTransitionNode()).getTransitionTime();
+
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> shelvedExclusiveAlarm.setLimitState(ExclusiveLimitState.LOW));
+
+      assertEquals(eventId, shelvedExclusiveAlarm.currentBranch().getLastEventId());
+      assertEquals(eventTime, shelvedExclusiveAlarm.currentBranch().getLastEventTime());
+      assertEquals(conditionTime, shelvedExclusiveAlarm.getNode().getTime());
+      assertEquals(activeTransitionTime, activeStateNode.getTransitionTime());
+      assertEquals(
+          limitTransitionTime,
+          requireNonNull(limitStateNode.getLastTransitionNode()).getTransitionTime());
+      assertEquals(
+          shelvingTransitionTime,
+          requireNonNull(shelvingState.getLastTransitionNode()).getTransitionTime());
+      assertEquals("TimedShelved", requireNonNull(shelvingState.getCurrentState()).text());
+      assertEquals(Boolean.TRUE, shelvedExclusiveAlarm.getNode().getSuppressedOrShelved());
+      assertTrue(shelvedExclusiveAlarm.isActive());
+      assertEquals(ExclusiveLimitState.HIGH, shelvedExclusiveAlarm.getLimitState());
+      assertEquals(
+          NodeIds.ExclusiveLimitStateMachineType_High,
+          limitStateNode.getCurrentStateNode().getId());
+    } finally {
+      resetShelvedExclusiveAlarm();
+    }
+  }
+
+  @Test
+  void duplicateLimitStateCallIsSilentWithoutDueShelvingOrSeverityCorrection() throws Exception {
+    appDrivenAlarm.setLimitState(null);
+
+    var subscription = new OpcUaSubscription(client);
+    subscription.create();
+
+    try {
+      EventFilter eventFilter =
+          conditionNameFilter(
+              "AppDriven", EventTestSupport.eventField(NodeIds.BaseEventType, "Message"));
+      List<Variant[]> events =
+          EventTestSupport.monitorEvents(subscription, NodeIds.Server, eventFilter);
+
+      appDrivenAlarm.setLimitState(ExclusiveLimitState.HIGH);
+      EventTestSupport.awaitEvent(
+          events, "initial app-driven activation", e -> "Active/High".equals(messageOf(e)));
+
+      ByteString eventId = appDrivenAlarm.currentBranch().getLastEventId();
+      DateTime eventTime = appDrivenAlarm.currentBranch().getLastEventTime();
+      DateTime activeTransitionTime =
+          appDrivenAlarm.getNode().getActiveStateNode().getTransitionTime();
+      DateTime limitTransitionTime =
+          requireNonNull(appDrivenAlarm.getNode().getLimitStateNode().getLastTransitionNode())
+              .getTransitionTime();
+      events.clear();
+
+      appDrivenAlarm.setLimitState(ExclusiveLimitState.HIGH);
+
+      assertEquals(eventId, appDrivenAlarm.currentBranch().getLastEventId());
+      assertEquals(eventTime, appDrivenAlarm.currentBranch().getLastEventTime());
+      assertEquals(
+          activeTransitionTime, appDrivenAlarm.getNode().getActiveStateNode().getTransitionTime());
+      assertEquals(
+          limitTransitionTime,
+          requireNonNull(appDrivenAlarm.getNode().getLimitStateNode().getLastTransitionNode())
+              .getTransitionTime());
+      EventTestSupport.assertNoEvent(events, "duplicate app-driven limit state", e -> true);
+    } finally {
+      subscription.delete();
+      appDrivenAlarm.setLimitState(null);
+    }
+  }
+
+  @Test
+  void duplicateLimitStateCallAppliesDueLazyShelvingExpiryBeforeNoOpCheck() throws Exception {
+    resetShelvedExclusiveAlarm();
+    try {
+      shelvedExclusiveAlarm.setLimitState(ExclusiveLimitState.HIGH);
+      makeShelvingExpiryDue(shelvedExclusiveAlarm);
+      ByteString shelvedEventId = shelvedExclusiveAlarm.currentBranch().getLastEventId();
+
+      var subscription = new OpcUaSubscription(client);
+      subscription.create();
+
+      try {
+        EventFilter eventFilter =
+            conditionNameFilter(
+                "ShelvedExclusive",
+                EventTestSupport.eventField(NodeIds.BaseEventType, "Message"),
+                EventTestSupport.eventField(NodeIds.AlarmConditionType, "SuppressedOrShelved"),
+                EventTestSupport.eventField(NodeIds.AlarmConditionType, "ActiveState", "Id"),
+                EventTestSupport.eventField(
+                    NodeIds.ExclusiveLimitAlarmType, "LimitState", "CurrentState"));
+        List<Variant[]> events =
+            EventTestSupport.monitorEvents(subscription, NodeIds.Server, eventFilter);
+
+        // A due shelving deadline is a separate Part 9 state change even when the requested alarm
+        // tuple itself is unchanged.
+        shelvedExclusiveAlarm.setLimitState(ExclusiveLimitState.HIGH);
+
+        Variant[] unshelved =
+            EventTestSupport.awaitEvent(
+                events, "lazy Unshelved transition", e -> "Unshelved".equals(messageOf(e)));
+        assertEquals(Boolean.FALSE, unshelved[1].value());
+        assertEquals(Boolean.TRUE, unshelved[2].value());
+        assertEquals("High", localizedTextOf(unshelved[3]));
+        assertUnshelved(shelvedExclusiveAlarm);
+        assertTrue(shelvedExclusiveAlarm.isActive());
+        assertEquals(ExclusiveLimitState.HIGH, shelvedExclusiveAlarm.getLimitState());
+        assertNotEquals(shelvedEventId, shelvedExclusiveAlarm.currentBranch().getLastEventId());
+
+        EventTestSupport.assertNoEvent(
+            events,
+            "alarm-state event for the unchanged tuple",
+            e -> "Active/High".equals(messageOf(e)));
+        assertEquals(1, events.size(), "only the due shelving expiry should emit");
+      } finally {
+        subscription.delete();
+      }
+    } finally {
+      resetShelvedExclusiveAlarm();
+    }
+  }
+
   private void assertInvalidExclusiveLimits(Consumer<ConditionBuilder> configure) {
     assertThrows(
         IllegalArgumentException.class, () -> ExclusiveLevelAlarm.create(nodeContext, configure));
@@ -912,6 +1103,17 @@ public class LimitAlarmTest extends AbstractClientServerTest {
     shelvingRuntime.makeExpiryDueForTesting();
   }
 
+  private void resetShelvedExclusiveAlarm() throws Exception {
+    ShelvedStateMachineTypeNode shelvingState =
+        requireNonNull(shelvedExclusiveAlarm.getShelvingState());
+    NodeId unshelveMethodId = requireNonNull(shelvingState.getUnshelveMethodNode()).getNodeId();
+
+    call(shelvingState.getNodeId(), unshelveMethodId);
+    requireNonNull(shelvedExclusiveAlarm.getShelvingRuntime())
+        .setExpiryTimerSuppressedForTesting(false);
+    shelvedExclusiveAlarm.setLimitState(null);
+  }
+
   private static void assertUnshelved(LimitAlarm alarm) {
     ShelvedStateMachineTypeNode shelvingState = requireNonNull(alarm.getShelvingState());
     LocalizedText currentState = requireNonNull(shelvingState.getCurrentState());
@@ -928,33 +1130,8 @@ public class LimitAlarmTest extends AbstractClientServerTest {
     return requireNonNull(response.getResults())[0];
   }
 
-  /**
-   * Create an {@link EventFilter} with the given select clauses, matching only events whose
-   * ConditionName equals {@code conditionName} — scoping each test to its own alarm's events.
-   */
-  private static EventFilter conditionNameFilter(
-      String conditionName, SimpleAttributeOperand... selectClauses) {
-
-    var whereClause =
-        new ContentFilter(
-            new ContentFilterElement[] {
-              new ContentFilterElement(
-                  FilterOperator.Equals,
-                  new ExtensionObject[] {
-                    ExtensionObject.encode(
-                        DefaultEncodingContext.INSTANCE,
-                        EventTestSupport.eventField(NodeIds.ConditionType, "ConditionName")),
-                    ExtensionObject.encode(
-                        DefaultEncodingContext.INSTANCE,
-                        new LiteralOperand(new Variant(conditionName)))
-                  })
-            });
-
-    return new EventFilter(selectClauses, whereClause);
-  }
-
   private static @Nullable String messageOf(Variant[] eventFields) {
-    return eventFields[0].value() instanceof LocalizedText text ? text.text() : null;
+    return localizedTextOf(eventFields[0]);
   }
 
   private static boolean activeIdOf(Variant[] eventFields) {

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/test/EventTestSupport.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/test/EventTestSupport.java
@@ -25,6 +25,7 @@ import org.eclipse.milo.opcua.stack.core.AttributeId;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
 import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
@@ -34,6 +35,7 @@ import org.eclipse.milo.opcua.stack.core.types.structured.ContentFilterElement;
 import org.eclipse.milo.opcua.stack.core.types.structured.EventFilter;
 import org.eclipse.milo.opcua.stack.core.types.structured.LiteralOperand;
 import org.eclipse.milo.opcua.stack.core.types.structured.SimpleAttributeOperand;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Shared helpers for tests that monitor and assert on client-received events: monitored event items
@@ -84,6 +86,36 @@ public final class EventTestSupport {
             });
 
     return new EventFilter(selectClauses, whereClause);
+  }
+
+  /**
+   * Create an {@link EventFilter} with the given select clauses, matching only events whose
+   * ConditionName equals {@code conditionName} — scoping a test's items to one Condition instance.
+   */
+  public static EventFilter conditionNameFilter(
+      String conditionName, SimpleAttributeOperand... selectClauses) {
+
+    var whereClause =
+        new ContentFilter(
+            new ContentFilterElement[] {
+              new ContentFilterElement(
+                  FilterOperator.Equals,
+                  new ExtensionObject[] {
+                    ExtensionObject.encode(
+                        DefaultEncodingContext.INSTANCE,
+                        eventField(NodeIds.ConditionType, "ConditionName")),
+                    ExtensionObject.encode(
+                        DefaultEncodingContext.INSTANCE,
+                        new LiteralOperand(new Variant(conditionName)))
+                  })
+            });
+
+    return new EventFilter(selectClauses, whereClause);
+  }
+
+  /** The text of a {@link LocalizedText} event field, or {@code null} if the field is not one. */
+  public static @Nullable String localizedTextOf(Variant eventField) {
+    return eventField.value() instanceof LocalizedText text ? text.text() : null;
   }
 
   /**

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/AlarmCondition.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/AlarmCondition.java
@@ -257,9 +257,26 @@ public class AlarmCondition extends AcknowledgeableCondition {
       ConditionSnapshot.@Nullable BranchSnapshot trunkSnapshot,
       DateTime time) {
 
+    boolean restoredActive = trunkSnapshot != null && Boolean.TRUE.equals(trunkSnapshot.active());
+    applySnapshot(snapshot, trunkSnapshot, restoredActive, time);
+  }
+
+  /**
+   * Apply {@code snapshot} with a caller-selected restored ActiveState.
+   *
+   * <p>Base alarms preserve the captured Active flag. Limit alarms normalize Active against the
+   * limit states representable by the destination instance and pass the result here rather than
+   * re-deriving it. Restore selects state only; it must not perform a live alarm transition or emit
+   * an event.
+   */
+  void applySnapshot(
+      ConditionSnapshot snapshot,
+      ConditionSnapshot.@Nullable BranchSnapshot trunkSnapshot,
+      boolean restoredActive,
+      DateTime time) {
+
     super.applySnapshot(snapshot, trunkSnapshot, time);
 
-    boolean restoredActive = trunkSnapshot != null && Boolean.TRUE.equals(trunkSnapshot.active());
     if (isActive() != restoredActive) {
       setTwoState(activeState, restoredActive, ACTIVE_TEXTS, time);
       active = restoredActive;

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/Condition.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/Condition.java
@@ -613,6 +613,7 @@ public class Condition {
         branch.isConfirmed(),
         captureActive(),
         captureActiveLimits(),
+        captureEffectiveLimitState(),
         branch.isRetained(),
         branch.getLastEventId(),
         branch.getLastEventTime(),
@@ -632,6 +633,11 @@ public class Condition {
   /** Capture the violated limits for a branch snapshot; non-limit Conditions have none. */
   Set<ExclusiveLimitState> captureActiveLimits() {
     return Set.of();
+  }
+
+  /** Capture the selected effective limit for a branch snapshot; non-limit Conditions have none. */
+  @Nullable ExclusiveLimitState captureEffectiveLimitState() {
+    return null;
   }
 
   /**
@@ -990,7 +996,7 @@ public class Condition {
     if (variable != null && variable.getSourceTimestamp() == null) {
       DataValue current = variable.getValue();
       DateTime now = DateTime.now();
-      if (current == null || current.getValue() == null || current.getValue().getValue() == null) {
+      if (current == null || current.getValue().isNull()) {
         setConditionVariable(variable, initialValue, now);
       } else {
         variable.setSourceTimestamp(now);

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/ConditionBuilder.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/ConditionBuilder.java
@@ -60,6 +60,10 @@ public class ConditionBuilder {
       BrowsePath.of(
           new QualifiedName(0, "ActiveState"), new QualifiedName(0, "EffectiveDisplayName"));
 
+  private static final BrowsePath ACTIVE_STATE_EFFECTIVE_TRANSITION_TIME =
+      BrowsePath.of(
+          new QualifiedName(0, "ActiveState"), new QualifiedName(0, "EffectiveTransitionTime"));
+
   private static final BrowsePath SHELVING_STATE_LAST_TRANSITION =
       BrowsePath.of(new QualifiedName(0, "ShelvingState"), new QualifiedName(0, "LastTransition"));
 
@@ -902,6 +906,9 @@ public class ConditionBuilder {
                         || optionalIncludes.contains(declaration.browseName().name())
                         || (includeLimitMembers
                             && ACTIVE_STATE_EFFECTIVE_DISPLAY_NAME.equals(declaration.browsePath()))
+                        || (includeLimitMembers
+                            && ACTIVE_STATE_EFFECTIVE_TRANSITION_TIME.equals(
+                                declaration.browsePath()))
                         || (withShelving
                             && SHELVING_STATE_LAST_TRANSITION.equals(declaration.browsePath()))
                         || (includeLimitMembers

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/ConditionSnapshot.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/ConditionSnapshot.java
@@ -31,8 +31,9 @@ import org.jspecify.annotations.Nullable;
  * EventId and Time are deliberately not carried: §5.5.7 permits regenerating a refresh replay from
  * current state, which is what restored branches do.
  *
- * <p>Any component may be {@code null} (or empty): restore substitutes the §4.12 recovery defaults
- * — Enabled, Acked and Confirmed {@code false}, Unshelved — so older or partial snapshots restore
+ * <p>Components annotated {@link Nullable} may be {@code null}; collection components and their
+ * members must be non-null but may be empty. Restore substitutes the §4.12 recovery defaults —
+ * Enabled, Acked and Confirmed {@code false}, Unshelved — so older or partial snapshots restore
  * safely.
  *
  * <p>Snapshots may contain operator identity (ClientUserId) and operator comments. Storage and
@@ -96,6 +97,17 @@ public record ConditionSnapshot(
   /**
    * The state of one {@link ConditionBranch}.
    *
+   * <p>The effective limit state participates in this record's equality, hash code, string
+   * representation, and external serialized shape. A value that does not belong to {@code
+   * activeLimits} is normalized to absent at construction and restores through the scalar fallback.
+   *
+   * <p>Limit-alarm restore intersects {@code activeLimits} with the destination instance's
+   * supported, configured states. A persisted effective state is retained only when it remains in
+   * that set; otherwise restore uses the scalar fallback, and Active normalizes to false when no
+   * captured state is representable. A captured top-level Severity takes precedence over current
+   * destination configuration; when absent, restore derives Severity from the normalized effective
+   * state without manufacturing a LastSeverity transition.
+   *
    * @param branchId the BranchId, or {@code null} for the trunk.
    * @param acked the acknowledged state, or {@code null} to default to {@code false} (§4.12).
    * @param confirmed the confirmed state, or {@code null} to default to {@code false} (§4.12).
@@ -103,6 +115,10 @@ public record ConditionSnapshot(
    *     inactive on restore).
    * @param activeLimits the violated limits of a limit alarm: at most one for an exclusive alarm,
    *     any combination for a non-exclusive alarm, empty when inactive or not a limit alarm.
+   * @param effectiveLimitState the active limit selected for Message, EffectiveDisplayName, and
+   *     Severity, or {@code null} when inactive, not a limit alarm, or captured by an older or
+   *     partial snapshot. A {@code null} value with non-empty {@code activeLimits} requests the
+   *     scalar fallback during restore.
    * @param retained the branch's Retain state; recomputed from the restored state for the trunk.
    * @param lastEventId the EventId of the branch's last event, or {@code null} if none.
    * @param lastEventTime the Time of the branch's last event, or {@code null} if none.
@@ -114,13 +130,26 @@ public record ConditionSnapshot(
       @Nullable Boolean confirmed,
       @Nullable Boolean active,
       Set<ExclusiveLimitState> activeLimits,
+      @Nullable ExclusiveLimitState effectiveLimitState,
       boolean retained,
       @Nullable ByteString lastEventId,
       @Nullable DateTime lastEventTime,
       List<AcceptedEventId> eventIdWindow) {
 
+    /**
+     * Defensively copy the branch collections and normalize the effective limit selection.
+     *
+     * <p>An effective limit state that does not belong to {@code activeLimits} — possible when
+     * behavior state and directly-written limit-state nodes disagree at capture — is recorded as
+     * absent, so the snapshot restores through the scalar fallback instead of construction failing.
+     *
+     * @throws NullPointerException if either collection or any collection member is {@code null}.
+     */
     public BranchSnapshot {
       activeLimits = Set.copyOf(activeLimits);
+      if (effectiveLimitState != null && !activeLimits.contains(effectiveLimitState)) {
+        effectiveLimitState = null;
+      }
       eventIdWindow = List.copyOf(eventIdWindow);
     }
   }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/ExclusiveLimitAlarm.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/ExclusiveLimitAlarm.java
@@ -10,6 +10,7 @@
 
 package org.eclipse.milo.opcua.sdk.server.conditions;
 
+import java.util.EnumSet;
 import java.util.Set;
 import java.util.function.Consumer;
 import org.eclipse.milo.opcua.sdk.server.model.objects.ExclusiveLimitAlarmTypeNode;
@@ -28,9 +29,11 @@ import org.jspecify.annotations.Nullable;
  * <p>{@link #evaluate} derives the state from the configured limits with deadband hysteresis:
  * escalation (or a violation on the other side) applies immediately, while de-escalation and
  * return-to-normal are held until the value retreats within the current limit by its deadband.
- * {@link #setActive(boolean, ExclusiveLimitState)} is the app-driven alternative. Each transition
- * generates one event carrying the new limit state and its per-limit severity, and is a new state
- * needing acknowledgement.
+ * {@link #setLimitState} is the concise app-driven alternative; {@link #setActive(boolean,
+ * ExclusiveLimitState)} remains available when the caller also represents Active explicitly.
+ * Limit-state changes are applied atomically with ActiveState, presentation, and Severity.
+ * Activation and active-to-active limit changes start a new acknowledgement cycle; deactivation
+ * preserves any outstanding obligation, and a Severity-only correction does not renew it.
  */
 public class ExclusiveLimitAlarm extends LimitAlarm {
 
@@ -156,13 +159,28 @@ public class ExclusiveLimitAlarm extends LimitAlarm {
   }
 
   /**
+   * Apply an already-computed exclusive limit state. A non-null state activates the alarm in that
+   * state; {@code null} deactivates it. Reapplying the current state with unchanged effective
+   * Severity is a no-op after any due lazy shelving expiry has been applied.
+   *
+   * @param state the limit state to apply, or {@code null} to deactivate the alarm.
+   * @throws IllegalArgumentException if {@code state} names an unconfigured limit.
+   */
+  public void setLimitState(@Nullable ExclusiveLimitState state) {
+    setActive(state != null, state);
+  }
+
+  /**
    * Set the active and limit state of the alarm directly — the fully app-driven alternative to
-   * {@link #evaluate}. A call that does not change the state is a no-op.
+   * {@link #evaluate}. {@link #setLimitState} is the equivalent concise form when the limit state
+   * already expresses whether the alarm is active. A call that changes neither state nor effective
+   * Severity is a no-op after any due lazy shelving expiry has been applied.
    *
    * @param active the new active state.
    * @param limitState the violated limit; required when activating, must be {@code null} when
    *     deactivating.
-   * @throws IllegalArgumentException if {@code active} and {@code limitState} disagree.
+   * @throws IllegalArgumentException if {@code active} and {@code limitState} disagree, or if an
+   *     active state names an unconfigured limit.
    */
   public void setActive(boolean active, @Nullable ExclusiveLimitState limitState) {
     if (active && limitState == null) {
@@ -188,8 +206,8 @@ public class ExclusiveLimitAlarm extends LimitAlarm {
    * {@inheritDoc}
    *
    * <p>An exclusive limit alarm activates into a limit state: deactivation clears the LimitState
-   * machine, activation must go through {@link #setActive(boolean, ExclusiveLimitState)} or {@link
-   * #evaluate}.
+   * machine, activation must go through {@link #setLimitState}, {@link #setActive(boolean,
+   * ExclusiveLimitState)}, or {@link #evaluate}.
    *
    * @throws IllegalArgumentException if {@code active} is {@code true}.
    */
@@ -198,7 +216,7 @@ public class ExclusiveLimitAlarm extends LimitAlarm {
     if (active) {
       throw new IllegalArgumentException(
           "an exclusive limit alarm activates into a limit state;"
-              + " use setActive(true, ExclusiveLimitState) or evaluate(value)");
+              + " use setLimitState(state), setActive(true, state), or evaluate(value)");
     }
 
     setActive(false, null);
@@ -211,21 +229,27 @@ public class ExclusiveLimitAlarm extends LimitAlarm {
   }
 
   @Override
+  @Nullable ExclusiveLimitState captureEffectiveLimitState() {
+    return getLimitState();
+  }
+
+  @Override
   void applySnapshot(
       ConditionSnapshot snapshot,
       ConditionSnapshot.@Nullable BranchSnapshot trunkSnapshot,
       DateTime time) {
 
-    super.applySnapshot(snapshot, trunkSnapshot, time);
+    boolean wasActive = isActive();
+    ExclusiveLimitState previousState = getLimitState();
+    ExclusiveLimitState target = restoredLimitState(trunkSnapshot);
 
-    ExclusiveLimitState target =
-        isActive() && trunkSnapshot != null
-            ? ExclusiveLimitState.mostSevere(trunkSnapshot.activeLimits())
-            : null;
+    super.applySnapshot(snapshot, trunkSnapshot, target != null, time);
 
     // Restore replaces the machine state: an inactive snapshot clears a previous restore's limit.
     limitStateMachine.setState(target, time);
-    setActiveEffectiveDisplayName(target);
+
+    applyRestoredPresentation(
+        target, wasActive == (target == null) || previousState != target, snapshot, time);
   }
 
   /**
@@ -255,6 +279,27 @@ public class ExclusiveLimitAlarm extends LimitAlarm {
     return entered;
   }
 
+  /** Select the one configured state represented by a captured branch. */
+  private @Nullable ExclusiveLimitState restoredLimitState(
+      ConditionSnapshot.@Nullable BranchSnapshot trunkSnapshot) {
+
+    if (trunkSnapshot == null || !Boolean.TRUE.equals(trunkSnapshot.active())) {
+      return null;
+    }
+
+    EnumSet<ExclusiveLimitState> supportedStates = EnumSet.noneOf(ExclusiveLimitState.class);
+    for (ExclusiveLimitState state : trunkSnapshot.activeLimits()) {
+      if (hasConfiguredLimit(state)) {
+        supportedStates.add(state);
+      }
+    }
+
+    ExclusiveLimitState persistedState = trunkSnapshot.effectiveLimitState();
+    return persistedState != null && supportedStates.contains(persistedState)
+        ? persistedState
+        : ExclusiveLimitState.mostSevere(supportedStates);
+  }
+
   /**
    * Apply a transition to {@code target} ({@code null} = inactive) as one state change: the
    * LimitState machine, then the shared activation tail (ActiveState with the
@@ -263,16 +308,19 @@ public class ExclusiveLimitAlarm extends LimitAlarm {
    */
   private void applyExclusiveState(@Nullable ExclusiveLimitState target) {
     boolean targetActive = target != null;
-    boolean limitStateChanged = getLimitState() != target || isActive() != targetActive;
+    boolean modeledStateChanged = getLimitState() != target;
+    boolean alarmStateChanged = modeledStateChanged || isActive() != targetActive;
     boolean severityChanged = effectiveSeverityChanged(target);
 
     withStateChange(
         transitionMessage(target),
-        () -> limitStateChanged || severityChanged,
+        () -> alarmStateChanged || severityChanged,
         now -> {
-          if (limitStateChanged) {
-            limitStateMachine.setState(target, now);
-            applyActiveTransition(target, true, now);
+          if (alarmStateChanged) {
+            if (modeledStateChanged) {
+              limitStateMachine.setState(target, now);
+            }
+            applyActiveTransition(target, modeledStateChanged, modeledStateChanged, now);
           } else {
             applyEffectiveSeverity(target, now);
           }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/LimitAlarm.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/LimitAlarm.java
@@ -34,7 +34,8 @@ import org.jspecify.annotations.Nullable;
  * build time only.
  *
  * <p>The SDK never samples the alarm's input: the application observes its process value and calls
- * {@link #evaluate}, or drives the state directly via the {@code setActive} variants.
+ * {@link #evaluate}, or applies an already-computed state through {@link
+ * ExclusiveLimitAlarm#setLimitState} or {@link NonExclusiveLimitAlarm#setLimitStates}.
  */
 public abstract class LimitAlarm extends AlarmCondition {
 
@@ -48,6 +49,7 @@ public abstract class LimitAlarm extends AlarmCondition {
       new EnumMap<>(ExclusiveLimitState.class);
 
   private final @Nullable PropertyTypeNode activeStateEffectiveDisplayName;
+  private final @Nullable PropertyTypeNode activeStateEffectiveTransitionTime;
 
   /**
    * The Condition's current base Severity: reported while active without a per-limit override and
@@ -88,6 +90,16 @@ public abstract class LimitAlarm extends AlarmCondition {
     TwoStateVariableTypeNode activeState = node.getActiveStateNode();
     activeStateEffectiveDisplayName =
         activeState != null ? activeState.getEffectiveDisplayNameNode() : null;
+    activeStateEffectiveTransitionTime =
+        activeState != null ? activeState.getEffectiveTransitionTimeNode() : null;
+
+    if (activeStateEffectiveTransitionTime != null
+        && currentValue(activeStateEffectiveTransitionTime) == null) {
+      DateTime transitionTime = activeState.getTransitionTime();
+      activeStateEffectiveTransitionTime.setValue(
+          new DataValue(
+              new Variant(transitionTime != null ? transitionTime : DateTime.NULL_VALUE)));
+    }
   }
 
   @Override
@@ -171,6 +183,17 @@ public abstract class LimitAlarm extends AlarmCondition {
   }
 
   /**
+   * Restore the effective Severity without creating a LastSeverity transition. A captured Severity
+   * takes precedence; callers use this only when a snapshot did not contain one.
+   */
+  void restoreEffectiveSeverity(@Nullable ExclusiveLimitState effectiveState) {
+    UShort severity = effectiveSeverity(effectiveState);
+    if (severity != null) {
+      getNode().setSeverity(severity);
+    }
+  }
+
+  /**
    * Check whether {@code limit} is — or, applying its deadband, remains — violated at {@code
    * value}: entry requires crossing the limit itself; leaving additionally requires retreating
    * within the limit by the deadband (§5.8.18: hysteresis against chattering).
@@ -226,32 +249,82 @@ public abstract class LimitAlarm extends AlarmCondition {
         new DataValue(new Variant(LocalizedText.english(text))));
   }
 
+  /** Advance ActiveState's optional EffectiveTransitionTime, where present. */
+  void setActiveEffectiveTransitionTime(DateTime time) {
+    if (activeStateEffectiveTransitionTime != null) {
+      activeStateEffectiveTransitionTime.setValue(new DataValue(new Variant(time)));
+    }
+  }
+
   /**
    * Apply the activation tail shared by both concrete limit-alarm types, after the subclass has
    * written its own limit-state shape: ActiveState (with the acknowledgement-needed rule),
-   * ActiveState's EffectiveDisplayName sub-state text, and the per-limit Severity of the most
-   * severe violated limit.
+   * ActiveState's effective presentation and transition time, and the per-limit Severity of the
+   * selected violated limit.
    *
    * <p>Must be called while holding the Condition's lock, inside a {@link StateMutation}.
    *
-   * @param mostSevere the most severe violated limit, or {@code null} if the alarm is now inactive.
-   * @param limitStateChanged whether one or more limit states changed and therefore start a new
-   *     acknowledgement cycle while the alarm remains active.
+   * @param effectiveState the violated limit selected for presentation and Severity, or {@code
+   *     null} if the alarm is now inactive.
+   * @param reducedStateChanged whether the limit membership or selected effective state changed and
+   *     therefore starts a new acknowledgement cycle while the alarm remains active.
+   * @param modeledSubStateChanged whether a modeled limit state entered or left; selector-only
+   *     changes are not modeled substate transitions.
    * @param time the transition time.
    */
   void applyActiveTransition(
-      @Nullable ExclusiveLimitState mostSevere, boolean limitStateChanged, DateTime time) {
-    boolean targetActive = mostSevere != null;
+      @Nullable ExclusiveLimitState effectiveState,
+      boolean reducedStateChanged,
+      boolean modeledSubStateChanged,
+      DateTime time) {
+    boolean targetActive = effectiveState != null;
+    boolean activeStateChanged = isActive() != targetActive;
 
-    if (isActive() != targetActive) {
+    if (activeStateChanged) {
       applyActive(targetActive, time);
-    } else if (targetActive && limitStateChanged) {
-      // A change in the violated limit(s) while already active is a state needing acknowledgement.
+    } else if (targetActive && reducedStateChanged) {
+      // A changed limit membership or effective selection is a fresh acknowledgement obligation.
       applyAcked(currentBranch(), false, time);
     }
 
-    setActiveEffectiveDisplayName(mostSevere);
-    applyEffectiveSeverity(mostSevere, time);
+    setActiveEffectiveDisplayName(effectiveState);
+    if (activeStateChanged || modeledSubStateChanged) {
+      setActiveEffectiveTransitionTime(time);
+    }
+    applyEffectiveSeverity(effectiveState, time);
+  }
+
+  /**
+   * Apply the restore presentation tail shared by both limit-alarm types, after the subclass has
+   * restored its modeled limit state: ActiveState's EffectiveDisplayName always tracks the restored
+   * effective state, EffectiveTransitionTime advances only when {@code transitionChanged}, Message
+   * is regenerated from the restored state, and Severity is derived when the snapshot did not carry
+   * one. This also replaces presentation left by an earlier pre-live restore when the new snapshot
+   * has no trunk branch.
+   *
+   * <p>Called while holding the Condition's lock.
+   *
+   * @param effectiveState the restored effective limit state, or {@code null} when inactive.
+   * @param transitionChanged whether the restored active or limit state differs from the previous
+   *     state.
+   * @param snapshot the snapshot being restored.
+   * @param time the shared restore transition time.
+   */
+  void applyRestoredPresentation(
+      @Nullable ExclusiveLimitState effectiveState,
+      boolean transitionChanged,
+      ConditionSnapshot snapshot,
+      DateTime time) {
+
+    setActiveEffectiveDisplayName(effectiveState);
+    if (transitionChanged) {
+      setActiveEffectiveTransitionTime(time);
+    }
+
+    getNode().setMessage(LocalizedText.english(transitionMessage(effectiveState)));
+    if (snapshot.severity() == null) {
+      restoreEffectiveSeverity(effectiveState);
+    }
   }
 
   /** The event Message for a transition into {@code state} ({@code null} = inactive). */

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/NonExclusiveLimitAlarm.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/NonExclusiveLimitAlarm.java
@@ -30,15 +30,19 @@ import org.jspecify.annotations.Nullable;
  * ActiveState, so multiple limits can be violated simultaneously (a value above HighHigh violates
  * High too).
  *
- * <p>{@link #evaluate} applies each limit's threshold and deadband hysteresis independently;
- * ActiveState is the disjunction of the limit states. Each evaluation that changes any state
- * generates one event carrying the per-limit severity of the most severe violated limit, and is a
- * new state needing acknowledgement.
+ * <p>{@link #evaluate} applies each limit's threshold and deadband hysteresis independently and
+ * uses Milo's scalar precedence to select the effective state. Applications that compute a compound
+ * result themselves use {@link #setLimitStates} to replace the complete active set and select its
+ * effective state without imposing scalar ordering. Each reduced-state change is applied
+ * atomically; activation and changes while the alarm remains active start a new acknowledgement
+ * cycle.
  */
 public class NonExclusiveLimitAlarm extends LimitAlarm {
 
   private final Map<ExclusiveLimitState, TwoStateVariableTypeNode> limitStates =
       new EnumMap<>(ExclusiveLimitState.class);
+
+  private volatile @Nullable ExclusiveLimitState effectiveLimitState;
 
   /**
    * Create NonExclusiveLimitAlarm behavior wrapping {@code node}.
@@ -52,6 +56,8 @@ public class NonExclusiveLimitAlarm extends LimitAlarm {
     putLimitState(ExclusiveLimitState.HIGH, node.getHighStateNode());
     putLimitState(ExclusiveLimitState.LOW, node.getLowStateNode());
     putLimitState(ExclusiveLimitState.LOW_LOW, node.getLowLowStateNode());
+
+    effectiveLimitState = mostSevereViolated(currentActiveLimitStates());
   }
 
   private void putLimitState(ExclusiveLimitState limit, @Nullable TwoStateVariableTypeNode state) {
@@ -147,6 +153,59 @@ public class NonExclusiveLimitAlarm extends LimitAlarm {
     return booleanId(limitStates.get(limit), false);
   }
 
+  /**
+   * Atomically replace the complete set of active limit states with an application-computed result.
+   * An empty set requires a null effective state; a non-empty set requires an effective state that
+   * belongs to it. The effective state controls Message, ActiveState's EffectiveDisplayName, and
+   * Severity without restricting which configured states may coexist.
+   *
+   * <pre>{@code
+   * alarm.setLimitStates(
+   *     Set.of(ExclusiveLimitState.HIGH, ExclusiveLimitState.LOW),
+   *     ExclusiveLimitState.LOW);
+   * }</pre>
+   *
+   * <p>The input set is copied before the Condition is touched. Activation and changing either
+   * membership or the effective state while the alarm remains active start a new acknowledgement
+   * cycle. Reapplying an identical tuple is a no-op after any due lazy shelving expiry when
+   * ActiveState is coherent and the effective Severity is unchanged; an incoherent loaded
+   * ActiveState is repaired, and a Severity correction is applied as a configuration event without
+   * starting a new acknowledgement cycle.
+   *
+   * <p>All modeled state writes in one call share one transition time. Changed per-limit states
+   * receive that time, ActiveState.TransitionTime changes only when Active changes, and membership
+   * changes advance ActiveState.EffectiveTransitionTime. Changing only {@code effectiveState}
+   * renews acknowledgement and updates presentation without changing any of those modeled-state
+   * transition times.
+   *
+   * @param activeStates the complete set of limit states that should be active.
+   * @param effectiveState the active state selected for Message, EffectiveDisplayName, and
+   *     Severity, or {@code null} when {@code activeStates} is empty.
+   * @throws IllegalArgumentException if the set and effective state do not form a valid tuple, or
+   *     if a requested state lacks either its modeled state variable or configured limit Property.
+   */
+  public void setLimitStates(
+      Set<ExclusiveLimitState> activeStates, @Nullable ExclusiveLimitState effectiveState) {
+
+    Set<ExclusiveLimitState> normalizedStates = Set.copyOf(activeStates);
+    validateLimitStates(normalizedStates, effectiveState);
+
+    runLocked(
+        () -> {
+          applyShelvingExpiryIfDue();
+          applyLimitStates(normalizedStates, effectiveState);
+        });
+  }
+
+  /**
+   * Get the active limit state currently selected for Message, EffectiveDisplayName, and Severity.
+   *
+   * @return the selected effective state, or {@code null} while no limit state is active.
+   */
+  public @Nullable ExclusiveLimitState getEffectiveLimitState() {
+    return effectiveLimitState;
+  }
+
   @Override
   public void evaluate(double value) {
     runLocked(
@@ -159,23 +218,18 @@ public class NonExclusiveLimitAlarm extends LimitAlarm {
             return;
           }
 
-          var targets = new EnumMap<ExclusiveLimitState, Boolean>(ExclusiveLimitState.class);
-          var changed = new EnumMap<ExclusiveLimitState, Boolean>(ExclusiveLimitState.class);
+          EnumSet<ExclusiveLimitState> targets = EnumSet.noneOf(ExclusiveLimitState.class);
 
           for (ExclusiveLimitState limit : limitStates.keySet()) {
             boolean wasViolated = isLimitActive(limit);
             boolean violated = limitViolated(limit, wasViolated, value);
 
-            targets.put(limit, violated);
-            if (violated != wasViolated) {
-              changed.put(limit, violated);
+            if (violated) {
+              targets.add(limit);
             }
           }
 
-          ExclusiveLimitState mostSevere = mostSevereViolated(targets);
-          if (!changed.isEmpty() || effectiveSeverityChanged(mostSevere)) {
-            applyLimitStates(targets, changed);
-          }
+          applyLimitStates(targets, mostSevereViolated(targets));
         });
   }
 
@@ -184,8 +238,9 @@ public class NonExclusiveLimitAlarm extends LimitAlarm {
    *
    * <p>A non-exclusive limit alarm activates into one or more independent limit states, so it
    * cannot be activated without naming them: {@link #setActive(boolean) setActive(true)} throws,
-   * and applications drive activation through {@link #evaluate}. {@code setActive(false)} clears
-   * every violated limit state and deactivates the alarm as one transition.
+   * and applications drive activation through {@link #setLimitStates} or {@link #evaluate}. {@code
+   * setActive(false)} clears every violated limit state and deactivates the alarm as one
+   * transition.
    *
    * @throws IllegalArgumentException if {@code active} is {@code true}.
    */
@@ -194,39 +249,24 @@ public class NonExclusiveLimitAlarm extends LimitAlarm {
     if (active) {
       throw new IllegalArgumentException(
           "a non-exclusive limit alarm activates into one or more limit states;"
-              + " use evaluate(value)");
+              + " use setLimitStates(activeStates, effectiveState) or evaluate(value)");
     }
 
     runLocked(
         () -> {
           applyShelvingExpiryIfDue();
-
-          var targets = new EnumMap<ExclusiveLimitState, Boolean>(ExclusiveLimitState.class);
-          var changed = new EnumMap<ExclusiveLimitState, Boolean>(ExclusiveLimitState.class);
-
-          for (ExclusiveLimitState limit : limitStates.keySet()) {
-            targets.put(limit, false);
-            if (isLimitActive(limit)) {
-              changed.put(limit, false);
-            }
-          }
-
-          if (!changed.isEmpty()) {
-            applyLimitStates(targets, changed);
-          }
+          applyLimitStates(Set.of(), null);
         });
   }
 
   @Override
   Set<ExclusiveLimitState> captureActiveLimits() {
-    var activeLimits = EnumSet.noneOf(ExclusiveLimitState.class);
-    for (ExclusiveLimitState limit : limitStates.keySet()) {
-      if (isLimitActive(limit)) {
-        activeLimits.add(limit);
-      }
-    }
+    return currentActiveLimitStates();
+  }
 
-    return activeLimits;
+  @Override
+  @Nullable ExclusiveLimitState captureEffectiveLimitState() {
+    return effectiveLimitState;
   }
 
   @Override
@@ -235,13 +275,16 @@ public class NonExclusiveLimitAlarm extends LimitAlarm {
       ConditionSnapshot.@Nullable BranchSnapshot trunkSnapshot,
       DateTime time) {
 
-    super.applySnapshot(snapshot, trunkSnapshot, time);
+    boolean wasActive = isActive();
+    Set<ExclusiveLimitState> previousStates = currentActiveLimitStates();
+    Set<ExclusiveLimitState> activeLimits = restoredActiveLimits(trunkSnapshot);
+    ExclusiveLimitState restoredEffectiveState =
+        restoredEffectiveLimitState(trunkSnapshot, activeLimits);
+
+    super.applySnapshot(snapshot, trunkSnapshot, !activeLimits.isEmpty(), time);
 
     // Restore replaces every configured limit state: limits the snapshot omits go inactive, so an
     // earlier restore's violations cannot linger.
-    Set<ExclusiveLimitState> activeLimits =
-        isActive() && trunkSnapshot != null ? trunkSnapshot.activeLimits() : Set.of();
-
     for (Map.Entry<ExclusiveLimitState, TwoStateVariableTypeNode> entry : limitStates.entrySet()) {
       ExclusiveLimitState limit = entry.getKey();
       boolean violated = activeLimits.contains(limit);
@@ -250,39 +293,129 @@ public class NonExclusiveLimitAlarm extends LimitAlarm {
       }
     }
 
-    setActiveEffectiveDisplayName(ExclusiveLimitState.mostSevere(activeLimits));
+    effectiveLimitState = restoredEffectiveState;
+
+    applyRestoredPresentation(
+        restoredEffectiveState,
+        wasActive == activeLimits.isEmpty() || !previousStates.equals(activeLimits),
+        snapshot,
+        time);
   }
 
   /**
-   * Apply the per-limit target states as one state change: write the {@code changed} limit state
-   * variables, then the activation tail shared by all limit alarms (ActiveState with the
-   * acknowledgement-needed rule, EffectiveDisplayName, and the per-limit severity of the most
-   * severe violated limit) — one event per evaluation that changes anything.
+   * Apply a complete reduced state as one Condition mutation. The caller holds the Condition lock
+   * and has already applied any due shelving expiry.
    *
-   * @param targets every configured limit's target violation state, for the most-severe decision.
-   * @param changed only the limits whose state changed, to be written; empty for a
-   *     runtime-configuration-only Severity change.
+   * @param activeStates the complete target membership.
+   * @param selectedState the target effective state, or {@code null} for an empty membership.
    */
   private void applyLimitStates(
-      Map<ExclusiveLimitState, Boolean> targets, Map<ExclusiveLimitState, Boolean> changed) {
+      Set<ExclusiveLimitState> activeStates, @Nullable ExclusiveLimitState selectedState) {
 
-    ExclusiveLimitState mostSevere = mostSevereViolated(targets);
-    boolean limitStateChanged = !changed.isEmpty();
+    Set<ExclusiveLimitState> currentStates = currentActiveLimitStates();
+    boolean membershipChanged = !currentStates.equals(activeStates);
+    boolean selectionChanged = effectiveLimitState != selectedState;
+    boolean activeStateChanged = isActive() == activeStates.isEmpty();
+    boolean severityChanged = effectiveSeverityChanged(selectedState);
+
+    if (!membershipChanged && !selectionChanged && !activeStateChanged && !severityChanged) {
+      return;
+    }
+
+    boolean reducedStateChanged = membershipChanged || selectionChanged;
 
     withStateChange(
-        transitionMessage(mostSevere),
+        transitionMessage(selectedState),
         now -> {
-          for (Map.Entry<ExclusiveLimitState, Boolean> entry : changed.entrySet()) {
+          for (Map.Entry<ExclusiveLimitState, TwoStateVariableTypeNode> entry :
+              limitStates.entrySet()) {
             ExclusiveLimitState limit = entry.getKey();
-            setTwoState(limitStates.get(limit), entry.getValue(), stateTexts(limit), now);
+            boolean targetActive = activeStates.contains(limit);
+            if (isLimitActive(limit) != targetActive) {
+              setTwoState(entry.getValue(), targetActive, stateTexts(limit), now);
+            }
           }
 
-          if (limitStateChanged) {
-            applyActiveTransition(mostSevere, true, now);
+          effectiveLimitState = selectedState;
+
+          if (reducedStateChanged || activeStateChanged) {
+            applyActiveTransition(selectedState, reducedStateChanged, membershipChanged, now);
           } else {
-            applyEffectiveSeverity(mostSevere, now);
+            applyEffectiveSeverity(selectedState, now);
           }
         });
+  }
+
+  /** Validate an application-computed tuple before shelving or Condition state is touched. */
+  private void validateLimitStates(
+      Set<ExclusiveLimitState> activeStates, @Nullable ExclusiveLimitState selectedState) {
+
+    if (activeStates.isEmpty() && selectedState != null) {
+      throw new IllegalArgumentException(
+          "an inactive non-exclusive limit alarm cannot have an effective limit state");
+    }
+    if (!activeStates.isEmpty() && selectedState == null) {
+      throw new IllegalArgumentException(
+          "an active non-exclusive limit alarm requires an effective limit state");
+    }
+    if (selectedState != null && !activeStates.contains(selectedState)) {
+      throw new IllegalArgumentException("the effective limit state must belong to active states");
+    }
+
+    for (ExclusiveLimitState state : activeStates) {
+      if (!limitStates.containsKey(state) || !hasConfiguredLimit(state)) {
+        throw new IllegalArgumentException(
+            "cannot activate an unsupported " + state.stateName() + " limit state");
+      }
+    }
+  }
+
+  /** Read the currently active modeled limit states into an unshared set. */
+  private Set<ExclusiveLimitState> currentActiveLimitStates() {
+    EnumSet<ExclusiveLimitState> activeStates = EnumSet.noneOf(ExclusiveLimitState.class);
+
+    for (ExclusiveLimitState limit : limitStates.keySet()) {
+      if (isLimitActive(limit)) {
+        activeStates.add(limit);
+      }
+    }
+
+    return activeStates;
+  }
+
+  /** Select the captured active states representable by this destination instance. */
+  private Set<ExclusiveLimitState> restoredActiveLimits(
+      ConditionSnapshot.@Nullable BranchSnapshot trunkSnapshot) {
+
+    EnumSet<ExclusiveLimitState> activeStates = EnumSet.noneOf(ExclusiveLimitState.class);
+
+    if (trunkSnapshot == null || !Boolean.TRUE.equals(trunkSnapshot.active())) {
+      return activeStates;
+    }
+
+    for (ExclusiveLimitState state : trunkSnapshot.activeLimits()) {
+      if (limitStates.containsKey(state) && hasConfiguredLimit(state)) {
+        activeStates.add(state);
+      }
+    }
+
+    return activeStates;
+  }
+
+  /** Use a valid persisted selection, or the scalar selector for a legacy or partial snapshot. */
+  private static @Nullable ExclusiveLimitState restoredEffectiveLimitState(
+      ConditionSnapshot.@Nullable BranchSnapshot trunkSnapshot,
+      Set<ExclusiveLimitState> activeStates) {
+
+    if (activeStates.isEmpty()) {
+      return null;
+    }
+
+    ExclusiveLimitState persistedState =
+        trunkSnapshot != null ? trunkSnapshot.effectiveLimitState() : null;
+    return persistedState != null && activeStates.contains(persistedState)
+        ? persistedState
+        : mostSevereViolated(activeStates);
   }
 
   /**
@@ -291,10 +424,10 @@ public class NonExclusiveLimitAlarm extends LimitAlarm {
    * HighHigh (which also violates High) reports HighHigh and below LowLow reports LowLow.
    */
   private static @Nullable ExclusiveLimitState mostSevereViolated(
-      Map<ExclusiveLimitState, Boolean> targets) {
+      Set<ExclusiveLimitState> targets) {
 
     for (ExclusiveLimitState limit : ExclusiveLimitState.BY_EXCURSION) {
-      if (Boolean.TRUE.equals(targets.get(limit))) {
+      if (targets.contains(limit)) {
         return limit;
       }
     }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/package-info.java
@@ -40,6 +40,28 @@
  * Condition through the ConditionManager, leaving the shared node and any application-installed
  * handler unchanged.
  *
+ * <h2>Limit-alarm data flow</h2>
+ *
+ * <p>Limit-alarm behavior separates domain evaluation from Condition state application. The {@code
+ * evaluate(double)} methods implement Milo's standard scalar limit and deadband policy. The
+ * reduced-state APIs on {@link org.eclipse.milo.opcua.sdk.server.conditions.ExclusiveLimitAlarm}
+ * and {@link org.eclipse.milo.opcua.sdk.server.conditions.NonExclusiveLimitAlarm} instead accept a
+ * trusted outcome already computed by the application. Milo applies either outcome through the
+ * Condition mutation boundary, which owns acknowledgement cycles, transition timing, shelving,
+ * Retain, snapshots, and event generation.
+ *
+ * <p>Custom limit-alarm subtypes remain responsible for array or compound reduction and, for
+ * non-exclusive alarms, selection of the primary state used for event presentation. Attaching or
+ * adopting stock behavior preserves the generated subtype's NodeIds, HasTypeDefinition, EventType,
+ * and subtype-specific members. Creation and adoption add the standard optional {@code
+ * ActiveState/EffectiveTransitionTime} member for limit alarms; attaching a complete instance
+ * preserves its existing optional-member shape.
+ *
+ * <p>Subtype-specific state cannot currently be written atomically with the private standard limit
+ * transition. Custom fields that must share the same transition and event boundary therefore need a
+ * separately designed behavior-extension seam rather than direct node writes around a reduced-state
+ * API call.
+ *
  * <p>The {@link org.eclipse.milo.opcua.sdk.server.conditions.DefaultConditionManager} releases the
  * runtime resources of each registered {@link
  * org.eclipse.milo.opcua.sdk.server.conditions.Condition} when the Condition is unregistered,


### PR DESCRIPTION
Limit alarms work well when Milo evaluates a single numeric value, but the API is awkward for applications that have already calculated the alarm state themselves. Exclusive callers must redundantly provide both Active and a limit state, while non-exclusive callers cannot atomically provide the complete active set and choose which state controls the message, display name, and severity. Writing the individual nodes directly bypasses Milo's Condition transition rules.

This PR adds direct state APIs for both alarm types. Applications can provide an exclusive state, or a complete non-exclusive state set with an explicitly selected effective state. Milo still owns validation, locking, acknowledgements, timestamps, shelving, Retain, snapshots, and event generation, so each application-driven update remains one coherent Condition transition.

## What changed

- Add `ExclusiveLimitAlarm.setLimitState(...)`, where `null` deactivates the alarm.
- Add `NonExclusiveLimitAlarm.setLimitStates(...)` and `getEffectiveLimitState()`.
- Validate and defensively copy non-exclusive state tuples before touching Condition state.
- Use the caller-selected effective state for Message, EffectiveDisplayName, and Severity.
- Preserve the effective state across snapshot capture and restore.
- Maintain `ActiveState.EffectiveTransitionTime` for modeled limit-state changes.
- Preserve custom subtype and optional-node behavior through attach and adopt.
- Add focused coverage for state transitions, acknowledgements, timestamps, shelving, snapshots, and custom subtypes.

Existing `evaluate(double)` behavior remains unchanged for applications that want Milo's standard scalar limit evaluation.
