### PR TITLE
Make watchForChanges actually reload the KeyStore

### DIFF
--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/KeyStoreCertificateStore.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/KeyStoreCertificateStore.java
@@ -15,6 +15,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.ClosedWatchServiceException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -104,6 +105,8 @@ public class KeyStoreCertificateStore implements CertificateStore, Closeable {
       try {
         watchThread.join(5000);
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+
         throw new IOException(e);
       }
     }
@@ -373,54 +376,111 @@ public class KeyStoreCertificateStore implements CertificateStore, Closeable {
   }
 
   private void configureWatchService(File keyStoreFile) throws IOException {
+    Path keyStorePath = keyStoreFile.toPath();
+    Path watchedDirectory = keyStorePath.getParent();
+
     watchService = FileSystems.getDefault().newWatchService();
 
+    // ENTRY_CREATE matters as much as ENTRY_MODIFY here: writing a file by renaming a temporary
+    // one over it is the usual way to replace a KeyStore safely, and a rename arrives as a
+    // creation. This store writes its own file that way.
     WatchKey watchKey =
-        keyStoreFile
-            .toPath()
-            .getParent()
-            .register(watchService, StandardWatchEventKinds.ENTRY_MODIFY);
+        watchedDirectory.register(
+            watchService,
+            StandardWatchEventKinds.ENTRY_CREATE,
+            StandardWatchEventKinds.ENTRY_MODIFY);
 
-    watchThread =
-        new Thread(
-            new Runnable() {
-              @Override
-              public void run() {
-                while (true) {
-                  try {
-                    WatchKey key = watchService.take();
-                    if (key == watchKey) {
-                      key.pollEvents().forEach(this::processWatchEvent);
-                    }
-                  } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                  }
-                }
-              }
-
-              private void processWatchEvent(WatchEvent<?> event) {
-                if (event.kind() == StandardWatchEventKinds.ENTRY_MODIFY
-                    && event.context() instanceof Path p) {
-
-                  if (p.toAbsolutePath().equals(keyStoreFile.toPath().toAbsolutePath())) {
-                    try {
-                      keyStoreLock.lock();
-
-                      entries.clear();
-                      loadEntries();
-                    } catch (Exception ignored) {
-                      // ignored
-                    } finally {
-                      keyStoreLock.unlock();
-                    }
-                  }
-                }
-              }
-            });
-
+    watchThread = new Thread(() -> watchForChanges(watchKey, watchedDirectory, keyStorePath));
     watchThread.setName("milo-key-store-watcher");
     watchThread.setDaemon(true);
     watchThread.start();
