### PR TITLE
Add custom Condition instance lifecycle APIs

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/conditions/ConditionAttachAdoptTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/conditions/ConditionAttachAdoptTest.java
@@ -1017,48 +1017,22 @@ public class ConditionAttachAdoptTest extends AbstractClientServerTest {
     var nodeManager = testNamespace.getNodeManager();
     NodeId typeId = newNodeId("ConditionAttachAdoptTest/" + name + "Type");
     UaObjectTypeNode typeNode =
-        new UaObjectTypeNode(
+        VendorTypeFixtures.defineVendorSubtype(
             context,
+            nodeManager,
             typeId,
             newQualifiedName(name + "Type"),
-            LocalizedText.english(name + "Type"),
-            LocalizedText.NULL_VALUE,
-            uint(0),
-            uint(0),
-            false);
-    typeNode.addReference(
-        new Reference(
-            typeId, NodeIds.HasSubtype, NodeIds.NonExclusiveLimitAlarmType.expanded(), false));
-    nodeManager.addNode(typeNode);
+            NodeIds.NonExclusiveLimitAlarmType);
 
     QualifiedName vendorMemberName = newQualifiedName("ReductionMask");
-    UaVariableNode vendorDeclaration =
-        new UaVariableNode(
-            context,
-            newNodeId("ConditionAttachAdoptTest/" + name + "Type/ReductionMask"),
-            vendorMemberName,
-            LocalizedText.english("ReductionMask"),
-            LocalizedText.NULL_VALUE,
-            uint(0),
-            uint(0));
-    vendorDeclaration.setDataType(NodeIds.UInt32);
-    vendorDeclaration.setValue(new DataValue(new Variant(uint(0))));
-    vendorDeclaration.addReference(
-        new Reference(
-            vendorDeclaration.getNodeId(),
-            NodeIds.HasTypeDefinition,
-            NodeIds.BaseDataVariableType.expanded(),
-            true));
-    vendorDeclaration.addReference(
-        new Reference(
-            vendorDeclaration.getNodeId(),
-            NodeIds.HasModellingRule,
-            NodeIds.ModellingRule_Mandatory.expanded(),
-            true));
-    nodeManager.addNode(vendorDeclaration);
-    typeNode.addReference(
-        new Reference(
-            typeId, NodeIds.HasComponent, vendorDeclaration.getNodeId().expanded(), true));
+    VendorTypeFixtures.declareMandatoryUInt32Member(
+        nodeManager,
+        typeNode,
+        newNodeId("ConditionAttachAdoptTest/" + name + "Type/ReductionMask"),
+        vendorMemberName,
+        NodeIds.BaseDataVariableType,
+        NodeIds.HasComponent,
+        uint(0));
 
     BrowsePath vendorMemberPath = BrowsePath.of(vendorMemberName);
     BrowsePath activeEffectiveDisplayName =

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/conditions/CustomConditionInstanceTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/conditions/CustomConditionInstanceTest.java
@@ -1,0 +1,400 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.conditions;
+
+import static java.util.Objects.requireNonNull;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ubyte;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.milo.opcua.sdk.core.Reference;
+import org.eclipse.milo.opcua.sdk.server.model.objects.SystemDiagnosticAlarmTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNodeContext;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.instantiation.InstantiationDiagnostic;
+import org.eclipse.milo.opcua.sdk.server.nodes.instantiation.InstantiationException;
+import org.eclipse.milo.opcua.sdk.test.AbstractClientServerTest;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.UaRuntimeException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.structured.AccessRestrictionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.RolePermissionType;
+import org.junit.jupiter.api.Test;
+
+/** Coverage for creating, attaching, and adopting custom Condition types and behaviors. */
+public class CustomConditionInstanceTest extends AbstractClientServerTest {
+
+  // A registered generated node class and behavior factory must survive the complete create
+  // lifecycle; a post-creation cast would fail too late and leave an unusable instance behind.
+  @Test
+  void createInstanceConstructsRegisteredCustomNodeAndBehavior() throws Exception {
+    VendorType fixture = defineVendorType("RegisteredCreate", true);
+    NodeId instanceId = newNodeId("CustomConditionInstanceTest/RegisteredCreate");
+
+    VendorSystemDiagnosticAlarm alarm =
+        Condition.createInstance(
+            testNamespace.getNodeContext(),
+            VendorSystemDiagnosticAlarmTypeNode.class,
+            fixture.typeId(),
+            builder ->
+                builder
+                    .nodeId(instanceId)
+                    .browseName(newQualifiedName("RegisteredCreate"))
+                    .severity(ushort(600)),
+            VendorSystemDiagnosticAlarm::new);
+
+    assertEquals(VendorSystemDiagnosticAlarmTypeNode.class, alarm.getNode().getClass());
+    assertCustomIdentity(alarm, fixture);
+    assertEquals(uint(73), alarm.getNode().getProperty(fixture.memberName()).orElseThrow());
+
+    alarm.setActive(true);
+    assertTrue(alarm.isActive());
+    assertFalse(alarm.isAcked());
+    assertTrue(alarm.isRetained());
+  }
+
+  // A custom information-model type does not require a generated Java class: callers can request
+  // the nearest stock node class while preserving the custom HasTypeDefinition and EventType.
+  @Test
+  void createInstanceSupportsCustomTypeWithStockNodeAndBehavior() throws Exception {
+    VendorType fixture = defineVendorType("StockBehavior", false);
+
+    SystemDiagnosticAlarm alarm =
+        Condition.createInstance(
+            testNamespace.getNodeContext(),
+            SystemDiagnosticAlarmTypeNode.class,
+            fixture.typeId(),
+            builder ->
+                builder
+                    .nodeId(newNodeId("CustomConditionInstanceTest/StockBehavior"))
+                    .browseName(newQualifiedName("StockBehavior")),
+            SystemDiagnosticAlarm::new);
+
+    assertEquals(SystemDiagnosticAlarmTypeNode.class, alarm.getNode().getClass());
+    assertCustomIdentity(alarm, fixture);
+    assertEquals(uint(73), alarm.getNode().getProperty(fixture.memberName()).orElseThrow());
+  }
+
+  // Typed construction must diagnose a missing custom Java registration before committing any
+  // nodes; this replaces the ClassCastException-after-creation failure mode.
+  @Test
+  void createInstanceRejectsUnregisteredCustomNodeClassWithoutResidue() {
+    VendorType fixture = defineVendorType("MissingRegistration", false);
+    NodeId instanceId = newNodeId("CustomConditionInstanceTest/MissingRegistration");
+
+    InstantiationException exception =
+        assertThrows(
+            InstantiationException.class,
+            () ->
+                Condition.createInstance(
+                    testNamespace.getNodeContext(),
+                    VendorSystemDiagnosticAlarmTypeNode.class,
+                    fixture.typeId(),
+                    builder ->
+                        builder
+                            .nodeId(instanceId)
+                            .browseName(newQualifiedName("MissingRegistration")),
+                    VendorSystemDiagnosticAlarm::new));
+
+    assertTrue(
+        exception.getDiagnostics().stream()
+            .anyMatch(
+                diagnostic ->
+                    diagnostic.code() == InstantiationDiagnostic.Code.INVALID_ROOT_CLASS));
+    assertFalse(testNamespace.getNodeManager().containsNode(instanceId));
+  }
+
+  // Custom behavior attachment must preserve the exact generated node object rather than
+  // replacing it with the stock node class or rebuilding its subtype-specific members.
+  @Test
+  void attachInstanceWrapsExistingCustomNode() throws Exception {
+    VendorType fixture = defineVendorType("Attach", true);
+    VendorSystemDiagnosticAlarm original = createVendorAlarm("Attach", fixture);
+
+    VendorSystemDiagnosticAlarm attached =
+        Condition.attachInstance(original.getNode(), VendorSystemDiagnosticAlarm::new);
+
+    assertNotSame(original, attached);
+    assertSame(original.getNode(), attached.getNode());
+    assertCustomIdentity(attached, fixture);
+    assertEquals(uint(73), attached.getNode().getProperty(fixture.memberName()).orElseThrow());
+  }
+
+  // Custom behavior adoption must complete missing standard state in place while retaining the
+  // generated root identity and its custom TypeDefinition.
+  @Test
+  void adoptInstanceCompletesExistingCustomNodeInPlace() throws Exception {
+    VendorType fixture = defineVendorType("Adopt", true);
+    VendorSystemDiagnosticAlarm original = createVendorAlarm("Adopt", fixture);
+    UaNode deletedEnabledState = requireNonNull(original.getNode().getEnabledStateNode());
+    deletedEnabledState.delete();
+
+    VendorSystemDiagnosticAlarm adopted =
+        Condition.adoptInstance(
+            testNamespace.getNodeContext(),
+            original.getConditionId(),
+            VendorSystemDiagnosticAlarmTypeNode.class,
+            builder -> {},
+            VendorSystemDiagnosticAlarm::new);
+
+    assertSame(original.getNode(), adopted.getNode());
+    assertNotSame(deletedEnabledState, requireNonNull(adopted.getNode().getEnabledStateNode()));
+    assertCustomIdentity(adopted, fixture);
+    assertEquals(uint(73), adopted.getNode().getProperty(fixture.memberName()).orElseThrow());
+  }
+
+  // A behaviorFactory returning null violates its contract; the failure must surface through the
+  // documented UaException channel and roll back the already-committed instance tree.
+  @Test
+  void createInstanceRejectsNullBehaviorFactoryResultWithoutResidue() {
+    VendorType fixture = defineVendorType("NullFactoryResult", true);
+    NodeId instanceId = newNodeId("CustomConditionInstanceTest/NullFactoryResult");
+
+    //noinspection DataFlowIssue
+    UaException exception =
+        assertThrows(
+            UaException.class,
+            () ->
+                Condition.createInstance(
+                    testNamespace.getNodeContext(),
+                    VendorSystemDiagnosticAlarmTypeNode.class,
+                    fixture.typeId(),
+                    builder ->
+                        builder
+                            .nodeId(instanceId)
+                            .browseName(newQualifiedName("NullFactoryResult")),
+                    node -> null));
+
+    assertEquals(StatusCodes.Bad_InternalError, exception.getStatusCode().getValue());
+    assertFalse(
+        testNamespace.getNodeManager().containsNode(instanceId),
+        "rejected instance must not remain in the address space");
+  }
+
+  // Failed creation must undo only the source wiring it added: the source must not remain in the
+  // notifier hierarchy, and a HasCondition reference that existed before creation must survive.
+  @Test
+  void createInstanceFailureRollsBackOnlyOwnedSourceWiring() {
+    VendorType fixture = defineVendorType("SourceWiringRollback", true);
+    NodeId instanceId = newNodeId("CustomConditionInstanceTest/SourceWiringRollback");
+    NodeId sourceId = newNodeId("CustomConditionInstanceTest/SourceWiringRollbackSource");
+    UaObjectNode source =
+        new UaObjectNode(
+            testNamespace.getNodeContext(),
+            sourceId,
+            newQualifiedName("SourceWiringRollbackSource"),
+            LocalizedText.english("SourceWiringRollbackSource"),
+            LocalizedText.NULL_VALUE,
+            uint(0),
+            uint(0),
+            ubyte(0));
+    source.addReference(
+        new Reference(
+            sourceId, NodeIds.HasTypeDefinition, NodeIds.BaseObjectType.expanded(), true));
+    testNamespace.getNodeManager().addNode(source);
+
+    Reference hasCondition =
+        new Reference(sourceId, NodeIds.HasCondition, instanceId.expanded(), true);
+    Reference hasEventSource =
+        new Reference(NodeIds.Server, NodeIds.HasEventSource, sourceId.expanded(), true);
+    testNamespace.getNodeManager().addReferences(hasCondition, server.getNamespaceTable());
+
+    assertFalse(
+        server.getAddressSpaceManager().getManagedReferences(NodeIds.Server).stream()
+            .anyMatch(hasEventSource::equals));
+
+    //noinspection DataFlowIssue
+    UaException exception =
+        assertThrows(
+            UaException.class,
+            () ->
+                Condition.createInstance(
+                    testNamespace.getNodeContext(),
+                    VendorSystemDiagnosticAlarmTypeNode.class,
+                    fixture.typeId(),
+                    builder ->
+                        builder
+                            .nodeId(instanceId)
+                            .browseName(newQualifiedName("SourceWiringRollback"))
+                            .conditionSource(source),
+                    node -> null));
+
+    assertEquals(StatusCodes.Bad_InternalError, exception.getStatusCode().getValue());
+    assertFalse(testNamespace.getNodeManager().containsNode(instanceId));
+    assertEquals(
+        1,
+        testNamespace.getNodeManager().getReferences(sourceId).stream()
+            .filter(hasCondition::equals)
+            .count(),
+        "pre-existing HasCondition must survive rollback");
+    assertFalse(
+        server.getAddressSpaceManager().getManagedReferences(NodeIds.Server).stream()
+            .anyMatch(hasEventSource::equals),
+        "rollback must remove the HasEventSource it added");
+  }
+
+  // A behaviorFactory that wraps some other node would return behavior with no control over the
+  // created instance; the create must fail and delete the committed tree, leaving the foreign
+  // condition untouched.
+  @Test
+  void createInstanceRejectsBehaviorWrappingForeignNodeWithoutResidue() throws Exception {
+    VendorType fixture = defineVendorType("ForeignNode", true);
+    VendorSystemDiagnosticAlarm decoy = createVendorAlarm("ForeignNodeDecoy", fixture);
+    NodeId instanceId = newNodeId("CustomConditionInstanceTest/ForeignNode");
+
+    UaException exception =
+        assertThrows(
+            UaException.class,
+            () ->
+                Condition.createInstance(
+                    testNamespace.getNodeContext(),
+                    VendorSystemDiagnosticAlarmTypeNode.class,
+                    fixture.typeId(),
+                    builder ->
+                        builder.nodeId(instanceId).browseName(newQualifiedName("ForeignNode")),
+                    node -> decoy));
+
+    assertEquals(StatusCodes.Bad_InternalError, exception.getStatusCode().getValue());
+    assertFalse(
+        testNamespace.getNodeManager().containsNode(instanceId),
+        "rejected instance must not remain in the address space");
+    assertTrue(
+        testNamespace.getNodeManager().containsNode(decoy.getConditionId()),
+        "rollback must not touch the foreign condition");
+  }
+
+  // Part 9 requires Enable on every Condition instance; attachment must reject an incomplete
+  // method surface before any behavior wraps the instance.
+  @Test
+  void attachInstanceRejectsInvalidMethodSurface() throws Exception {
+    VendorType fixture = defineVendorType("InvalidSurface", true);
+    VendorSystemDiagnosticAlarm original = createVendorAlarm("InvalidSurface", fixture);
+    requireNonNull(original.getNode().getEnableMethodNode()).delete();
+
+    UaRuntimeException exception =
+        assertThrows(
+            UaRuntimeException.class,
+            () -> Condition.attachInstance(original.getNode(), VendorSystemDiagnosticAlarm::new));
+
+    assertEquals(StatusCodes.Bad_InvalidState, exception.getStatusCode().getValue());
+  }
+
+  private VendorSystemDiagnosticAlarm createVendorAlarm(String name, VendorType fixture)
+      throws UaException {
+    return Condition.createInstance(
+        testNamespace.getNodeContext(),
+        VendorSystemDiagnosticAlarmTypeNode.class,
+        fixture.typeId(),
+        builder ->
+            builder
+                .nodeId(newNodeId("CustomConditionInstanceTest/" + name))
+                .browseName(newQualifiedName(name)),
+        VendorSystemDiagnosticAlarm::new);
+  }
+
+  private VendorType defineVendorType(String name, boolean registerNodeClass) {
+    NodeId typeId = newNodeId("CustomConditionInstanceTest/" + name + "Type");
+    UaObjectTypeNode typeNode =
+        VendorTypeFixtures.defineVendorSubtype(
+            testNamespace.getNodeContext(),
+            testNamespace.getNodeManager(),
+            typeId,
+            newQualifiedName(name + "Type"),
+            NodeIds.SystemDiagnosticAlarmType);
+
+    QualifiedName memberName = newQualifiedName("DiagnosticCode");
+    VendorTypeFixtures.declareMandatoryUInt32Member(
+        testNamespace.getNodeManager(),
+        typeNode,
+        newNodeId("CustomConditionInstanceTest/" + name + "Type/DiagnosticCode"),
+        memberName,
+        NodeIds.PropertyType,
+        NodeIds.HasProperty,
+        uint(73));
+
+    if (registerNodeClass) {
+      server
+          .getObjectTypeManager()
+          .registerObjectType(
+              typeId,
+              VendorSystemDiagnosticAlarmTypeNode.class,
+              VendorSystemDiagnosticAlarmTypeNode::new);
+    }
+
+    return new VendorType(typeId, memberName);
+  }
+
+  private static void assertCustomIdentity(Condition condition, VendorType fixture) {
+    assertEquals(fixture.typeId(), condition.getNode().getEventType());
+    assertTrue(
+        condition.getNode().getReferences().stream()
+            .anyMatch(
+                reference ->
+                    reference.isForward()
+                        && NodeIds.HasTypeDefinition.equals(reference.getReferenceTypeId())
+                        && fixture.typeId().expanded().equals(reference.getTargetNodeId())));
+  }
+
+  private record VendorType(NodeId typeId, QualifiedName memberName) {}
+
+  private static final class VendorSystemDiagnosticAlarm extends SystemDiagnosticAlarm {
+
+    private VendorSystemDiagnosticAlarm(VendorSystemDiagnosticAlarmTypeNode node) {
+      super(node);
+    }
+
+    @Override
+    public VendorSystemDiagnosticAlarmTypeNode getNode() {
+      return (VendorSystemDiagnosticAlarmTypeNode) super.getNode();
+    }
+  }
+
+  private static final class VendorSystemDiagnosticAlarmTypeNode
+      extends SystemDiagnosticAlarmTypeNode {
+
+    private VendorSystemDiagnosticAlarmTypeNode(
+        UaNodeContext context,
+        NodeId nodeId,
+        QualifiedName browseName,
+        LocalizedText displayName,
+        LocalizedText description,
+        UInteger writeMask,
+        UInteger userWriteMask,
+        RolePermissionType[] rolePermissions,
+        RolePermissionType[] userRolePermissions,
+        AccessRestrictionType accessRestrictions) {
+      super(
+          context,
+          nodeId,
+          browseName,
+          displayName,
+          description,
+          writeMask,
+          userWriteMask,
+          rolePermissions,
+          userRolePermissions,
+          accessRestrictions);
+    }
+  }
+}

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/conditions/VendorTypeFixtures.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/conditions/VendorTypeFixtures.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.conditions;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+
+import org.eclipse.milo.opcua.sdk.core.Reference;
+import org.eclipse.milo.opcua.sdk.server.UaNodeManager;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNodeContext;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableNode;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+
+/**
+ * Shared construction of vendor Condition ObjectType fixtures: a subtype of a stock alarm type
+ * declaring a mandatory UInt32 member, modeled the way the SDK's instantiation and adoption paths
+ * expect it (HasSubtype on the type; HasTypeDefinition and a Mandatory ModellingRule on the member
+ * declaration).
+ */
+final class VendorTypeFixtures {
+
+  private VendorTypeFixtures() {}
+
+  /** Define a vendor ObjectType subtyping {@code supertypeId} and add it to {@code nodeManager}. */
+  static UaObjectTypeNode defineVendorSubtype(
+      UaNodeContext context,
+      UaNodeManager nodeManager,
+      NodeId typeId,
+      QualifiedName browseName,
+      NodeId supertypeId) {
+
+    UaObjectTypeNode typeNode =
+        new UaObjectTypeNode(
+            context,
+            typeId,
+            browseName,
+            LocalizedText.english(browseName.name()),
+            LocalizedText.NULL_VALUE,
+            uint(0),
+            uint(0),
+            false);
+    typeNode.addReference(new Reference(typeId, NodeIds.HasSubtype, supertypeId.expanded(), false));
+    nodeManager.addNode(typeNode);
+
+    return typeNode;
+  }
+
+  /**
+   * Declare a mandatory UInt32 member on {@code typeNode} and add the declaration to {@code
+   * nodeManager}.
+   *
+   * @param memberTypeDefinitionId the member's VariableType, e.g. PropertyType or
+   *     BaseDataVariableType.
+   * @param memberReferenceTypeId the declaring reference, e.g. HasProperty or HasComponent.
+   */
+  static UaVariableNode declareMandatoryUInt32Member(
+      UaNodeManager nodeManager,
+      UaObjectTypeNode typeNode,
+      NodeId memberId,
+      QualifiedName memberName,
+      NodeId memberTypeDefinitionId,
+      NodeId memberReferenceTypeId,
+      UInteger initialValue) {
+
+    UaVariableNode declaration =
+        new UaVariableNode(
+            typeNode.getNodeContext(),
+            memberId,
+            memberName,
+            LocalizedText.english(memberName.name()),
+            LocalizedText.NULL_VALUE,
+            uint(0),
+            uint(0));
+    declaration.setDataType(NodeIds.UInt32);
+    declaration.setValue(new DataValue(new Variant(initialValue)));
+    declaration.addReference(
+        new Reference(
+            memberId, NodeIds.HasTypeDefinition, memberTypeDefinitionId.expanded(), true));
+    declaration.addReference(
+        new Reference(
+            memberId, NodeIds.HasModellingRule, NodeIds.ModellingRule_Mandatory.expanded(), true));
+    nodeManager.addNode(declaration);
+
+    typeNode.addReference(
+        new Reference(typeNode.getNodeId(), memberReferenceTypeId, memberId.expanded(), true));
+
+    return declaration;
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/Condition.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/Condition.java
@@ -35,6 +35,7 @@ import org.eclipse.milo.opcua.sdk.server.model.variables.PropertyTypeNode;
 import org.eclipse.milo.opcua.sdk.server.model.variables.TwoStateVariableTypeNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaMethodNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNodeContext;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.filters.AttributeFilter;
 import org.eclipse.milo.opcua.sdk.server.nodes.filters.AttributeFilterChain;
@@ -192,6 +193,151 @@ public class Condition {
   }
 
   /**
+   * Create an instance of a custom Condition ObjectType and wrap it in application-selected
+   * behavior.
+   *
+   * <p>This is the typed lifecycle entry point for vendor subtypes and custom behavior subclasses.
+   * The ObjectType identified by {@code typeDefinitionId} must resolve through the server's {@link
+   * org.eclipse.milo.opcua.sdk.server.ObjectTypeManager} to {@code nodeClass} or one of its
+   * subclasses. The behavior factory is invoked only after the complete instance has been committed
+   * to the target NodeManager and its standard Condition fields have been initialized.
+   *
+   * <p>Pass a generated custom node class only after registering its constructor with the server's
+   * ObjectTypeManager. A caller that needs a custom OPC UA TypeDefinition but no custom Java node
+   * class can pass the nearest stock Condition node class instead; the instance still retains the
+   * custom HasTypeDefinition and EventType.
+   *
+   * <p>This method applies the common {@link ConditionBuilder} configuration but does not impose
+   * the additional configuration validation performed by concrete factories such as {@link
+   * org.eclipse.milo.opcua.sdk.server.conditions.ExclusiveLimitAlarm#create}. A custom behavior
+   * factory owns any subtype-specific validation. The returned behavior is not registered with the
+   * server's {@link ConditionManager}.
+   *
+   * <p>Creation is residue-free: if a failure occurs after the instance tree has been committed —
+   * an invalid method surface, a {@code behaviorFactory} that returns {@code null} or a behavior
+   * wrapping a different node, or an exception thrown by the factory itself — the committed nodes
+   * and their condition source wiring are deleted before the exception propagates.
+   *
+   * @param <N> the Java node type expected for the custom instance root.
+   * @param <T> the Condition behavior type returned by {@code behaviorFactory}.
+   * @param context the context the instance is created under.
+   * @param nodeClass the generated or application-defined Java node class expected for the root.
+   * @param typeDefinitionId the NodeId of the custom Condition ObjectType to instantiate.
+   * @param configure the common Condition instance configuration.
+   * @param behaviorFactory the factory that wraps the typed root node in its behavior.
+   * @return the created custom Condition behavior.
+   * @throws UaException if the type cannot be instantiated as {@code nodeClass}, instance creation
+   *     fails, or {@code behaviorFactory} returns {@code null} or a behavior that does not wrap the
+   *     supplied node.
+   */
+  public static <N extends ConditionTypeNode, T extends Condition> T createInstance(
+      UaNodeContext context,
+      Class<N> nodeClass,
+      NodeId typeDefinitionId,
+      Consumer<ConditionBuilder> configure,
+      Function<? super N, ? extends T> behaviorFactory)
+      throws UaException {
+
+    ConditionBuilder builder = new ConditionBuilder(context);
+    configure.accept(builder);
+
+    try {
+      N node = builder.buildNode(nodeClass, typeDefinitionId);
+
+      return initializeBehavior(node, behaviorFactory);
+    } catch (Exception e) {
+      try {
+        builder.deleteCreatedInstance();
+      } catch (RuntimeException rollbackFailure) {
+        e.addSuppressed(rollbackFailure);
+      }
+      throw e;
+    }
+  }
+
+  /**
+   * Attach application-selected behavior to a complete custom Condition instance already present in
+   * the address space.
+   *
+   * <p>The existing node and all of its subtype-specific members and identities are preserved. The
+   * returned behavior is not registered with the server's {@link ConditionManager}.
+   *
+   * @param <N> the Java node type of the existing instance root.
+   * @param <T> the Condition behavior type returned by {@code behaviorFactory}.
+   * @param node the complete typed Condition instance.
+   * @param behaviorFactory the factory that wraps the node in its behavior.
+   * @return the attached custom Condition behavior.
+   * @throws UaRuntimeException if the instance has an invalid method surface, or {@code
+   *     behaviorFactory} returns {@code null} or a behavior that does not wrap the supplied node.
+   */
+  public static <N extends ConditionTypeNode, T extends Condition> T attachInstance(
+      N node, Function<? super N, ? extends T> behaviorFactory) {
+    return attachInstance(node, options -> {}, behaviorFactory);
+  }
+
+  /**
+   * Attach application-selected behavior to a complete custom Condition instance already present in
+   * the address space and wire its Condition source.
+   *
+   * <p>The existing node and all of its subtype-specific members and identities are preserved. The
+   * returned behavior is not registered with the server's {@link ConditionManager}.
+   *
+   * @param <N> the Java node type of the existing instance root.
+   * @param <T> the Condition behavior type returned by {@code behaviorFactory}.
+   * @param node the complete typed Condition instance.
+   * @param configure the source-wiring options to apply.
+   * @param behaviorFactory the factory that wraps the node in its behavior.
+   * @return the attached custom Condition behavior.
+   * @throws UaRuntimeException if the instance has an invalid method surface, or {@code
+   *     behaviorFactory} returns {@code null} or a behavior that does not wrap the supplied node.
+   */
+  public static <N extends ConditionTypeNode, T extends Condition> T attachInstance(
+      N node, Consumer<AttachOptions> configure, Function<? super N, ? extends T> behaviorFactory) {
+    return attach(node, configure, behaviorFactory);
+  }
+
+  /**
+   * Complete a partial custom Condition instance in place and wrap it in application-selected
+   * behavior.
+   *
+   * <p>The existing HasTypeDefinition, EventType, NodeIds, stored configuration, and
+   * subtype-specific members are preserved. Common values supplied through {@code configure}
+   * override stored values according to the normal adopt lifecycle. The returned behavior is not
+   * registered with the server's {@link ConditionManager}.
+   *
+   * <p>A failure after the instance has been completed in place — an invalid method surface, or a
+   * {@code behaviorFactory} that violates its contract — leaves the completed instance in the
+   * address space; adoption may be retried with the same NodeId once the cause is corrected.
+   *
+   * @param <N> the Java node type expected for the existing instance root.
+   * @param <T> the Condition behavior type returned by {@code behaviorFactory}.
+   * @param context the context whose NodeManager owns the existing instance.
+   * @param nodeId the NodeId of the existing Condition instance.
+   * @param nodeClass the generated or application-defined Java node class expected for the root.
+   * @param configure the common Condition configuration to apply while completing the instance.
+   * @param behaviorFactory the factory that wraps the typed root node in its behavior.
+   * @return the adopted custom Condition behavior.
+   * @throws UaException if the existing node is incompatible, cannot be completed, has an invalid
+   *     method surface, or {@code behaviorFactory} returns {@code null} or a behavior that does not
+   *     wrap the supplied node.
+   */
+  public static <N extends ConditionTypeNode, T extends Condition> T adoptInstance(
+      UaNodeContext context,
+      NodeId nodeId,
+      Class<N> nodeClass,
+      Consumer<ConditionBuilder> configure,
+      Function<? super N, ? extends T> behaviorFactory)
+      throws UaException {
+
+    ConditionBuilder builder = ConditionBuilder.forAdoption(context, nodeId, nodeClass);
+    configure.accept(builder);
+
+    N node = builder.buildAdoptedNode(nodeClass);
+
+    return initializeBehavior(node, behaviorFactory);
+  }
+
+  /**
    * Shared tail of the condition/alarm {@code create} entry points: instantiate the typed instance
    * node from {@code typeDefinitionId}, wrap it in its behavior via {@code behavior}, and install
    * the instance's method handlers. The {@code behavior} function re-casts the node to the concrete
@@ -207,11 +353,26 @@ public class Condition {
       ConditionBuilder builder, NodeId typeDefinitionId, Function<ConditionTypeNode, T> behavior)
       throws UaException {
 
-    ConditionTypeNode node = builder.buildNode(typeDefinitionId);
+    try {
+      ConditionTypeNode node = builder.buildNode(typeDefinitionId);
+
+      return initializeBehavior(node, behavior);
+    } catch (Exception e) {
+      try {
+        builder.deleteCreatedInstance();
+      } catch (RuntimeException rollbackFailure) {
+        e.addSuppressed(rollbackFailure);
+      }
+      throw e;
+    }
+  }
+
+  private static <N extends ConditionTypeNode, T extends Condition> T initializeBehavior(
+      N node, Function<? super N, ? extends T> behavior) throws UaException {
     MethodSurface methodSurface = ConditionNodeTraversal.discoverMethodSurface(node);
     ConditionNodeTraversal.validateMethodSurface(node, methodSurface);
 
-    T condition = behavior.apply(node);
+    T condition = applyBehaviorFactory(node, behavior);
     condition.rehydrateCurrentBranch();
     condition.installMethodHandlers(methodSurface);
 
@@ -224,26 +385,41 @@ public class Condition {
    * <p>Discovery is completed before constructors populate missing runtime defaults, so malformed
    * method surfaces fail before attachment mutates the instance.
    */
-  static <T extends Condition> T attach(
-      ConditionTypeNode node,
-      Consumer<AttachOptions> configure,
-      Function<ConditionTypeNode, T> behavior) {
+  static <N extends ConditionTypeNode, T extends Condition> T attach(
+      N node, Consumer<AttachOptions> configure, Function<? super N, ? extends T> behavior) {
 
     AttachOptions options = new AttachOptions();
     configure.accept(options);
 
-    MethodSurface methodSurface;
+    T condition;
     try {
-      methodSurface = ConditionNodeTraversal.discoverMethodSurface(node);
-      ConditionNodeTraversal.validateMethodSurface(node, methodSurface);
+      condition = initializeBehavior(node, behavior);
     } catch (UaException e) {
       throw new UaRuntimeException(e.getStatusCode().getValue(), e);
     }
 
-    T condition = behavior.apply(node);
-    condition.rehydrateCurrentBranch();
-    condition.installMethodHandlers(methodSurface);
     ConditionWiring.wire(node, options.conditionSource());
+
+    return condition;
+  }
+
+  private static <N extends ConditionTypeNode, T extends Condition> T applyBehaviorFactory(
+      N node, Function<? super N, ? extends @Nullable T> behaviorFactory) throws UaException {
+
+    // The factory is application code that may not be nullness-checked, so its result is the
+    // boundary where a null can actually arrive.
+    T condition = behaviorFactory.apply(node);
+
+    if (condition == null) {
+      throw new UaException(StatusCodes.Bad_InternalError, "behaviorFactory returned null");
+    }
+
+    // Compare the constructor-captured node, not getNode(): subclasses may override getNode(), and
+    // an override must not be able to defeat (or accidentally fail) the wrap-contract check.
+    if (((Condition) condition).node != node) {
+      throw new UaException(
+          StatusCodes.Bad_InternalError, "behaviorFactory must wrap the supplied Condition node");
+    }
 
     return condition;
   }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/ConditionBuilder.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/ConditionBuilder.java
@@ -101,6 +101,14 @@ public class ConditionBuilder {
   private final @Nullable ConditionTypeNode adoptedNode;
   private final @Nullable NodeId adoptedTypeDefinitionId;
 
+  /**
+   * The committed instantiation of a created (non-adopted) instance, retained so {@link
+   * #deleteCreatedInstance} can roll it back if post-commit initialization fails.
+   */
+  private @Nullable InstantiationResult<? extends ConditionTypeNode> createdResult;
+
+  private ConditionWiring.@Nullable WiringJournal createdWiring;
+
   private boolean displayNameConfigured;
   private boolean conditionNameConfigured;
   private boolean conditionClassConfigured;
@@ -830,11 +838,24 @@ public class ConditionBuilder {
 
   /** Instantiate or complete the Condition node, initialize it, and wire its condition source. */
   ConditionTypeNode buildNode(NodeId typeDefinitionId) throws UaException {
+    NodeId effectiveTypeDefinitionId =
+        adoptedNode != null ? requireNonNull(adoptedTypeDefinitionId) : typeDefinitionId;
+
+    return buildNode(ConditionTypeNode.class, effectiveTypeDefinitionId);
+  }
+
+  /**
+   * Instantiate or complete the Condition node as {@code expectedNodeClass}, initialize it, and
+   * wire its condition source.
+   *
+   * <p>{@code typeDefinitionId} is used as-is: when adopting, the caller must pass the adopted
+   * instance's existing TypeDefinition (see {@link #buildAdoptedNode}).
+   */
+  <N extends ConditionTypeNode> N buildNode(Class<N> expectedNodeClass, NodeId typeDefinitionId)
+      throws UaException {
     NodeId nodeId = requireNonNull(this.nodeId, "nodeId must be set");
     QualifiedName browseName = requireNonNull(this.browseName, "browseName must be set");
     boolean adopting = adoptedNode != null;
-    NodeId effectiveTypeDefinitionId =
-        adopting ? requireNonNull(adoptedTypeDefinitionId) : typeDefinitionId;
     Map<BrowsePath, NodeId> assignedNodeIds =
         adopting
             ? ConditionNodeTraversal.discoverAssignedNodeIds(requireNonNull(adoptedNode))
@@ -893,8 +914,8 @@ public class ConditionBuilder {
     boolean includeLimitMembers =
         adoptedNode instanceof LimitAlarmTypeNode || hasConfiguredLimits();
 
-    InstantiationRequest.Builder<ConditionTypeNode> requestBuilder =
-        InstantiationRequest.of(rootClassForRequest(), effectiveTypeDefinitionId)
+    InstantiationRequest.Builder<N> requestBuilder =
+        InstantiationRequest.of(rootClassForRequest(expectedNodeClass), typeDefinitionId)
             .nodeId(nodeId)
             .browseName(browseName)
             .displayName(
@@ -929,27 +950,94 @@ public class ConditionBuilder {
           });
     }
 
-    InstantiationRequest<ConditionTypeNode> request = requestBuilder.build();
+    InstantiationRequest<N> request = requestBuilder.build();
 
-    InstantiationResult<ConditionTypeNode> result =
-        context.getServer().getNodeInstantiator().instantiate(request);
-    ConditionTypeNode node = result.root();
+    InstantiationResult<N> result = context.getServer().getNodeInstantiator().instantiate(request);
+    N node = result.root();
+    if (!adopting) {
+      createdResult = result;
+    }
 
     if (adopting) {
-      initializeAdoptedNode(node, effectiveTypeDefinitionId);
+      initializeAdoptedNode(node, typeDefinitionId);
     } else {
-      initializeCreatedNode(node, effectiveTypeDefinitionId);
+      initializeCreatedNode(node, typeDefinitionId);
     }
-    ConditionWiring.wire(node, conditionSource);
+    ConditionWiring.WiringJournal wiring = ConditionWiring.wire(node, conditionSource);
+    if (!adopting) {
+      createdWiring = wiring;
+    }
 
     return node;
   }
 
+  /** Complete an adopted Condition node using its existing TypeDefinition. */
+  <N extends ConditionTypeNode> N buildAdoptedNode(Class<N> expectedNodeClass) throws UaException {
+    if (adoptedNode == null) {
+      throw new IllegalStateException("builder is not adopting an existing Condition instance");
+    }
+
+    return buildNode(expectedNodeClass, requireNonNull(adoptedTypeDefinitionId));
+  }
+
+  /**
+   * Delete everything {@link #buildNode} committed for a created instance — the instantiated node
+   * tree and its condition source wiring — so a failure after commit leaves no residue in the
+   * address space. No-op when the builder is adopting an existing instance or nothing was
+   * committed.
+   */
+  void deleteCreatedInstance() {
+    InstantiationResult<? extends ConditionTypeNode> result = createdResult;
+    ConditionWiring.WiringJournal wiring = createdWiring;
+    if (result == null && wiring == null) {
+      return;
+    }
+    createdResult = null;
+    createdWiring = null;
+
+    RuntimeException failure = null;
+    if (wiring != null) {
+      try {
+        wiring.rollBack();
+      } catch (RuntimeException e) {
+        failure = e;
+      }
+    }
+
+    if (result != null) {
+      try {
+        result.deleteCreated();
+      } catch (RuntimeException e) {
+        if (failure == null) {
+          failure = e;
+        } else {
+          failure.addSuppressed(e);
+        }
+      }
+    }
+
+    if (failure != null) {
+      throw failure;
+    }
+  }
+
   @SuppressWarnings("unchecked")
-  private Class<ConditionTypeNode> rootClassForRequest() {
-    return adoptedNode != null
-        ? (Class<ConditionTypeNode>) adoptedNode.getClass()
-        : ConditionTypeNode.class;
+  private <N extends ConditionTypeNode> Class<N> rootClassForRequest(Class<N> expectedNodeClass) {
+    ConditionTypeNode adoptedNode = this.adoptedNode;
+    if (adoptedNode == null) {
+      return expectedNodeClass;
+    }
+
+    Class<? extends ConditionTypeNode> adoptedClass = adoptedNode.getClass();
+    if (!expectedNodeClass.isAssignableFrom(adoptedClass)) {
+      throw new IllegalArgumentException(
+          "adopted node is "
+              + adoptedClass.getName()
+              + ", expected "
+              + expectedNodeClass.getName());
+    }
+
+    return (Class<N>) adoptedClass;
   }
 
   private void initializeCreatedNode(ConditionTypeNode node, NodeId typeDefinitionId) {

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/ConditionWiring.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/ConditionWiring.java
@@ -10,6 +10,8 @@
 
 package org.eclipse.milo.opcua.sdk.server.conditions;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.eclipse.milo.opcua.sdk.core.Reference;
 import org.eclipse.milo.opcua.sdk.core.typetree.ReferenceTypeTree;
 import org.eclipse.milo.opcua.sdk.server.NodeManager;
@@ -27,27 +29,40 @@ final class ConditionWiring {
 
   private ConditionWiring() {}
 
-  static void wire(ConditionTypeNode condition, @Nullable UaNode source) {
+  static WiringJournal wire(ConditionTypeNode condition, @Nullable UaNode source) {
+    WiringJournal journal = new WiringJournal();
     if (source == null) {
-      return;
+      return journal;
     }
 
-    condition.setSourceNode(source.getNodeId());
+    try {
+      condition.setSourceNode(source.getNodeId());
 
-    LocalizedText sourceDisplayName = source.getDisplayName();
-    String sourceName = sourceDisplayName != null ? sourceDisplayName.text() : null;
-    condition.setSourceName(sourceName != null ? sourceName : source.getBrowseName().name());
+      LocalizedText sourceDisplayName = source.getDisplayName();
+      String sourceName = sourceDisplayName != null ? sourceDisplayName.text() : null;
+      condition.setSourceName(sourceName != null ? sourceName : source.getBrowseName().name());
 
-    Reference hasCondition =
-        new Reference(
-            source.getNodeId(), NodeIds.HasCondition, condition.getNodeId().expanded(), true);
+      Reference hasCondition =
+          new Reference(
+              source.getNodeId(), NodeIds.HasCondition, condition.getNodeId().expanded(), true);
 
-    addReferenceIfAbsent(source, hasCondition);
+      addReferenceIfAbsent(source, hasCondition, journal);
 
-    ensureEventSourceWiring(condition, source);
+      ensureEventSourceWiring(condition, source, journal);
+
+      return journal;
+    } catch (RuntimeException e) {
+      try {
+        journal.rollBack();
+      } catch (RuntimeException rollbackFailure) {
+        e.addSuppressed(rollbackFailure);
+      }
+      throw e;
+    }
   }
 
-  private static void ensureEventSourceWiring(ConditionTypeNode condition, UaNode source) {
+  private static void ensureEventSourceWiring(
+      ConditionTypeNode condition, UaNode source, WiringJournal journal) {
     var context = condition.getNodeContext();
     ReferenceTypeTree referenceTypeTree = context.getServer().getReferenceTypeTree();
 
@@ -78,7 +93,7 @@ final class ConditionWiring {
         .getManagedNode(NodeIds.Server)
         .ifPresent(
             serverNode -> {
-              addReferenceIfAbsent(serverNode, hasEventSource);
+              addReferenceIfAbsent(serverNode, hasEventSource, journal);
             });
   }
 
@@ -87,16 +102,62 @@ final class ConditionWiring {
    * multiset, so the deduplicating commit is the point at which concurrent wiring calls must
    * converge; a contains-then-add sequence cannot repair duplicate occurrences afterwards.
    */
-  private static void addReferenceIfAbsent(UaNode owner, Reference reference) {
+  private static void addReferenceIfAbsent(
+      UaNode owner, Reference reference, WiringJournal journal) {
     NodeManager<UaNode> nodeManager = owner.getNodeManager();
     NodeManagerBatch.Builder<UaNode> batch = NodeManagerBatch.builder();
     batch.addReference(reference);
     reference.invert(owner.getNodeContext().getNamespaceTable()).ifPresent(batch::addReference);
 
     try {
-      nodeManager.commit(batch.build());
+      journal.record(nodeManager, nodeManager.commit(batch.build()));
     } catch (NodeManagerBatchException e) {
+      journal.record(nodeManager, e.getApplied());
       throw new UaRuntimeException(e.getStatusCode().getValue(), e);
     }
   }
+
+  /** Exact per-NodeManager journal of references added by one source-wiring operation. */
+  static final class WiringJournal {
+
+    private final List<AppliedReferences> appliedReferences = new ArrayList<>();
+    private boolean rolledBack;
+
+    private void record(NodeManager<UaNode> nodeManager, NodeManager.CommitResult applied) {
+      if (!applied.addedReferences().isEmpty()) {
+        appliedReferences.add(new AppliedReferences(nodeManager, applied.addedReferences()));
+      }
+    }
+
+    /** Remove only the reference occurrences that this wiring operation added. */
+    void rollBack() {
+      if (rolledBack) {
+        return;
+      }
+      rolledBack = true;
+
+      RuntimeException failure = null;
+      for (int i = appliedReferences.size() - 1; i >= 0; i--) {
+        AppliedReferences applied = appliedReferences.get(i);
+        List<Reference> references = applied.references();
+        for (int j = references.size() - 1; j >= 0; j--) {
+          try {
+            applied.nodeManager().removeReference(references.get(j));
+          } catch (RuntimeException e) {
+            if (failure == null) {
+              failure = e;
+            } else {
+              failure.addSuppressed(e);
+            }
+          }
+        }
+      }
+
+      if (failure != null) {
+        throw failure;
+      }
+    }
+  }
+
+  private record AppliedReferences(NodeManager<UaNode> nodeManager, List<Reference> references) {}
 }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/package-info.java
@@ -30,6 +30,15 @@
  * recovery path when a loaded NodeSet can provide generic alarm state but lacks a usable numeric
  * limit configuration.
  *
+ * <p>Applications that define a custom Condition ObjectType or a custom Java behavior use {@link
+ * org.eclipse.milo.opcua.sdk.server.conditions.Condition#createInstance} to create the typed node
+ * tree and behavior together. {@link
+ * org.eclipse.milo.opcua.sdk.server.conditions.Condition#attachInstance} and {@link
+ * org.eclipse.milo.opcua.sdk.server.conditions.Condition#adoptInstance} provide the corresponding
+ * lifecycles for existing custom instances. These extension entry points own instance construction,
+ * method discovery, and handler installation; they do not add custom state-transition semantics or
+ * concrete behavior-specific builder validation.
+ *
  * <p>All three return behavior without registering it. Applications must pass the result to their
  * {@link org.eclipse.milo.opcua.sdk.server.conditions.ConditionManager} before clients invoke
  * Condition methods or request ConditionRefresh. Unregistering or replacing a behavior releases its


### PR DESCRIPTION
Milo knew how to build its built-in Condition and Alarm types, but it did not have a safe equivalent for types supplied by an application. Users had to either accept the stock Java node and behavior or reproduce Milo's internal setup themselves, which could fail late or leave partially created nodes behind.

This PR adds typed create, attach, and adopt entry points for custom Condition instances. The application identifies its OPC UA type, expected Java node class, and Java behavior factory; Milo still performs the normal node construction, initialization, method validation, handler installation, and source wiring. If creation fails after nodes have been added, Milo removes the created tree and only the source wiring added by that attempt.

## What changed

- Add `Condition.createInstance(...)` for custom OPC UA types and behavior subclasses.
- Add `Condition.attachInstance(...)` for complete custom instances already in the address space.
- Add `Condition.adoptInstance(...)` for completing partial custom instances in place.
- Support custom OPC UA types using either a registered custom Java node class or the nearest stock node class.
- Validate that the behavior factory wraps the node Milo supplied.
- Diagnose missing custom node registrations during instantiation instead of failing later with a cast error.
- Roll back created nodes and owned source references when post-commit creation fails.
- Add focused coverage for custom types, custom behaviors, attach/adopt identity preservation, invalid factories, rollback, and method-surface validation.

This PR intentionally covers custom type and instance lifecycle only. It does not introduce custom state-transition semantics; the typed node and behavior extension points leave that work open for a later change.
