### PR TITLE
Merge main into integration/1.2

### DIFF
--- a/milo-examples/server-examples/src/main/java/org/eclipse/milo/examples/server/KeyStoreLoader.java
+++ b/milo-examples/server-examples/src/main/java/org/eclipse/milo/examples/server/KeyStoreLoader.java
@@ -11,9 +11,9 @@
 package org.eclipse.milo.examples.server;
 
 import com.google.common.collect.Sets;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.Key;
 import java.security.KeyPair;
@@ -48,11 +48,11 @@ class KeyStoreLoader {
   KeyStoreLoader load(Path baseDir) throws Exception {
     KeyStore keyStore = KeyStore.getInstance("PKCS12");
 
-    File serverKeyStore = baseDir.resolve("example-server.pfx").toFile();
+    Path serverKeyStore = baseDir.resolve("example-server.pfx");
 
     logger.info("Loading KeyStore at {}", serverKeyStore);
 
-    if (!serverKeyStore.exists()) {
+    if (!Files.exists(serverKeyStore)) {
       keyStore.load(null, PASSWORD);
 
       KeyPair keyPair = SelfSignedCertificateGenerator.generateRsaKeyPair(2048);
@@ -86,9 +86,13 @@ class KeyStoreLoader {
 
       keyStore.setKeyEntry(
           SERVER_ALIAS, keyPair.getPrivate(), PASSWORD, new X509Certificate[] {certificate});
-      keyStore.store(new FileOutputStream(serverKeyStore), PASSWORD);
+      try (OutputStream out = Files.newOutputStream(serverKeyStore)) {
+        keyStore.store(out, PASSWORD);
+      }
     } else {
-      keyStore.load(new FileInputStream(serverKeyStore), PASSWORD);
+      try (InputStream in = Files.newInputStream(serverKeyStore)) {
+        keyStore.load(in, PASSWORD);
+      }
     }
 
     Key serverPrivateKey = keyStore.getKey(SERVER_ALIAS, PASSWORD);

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/test/KeyStoreLoader.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/test/KeyStoreLoader.java
@@ -11,8 +11,10 @@
 package org.eclipse.milo.opcua.sdk.test;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.Key;
 import java.security.KeyPair;
 import java.security.KeyStore;
@@ -46,11 +48,11 @@ class KeyStoreLoader {
   KeyStoreLoader load(File baseDir) throws Exception {
     KeyStore keyStore = KeyStore.getInstance("PKCS12");
 
-    File serverKeyStore = baseDir.toPath().resolve("example-server.pfx").toFile();
+    Path serverKeyStore = baseDir.toPath().resolve("example-server.pfx");
 
     LOGGER.debug("Loading KeyStore at {}", serverKeyStore);
 
-    if (!serverKeyStore.exists()) {
+    if (!Files.exists(serverKeyStore)) {
       keyStore.load(null, PASSWORD);
 
       KeyPair keyPair = SelfSignedCertificateGenerator.generateRsaKeyPair(2048);
@@ -84,9 +86,13 @@ class KeyStoreLoader {
 
       keyStore.setKeyEntry(
           SERVER_ALIAS, keyPair.getPrivate(), PASSWORD, new X509Certificate[] {certificate});
-      keyStore.store(new FileOutputStream(serverKeyStore), PASSWORD);
+      try (OutputStream out = Files.newOutputStream(serverKeyStore)) {
+        keyStore.store(out, PASSWORD);
+      }
     } else {
-      keyStore.load(new FileInputStream(serverKeyStore), PASSWORD);
+      try (InputStream in = Files.newInputStream(serverKeyStore)) {
+        keyStore.load(in, PASSWORD);
+      }
     }
 
     Key serverPrivateKey = keyStore.getKey(SERVER_ALIAS, PASSWORD);

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/KeyStoreCertificateStore.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/KeyStoreCertificateStore.java
@@ -16,13 +16,16 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.FileSystems;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardWatchEventKinds;
 import java.nio.file.WatchEvent;
 import java.nio.file.WatchKey;
 import java.nio.file.WatchService;
 import java.security.Key;
 import java.security.KeyStore;
+import java.security.KeyStoreException;
 import java.security.PrivateKey;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
@@ -35,6 +38,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,10 +68,12 @@ public class KeyStoreCertificateStore implements CertificateStore, Closeable {
 
       keyStore = KeyStore.getInstance("pkcs12");
 
-      File keyStoreFile = settings.keyStorePath.toFile();
+      File keyStoreFile = settings.keyStorePath.toAbsolutePath().toFile();
 
       if (keyStoreFile.exists()) {
-        keyStore.load(new FileInputStream(keyStoreFile), settings.getKeyStorePassword.get());
+        try (var inputStream = new FileInputStream(keyStoreFile)) {
+          keyStore.load(inputStream, settings.getKeyStorePassword.get());
+        }
 
         try {
           keyStoreLock.lock();
@@ -79,7 +85,7 @@ public class KeyStoreCertificateStore implements CertificateStore, Closeable {
       } else {
         keyStore.load(null, settings.getKeyStorePassword.get());
 
-        keyStore.store(new FileOutputStream(keyStoreFile), settings.getKeyStorePassword.get());
+        storeKeyStore();
       }
 
       if (settings.watchForChanges) {
@@ -172,17 +178,20 @@ public class KeyStoreCertificateStore implements CertificateStore, Closeable {
       String alias = getAlias(certificateTypeId);
 
       if (alias != null) {
-        KeyStore.Entry entry =
-            keyStore.getEntry(
-                alias, new KeyStore.PasswordProtection(settings.getAliasPassword.apply(alias)));
+        char[] password = settings.getAliasPassword.apply(alias);
+
+        KeyStore.Entry entry = keyStore.getEntry(alias, new KeyStore.PasswordProtection(password));
 
         if (entry instanceof KeyStore.PrivateKeyEntry privateKeyEntry) {
           keyStore.deleteEntry(alias);
           entries.remove(alias);
 
-          keyStore.store(
-              new FileOutputStream(settings.keyStorePath.toFile()),
-              settings.getKeyStorePassword.get());
+          try {
+            storeKeyStore();
+          } catch (Exception e) {
+            restoreEntry(alias, entry, password, e);
+            throw e;
+          }
 
           return new Entry(
               privateKeyEntry.getPrivateKey(),
@@ -209,11 +218,25 @@ public class KeyStoreCertificateStore implements CertificateStore, Closeable {
 
       String alias = getAlias(certificateTypeId);
 
-      keyStore.setKeyEntry(
-          alias, entry.privateKey, settings.getAliasPassword.apply(alias), entry.certificateChain);
+      if (alias == null) {
+        return;
+      }
 
-      keyStore.store(
-          new FileOutputStream(settings.keyStorePath.toFile()), settings.getKeyStorePassword.get());
+      char[] password = settings.getAliasPassword.apply(alias);
+
+      KeyStore.Entry previousEntry =
+          keyStore.isKeyEntry(alias)
+              ? keyStore.getEntry(alias, new KeyStore.PasswordProtection(password))
+              : null;
+
+      keyStore.setKeyEntry(alias, entry.privateKey, password, entry.certificateChain);
+
+      try {
+        storeKeyStore();
+      } catch (Exception e) {
+        restoreEntry(alias, previousEntry, password, e);
+        throw e;
+      }
 
       entries.put(alias, entry);
     } finally {
@@ -225,9 +248,10 @@ public class KeyStoreCertificateStore implements CertificateStore, Closeable {
    * Get the alias to use when accessing certificates of type {@code certificateTypeId}.
    *
    * @param certificateTypeId the {@link NodeId} of the certificate type.
-   * @return the alias to use when accessing certificates of type {@code certificateTypeId}.
+   * @return the alias to use when accessing certificates of type {@code certificateTypeId}, or
+   *     {@code null} if the certificate type is not supported.
    */
-  protected String getAlias(NodeId certificateTypeId) {
+  protected @Nullable String getAlias(NodeId certificateTypeId) {
     if (certificateTypeId.equals(NodeIds.RsaSha256ApplicationCertificateType)) {
       return "server-rsa-sha256";
     } else {
@@ -246,6 +270,106 @@ public class KeyStoreCertificateStore implements CertificateStore, Closeable {
     // `cache` for faster subsequent access.
 
     get(NodeIds.RsaSha256ApplicationCertificateType);
+  }
+
+  /**
+   * Write the KeyStore to a temporary file in the same directory and then move it into place,
+   * replacing any existing file.
+   *
+   * <p>Opening the KeyStore file directly would truncate it before the new contents have been
+   * written, so a failure part way through the write would leave behind a KeyStore with no keys in
+   * it.
+   *
+   * @throws Exception if an error occurs while writing the KeyStore.
+   */
+  private void storeKeyStore() throws Exception {
+    Path keyStorePath = resolveKeyStorePath();
+    Path tempPath = Files.createTempFile(keyStorePath.getParent(), ".keystore", ".tmp");
+
+    try {
+      copyPosixFilePermissions(keyStorePath, tempPath);
+
+      try (var outputStream = new FileOutputStream(tempPath.toFile())) {
+        keyStore.store(outputStream, settings.getKeyStorePassword.get());
+
+        // Force the contents to disk before the move, so a crash can't leave the moved-into-place
+        // file holding nothing.
+        outputStream.getFD().sync();
+      }
+
+      Files.move(
+          tempPath,
+          keyStorePath,
+          StandardCopyOption.REPLACE_EXISTING,
+          StandardCopyOption.ATOMIC_MOVE);
+    } catch (Exception e) {
+      try {
+        Files.deleteIfExists(tempPath);
+      } catch (IOException ex) {
+        e.addSuppressed(ex);
+      }
+
+      throw e;
+    }
+  }
+
+  /**
+   * Resolve the path to write the KeyStore to, following symbolic links so that an existing link is
+   * updated in place rather than replaced by a regular file.
+   *
+   * @return the absolute, link-resolved path of the KeyStore file.
+   * @throws IOException if an error occurs while resolving the path.
+   */
+  private Path resolveKeyStorePath() throws IOException {
+    Path keyStorePath = settings.keyStorePath.toAbsolutePath();
+
+    return Files.exists(keyStorePath) ? keyStorePath.toRealPath() : keyStorePath;
+  }
+
+  /**
+   * Copy the POSIX permissions of {@code from} onto {@code to}, if {@code from} exists and the file
+   * system supports them.
+   *
+   * <p>Temporary files are created readable only by their owner, so without this the KeyStore would
+   * lose any permissions the user had configured every time it was replaced.
+   *
+   * @param from the file to read permissions from.
+   * @param to the file to apply them to.
+   * @throws IOException if an error occurs while reading or applying the permissions.
+   */
+  private static void copyPosixFilePermissions(Path from, Path to) throws IOException {
+    if (Files.exists(from)
+        && from.getFileSystem().supportedFileAttributeViews().contains("posix")) {
+
+      Files.setPosixFilePermissions(to, Files.getPosixFilePermissions(from));
+    }
+  }
+
+  /**
+   * Restore {@code previousEntry} under {@code alias} after a failed write, so the in-memory
+   * KeyStore does not diverge from the file on disk.
+   *
+   * <p>The {@code entries} cache needs no equivalent treatment: {@link #get(NodeId)} falls back to
+   * the KeyStore and repopulates it.
+   *
+   * @param alias the alias to restore.
+   * @param previousEntry the entry that was present before the write, or {@code null} if there was
+   *     none.
+   * @param password the password protecting {@code alias}.
+   * @param cause the failure being recovered from, which any failure to restore is attached to.
+   */
+  private void restoreEntry(
+      String alias, KeyStore.@Nullable Entry previousEntry, char[] password, Exception cause) {
+
+    try {
+      if (previousEntry != null) {
+        keyStore.setEntry(alias, previousEntry, new KeyStore.PasswordProtection(password));
+      } else {
+        keyStore.deleteEntry(alias);
+      }
+    } catch (KeyStoreException e) {
+      cause.addSuppressed(e);
+    }
   }
 
   private void configureWatchService(File keyStoreFile) throws IOException {

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/KeyStoreCertificateStore.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/KeyStoreCertificateStore.java
@@ -15,6 +15,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.ClosedWatchServiceException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -104,6 +105,8 @@ public class KeyStoreCertificateStore implements CertificateStore, Closeable {
       try {
         watchThread.join(5000);
       } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+
         throw new IOException(e);
       }
     }
@@ -373,54 +376,111 @@ public class KeyStoreCertificateStore implements CertificateStore, Closeable {
   }
 
   private void configureWatchService(File keyStoreFile) throws IOException {
+    Path keyStorePath = keyStoreFile.toPath();
+    Path watchedDirectory = keyStorePath.getParent();
+
     watchService = FileSystems.getDefault().newWatchService();
 
+    // ENTRY_CREATE matters as much as ENTRY_MODIFY here: writing a file by renaming a temporary
+    // one over it is the usual way to replace a KeyStore safely, and a rename arrives as a
+    // creation. This store writes its own file that way.
     WatchKey watchKey =
-        keyStoreFile
-            .toPath()
-            .getParent()
-            .register(watchService, StandardWatchEventKinds.ENTRY_MODIFY);
+        watchedDirectory.register(
+            watchService,
+            StandardWatchEventKinds.ENTRY_CREATE,
+            StandardWatchEventKinds.ENTRY_MODIFY);
 
-    watchThread =
-        new Thread(
-            new Runnable() {
-              @Override
-              public void run() {
-                while (true) {
-                  try {
-                    WatchKey key = watchService.take();
-                    if (key == watchKey) {
-                      key.pollEvents().forEach(this::processWatchEvent);
-                    }
-                  } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                  }
-                }
-              }
-
-              private void processWatchEvent(WatchEvent<?> event) {
-                if (event.kind() == StandardWatchEventKinds.ENTRY_MODIFY
-                    && event.context() instanceof Path p) {
-
-                  if (p.toAbsolutePath().equals(keyStoreFile.toPath().toAbsolutePath())) {
-                    try {
-                      keyStoreLock.lock();
-
-                      entries.clear();
-                      loadEntries();
-                    } catch (Exception ignored) {
-                      // ignored
-                    } finally {
-                      keyStoreLock.unlock();
-                    }
-                  }
-                }
-              }
-            });
-
+    watchThread = new Thread(() -> watchForChanges(watchKey, watchedDirectory, keyStorePath));
     watchThread.setName("milo-key-store-watcher");
     watchThread.setDaemon(true);
     watchThread.start();
+  }
+
+  private void watchForChanges(WatchKey watchKey, Path watchedDirectory, Path keyStorePath) {
+    while (true) {
+      WatchKey key;
+
+      try {
+        key = watchService.take();
+      } catch (ClosedWatchServiceException e) {
+        return;
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+
+        return;
+      }
+
+      if (key == watchKey
+          && key.pollEvents().stream()
+              .anyMatch(e -> isKeyStoreEvent(e, watchedDirectory, keyStorePath))) {
+
+        reload(keyStorePath);
+      }
+
+      // A WatchKey stays signalled, and is never queued again, until it has been reset.
+      if (!key.reset()) {
+        logger.warn(
+            "No longer watching {} for changes: the watch key is no longer valid", keyStorePath);
+
+        return;
+      }
+    }
+  }
+
+  /**
+   * Determine whether {@code event} refers to the KeyStore file.
+   *
+   * <p>A {@link WatchEvent} delivered by a directory watch carries a context relative to the
+   * watched directory, so it has to be resolved against that directory rather than against the
+   * working directory.
+   *
+   * @param event the {@link WatchEvent} to examine.
+   * @param watchedDirectory the directory the event was delivered for.
+   * @param keyStorePath the path of the KeyStore file.
+   * @return {@code true} if the KeyStore file may have changed.
+   */
+  static boolean isKeyStoreEvent(WatchEvent<?> event, Path watchedDirectory, Path keyStorePath) {
+
+    if (event.kind() == StandardWatchEventKinds.OVERFLOW) {
+      // Events were dropped, and there is no way to tell whether the KeyStore was among them.
+      return true;
+    }
+
+    return event.context() instanceof Path context
+        && watchedDirectory.resolve(context).equals(keyStorePath);
+  }
+
+  /**
+   * Re-read the KeyStore file and repopulate the entries loaded from it.
+   *
+   * <p>The file is read into a new {@link KeyStore} that replaces the current one only once it has
+   * loaded, so a KeyStore that is unreadable, or is still being written, leaves the one in use
+   * untouched.
+   *
+   * @param keyStorePath the path of the KeyStore file.
+   */
+  void reload(Path keyStorePath) {
+    try {
+      KeyStore reloaded = KeyStore.getInstance("pkcs12");
+
+      try (var inputStream = new FileInputStream(keyStorePath.toFile())) {
+        reloaded.load(inputStream, settings.getKeyStorePassword.get());
+      }
+
+      keyStoreLock.lock();
+      try {
+        keyStore = reloaded;
+
+        entries.clear();
+        loadEntries();
+      } finally {
+        keyStoreLock.unlock();
+      }
+
+      logger.debug("Reloaded KeyStore at {}", keyStorePath);
+    } catch (Exception e) {
+      logger.warn("Error reloading KeyStore at {}", keyStorePath, e);
+    }
   }
 
   /**

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/security/KeyStoreCertificateStoreTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/security/KeyStoreCertificateStoreTest.java
@@ -19,8 +19,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchEvent;
 import java.security.KeyPair;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -105,10 +108,121 @@ class KeyStoreCertificateStoreTest extends CertificateStoreTest {
     assertFalse(reopened.contains(certificateTypeId));
   }
 
+  /**
+   * Reloading has to re-read the file: {@code loadEntries()} alone only re-queries the KeyStore
+   * already held in memory, which cannot see anything another writer has done.
+   */
+  @Test
+  void reloadPicksUpExternalChanges() throws Exception {
+    var certificateTypeId = new NodeId(2, "external");
+
+    KeyStoreCertificateStore store = newKeyStoreCertificateStore("password"::toCharArray);
+    store.initialize();
+
+    // A second store over the same file stands in for anything that rewrites the KeyStore
+    // out from under this one.
+    newCertificateStore().set(certificateTypeId, newEntry());
+    assertFalse(store.contains(certificateTypeId));
+
+    store.reload(keyStorePath);
+
+    assertTrue(store.contains(certificateTypeId));
+    assertNotNull(store.get(certificateTypeId));
+  }
+
+  @Test
+  void watchEventsResolveAgainstTheWatchedDirectory() {
+    Path watchedDirectory = keyStorePath.getParent();
+
+    // A directory watch reports the file name relative to the directory it was registered on,
+    // not a path that can be resolved against the working directory.
+    assertTrue(
+        KeyStoreCertificateStore.isKeyStoreEvent(
+            watchEvent(StandardWatchEventKinds.ENTRY_CREATE, keyStorePath.getFileName()),
+            watchedDirectory,
+            keyStorePath));
+
+    assertFalse(
+        KeyStoreCertificateStore.isKeyStoreEvent(
+            watchEvent(StandardWatchEventKinds.ENTRY_MODIFY, Path.of(".keystore123.tmp")),
+            watchedDirectory,
+            keyStorePath));
+
+    // Nothing is known about what was dropped, so an overflow has to be treated as a change.
+    assertTrue(
+        KeyStoreCertificateStore.isKeyStoreEvent(
+            watchEvent(StandardWatchEventKinds.OVERFLOW, null), watchedDirectory, keyStorePath));
+  }
+
+  @Test
+  void watchForChangesReloadsTheKeyStore() throws Exception {
+    var certificateTypeId = new NodeId(2, "watched");
+
+    KeyStoreCertificateStore store = newKeyStoreCertificateStore("password"::toCharArray, true);
+    store.initialize();
+
+    try {
+      newCertificateStore().set(certificateTypeId, newEntry());
+
+      // The KeyStore is replaced by a rename, which arrives as a creation rather than a
+      // modification, and on platforms without a native watcher it arrives only when the polling
+      // interval next elapses.
+      assertTrue(
+          awaitContains(store, certificateTypeId),
+          "watchForChanges did not reload the KeyStore within the timeout");
+    } finally {
+      store.close();
+    }
+  }
+
+  private static boolean awaitContains(CertificateStore store, NodeId certificateTypeId)
+      throws Exception {
+
+    long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(30);
+
+    while (System.nanoTime() < deadline) {
+      if (store.contains(certificateTypeId)) {
+        return true;
+      }
+
+      Thread.sleep(50);
+    }
+
+    return store.contains(certificateTypeId);
+  }
+
+  private static WatchEvent<?> watchEvent(WatchEvent.Kind<?> kind, @Nullable Object context) {
+    @SuppressWarnings("unchecked")
+    var typedKind = (WatchEvent.Kind<Object>) kind;
+
+    return new WatchEvent<>() {
+      @Override
+      public WatchEvent.Kind<Object> kind() {
+        return typedKind;
+      }
+
+      @Override
+      public int count() {
+        return 1;
+      }
+
+      @Override
+      public @Nullable Object context() {
+        return context;
+      }
+    };
+  }
+
   private KeyStoreCertificateStore newKeyStoreCertificateStore(Supplier<char[]> keyStorePassword) {
+    return newKeyStoreCertificateStore(keyStorePassword, false);
+  }
+
+  private KeyStoreCertificateStore newKeyStoreCertificateStore(
+      Supplier<char[]> keyStorePassword, boolean watchForChanges) {
+
     return new KeyStoreCertificateStore(
         new KeyStoreCertificateStore.Settings(
-            keyStorePath, keyStorePassword, alias -> "password".toCharArray())) {
+            keyStorePath, keyStorePassword, alias -> "password".toCharArray(), watchForChanges)) {
 
       @Override
       protected @Nullable String getAlias(NodeId certificateTypeId) {

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/security/KeyStoreCertificateStoreTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/security/KeyStoreCertificateStoreTest.java
@@ -10,12 +10,24 @@
 
 package org.eclipse.milo.opcua.stack.core.security;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.KeyPair;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 
 class KeyStoreCertificateStoreTest extends CertificateStoreTest {
 
@@ -27,8 +39,8 @@ class KeyStoreCertificateStoreTest extends CertificateStoreTest {
   @AfterEach
   void deleteTestFiles() {
     try {
-      Files.deleteIfExists(testPath);
       Files.deleteIfExists(keyStorePath);
+      Files.deleteIfExists(testPath);
     } catch (Exception ignored) {
       testPath.toFile().deleteOnExit();
       keyStorePath.toFile().deleteOnExit();
@@ -37,19 +49,79 @@ class KeyStoreCertificateStoreTest extends CertificateStoreTest {
 
   @Override
   protected CertificateStore newCertificateStore() throws Exception {
-    var store =
-        new KeyStoreCertificateStore(
-            new KeyStoreCertificateStore.Settings(
-                keyStorePath, "password"::toCharArray, alias -> "password".toCharArray())) {
-
-          @Override
-          protected @Nullable String getAlias(NodeId certificateTypeId) {
-            return certificateTypeId.getIdentifier().toString();
-          }
-        };
+    KeyStoreCertificateStore store = newKeyStoreCertificateStore("password"::toCharArray);
 
     store.initialize();
 
     return store;
+  }
+
+  /**
+   * Opening a second store over the same file is the only way to tell that {@link
+   * CertificateStore#set(NodeId, CertificateStore.Entry)} actually wrote anything; the assertions
+   * inherited from {@link CertificateStoreTest} all pass against the in-memory KeyStore alone.
+   */
+  @Test
+  void entriesAreWrittenToDisk() throws Exception {
+    var certificateTypeId = new NodeId(2, "persisted");
+
+    certificateStore.set(certificateTypeId, newEntry());
+
+    assertNotNull(newCertificateStore().get(certificateTypeId));
+  }
+
+  @Test
+  void failedWriteLeavesKeyStoreIntact() throws Exception {
+    var certificateTypeId = new NodeId(2, "unwritable");
+    var failWrite = new AtomicBoolean(false);
+
+    KeyStoreCertificateStore store =
+        newKeyStoreCertificateStore(
+            () -> {
+              if (failWrite.get()) {
+                throw new IllegalStateException("KeyStore password unavailable");
+              }
+              return "password".toCharArray();
+            });
+
+    store.initialize();
+    store.set(new NodeId(2, "survivor"), newEntry());
+
+    failWrite.set(true);
+    assertThrows(IllegalStateException.class, () -> store.set(certificateTypeId, newEntry()));
+    failWrite.set(false);
+
+    // The failed write must be rolled back in memory...
+    assertFalse(store.contains(certificateTypeId));
+
+    // ...must not have left a partially written temporary file behind...
+    try (Stream<Path> files = Files.list(testPath)) {
+      assertEquals(List.of(keyStorePath), files.toList());
+    }
+
+    // ...and must not have damaged what was already on disk.
+    CertificateStore reopened = newCertificateStore();
+    assertTrue(reopened.contains(new NodeId(2, "survivor")));
+    assertFalse(reopened.contains(certificateTypeId));
+  }
+
+  private KeyStoreCertificateStore newKeyStoreCertificateStore(Supplier<char[]> keyStorePassword) {
+    return new KeyStoreCertificateStore(
+        new KeyStoreCertificateStore.Settings(
+            keyStorePath, keyStorePassword, alias -> "password".toCharArray())) {
+
+      @Override
+      protected @Nullable String getAlias(NodeId certificateTypeId) {
+        return certificateTypeId.getIdentifier().toString();
+      }
+    };
+  }
+
+  private static CertificateStore.Entry newEntry() {
+    var factory = new TestCertificateFactory();
+    KeyPair keyPair = factory.createRsaSha256KeyPair();
+
+    return new CertificateStore.Entry(
+        keyPair.getPrivate(), factory.createRsaSha256CertificateChain(keyPair));
   }
 }


### PR DESCRIPTION
Brings `integration/1.2` up to date with `main`.

## Commits from main

- `a0170a1` Write the KeyStore atomically and close its streams
- `6dc726c` Close KeyStore streams in the example loaders
- `2b65449` Make watchForChanges actually reload the KeyStore
- `2cb1643` Merge pull request #1842 from eclipse-milo/fix/keystore-watch-for-changes

## Conflict resolution

One conflict, in `KeyStoreCertificateStoreTest`. Both branches added tests to the same file
on top of a common base:

- `main` refactored `newCertificateStore()` into a `newKeyStoreCertificateStore()` helper and
  added tests for atomic writes, reload, and the watch service.
- `integration/1.2` added tests for the ECC default aliases and for `initialize()` skipping
  unmanaged and missing preloaded aliases.

Kept main's structure and tests, re-applied integration/1.2's three tests on top, and unioned
the imports. Nothing was dropped from either side.

`KeyStoreCertificateStore` itself merged cleanly: main's atomic-write and reload changes apply
over integration/1.2's ECC alias support without overlap.

## Verification

- `mvn spotless:apply` — no changes
- `mvn clean compile` — passes
- `mvn -pl opc-ua-stack/stack-core test -Dtest=KeyStoreCertificateStoreTest` — 13 tests, all pass