+  }
+
+  private void watchForChanges(WatchKey watchKey, Path watchedDirectory, Path keyStorePath) {
+    while (true) {
+      WatchKey key;
+
+      try {
+        key = watchService.take();
+      } catch (ClosedWatchServiceException e) {
+        return;
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+
+        return;
+      }
+
+      if (key == watchKey
+          && key.pollEvents().stream()
+              .anyMatch(e -> isKeyStoreEvent(e, watchedDirectory, keyStorePath))) {
+
+        reload(keyStorePath);
+      }
+
+      // A WatchKey stays signalled, and is never queued again, until it has been reset.
+      if (!key.reset()) {
+        logger.warn(
+            "No longer watching {} for changes: the watch key is no longer valid", keyStorePath);
+
+        return;
+      }
+    }
+  }
+
+  /**
+   * Determine whether {@code event} refers to the KeyStore file.
+   *
+   * <p>A {@link WatchEvent} delivered by a directory watch carries a context relative to the
+   * watched directory, so it has to be resolved against that directory rather than against the
+   * working directory.
+   *
+   * @param event the {@link WatchEvent} to examine.
+   * @param watchedDirectory the directory the event was delivered for.
+   * @param keyStorePath the path of the KeyStore file.
+   * @return {@code true} if the KeyStore file may have changed.
+   */
+  static boolean isKeyStoreEvent(WatchEvent<?> event, Path watchedDirectory, Path keyStorePath) {
+
+    if (event.kind() == StandardWatchEventKinds.OVERFLOW) {
+      // Events were dropped, and there is no way to tell whether the KeyStore was among them.
+      return true;
+    }
+
+    return event.context() instanceof Path context
+        && watchedDirectory.resolve(context).equals(keyStorePath);
+  }
+
+  /**
+   * Re-read the KeyStore file and repopulate the entries loaded from it.
+   *
+   * <p>The file is read into a new {@link KeyStore} that replaces the current one only once it has
+   * loaded, so a KeyStore that is unreadable, or is still being written, leaves the one in use
+   * untouched.
+   *
+   * @param keyStorePath the path of the KeyStore file.
+   */
+  void reload(Path keyStorePath) {
+    try {
+      KeyStore reloaded = KeyStore.getInstance("pkcs12");
+
+      try (var inputStream = new FileInputStream(keyStorePath.toFile())) {
+        reloaded.load(inputStream, settings.getKeyStorePassword.get());
+      }
+
+      keyStoreLock.lock();
+      try {
+        keyStore = reloaded;
+
+        entries.clear();
+        loadEntries();
+      } finally {
+        keyStoreLock.unlock();
+      }
+
+      logger.debug("Reloaded KeyStore at {}", keyStorePath);
+    } catch (Exception e) {
+      logger.warn("Error reloading KeyStore at {}", keyStorePath, e);
+    }
   }
 
   /**

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/security/KeyStoreCertificateStoreTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/security/KeyStoreCertificateStoreTest.java
@@ -19,8 +19,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
 import java.security.KeyPair;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -105,10 +108,121 @@ class KeyStoreCertificateStoreTest extends CertificateStoreTest {
     assertFalse(reopened.contains(certificateTypeId));
   }
 
+  /**
+   * Reloading has to re-read the file: {@code loadEntries()} alone only re-queries the KeyStore
+   * already held in memory, which cannot see anything another writer has done.
+   */
+  @Test
+  void reloadPicksUpExternalChanges() throws Exception {
+    var certificateTypeId = new NodeId(2, "external");
+
+    KeyStoreCertificateStore store = newKeyStoreCertificateStore("password"::toCharArray);
+    store.initialize();
+
+    // A second store over the same file stands in for anything that rewrites the KeyStore
+    // out from under this one.
+    newCertificateStore().set(certificateTypeId, newEntry());
+    assertFalse(store.contains(certificateTypeId));
+
+    store.reload(keyStorePath);
+
+    assertTrue(store.contains(certificateTypeId));
+    assertNotNull(store.get(certificateTypeId));
+  }
+
+  @Test
+  void watchEventsResolveAgainstTheWatchedDirectory() {
+    Path watchedDirectory = keyStorePath.getParent();
+
+    // A directory watch reports the file name relative to the directory it was registered on,
+    // not a path that can be resolved against the working directory.
+    assertTrue(
+        KeyStoreCertificateStore.isKeyStoreEvent(
+            watchEvent(StandardWatchEventKinds.ENTRY_CREATE, keyStorePath.getFileName()),
+            watchedDirectory,
+            keyStorePath));
+
+    assertFalse(
+        KeyStoreCertificateStore.isKeyStoreEvent(
+            watchEvent(StandardWatchEventKinds.ENTRY_MODIFY, Path.of(".keystore123.tmp")),
+            watchedDirectory,
+            keyStorePath));
+
+    // Nothing is known about what was dropped, so an overflow has to be treated as a change.
+    assertTrue(
+        KeyStoreCertificateStore.isKeyStoreEvent(
+            watchEvent(StandardWatchEventKinds.OVERFLOW, null), watchedDirectory, keyStorePath));
+  }
+
+  @Test
+  void watchForChangesReloadsTheKeyStore() throws Exception {
+    var certificateTypeId = new NodeId(2, "watched");
+
+    KeyStoreCertificateStore store = newKeyStoreCertificateStore("password"::toCharArray, true);
+    store.initialize();
+
+    try {
+      newCertificateStore().set(certificateTypeId, newEntry());
+
+      // The KeyStore is replaced by a rename, which arrives as a creation rather than a
+      // modification, and on platforms without a native watcher it arrives only when the polling
+      // interval next elapses.
+      assertTrue(
+          awaitContains(store, certificateTypeId),
+          "watchForChanges did not reload the KeyStore within the timeout");
+    } finally {
+      store.close();
+    }
+  }
+
+  private static boolean awaitContains(CertificateStore store, NodeId certificateTypeId)
+      throws Exception {
+
+    long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(30);
+
+    while (System.nanoTime() < deadline) {
+      if (store.contains(certificateTypeId)) {
+        return true;
+      }
+
+      Thread.sleep(50);
+    }
+
+    return store.contains(certificateTypeId);
+  }
+
+  private static WatchEvent<?> watchEvent(WatchEvent.Kind<?> kind, @Nullable Object context) {
+    @SuppressWarnings("unchecked")
+    var typedKind = (WatchEvent.Kind<Object>) kind;
+
+    return new WatchEvent<>() {
+      @Override
+      public WatchEvent.Kind<Object> kind() {
+        return typedKind;
+      }
+
+      @Override
+      public int count() {
+        return 1;
+      }
+
+      @Override
+      public @Nullable Object context() {
+        return context;
+      }
+    };
+  }
+
   private KeyStoreCertificateStore newKeyStoreCertificateStore(Supplier<char[]> keyStorePassword) {
+    return newKeyStoreCertificateStore(keyStorePassword, false);
+  }
+
+  private KeyStoreCertificateStore newKeyStoreCertificateStore(
+      Supplier<char[]> keyStorePassword, boolean watchForChanges) {
+
     return new KeyStoreCertificateStore(
         new KeyStoreCertificateStore.Settings(
-            keyStorePath, keyStorePassword, alias -> "password".toCharArray())) {
+            keyStorePath, keyStorePassword, alias -> "password".toCharArray(), watchForChanges)) {
 
       @Override
       protected @Nullable String getAlias(NodeId certificateTypeId) {


### PR DESCRIPTION
Stacked on #1841 — review that one first. The diff shown here is against `fix/keystore-certificate-store-writes` and will shrink to just the watcher changes once #1841 merges.

`KeyStoreCertificateStore.Settings.watchForChanges` promises that a keystore replaced on disk gets picked up without restarting the server. It could not have worked, for several independent reasons, any one of which was enough on its own.

The watcher never called `reset()` on its `WatchKey`. A key stays signalled and is never queued again until it's reset, so after the first batch of events `take()` blocked for the life of the process — the watcher could fire at most once. That wouldn't have helped anyway, because the event filter compared `p.toAbsolutePath()` against the keystore path, and a directory watch reports a context relative to the watched directory while `toAbsolutePath()` resolves against `user.dir`. Unless the keystore happened to sit in the process working directory, the comparison never matched. On top of that only `ENTRY_MODIFY` was registered, so replacing a keystore the safe way — renaming a temporary file over it, which is exactly what this store does as of #1841 — produced no event at all; on Linux that registration becomes an inotify mask that `IN_MOVED_TO` isn't part of.

Underneath all of it, the reload didn't reload. It cleared the entry cache and called `loadEntries()`, which re-queries the `KeyStore` already held in memory since `initialize()`. The cache was emptied and immediately refilled with identical stale entries. Even with everything above fixed, the file was never re-read, so a renewed certificate could not have been seen.

The watcher now resets its key, registers `ENTRY_CREATE` alongside `ENTRY_MODIFY`, and resolves event contexts against the directory the watch was registered on. Reloading reads into a new `KeyStore` and swaps it in only once it has loaded, so a file that's unreadable, or still being written, leaves the one in use untouched. Overflow events are treated as a change, since there's no way to tell what was dropped.

One more thing surfaced while testing this. `close()` closes the `WatchService` while the watcher thread is parked in `take()`, which raises `ClosedWatchServiceException`. Nothing caught it, so it propagated out of `run()` and every shutdown left an uncaught exception behind. The thread now exits cleanly, and an interrupt during `close()` restores the interrupt flag instead of swallowing it.

## Testing

The end-to-end test enables the setting, has a second store rewrite the file, and waits for the first one to notice. I ran it against the previous implementation to confirm it earns its keep: it times out there after thirty seconds and passes in well under a second against this one. A test that drives a feature purely through the public API is worth very little if it passes either way, and this one didn't.

Narrower tests pin the reload-from-disk behaviour without involving a watch service at all, so a regression there fails deterministically instead of as a timeout, and cover the event path resolution and overflow handling directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
