### PR TITLE
Add GDS client support (Pull Model and trust lists)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,19 @@ Releases are published to Maven Central and snapshots to Sonatype.
 </dependency>
 ```
 
+#### GDS Client (1.2.0 and later)
+
+Registers an application with a Global Discovery Server, requests certificates through the Pull
+Model, and reads GDS trust lists. See [docs/features/gds-client.md](docs/features/gds-client.md).
+
+```xml
+<dependency>
+    <groupId>org.eclipse.milo</groupId>
+    <artifactId>milo-sdk-client-gds</artifactId>
+    <version>1.2.0-SNAPSHOT</version>
+</dependency>
+```
+
 Referencing a `SNAPSHOT` release requires the Sonatype snapshot repository be added to your pom file:
 
 ```xml

--- a/docs/features/gds-client.md
+++ b/docs/features/gds-client.md
@@ -1,0 +1,246 @@
+# GDS client
+
+An OPC UA Global Discovery Server (GDS, OPC 10000-12) registers applications, issues their
+certificates, and distributes the trust lists they validate against. Milo ships the GDS
+information model as generated code inside the core SDK modules and a client layer in the
+`milo-sdk-client-gds` module, so an application can register itself, obtain and renew certificates
+through the Pull Model (Part 12 §7.6), and keep a GDS-managed trust list without reimplementing the
+namespace, the `Directory` method calls, or the FileType read loop.
+
+* * *
+
+## Table of contents
+
+- [Overview](#overview)
+- [How it works](#how-it-works)
+- [Usage](#usage)
+- [Generated model](#generated-model)
+- [Limitations](#limitations)
+
+* * *
+
+## Overview
+
+Support is split into two layers.
+
+The **generated model** ships in every Milo client and server jar, the same way the namespace 0
+model does. It lives in subpackages of the existing modules:
+
+| Module           | Package                                              | Contents                                                                                          |
+|------------------|------------------------------------------------------|---------------------------------------------------------------------------------------------------|
+| `milo-stack-core` | `org.eclipse.milo.opcua.stack.core.gds`             | `GdsNodeIds` (one `ExpandedNodeId` per GDS node), `DataTypeInitializer`                          |
+| `milo-stack-core` | `org.eclipse.milo.opcua.stack.core.gds.types`       | `ApplicationRecordDataType` with its codec and `StructureDefinition`                             |
+| `milo-dtd-core`   | `org.eclipse.milo.opcua.sdk.core.dtd.gds`           | `BinaryDataTypeDictionaryInitializer` for the legacy type dictionary mechanism (deprecated)      |
+| `milo-sdk-client` | `org.eclipse.milo.opcua.sdk.client.gds`             | `ObjectTypeInitializer`, `VariableTypeInitializer`                                                |
+| `milo-sdk-client` | `org.eclipse.milo.opcua.sdk.client.gds.model.objects` | Client node classes for `DirectoryType`, `CertificateDirectoryType`, the KeyCredential and AuthorizationService types, and the GDS audit event types |
+| `milo-sdk-server` | `org.eclipse.milo.opcua.sdk.server.gds` and `.model.objects` | The server-side mirror of the same types, for a GDS hosted on Milo                        |
+
+The **client layer** is the module `opc-ua-sdk/sdk-client-gds` (artifact `milo-sdk-client-gds`,
+listed in `milo-bom`). It depends only on `milo-sdk-client` and shares the package
+`org.eclipse.milo.opcua.sdk.client.gds` with the generated client initializers:
+
+- `GdsClient` wraps a connected `OpcUaClient` and exposes every `DirectoryType` and
+  `CertificateDirectoryType` method with a typed signature, plus reads of a CertificateGroup's
+  `CertificateTypes` and a TrustList's `LastUpdateTime` and `UpdateFrequency`.
+- `TrustListReader` reads a `TrustListType` object with the FileType `Open`, `Read`, and `Close`
+  methods and decodes the body into a `TrustListDataType`.
+- `TrustListApplier` installs a `TrustListDataType` into a `TrustListManager` and builds one back
+  from a manager.
+
+The module stops at these typed primitives. Scheduling, persistence of the `ApplicationId` and
+pending `RequestId`s, retry policy, and what to do with an issued certificate depend on the
+application's configuration and lifecycle, so there is no Pull engine; the application drives the
+sequence.
+
+* * *
+
+## How it works
+
+### Namespace resolution and type registration
+
+The GDS namespace `http://opcfoundation.org/UA/GDS/` gets a different index on every server, so
+nothing in the model can be registered before a client has read the server's namespace array.
+`GdsClient.create(client)` looks the URI up in the client's `NamespaceTable` (re-reading the array
+from the server once if the local copy lacks it), fails with `Bad_NotFound` if the server does not
+host the namespace, and otherwise:
+
+1. registers the `ApplicationRecordDataType` codec with the client's static `DataTypeManager`
+   through `DataTypeInitializer`, so the structure can be sent as a method input and decoded from
+   method outputs;
+2. registers the GDS object types with the client's `ObjectTypeManager` through
+   `ObjectTypeInitializer`, so `AddressSpace.getObjectNode(directoryId)` returns a
+   `CertificateDirectoryTypeNode`;
+3. resolves the `Directory` object id (`GdsNodeIds.Directory`, `i=141`).
+
+The namespace index is captured once. A client that is later pointed at a different GDS needs a
+new `GdsClient`.
+
+### Method invocation
+
+Every GDS method is a component of the `Directory` object with a NodeId fixed by the NodeSet, so
+each wrapper issues exactly one `Call` request with the known ids: `FindApplications` `i=143`,
+`RegisterApplication` `i=146`, `UpdateApplication` `i=200`, `UnregisterApplication` `i=149`,
+`GetApplication` `i=216`, `QueryApplications` `i=992`, `QueryServers` `i=151`,
+`StartSigningRequest` `i=157`, `StartNewKeyPairRequest` `i=154`, `FinishRequest` `i=163`,
+`GetCertificateGroups` `i=508`, `GetCertificates` `i=174`, `GetTrustList` `i=204`,
+`GetCertificateStatus` `i=225`, `RevokeCertificate` `i=15005`, `CheckRevocationStatus` `i=177`.
+No browse or argument read precedes a call. The generated node classes remain available for
+callers who want to navigate the `Applications` and `CertificateGroups` folders.
+
+Results are not interpreted. A Bad operation-level status becomes a `UaMethodException` (a
+`UaException`) carrying the server's `StatusCode`, so a caller branches on the codes Part 12
+defines: `Bad_NothingToDo` from `FinishRequest` means the request is still pending,
+`Bad_RequestNotAllowed` means it was rejected, `Bad_UserAccessDenied` means the session lacks the
+role, and `Bad_CertificateUriInvalid` means the CSR's ApplicationUri does not match the record.
+Output arguments are validated by type and count; a server that returns something other than the
+spec's argument list produces `Bad_UnexpectedError` with a message naming the method, the argument,
+and the types received. Multi-output methods return records (`FinishRequestResult`,
+`CertificatesResult`, `RevocationStatus`, `QueryApplicationsResult`, `QueryServersResult`).
+
+Optional outputs are normalized: a GDS answering a signing request may send either a null Variant
+or an empty ByteString for the `PrivateKey` output, and `FinishRequestResult.privateKey()` is null in
+both cases; `issuerCertificates()` is an empty array when the chain is not returned.
+`TrustListInfo.updateFrequency()` is null when the GDS does not expose the optional
+`UpdateFrequency` property.
+
+### TrustList files
+
+A TrustList is a `FileType` object whose body is the OPC UA Binary encoding of a bare
+`TrustListDataType`, not an `ExtensionObject` (Part 12 §7.8.2). `TrustListReader` calls `Open`
+with `OpenFileMode.Read`, loops `Read` until a chunk shorter than the requested length arrives,
+calls `Close` in all cases, and decodes the body with `TrustListDataType.Codec`; trailing bytes or a
+truncated body fail with `Bad_DecodingError` before anything is applied. The FileType methods are
+addressed by their `FileType` declaration ids (`FileType_Open` and so on), which Part 4 §5.12.2.2
+permits for any instance of a FileType subtype.
+
+The chunk size comes from the TrustList's optional `MaxByteStringLength` property, else 64 KiB,
+capped so a chunk fits inside the client's `EncodingLimits.getMaxMessageSize()`. An explicit-size
+overload exists for unusual servers.
+
+`TrustListApplier.apply` reads `SpecifiedLists` as `TrustListMasks` bits and replaces each
+specified list in the `TrustListManager` in full (`setIssuerCertificates`,
+`setTrustedCertificates`, `setIssuerCrls`, `setTrustedCrls`, in that order). Unspecified lists are
+untouched. Replacement rather than merging is what the Pull Model calls for: each specified list
+is the complete authoritative list, and a merge could never remove a certificate the GDS dropped.
+All entries are decoded before the first replacement, so a malformed certificate or CRL rejects the
+update and leaves the manager as it was.
+
+* * *
+
+## Usage
+
+Connect an ordinary `OpcUaClient` to the GDS with whatever identity and certificate validator the
+application chooses; the module makes no trust decisions. Then wrap it:
+
+```java
+GdsClient gds = GdsClient.create(client);
+
+// Part 12 §6.4: find first, register only when nothing is registered.
+ApplicationRecordDataType[] found = gds.findApplications(applicationUri);
+NodeId applicationId =
+    found.length == 0
+        ? gds.registerApplication(
+            new ApplicationRecordDataType(
+                NodeId.NULL_VALUE,
+                applicationUri,
+                ApplicationType.Client,
+                new LocalizedText[] {LocalizedText.english("My Application")},
+                productUri,
+                null,
+                null))
+        : found[0].getApplicationId();
+
+for (NodeId groupId : gds.getCertificateGroups(applicationId)) {
+  for (NodeId typeId : gds.readCertificateTypes(groupId)) {
+    if (gds.getCertificateStatus(applicationId, groupId, typeId)) {
+      ByteString csr = ByteString.of(CertificateUtil.generateCsr(keyPair, ...).getEncoded());
+      NodeId requestId = gds.startSigningRequest(applicationId, groupId, typeId, csr);
+      // Later, and again on Bad_NothingToDo:
+      FinishRequestResult issued = gds.finishRequest(applicationId, requestId);
+      X509Certificate certificate = CertificateUtil.decodeCertificate(issued.certificate().bytesOrEmpty());
+      GdsClient.verifyIssuedCertificate(certificate, keyPair.getPublic(), applicationUri);
+    }
+  }
+
+  NodeId trustListId = gds.getTrustList(applicationId, groupId);
+  TrustListInfo info = gds.readTrustListInfo(trustListId);
+  if (info.lastUpdateTime().getUtcTime() > lastApplied.getUtcTime()) {
+    TrustListDataType trustList = TrustListReader.read(client, trustListId);
+    TrustListApplier.apply(trustList, certificateGroup.getTrustListManager());
+  }
+}
+```
+
+Every method has an `...Async` twin returning a `CompletableFuture`. `StartSigningRequest`,
+`StartNewKeyPairRequest`, and `FinishRequest` need an encrypted channel, and `FinishRequest`
+should run on a channel using the same certificate as the matching start request (Part 12 §7.9.5).
+
+`GdsClient.verifyIssuedCertificate` checks that an issued certificate carries the caller's public
+key and ApplicationUri before it is installed. A certificate for the wrong key cannot be used for
+the channel and one with the wrong ApplicationUri is rejected by every peer, and neither problem is
+otherwise visible until a connection fails.
+
+A null CertificateTypeId means "the group's default". Some GDS implementations advertise abstract
+types in a CertificateGroup's `CertificateTypes` and reject them when passed back, so null is the
+portable choice when the list holds no concrete type the caller recognizes.
+
+`GdsPullExample` in `milo-examples/client-examples` runs the sequence once against a GDS named by
+the `gds.endpoint`, `gds.username`, and `gds.password` system properties, printing the issued
+certificate and the trust list counts without installing anything. While the GDS answers
+`Bad_NothingToDo`, the example polls `FinishRequest` every two seconds for up to a minute so an
+administrator can approve the request.
+
+* * *
+
+## Generated model
+
+The model is generated and checked in; no code generation runs in the Maven build. The source is
+the [opc-ua-gds-model](https://github.com/kevinherron/opc-ua-gds-model) repository at commit
+`efa229d` ("Regenerate model from GDS NodeSet2 1.05.07"), produced by the GDS generators in
+[opc-ua-codegen2](https://github.com/kevinherron/opc-ua-codegen2) from GDS NodeSet2 1.05.07 on a
+1.05.07 base, the same base as Milo's namespace 0 model. Every file is copied with its package
+rewritten and the Eclipse Milo license header prepended; nothing else changes.
+
+| Source package (`opc-ua-gds-model`)          | Milo package                                          | Module            |
+|----------------------------------------------|-------------------------------------------------------|-------------------|
+| `com.digitalpetri.opcua.gds`                 | `org.eclipse.milo.opcua.stack.core.gds`               | `stack-core`      |
+| `com.digitalpetri.opcua.gds.types`           | `org.eclipse.milo.opcua.stack.core.gds.types`         | `stack-core`      |
+| `com.digitalpetri.opcua.gds` (`BinaryDataTypeDictionaryInitializer` only) | `org.eclipse.milo.opcua.sdk.core.dtd.gds` | `dtd-core` |
+| `com.digitalpetri.opcua.gds.client`          | `org.eclipse.milo.opcua.sdk.client.gds`               | `sdk-client`      |
+| `com.digitalpetri.opcua.gds.client.objects`  | `org.eclipse.milo.opcua.sdk.client.gds.model.objects` | `sdk-client`      |
+| `com.digitalpetri.opcua.gds.server`          | `org.eclipse.milo.opcua.sdk.server.gds`               | `sdk-server`      |
+| `com.digitalpetri.opcua.gds.server.objects`  | `org.eclipse.milo.opcua.sdk.server.gds.model.objects` | `sdk-server`      |
+
+To pick up a new GDS NodeSet release:
+
+1. Regenerate in `opc-ua-gds-model` and commit there. Do not edit the Milo copy by hand.
+2. Copy `src/main/java` of `gds-model-core`, `gds-model-client`, and `gds-model-server` into the
+   Milo packages above, rewriting `package` and `import` lines by prefix (most specific prefix
+   first: `.client.objects` before `.client`, `.server.objects` before `.server`, `.types` before
+   the bare prefix). `BinaryDataTypeDictionaryInitializer` gets the `dtd-core` package because it
+   extends `DataTypeDictionaryInitializer` from that module.
+3. Prepend the EPL-2.0 header, run `mise exec -- mvn -q spotless:apply`, and compile.
+4. Update the commit and NodeSet version recorded in each `package-info.java` and in this
+   document.
+5. Diff the Milo packages against the source with the prefixes rewritten; only the header and
+   import order may differ.
+
+The GDS `DataTypeInitializer` and both `ObjectTypeInitializer`s take a `NamespaceTable` and must
+stay out of the namespace 0 startup path (`DefaultDataTypeManager.createAndInitialize` and the
+client and server namespace 0 initializers). `GdsClient.create` invokes them on the client side; a
+server hosting the GDS namespace invokes them itself after adding the URI to its table.
+
+* * *
+
+## Limitations
+
+- `GetCertificates`, `CheckRevocationStatus`, and `RevokeCertificate` are `Directory` instance
+  methods only from GDS NodeSet 1.05.07. Older deployments fail those wrappers with
+  `Bad_MethodInvalid` or `Bad_NodeIdUnknown`.
+- `StartNewKeyPairRequest` is a thin wrapper. No helper decodes the returned PFX or PEM private
+  key; prefer `StartSigningRequest` with a locally generated key pair.
+- `TrustListApplier.apply` issues four separate `set*` calls. `FileBasedTrustListManager` takes a
+  write lock per call, so a validation running concurrently can briefly see a mix of old and new
+  lists. Decoding first and applying issuer lists first bound the window.
+- KeyCredential management (Part 12 §8), AuthorizationServices (§9), and the GDS audit event types
+  are covered only by their generated model classes.

--- a/milo-bom/pom.xml
+++ b/milo-bom/pom.xml
@@ -53,6 +53,11 @@
       </dependency>
       <dependency>
         <groupId>org.eclipse.milo</groupId>
+        <artifactId>milo-sdk-client-gds</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.milo</groupId>
         <artifactId>milo-sdk-core</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/milo-examples/client-examples/pom.xml
+++ b/milo-examples/client-examples/pom.xml
@@ -36,6 +36,11 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.milo</groupId>
+      <artifactId>milo-sdk-client-gds</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.milo</groupId>
       <artifactId>milo-dtd-reader</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/GdsPullExample.java
+++ b/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/GdsPullExample.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.examples.client;
+
+import java.security.KeyPair;
+import java.security.cert.X509Certificate;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.client.gds.GdsClient;
+import org.eclipse.milo.opcua.sdk.client.gds.GdsClient.FinishRequestResult;
+import org.eclipse.milo.opcua.sdk.client.gds.GdsClient.TrustListInfo;
+import org.eclipse.milo.opcua.sdk.client.gds.TrustListApplier;
+import org.eclipse.milo.opcua.sdk.client.gds.TrustListReader;
+import org.eclipse.milo.opcua.sdk.client.identity.IdentityProvider;
+import org.eclipse.milo.opcua.sdk.client.identity.UsernameProvider;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.gds.types.ApplicationRecordDataType;
+import org.eclipse.milo.opcua.stack.core.security.MemoryTrustListManager;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.ApplicationType;
+import org.eclipse.milo.opcua.stack.core.types.structured.TrustListDataType;
+import org.eclipse.milo.opcua.stack.core.util.CertificateUtil;
+import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateGenerator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Runs the GDS Pull Model (OPC 10000-12 §7.6) once against a Global Discovery Server: find or
+ * register this client's application record, request a certificate for the default group, poll
+ * until it is issued, then read the group's TrustList.
+ *
+ * <p>Point it at a GDS with the {@code gds.endpoint}, {@code gds.username}, and {@code
+ * gds.password} system properties; the defaults match the OPC Foundation reference GDS from
+ * UA-.NETStandard. Registration and signing need an administrator account on most servers, and the
+ * GDS must trust the example client certificate (move it from its rejected store after the first
+ * attempt). The issued certificate and trust list are only printed; nothing is installed.
+ */
+public class GdsPullExample implements ClientExample {
+
+  public static void main(String[] args) throws Exception {
+    GdsPullExample example = new GdsPullExample();
+
+    new ClientExampleRunner(example, false).run();
+  }
+
+  private final Logger logger = LoggerFactory.getLogger(getClass());
+
+  @Override
+  public String getEndpointUrl() {
+    return System.getProperty("gds.endpoint", "opc.tcp://localhost:58810/GlobalDiscoveryServer");
+  }
+
+  @Override
+  public IdentityProvider getIdentityProvider() {
+    return new UsernameProvider(
+        System.getProperty("gds.username", "appadmin"), System.getProperty("gds.password", "demo"));
+  }
+
+  @Override
+  public void run(OpcUaClient client, CompletableFuture<OpcUaClient> future) throws Exception {
+    client.connect();
+
+    GdsClient gds = GdsClient.create(client);
+    String applicationUri = client.getConfig().getApplicationUri();
+
+    // Part 12 §6.4: look for an existing registration before creating one.
+    ApplicationRecordDataType[] found = gds.findApplications(applicationUri);
+    NodeId applicationId;
+    if (found.length == 0) {
+      applicationId = gds.registerApplication(clientRecord(client));
+      logger.info("Registered {} as {}", applicationUri, applicationId);
+    } else {
+      applicationId = found[0].getApplicationId();
+      logger.info("Found {} registration(s); using {}", found.length, applicationId);
+    }
+
+    NodeId groupId = gds.getCertificateGroups(applicationId)[0];
+    NodeId[] certificateTypes = gds.readCertificateTypes(groupId);
+    // Ask for RsaSha256 when the group advertises it, otherwise let the GDS pick the group's
+    // default: the list may hold only the abstract ApplicationCertificateType, which the
+    // reference GDS advertises but rejects as a CertificateTypeId.
+    NodeId certificateTypeId =
+        Arrays.asList(certificateTypes).contains(NodeIds.RsaSha256ApplicationCertificateType)
+            ? NodeIds.RsaSha256ApplicationCertificateType
+            : null;
+    logger.info(
+        "Group {} issues {}; update required: {}",
+        groupId,
+        Arrays.toString(certificateTypes),
+        gds.getCertificateStatus(applicationId, groupId, certificateTypeId));
+
+    // A throwaway key pair; a real application would use the key pair of the certificate it is
+    // renewing and install the result through its CertificateManager.
+    KeyPair keyPair = SelfSignedCertificateGenerator.generateRsaKeyPair(2048);
+    ByteString csr =
+        ByteString.of(
+            CertificateUtil.generateCsr(
+                    keyPair,
+                    "CN=Eclipse Milo GDS Pull Example",
+                    applicationUri,
+                    List.of("localhost"),
+                    List.of(),
+                    "SHA256withRSA")
+                .getEncoded());
+
+    NodeId requestId = gds.startSigningRequest(applicationId, groupId, certificateTypeId, csr);
+    logger.info("Signing request {} submitted", requestId);
+
+    FinishRequestResult issued = awaitIssued(gds, applicationId, requestId);
+    X509Certificate certificate =
+        CertificateUtil.decodeCertificate(issued.certificate().bytesOrEmpty());
+    GdsClient.verifyIssuedCertificate(certificate, keyPair.getPublic(), applicationUri);
+    logger.info(
+        "Issued certificate subject={} issuer={} notAfter={}",
+        certificate.getSubjectX500Principal(),
+        certificate.getIssuerX500Principal(),
+        certificate.getNotAfter());
+
+    NodeId trustListId = gds.getTrustList(applicationId, groupId);
+    TrustListInfo info = gds.readTrustListInfo(trustListId);
+    TrustListDataType trustList = TrustListReader.read(client, trustListId);
+
+    var trustListManager = new MemoryTrustListManager();
+    TrustListApplier.apply(trustList, trustListManager);
+    logger.info(
+        "TrustList {} (lastUpdateTime={}, updateFrequency={}): {} trusted certificates, {} trusted"
+            + " CRLs, {} issuer certificates, {} issuer CRLs",
+        trustListId,
+        info.lastUpdateTime(),
+        info.updateFrequency(),
+        trustListManager.getTrustedCertificates().size(),
+        trustListManager.getTrustedCrls().size(),
+        trustListManager.getIssuerCertificates().size(),
+        trustListManager.getIssuerCrls().size());
+
+    future.complete(client);
+  }
+
+  /** Poll FinishRequest while the GDS answers Bad_NothingToDo, i.e. while approval is pending. */
+  private FinishRequestResult awaitIssued(GdsClient gds, NodeId applicationId, NodeId requestId)
+      throws Exception {
+
+    for (int attempt = 1; ; attempt++) {
+      try {
+        return gds.finishRequest(applicationId, requestId);
+      } catch (UaException e) {
+        if (e.getStatusCode().value() != StatusCodes.Bad_NothingToDo || attempt >= 30) {
+          throw e;
+        }
+        logger.info("Request {} pending (attempt {}); approve it in the GDS", requestId, attempt);
+        TimeUnit.SECONDS.sleep(2);
+      }
+    }
+  }
+
+  private static ApplicationRecordDataType clientRecord(OpcUaClient client) {
+    return new ApplicationRecordDataType(
+        NodeId.NULL_VALUE,
+        client.getConfig().getApplicationUri(),
+        ApplicationType.Client,
+        new LocalizedText[] {client.getConfig().getApplicationName()},
+        client.getConfig().getProductUri(),
+        null,
+        null);
+  }
+}

--- a/opc-ua-sdk/dtd-core/src/main/java/org/eclipse/milo/opcua/sdk/core/dtd/gds/BinaryDataTypeDictionaryInitializer.java
+++ b/opc-ua-sdk/dtd-core/src/main/java/org/eclipse/milo/opcua/sdk/core/dtd/gds/BinaryDataTypeDictionaryInitializer.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.core.dtd.gds;
+
+import org.eclipse.milo.opcua.sdk.core.dtd.BinaryDataTypeCodec;
+import org.eclipse.milo.opcua.sdk.core.dtd.BinaryDataTypeDictionary;
+import org.eclipse.milo.opcua.sdk.core.dtd.DataTypeDictionaryInitializer;
+import org.eclipse.milo.opcua.stack.core.NamespaceTable;
+import org.eclipse.milo.opcua.stack.core.gds.types.ApplicationRecordDataType;
+import org.eclipse.milo.opcua.stack.core.types.DataTypeDictionary;
+
+public class BinaryDataTypeDictionaryInitializer extends DataTypeDictionaryInitializer {
+  @Override
+  protected void initializeStructs(
+      NamespaceTable namespaceTable, DataTypeDictionary binaryDictionary) throws Exception {
+    binaryDictionary.registerType(
+        new BinaryDataTypeDictionary.BinaryType(
+            "1:ApplicationRecordDataType",
+            ApplicationRecordDataType.TYPE_ID.toNodeIdOrThrow(namespaceTable),
+            ApplicationRecordDataType.BINARY_ENCODING_ID.toNodeIdOrThrow(namespaceTable),
+            BinaryDataTypeCodec.from(new ApplicationRecordDataType.Codec())));
+  }
+}

--- a/opc-ua-sdk/dtd-core/src/main/java/org/eclipse/milo/opcua/sdk/core/dtd/gds/package-info.java
+++ b/opc-ua-sdk/dtd-core/src/main/java/org/eclipse/milo/opcua/sdk/core/dtd/gds/package-info.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/**
+ * Legacy DataTypeDictionary registration for the OPC UA Global Discovery Server namespace.
+ *
+ * <p>{@link org.eclipse.milo.opcua.sdk.core.dtd.gds.BinaryDataTypeDictionaryInitializer} adds the
+ * {@code ApplicationRecordDataType} entry to the OPC UA Binary type dictionary, for applications
+ * that still exchange type information through OPC UA 1.03-style dictionaries instead of the
+ * DataTypeDefinition attribute. Like the rest of {@code org.eclipse.milo.opcua.sdk.core.dtd} it is
+ * deprecated for removal; new code should register the codec through {@link
+ * org.eclipse.milo.opcua.stack.core.gds.DataTypeInitializer} instead.
+ *
+ * <p>Generated code, copied from the {@code gds-model-core} module of <a
+ * href="https://github.com/kevinherron/opc-ua-gds-model">opc-ua-gds-model</a> at commit {@code
+ * efa229d}; see the regeneration notes in {@link org.eclipse.milo.opcua.stack.core.gds}.
+ */
+@Deprecated(forRemoval = true, since = "1.2.0")
+package org.eclipse.milo.opcua.sdk.core.dtd.gds;

--- a/opc-ua-sdk/integration-tests/pom.xml
+++ b/opc-ua-sdk/integration-tests/pom.xml
@@ -37,6 +37,12 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.milo</groupId>
+      <artifactId>milo-sdk-client-gds</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.milo</groupId>
       <artifactId>milo-dtd-reader</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/AbstractGdsClientTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/AbstractGdsClientTest.java
@@ -58,10 +58,10 @@ public abstract class AbstractGdsClientTest extends AbstractClientServerTest {
     gds.shutdown();
   }
 
-  protected static ApplicationRecordDataType clientRecord(String applicationUri) {
+  protected static ApplicationRecordDataType clientRecord() {
     return new ApplicationRecordDataType(
         NodeId.NULL_VALUE,
-        applicationUri,
+        APPLICATION_URI,
         ApplicationType.Client,
         new LocalizedText[] {LocalizedText.english("Milo GDS Test Client")},
         "urn:eclipse:milo:test:product",
@@ -70,7 +70,7 @@ public abstract class AbstractGdsClientTest extends AbstractClientServerTest {
   }
 
   protected NodeId registerTestApplication() throws UaException {
-    return gdsClient.registerApplication(clientRecord(APPLICATION_URI));
+    return gdsClient.registerApplication(clientRecord());
   }
 
   protected static ByteString csr(KeyPair keyPair, String applicationUri) throws Exception {

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/AbstractGdsClientTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/AbstractGdsClientTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.gds;
+
+import java.security.KeyPair;
+import java.util.List;
+import org.eclipse.milo.opcua.sdk.test.AbstractClientServerTest;
+import org.eclipse.milo.opcua.sdk.test.TestServer;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.gds.types.ApplicationRecordDataType;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.ApplicationType;
+import org.eclipse.milo.opcua.stack.core.util.CertificateUtil;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+
+/** A client/server test whose server hosts a {@link FakeGdsNamespace}. */
+public abstract class AbstractGdsClientTest extends AbstractClientServerTest {
+
+  protected static final String APPLICATION_URI = "urn:eclipse:milo:test:gds:application";
+
+  protected FakeGdsNamespace gds;
+  protected GdsClient gdsClient;
+
+  @Override
+  protected TestServer createTestServer() throws Exception {
+    TestServer testServer = super.createTestServer();
+
+    gds = new FakeGdsNamespace(testServer.getServer());
+    gds.startup();
+
+    return testServer;
+  }
+
+  @BeforeAll
+  void createGdsClient() throws UaException {
+    gdsClient = GdsClient.create(client);
+  }
+
+  @BeforeEach
+  void resetGds() {
+    gds.reset();
+  }
+
+  @AfterAll
+  void shutdownGds() {
+    gds.shutdown();
+  }
+
+  protected static ApplicationRecordDataType clientRecord(String applicationUri) {
+    return new ApplicationRecordDataType(
+        NodeId.NULL_VALUE,
+        applicationUri,
+        ApplicationType.Client,
+        new LocalizedText[] {LocalizedText.english("Milo GDS Test Client")},
+        "urn:eclipse:milo:test:product",
+        null,
+        null);
+  }
+
+  protected NodeId registerTestApplication() throws UaException {
+    return gdsClient.registerApplication(clientRecord(APPLICATION_URI));
+  }
+
+  protected static ByteString csr(KeyPair keyPair, String applicationUri) throws Exception {
+    return ByteString.of(
+        CertificateUtil.generateCsr(
+                keyPair,
+                "CN=Milo GDS Test Client",
+                applicationUri,
+                List.of(),
+                List.of(),
+                "SHA256withRSA")
+            .getEncoded());
+  }
+}

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/FakeGdsNamespace.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/FakeGdsNamespace.java
@@ -292,7 +292,7 @@ public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
     }
   }
 
-  private void addApplicationRecordDataType() throws UaException {
+  private void addApplicationRecordDataType() {
     NodeId dataTypeId = nodeId(GdsNodeIds.ApplicationRecordDataType);
     NodeId binaryEncodingId = nodeId(GdsNodeIds.ApplicationRecordDataType_Encoding_DefaultBinary);
 
@@ -386,12 +386,14 @@ public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
       NodeId parentReferenceTypeId) {
 
     UaObjectNode node =
-        UaObjectNode.builder(getNodeContext())
-            .setNodeId(nodeId)
-            .setBrowseName(browseName)
-            .setDisplayName(LocalizedText.english(browseName.name()))
-            .setTypeDefinition(typeDefinitionId)
-            .build();
+        UaObjectNode.build(
+            getNodeContext(),
+            b ->
+                b.setNodeId(nodeId)
+                    .setBrowseName(browseName)
+                    .setDisplayName(LocalizedText.english(browseName.name()))
+                    .setTypeDefinition(typeDefinitionId)
+                    .build());
 
     node.addReference(
         new Reference(
@@ -538,7 +540,7 @@ public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
         new Argument[] {argument("Data", NodeIds.ByteString, ValueRanks.Scalar)},
         inputs -> {
           UInteger handle = (UInteger) inputs[0].value();
-          int length = (Integer) inputs[1].value();
+          int length = Objects.requireNonNull((Integer) inputs[1].value());
 
           file.calls.add("Read(" + length + ")");
 
@@ -609,7 +611,7 @@ public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
             throw new UaException(StatusCodes.Bad_UserAccessDenied);
           }
 
-          var record = (ApplicationRecordDataType) inputs[0].value();
+          ApplicationRecordDataType record = applicationArgument(inputs[0]);
           NodeId applicationId = newNodeId("Applications/" + nextId.getAndIncrement());
 
           applications.put(applicationId, withId(record, applicationId));
@@ -624,7 +626,7 @@ public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
         new Argument[] {argument("Application", applicationRecordId, ValueRanks.Scalar)},
         new Argument[0],
         inputs -> {
-          var record = (ApplicationRecordDataType) inputs[0].value();
+          ApplicationRecordDataType record = applicationArgument(inputs[0]);
 
           requireApplication(record.getApplicationId());
           applications.put(record.getApplicationId(), record);
@@ -1053,6 +1055,14 @@ public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
     }
 
     return record;
+  }
+
+  private static ApplicationRecordDataType applicationArgument(Variant input) throws UaException {
+    if (input.value() instanceof ApplicationRecordDataType record) {
+      return record;
+    } else {
+      throw new UaException(StatusCodes.Bad_InvalidArgument);
+    }
   }
 
   private static ApplicationRecordDataType withId(

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/FakeGdsNamespace.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/FakeGdsNamespace.java
@@ -1,0 +1,1173 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.gds;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.cert.X509Certificate;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import org.bouncycastle.asn1.pkcs.Attribute;
+import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.Extensions;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.bouncycastle.pkcs.PKCS10CertificationRequest;
+import org.eclipse.milo.opcua.sdk.core.AccessLevel;
+import org.eclipse.milo.opcua.sdk.core.Reference;
+import org.eclipse.milo.opcua.sdk.core.ValueRanks;
+import org.eclipse.milo.opcua.sdk.server.ManagedNamespaceWithLifecycle;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.sdk.server.items.DataItem;
+import org.eclipse.milo.opcua.sdk.server.items.MonitoredItem;
+import org.eclipse.milo.opcua.sdk.server.methods.AbstractMethodInvocationHandler;
+import org.eclipse.milo.opcua.sdk.server.model.objects.DataTypeEncodingTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaDataTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaMethodNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.filters.AttributeFilters;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
+import org.eclipse.milo.opcua.stack.core.encoding.binary.OpcUaBinaryEncoder;
+import org.eclipse.milo.opcua.stack.core.gds.DataTypeInitializer;
+import org.eclipse.milo.opcua.stack.core.gds.GdsNodeIds;
+import org.eclipse.milo.opcua.stack.core.gds.types.ApplicationRecordDataType;
+import org.eclipse.milo.opcua.stack.core.types.DataTypeEncoding;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.OpenFileMode;
+import org.eclipse.milo.opcua.stack.core.types.structured.ApplicationDescription;
+import org.eclipse.milo.opcua.stack.core.types.structured.Argument;
+import org.eclipse.milo.opcua.stack.core.types.structured.ServerOnNetwork;
+import org.eclipse.milo.opcua.stack.core.types.structured.TrustListDataType;
+import org.eclipse.milo.opcua.stack.core.util.CertificateUtil;
+import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateBuilder;
+import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateGenerator;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * An in-memory GDS hosted on the test server: the GDS namespace, the {@code
+ * ApplicationRecordDataType}, the {@code Directory} object with every DirectoryType and
+ * CertificateDirectoryType method, two certificate groups, and their TrustList files.
+ *
+ * <p>Behaviour is deliberately simple and controllable from tests: registrations are kept in a map,
+ * signing requests are issued by a throwaway CA after a configurable number of {@code
+ * Bad_NothingToDo} polls, and each TrustList records the FileType calls made against it.
+ */
+public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
+
+  public static final String NAMESPACE_URI = GdsClient.NAMESPACE_URI;
+
+  /** Recorded FileType calls and served body of one TrustList object. */
+  public static final class TrustListFile {
+    private volatile byte[] body = new byte[0];
+    private volatile DateTime lastUpdateTime = DateTime.now();
+    private volatile int failReadAfter = -1;
+    private final AtomicInteger nextHandle = new AtomicInteger(1);
+    private final Map<UInteger, Integer> positions = new ConcurrentHashMap<>();
+    private final List<String> calls = new CopyOnWriteArrayList<>();
+
+    /** The FileType calls made so far, e.g. {@code Open}, {@code Read(4096)}, {@code Close}. */
+    public List<String> calls() {
+      return List.copyOf(calls);
+    }
+
+    void reset() {
+      calls.clear();
+      positions.clear();
+      failReadAfter = -1;
+    }
+
+    public DateTime lastUpdateTime() {
+      return lastUpdateTime;
+    }
+
+    /** Serve {@code trustList}, encoded as a bare structure (Part 12 §7.8.2). */
+    public void setTrustList(TrustListDataType trustList) {
+      setBody(encodeBare(trustList));
+    }
+
+    /** Serve raw bytes, e.g. a malformed body. */
+    public void setBody(byte[] body) {
+      this.body = body;
+      this.lastUpdateTime = DateTime.now();
+    }
+
+    /** Make Read fail with {@code Bad_UnexpectedError} after {@code reads} successful reads. */
+    public void failReadAfter(int reads) {
+      this.failReadAfter = reads;
+    }
+
+    public int openHandles() {
+      return positions.size();
+    }
+  }
+
+  private record SigningRequest(
+      NodeId applicationId, @Nullable PKCS10CertificationRequest csr, AtomicInteger polls) {}
+
+  private final KeyPair caKeyPair;
+  private final X509Certificate caCertificate;
+
+  private final Map<NodeId, ApplicationRecordDataType> applications = new ConcurrentHashMap<>();
+  private final Map<NodeId, SigningRequest> requests = new ConcurrentHashMap<>();
+  private final Map<NodeId, List<X509Certificate>> issued = new ConcurrentHashMap<>();
+  private final Set<ByteString> revoked = ConcurrentHashMap.newKeySet();
+  private final AtomicInteger nextId = new AtomicInteger(1);
+
+  private final TrustListFile applicationGroupTrustList = new TrustListFile();
+  private final TrustListFile userTokenGroupTrustList = new TrustListFile();
+
+  private volatile boolean registrationAllowed = true;
+  private volatile int pollsBeforeIssued = 0;
+  private volatile boolean rejectRequests = false;
+  private volatile boolean updateRequired = true;
+
+  public FakeGdsNamespace(OpcUaServer server) throws Exception {
+    super(server, NAMESPACE_URI);
+
+    caKeyPair = SelfSignedCertificateGenerator.generateRsaKeyPair(2048);
+    caCertificate =
+        new SelfSignedCertificateBuilder(caKeyPair)
+            .setCommonName("Fake GDS CA")
+            .setApplicationUri("urn:eclipse:milo:test:gds:ca")
+            .build();
+
+    getLifecycleManager().addStartupTask(this::addNodes);
+  }
+
+  // The GDS tests never subscribe to anything in this namespace.
+  @Override
+  public void onDataItemsCreated(List<DataItem> dataItems) {}
+
+  @Override
+  public void onDataItemsModified(List<DataItem> dataItems) {}
+
+  @Override
+  public void onDataItemsDeleted(List<DataItem> dataItems) {}
+
+  @Override
+  public void onMonitoringModeChanged(List<MonitoredItem> monitoredItems) {}
+
+  // region test knobs
+
+  public X509Certificate getCaCertificate() {
+    return caCertificate;
+  }
+
+  public TrustListFile getApplicationGroupTrustList() {
+    return applicationGroupTrustList;
+  }
+
+  /** The DefaultUserTokenGroup TrustList has no UpdateFrequency and no MaxByteStringLength. */
+  public TrustListFile getUserTokenGroupTrustList() {
+    return userTokenGroupTrustList;
+  }
+
+  public void setRegistrationAllowed(boolean registrationAllowed) {
+    this.registrationAllowed = registrationAllowed;
+  }
+
+  /**
+   * Number of FinishRequest calls that return {@code Bad_NothingToDo} before a request is issued.
+   */
+  public void setPollsBeforeIssued(int pollsBeforeIssued) {
+    this.pollsBeforeIssued = pollsBeforeIssued;
+  }
+
+  /** When true, FinishRequest fails with {@code Bad_RequestNotAllowed} for every request. */
+  public void setRejectRequests(boolean rejectRequests) {
+    this.rejectRequests = rejectRequests;
+  }
+
+  public void setUpdateRequired(boolean updateRequired) {
+    this.updateRequired = updateRequired;
+  }
+
+  public void reset() {
+    applications.clear();
+    requests.clear();
+    issued.clear();
+    revoked.clear();
+    registrationAllowed = true;
+    pollsBeforeIssued = 0;
+    rejectRequests = false;
+    updateRequired = true;
+    applicationGroupTrustList.reset();
+    userTokenGroupTrustList.reset();
+  }
+
+  public NodeId nodeId(ExpandedNodeId gdsNodeId) {
+    return gdsNodeId.toNodeId(getServer().getNamespaceTable()).orElseThrow();
+  }
+
+  // endregion
+
+  private void addNodes() {
+    try {
+      addApplicationRecordDataType();
+      addObjectTypes();
+
+      UaObjectNode directory =
+          addObject(
+              nodeId(GdsNodeIds.Directory),
+              newQualifiedName("Directory"),
+              nodeId(GdsNodeIds.CertificateDirectoryType),
+              NodeIds.ObjectsFolder,
+              NodeIds.Organizes);
+
+      UaObjectNode certificateGroups =
+          addObject(
+              nodeId(GdsNodeIds.Directory_CertificateGroups),
+              newQualifiedName("CertificateGroups"),
+              NodeIds.CertificateGroupFolderType,
+              directory.getNodeId(),
+              NodeIds.Organizes);
+
+      addCertificateGroup(
+          certificateGroups,
+          GdsNodeIds.Directory_CertificateGroups_DefaultApplicationGroup,
+          "DefaultApplicationGroup",
+          GdsNodeIds.Directory_CertificateGroups_DefaultApplicationGroup_CertificateTypes,
+          new NodeId[] {
+            NodeIds.RsaSha256ApplicationCertificateType,
+            NodeIds.EccNistP256ApplicationCertificateType
+          },
+          GdsNodeIds.Directory_CertificateGroups_DefaultApplicationGroup_TrustList,
+          applicationGroupTrustList,
+          true);
+
+      addCertificateGroup(
+          certificateGroups,
+          GdsNodeIds.Directory_CertificateGroups_DefaultUserTokenGroup,
+          "DefaultUserTokenGroup",
+          GdsNodeIds.Directory_CertificateGroups_DefaultUserTokenGroup_CertificateTypes,
+          new NodeId[] {NodeIds.RsaSha256ApplicationCertificateType},
+          GdsNodeIds.Directory_CertificateGroups_DefaultUserTokenGroup_TrustList,
+          userTokenGroupTrustList,
+          false);
+
+      addDirectoryMethods(directory);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private void addApplicationRecordDataType() throws UaException {
+    NodeId dataTypeId = nodeId(GdsNodeIds.ApplicationRecordDataType);
+    NodeId binaryEncodingId = nodeId(GdsNodeIds.ApplicationRecordDataType_Encoding_DefaultBinary);
+
+    var dataTypeNode =
+        new UaDataTypeNode(
+            getNodeContext(),
+            dataTypeId,
+            newQualifiedName("ApplicationRecordDataType"),
+            LocalizedText.english("ApplicationRecordDataType"),
+            LocalizedText.NULL_VALUE,
+            uint(0),
+            uint(0),
+            false);
+
+    dataTypeNode.addReference(
+        new Reference(
+            dataTypeId,
+            NodeIds.HasSubtype,
+            NodeIds.Structure.expanded(),
+            Reference.Direction.INVERSE));
+
+    dataTypeNode.setDataTypeDefinition(
+        ApplicationRecordDataType.definition(getServer().getNamespaceTable()));
+
+    getNodeManager().addNode(dataTypeNode);
+
+    var encodingNode =
+        new DataTypeEncodingTypeNode(
+            getNodeContext(),
+            binaryEncodingId,
+            DataTypeEncoding.BINARY_ENCODING_NAME,
+            LocalizedText.english("Default Binary"),
+            LocalizedText.NULL_VALUE,
+            uint(0),
+            uint(0),
+            null,
+            null,
+            null);
+
+    encodingNode.addReference(
+        new Reference(
+            binaryEncodingId,
+            NodeIds.HasTypeDefinition,
+            NodeIds.DataTypeEncodingType.expanded(),
+            Reference.Direction.FORWARD));
+    encodingNode.addReference(
+        new Reference(
+            binaryEncodingId,
+            NodeIds.HasEncoding,
+            dataTypeId.expanded(),
+            Reference.Direction.INVERSE));
+
+    getNodeManager().addNode(encodingNode);
+
+    DataTypeInitializer.initialize(
+        getServer().getNamespaceTable(), getServer().getStaticDataTypeManager());
+  }
+
+  private void addObjectTypes() {
+    addObjectType(nodeId(GdsNodeIds.DirectoryType), "DirectoryType", NodeIds.FolderType);
+    addObjectType(
+        nodeId(GdsNodeIds.CertificateDirectoryType),
+        "CertificateDirectoryType",
+        nodeId(GdsNodeIds.DirectoryType));
+  }
+
+  private void addObjectType(NodeId typeId, String name, NodeId supertypeId) {
+    var typeNode =
+        new UaObjectTypeNode(
+            getNodeContext(),
+            typeId,
+            newQualifiedName(name),
+            LocalizedText.english(name),
+            LocalizedText.NULL_VALUE,
+            uint(0),
+            uint(0),
+            false);
+
+    typeNode.addReference(
+        new Reference(
+            typeId, NodeIds.HasSubtype, supertypeId.expanded(), Reference.Direction.INVERSE));
+
+    getNodeManager().addNode(typeNode);
+  }
+
+  private UaObjectNode addObject(
+      NodeId nodeId,
+      QualifiedName browseName,
+      NodeId typeDefinitionId,
+      NodeId parentId,
+      NodeId parentReferenceTypeId) {
+
+    UaObjectNode node =
+        UaObjectNode.builder(getNodeContext())
+            .setNodeId(nodeId)
+            .setBrowseName(browseName)
+            .setDisplayName(LocalizedText.english(browseName.name()))
+            .setTypeDefinition(typeDefinitionId)
+            .build();
+
+    node.addReference(
+        new Reference(
+            nodeId, parentReferenceTypeId, parentId.expanded(), Reference.Direction.INVERSE));
+
+    getNodeManager().addNode(node);
+
+    return node;
+  }
+
+  private void addCertificateGroup(
+      UaObjectNode certificateGroups,
+      ExpandedNodeId groupId,
+      String name,
+      ExpandedNodeId certificateTypesId,
+      NodeId[] certificateTypes,
+      ExpandedNodeId trustListId,
+      TrustListFile file,
+      boolean optionalProperties) {
+
+    UaObjectNode group =
+        addObject(
+            nodeId(groupId),
+            new QualifiedName(0, name),
+            NodeIds.CertificateGroupType,
+            certificateGroups.getNodeId(),
+            NodeIds.HasComponent);
+
+    addProperty(
+        group,
+        nodeId(certificateTypesId),
+        "CertificateTypes",
+        NodeIds.NodeId,
+        ValueRanks.OneDimension,
+        new Variant(certificateTypes),
+        null);
+
+    UaObjectNode trustList =
+        addObject(
+            nodeId(trustListId),
+            new QualifiedName(0, "TrustList"),
+            NodeIds.TrustListType,
+            group.getNodeId(),
+            NodeIds.HasComponent);
+
+    addProperty(
+        trustList,
+        newNodeId(name + "/TrustList/LastUpdateTime"),
+        "LastUpdateTime",
+        NodeIds.UtcTime,
+        ValueRanks.Scalar,
+        new Variant(DateTime.MIN_VALUE),
+        () -> new Variant(file.lastUpdateTime));
+
+    if (optionalProperties) {
+      addProperty(
+          trustList,
+          newNodeId(name + "/TrustList/UpdateFrequency"),
+          "UpdateFrequency",
+          NodeIds.Duration,
+          ValueRanks.Scalar,
+          new Variant(60_000.0),
+          null);
+      addProperty(
+          trustList,
+          newNodeId(name + "/TrustList/MaxByteStringLength"),
+          "MaxByteStringLength",
+          NodeIds.UInt32,
+          ValueRanks.Scalar,
+          new Variant(uint(100)),
+          null);
+    }
+
+    addFileTypeMethods(trustList, name, file);
+  }
+
+  private void addProperty(
+      UaObjectNode parent,
+      NodeId nodeId,
+      String name,
+      NodeId dataTypeId,
+      int valueRank,
+      Variant value,
+      @Nullable Supplier<Variant> liveValue) {
+
+    UaVariableNode property =
+        new UaVariableNode.UaVariableNodeBuilder(getNodeContext())
+            .setNodeId(nodeId)
+            .setBrowseName(new QualifiedName(0, name))
+            .setDisplayName(LocalizedText.english(name))
+            .setDataType(dataTypeId)
+            .setValueRank(valueRank)
+            .setAccessLevel(AccessLevel.READ_ONLY)
+            .setUserAccessLevel(AccessLevel.READ_ONLY)
+            .setTypeDefinition(NodeIds.PropertyType)
+            .setValue(new DataValue(value))
+            .build();
+
+    if (liveValue != null) {
+      property
+          .getFilterChain()
+          .addLast(AttributeFilters.getValue(ctx -> new DataValue(liveValue.get())));
+    }
+
+    property.addReference(
+        new Reference(
+            nodeId,
+            NodeIds.HasProperty,
+            parent.getNodeId().expanded(),
+            Reference.Direction.INVERSE));
+
+    getNodeManager().addNode(property);
+  }
+
+  private void addFileTypeMethods(UaObjectNode trustList, String groupName, TrustListFile file) {
+    addMethod(
+        trustList,
+        newNodeId(groupName + "/TrustList/Open"),
+        new QualifiedName(0, "Open"),
+        new Argument[] {argument("Mode", NodeIds.Byte, ValueRanks.Scalar)},
+        new Argument[] {argument("FileHandle", NodeIds.UInt32, ValueRanks.Scalar)},
+        inputs -> {
+          file.calls.add("Open");
+
+          UByte mode = (UByte) inputs[0].value();
+          if (mode == null || mode.intValue() != OpenFileMode.Read.getValue()) {
+            throw new UaException(StatusCodes.Bad_InvalidArgument, "only Read mode is supported");
+          }
+
+          UInteger handle = uint(file.nextHandle.getAndIncrement());
+          file.positions.put(handle, 0);
+
+          return new Variant[] {Variant.ofUInt32(handle)};
+        });
+
+    addMethod(
+        trustList,
+        newNodeId(groupName + "/TrustList/Read"),
+        new QualifiedName(0, "Read"),
+        new Argument[] {
+          argument("FileHandle", NodeIds.UInt32, ValueRanks.Scalar),
+          argument("Length", NodeIds.Int32, ValueRanks.Scalar)
+        },
+        new Argument[] {argument("Data", NodeIds.ByteString, ValueRanks.Scalar)},
+        inputs -> {
+          UInteger handle = (UInteger) inputs[0].value();
+          int length = (Integer) inputs[1].value();
+
+          file.calls.add("Read(" + length + ")");
+
+          Integer position = file.positions.get(handle);
+          if (position == null) {
+            throw new UaException(StatusCodes.Bad_InvalidArgument, "unknown file handle");
+          }
+
+          long reads = file.calls.stream().filter(c -> c.startsWith("Read")).count();
+          if (file.failReadAfter >= 0 && reads > file.failReadAfter) {
+            throw new UaException(StatusCodes.Bad_UnexpectedError, "read failure injected");
+          }
+
+          byte[] body = file.body;
+          int end = Math.min(body.length, position + length);
+          byte[] chunk = Arrays.copyOfRange(body, Math.min(position, body.length), end);
+          file.positions.put(handle, end);
+
+          return new Variant[] {Variant.ofByteString(ByteString.of(chunk))};
+        });
+
+    addMethod(
+        trustList,
+        newNodeId(groupName + "/TrustList/Close"),
+        new QualifiedName(0, "Close"),
+        new Argument[] {argument("FileHandle", NodeIds.UInt32, ValueRanks.Scalar)},
+        new Argument[0],
+        inputs -> {
+          file.calls.add("Close");
+
+          UInteger handle = (UInteger) inputs[0].value();
+          if (file.positions.remove(handle) == null) {
+            throw new UaException(StatusCodes.Bad_InvalidArgument, "unknown file handle");
+          }
+
+          return new Variant[0];
+        });
+  }
+
+  private void addDirectoryMethods(UaObjectNode directory) {
+    NodeId applicationRecordId = nodeId(GdsNodeIds.ApplicationRecordDataType);
+
+    addMethod(
+        directory,
+        nodeId(GdsNodeIds.Directory_FindApplications),
+        newQualifiedName("FindApplications"),
+        new Argument[] {argument("ApplicationUri", NodeIds.String, ValueRanks.Scalar)},
+        new Argument[] {argument("Applications", applicationRecordId, ValueRanks.OneDimension)},
+        inputs -> {
+          String applicationUri = (String) inputs[0].value();
+
+          ApplicationRecordDataType[] matches =
+              applications.values().stream()
+                  .filter(a -> Objects.equals(a.getApplicationUri(), applicationUri))
+                  .toArray(ApplicationRecordDataType[]::new);
+
+          return new Variant[] {new Variant(matches)};
+        });
+
+    addMethod(
+        directory,
+        nodeId(GdsNodeIds.Directory_RegisterApplication),
+        newQualifiedName("RegisterApplication"),
+        new Argument[] {argument("Application", applicationRecordId, ValueRanks.Scalar)},
+        new Argument[] {argument("ApplicationId", NodeIds.NodeId, ValueRanks.Scalar)},
+        inputs -> {
+          if (!registrationAllowed) {
+            throw new UaException(StatusCodes.Bad_UserAccessDenied);
+          }
+
+          var record = (ApplicationRecordDataType) inputs[0].value();
+          NodeId applicationId = newNodeId("Applications/" + nextId.getAndIncrement());
+
+          applications.put(applicationId, withId(record, applicationId));
+
+          return new Variant[] {Variant.ofNodeId(applicationId)};
+        });
+
+    addMethod(
+        directory,
+        nodeId(GdsNodeIds.Directory_UpdateApplication),
+        newQualifiedName("UpdateApplication"),
+        new Argument[] {argument("Application", applicationRecordId, ValueRanks.Scalar)},
+        new Argument[0],
+        inputs -> {
+          var record = (ApplicationRecordDataType) inputs[0].value();
+
+          requireApplication(record.getApplicationId());
+          applications.put(record.getApplicationId(), record);
+
+          return new Variant[0];
+        });
+
+    addMethod(
+        directory,
+        nodeId(GdsNodeIds.Directory_UnregisterApplication),
+        newQualifiedName("UnregisterApplication"),
+        new Argument[] {argument("ApplicationId", NodeIds.NodeId, ValueRanks.Scalar)},
+        new Argument[0],
+        inputs -> {
+          NodeId applicationId = (NodeId) inputs[0].value();
+
+          requireApplication(applicationId);
+          applications.remove(applicationId);
+
+          return new Variant[0];
+        });
+
+    addMethod(
+        directory,
+        nodeId(GdsNodeIds.Directory_GetApplication),
+        newQualifiedName("GetApplication"),
+        new Argument[] {argument("ApplicationId", NodeIds.NodeId, ValueRanks.Scalar)},
+        new Argument[] {argument("Application", applicationRecordId, ValueRanks.Scalar)},
+        inputs -> {
+          NodeId applicationId = (NodeId) inputs[0].value();
+
+          return new Variant[] {new Variant(requireApplication(applicationId))};
+        });
+
+    addMethod(
+        directory,
+        nodeId(GdsNodeIds.Directory_QueryApplications),
+        newQualifiedName("QueryApplications"),
+        new Argument[] {
+          argument("StartingRecordId", NodeIds.UInt32, ValueRanks.Scalar),
+          argument("MaxRecordsToReturn", NodeIds.UInt32, ValueRanks.Scalar),
+          argument("ApplicationName", NodeIds.String, ValueRanks.Scalar),
+          argument("ApplicationUri", NodeIds.String, ValueRanks.Scalar),
+          argument("ApplicationType", NodeIds.UInt32, ValueRanks.Scalar),
+          argument("ProductUri", NodeIds.String, ValueRanks.Scalar),
+          argument("ServerCapabilities", NodeIds.String, ValueRanks.OneDimension)
+        },
+        new Argument[] {
+          argument("LastCounterResetTime", NodeIds.UtcTime, ValueRanks.Scalar),
+          argument("NextRecordId", NodeIds.UInt32, ValueRanks.Scalar),
+          argument("Applications", NodeIds.ApplicationDescription, ValueRanks.OneDimension)
+        },
+        inputs -> {
+          ApplicationDescription[] descriptions =
+              applications.values().stream()
+                  .map(FakeGdsNamespace::toDescription)
+                  .toArray(ApplicationDescription[]::new);
+
+          return new Variant[] {
+            Variant.ofDateTime(DateTime.MIN_VALUE),
+            Variant.ofUInt32(uint(0)),
+            new Variant(descriptions)
+          };
+        });
+
+    addMethod(
+        directory,
+        nodeId(GdsNodeIds.Directory_QueryServers),
+        newQualifiedName("QueryServers"),
+        new Argument[] {
+          argument("StartingRecordId", NodeIds.UInt32, ValueRanks.Scalar),
+          argument("MaxRecordsToReturn", NodeIds.UInt32, ValueRanks.Scalar),
+          argument("ApplicationName", NodeIds.String, ValueRanks.Scalar),
+          argument("ApplicationUri", NodeIds.String, ValueRanks.Scalar),
+          argument("ProductUri", NodeIds.String, ValueRanks.Scalar),
+          argument("ServerCapabilities", NodeIds.String, ValueRanks.OneDimension)
+        },
+        new Argument[] {
+          argument("LastCounterResetTime", NodeIds.UtcTime, ValueRanks.Scalar),
+          argument("Servers", NodeIds.ServerOnNetwork, ValueRanks.OneDimension)
+        },
+        inputs -> {
+          ServerOnNetwork[] servers =
+              applications.values().stream()
+                  .map(
+                      a ->
+                          new ServerOnNetwork(
+                              uint(0),
+                              a.getApplicationNames() != null && a.getApplicationNames().length > 0
+                                  ? a.getApplicationNames()[0].text()
+                                  : null,
+                              a.getDiscoveryUrls() != null && a.getDiscoveryUrls().length > 0
+                                  ? a.getDiscoveryUrls()[0]
+                                  : null,
+                              a.getServerCapabilities()))
+                  .toArray(ServerOnNetwork[]::new);
+
+          return new Variant[] {Variant.ofDateTime(DateTime.MIN_VALUE), new Variant(servers)};
+        });
+
+    addMethod(
+        directory,
+        nodeId(GdsNodeIds.Directory_StartSigningRequest),
+        newQualifiedName("StartSigningRequest"),
+        new Argument[] {
+          argument("ApplicationId", NodeIds.NodeId, ValueRanks.Scalar),
+          argument("CertificateGroupId", NodeIds.NodeId, ValueRanks.Scalar),
+          argument("CertificateTypeId", NodeIds.NodeId, ValueRanks.Scalar),
+          argument("CertificateRequest", NodeIds.ByteString, ValueRanks.Scalar)
+        },
+        new Argument[] {argument("RequestId", NodeIds.NodeId, ValueRanks.Scalar)},
+        inputs -> {
+          NodeId applicationId = (NodeId) inputs[0].value();
+          ByteString certificateRequest = (ByteString) inputs[3].value();
+
+          ApplicationRecordDataType record = requireApplication(applicationId);
+
+          PKCS10CertificationRequest csr = parseCsr(certificateRequest);
+
+          if (!Objects.equals(record.getApplicationUri(), sanUri(csr))) {
+            throw new UaException(StatusCodes.Bad_CertificateUriInvalid);
+          }
+
+          NodeId requestId = newNodeId("Requests/" + nextId.getAndIncrement());
+          requests.put(requestId, new SigningRequest(applicationId, csr, new AtomicInteger()));
+
+          return new Variant[] {Variant.ofNodeId(requestId)};
+        });
+
+    addMethod(
+        directory,
+        nodeId(GdsNodeIds.Directory_StartNewKeyPairRequest),
+        newQualifiedName("StartNewKeyPairRequest"),
+        new Argument[] {
+          argument("ApplicationId", NodeIds.NodeId, ValueRanks.Scalar),
+          argument("CertificateGroupId", NodeIds.NodeId, ValueRanks.Scalar),
+          argument("CertificateTypeId", NodeIds.NodeId, ValueRanks.Scalar),
+          argument("SubjectName", NodeIds.String, ValueRanks.Scalar),
+          argument("DomainNames", NodeIds.String, ValueRanks.OneDimension),
+          argument("PrivateKeyFormat", NodeIds.String, ValueRanks.Scalar),
+          argument("PrivateKeyPassword", NodeIds.String, ValueRanks.Scalar)
+        },
+        new Argument[] {argument("RequestId", NodeIds.NodeId, ValueRanks.Scalar)},
+        inputs -> {
+          NodeId applicationId = (NodeId) inputs[0].value();
+
+          requireApplication(applicationId);
+
+          NodeId requestId = newNodeId("Requests/" + nextId.getAndIncrement());
+          requests.put(requestId, new SigningRequest(applicationId, null, new AtomicInteger()));
+
+          return new Variant[] {Variant.ofNodeId(requestId)};
+        });
+
+    addMethod(
+        directory,
+        nodeId(GdsNodeIds.Directory_FinishRequest),
+        newQualifiedName("FinishRequest"),
+        new Argument[] {
+          argument("ApplicationId", NodeIds.NodeId, ValueRanks.Scalar),
+          argument("RequestId", NodeIds.NodeId, ValueRanks.Scalar)
+        },
+        new Argument[] {
+          argument("Certificate", NodeIds.ByteString, ValueRanks.Scalar),
+          argument("PrivateKey", NodeIds.ByteString, ValueRanks.Scalar),
+          argument("IssuerCertificates", NodeIds.ByteString, ValueRanks.OneDimension)
+        },
+        inputs -> {
+          NodeId applicationId = (NodeId) inputs[0].value();
+          NodeId requestId = (NodeId) inputs[1].value();
+
+          ApplicationRecordDataType record = requireApplication(applicationId);
+
+          SigningRequest request = requests.get(requestId);
+          if (request == null || !request.applicationId().equals(applicationId)) {
+            throw new UaException(StatusCodes.Bad_NotFound);
+          }
+          if (rejectRequests) {
+            throw new UaException(StatusCodes.Bad_RequestNotAllowed);
+          }
+          if (request.polls().getAndIncrement() < pollsBeforeIssued) {
+            throw new UaException(StatusCodes.Bad_NothingToDo);
+          }
+
+          try {
+            X509Certificate certificate;
+            // The reference GDS answers a signing request with an empty ByteString rather than a
+            // null Variant, so that is what a signing request returns here.
+            ByteString privateKey = ByteString.NULL_VALUE;
+
+            if (request.csr() != null) {
+              certificate = sign(request.csr());
+            } else {
+              KeyPair keyPair = SelfSignedCertificateGenerator.generateRsaKeyPair(2048);
+              certificate =
+                  sign(
+                      CertificateUtil.generateCsr(
+                          keyPair,
+                          "CN=" + record.getApplicationUri(),
+                          record.getApplicationUri(),
+                          List.of(),
+                          List.of(),
+                          "SHA256withRSA"));
+              privateKey = ByteString.of(keyPair.getPrivate().getEncoded());
+            }
+
+            issued
+                .computeIfAbsent(applicationId, k -> new CopyOnWriteArrayList<>())
+                .add(certificate);
+            requests.remove(requestId);
+
+            return new Variant[] {
+              Variant.ofByteString(ByteString.of(certificate.getEncoded())),
+              Variant.ofByteString(privateKey),
+              Variant.ofByteStringArray(
+                  new ByteString[] {ByteString.of(caCertificate.getEncoded())})
+            };
+          } catch (Exception e) {
+            throw new UaException(StatusCodes.Bad_InternalError, e);
+          }
+        });
+
+    addMethod(
+        directory,
+        nodeId(GdsNodeIds.Directory_GetCertificateGroups),
+        newQualifiedName("GetCertificateGroups"),
+        new Argument[] {argument("ApplicationId", NodeIds.NodeId, ValueRanks.Scalar)},
+        new Argument[] {argument("CertificateGroupIds", NodeIds.NodeId, ValueRanks.OneDimension)},
+        inputs -> {
+          requireApplication((NodeId) inputs[0].value());
+
+          return new Variant[] {
+            Variant.ofNodeIdArray(
+                new NodeId[] {
+                  nodeId(GdsNodeIds.Directory_CertificateGroups_DefaultApplicationGroup),
+                  nodeId(GdsNodeIds.Directory_CertificateGroups_DefaultUserTokenGroup)
+                })
+          };
+        });
+
+    addMethod(
+        directory,
+        nodeId(GdsNodeIds.Directory_GetCertificates),
+        newQualifiedName("GetCertificates"),
+        new Argument[] {
+          argument("ApplicationId", NodeIds.NodeId, ValueRanks.Scalar),
+          argument("CertificateGroupId", NodeIds.NodeId, ValueRanks.Scalar)
+        },
+        new Argument[] {
+          argument("CertificateTypeIds", NodeIds.NodeId, ValueRanks.OneDimension),
+          argument("Certificates", NodeIds.ByteString, ValueRanks.OneDimension)
+        },
+        inputs -> {
+          NodeId applicationId = (NodeId) inputs[0].value();
+          requireApplication(applicationId);
+
+          List<X509Certificate> certificates = issued.getOrDefault(applicationId, List.of());
+          var typeIds = new NodeId[certificates.size()];
+          var encoded = new ByteString[certificates.size()];
+
+          try {
+            for (int i = 0; i < certificates.size(); i++) {
+              typeIds[i] = NodeIds.RsaSha256ApplicationCertificateType;
+              encoded[i] = ByteString.of(certificates.get(i).getEncoded());
+            }
+          } catch (Exception e) {
+            throw new UaException(StatusCodes.Bad_InternalError, e);
+          }
+
+          return new Variant[] {Variant.ofNodeIdArray(typeIds), Variant.ofByteStringArray(encoded)};
+        });
+
+    addMethod(
+        directory,
+        nodeId(GdsNodeIds.Directory_GetTrustList),
+        newQualifiedName("GetTrustList"),
+        new Argument[] {
+          argument("ApplicationId", NodeIds.NodeId, ValueRanks.Scalar),
+          argument("CertificateGroupId", NodeIds.NodeId, ValueRanks.Scalar)
+        },
+        new Argument[] {argument("TrustListId", NodeIds.NodeId, ValueRanks.Scalar)},
+        inputs -> {
+          requireApplication((NodeId) inputs[0].value());
+
+          NodeId groupId = (NodeId) inputs[1].value();
+
+          if (groupId == null
+              || groupId.isNull()
+              || groupId.equals(
+                  nodeId(GdsNodeIds.Directory_CertificateGroups_DefaultApplicationGroup))) {
+            return new Variant[] {
+              Variant.ofNodeId(
+                  nodeId(GdsNodeIds.Directory_CertificateGroups_DefaultApplicationGroup_TrustList))
+            };
+          } else if (groupId.equals(
+              nodeId(GdsNodeIds.Directory_CertificateGroups_DefaultUserTokenGroup))) {
+            return new Variant[] {
+              Variant.ofNodeId(
+                  nodeId(GdsNodeIds.Directory_CertificateGroups_DefaultUserTokenGroup_TrustList))
+            };
+          } else {
+            throw new UaException(StatusCodes.Bad_NotFound);
+          }
+        });
+
+    addMethod(
+        directory,
+        nodeId(GdsNodeIds.Directory_GetCertificateStatus),
+        newQualifiedName("GetCertificateStatus"),
+        new Argument[] {
+          argument("ApplicationId", NodeIds.NodeId, ValueRanks.Scalar),
+          argument("CertificateGroupId", NodeIds.NodeId, ValueRanks.Scalar),
+          argument("CertificateTypeId", NodeIds.NodeId, ValueRanks.Scalar)
+        },
+        new Argument[] {argument("UpdateRequired", NodeIds.Boolean, ValueRanks.Scalar)},
+        inputs -> {
+          requireApplication((NodeId) inputs[0].value());
+
+          return new Variant[] {Variant.ofBoolean(updateRequired)};
+        });
+
+    addMethod(
+        directory,
+        nodeId(GdsNodeIds.Directory_RevokeCertificate),
+        newQualifiedName("RevokeCertificate"),
+        new Argument[] {
+          argument("ApplicationId", NodeIds.NodeId, ValueRanks.Scalar),
+          argument("Certificate", NodeIds.ByteString, ValueRanks.Scalar)
+        },
+        new Argument[0],
+        inputs -> {
+          requireApplication((NodeId) inputs[0].value());
+
+          revoked.add((ByteString) inputs[1].value());
+
+          return new Variant[0];
+        });
+
+    addMethod(
+        directory,
+        nodeId(GdsNodeIds.Directory_CheckRevocationStatus),
+        newQualifiedName("CheckRevocationStatus"),
+        new Argument[] {argument("Certificate", NodeIds.ByteString, ValueRanks.Scalar)},
+        new Argument[] {
+          argument("CertificateStatus", NodeIds.StatusCode, ValueRanks.Scalar),
+          argument("ValidityTime", NodeIds.UtcTime, ValueRanks.Scalar)
+        },
+        inputs -> {
+          ByteString certificate = (ByteString) inputs[0].value();
+
+          StatusCode status =
+              revoked.contains(certificate)
+                  ? new StatusCode(StatusCodes.Bad_CertificateRevoked)
+                  : StatusCode.GOOD;
+
+          return new Variant[] {
+            Variant.ofStatusCode(status),
+            Variant.ofDateTime(new DateTime(new Date(System.currentTimeMillis() + 3_600_000)))
+          };
+        });
+  }
+
+  @FunctionalInterface
+  private interface MethodBody {
+    Variant[] invoke(Variant[] inputs) throws UaException;
+  }
+
+  private void addMethod(
+      UaObjectNode parent,
+      NodeId nodeId,
+      QualifiedName browseName,
+      Argument[] inputArguments,
+      Argument[] outputArguments,
+      MethodBody body) {
+
+    UaMethodNode methodNode =
+        UaMethodNode.builder(getNodeContext())
+            .setNodeId(nodeId)
+            .setBrowseName(browseName)
+            .setDisplayName(LocalizedText.english(browseName.name()))
+            .build();
+
+    methodNode.addReference(
+        new Reference(
+            nodeId,
+            NodeIds.HasComponent,
+            parent.getNodeId().expanded(),
+            Reference.Direction.INVERSE));
+
+    methodNode.setInputArguments(inputArguments);
+    methodNode.setOutputArguments(outputArguments);
+    methodNode.setInvocationHandler(
+        new AbstractMethodInvocationHandler(methodNode) {
+          @Override
+          public Argument[] getInputArguments() {
+            return inputArguments;
+          }
+
+          @Override
+          public Argument[] getOutputArguments() {
+            return outputArguments;
+          }
+
+          @Override
+          protected Variant[] invoke(InvocationContext invocationContext, Variant[] inputValues)
+              throws UaException {
+            return body.invoke(inputValues);
+          }
+        });
+
+    getNodeManager().addNode(methodNode);
+  }
+
+  private static Argument argument(String name, NodeId dataTypeId, int valueRank) {
+    return new Argument(name, dataTypeId, valueRank, null, LocalizedText.NULL_VALUE);
+  }
+
+  private ApplicationRecordDataType requireApplication(@Nullable NodeId applicationId)
+      throws UaException {
+
+    ApplicationRecordDataType record =
+        applicationId != null ? applications.get(applicationId) : null;
+
+    if (record == null) {
+      throw new UaException(StatusCodes.Bad_NotFound);
+    }
+
+    return record;
+  }
+
+  private static ApplicationRecordDataType withId(
+      ApplicationRecordDataType record, NodeId applicationId) {
+
+    return new ApplicationRecordDataType(
+        applicationId,
+        record.getApplicationUri(),
+        record.getApplicationType(),
+        record.getApplicationNames(),
+        record.getProductUri(),
+        record.getDiscoveryUrls(),
+        record.getServerCapabilities());
+  }
+
+  private static ApplicationDescription toDescription(ApplicationRecordDataType record) {
+    LocalizedText[] names = record.getApplicationNames();
+
+    return new ApplicationDescription(
+        record.getApplicationUri(),
+        record.getProductUri(),
+        names != null && names.length > 0 ? names[0] : LocalizedText.NULL_VALUE,
+        record.getApplicationType(),
+        null,
+        null,
+        record.getDiscoveryUrls());
+  }
+
+  private static PKCS10CertificationRequest parseCsr(@Nullable ByteString certificateRequest)
+      throws UaException {
+
+    try {
+      return new PKCS10CertificationRequest(
+          certificateRequest != null ? certificateRequest.bytesOrEmpty() : new byte[0]);
+    } catch (Exception e) {
+      throw new UaException(StatusCodes.Bad_InvalidArgument, "certificateRequest", e);
+    }
+  }
+
+  private static @Nullable String sanUri(PKCS10CertificationRequest csr) {
+    Extensions extensions = requestedExtensions(csr);
+    GeneralNames names =
+        extensions != null
+            ? GeneralNames.fromExtensions(extensions, Extension.subjectAlternativeName)
+            : null;
+
+    if (names == null) {
+      return null;
+    }
+
+    return Arrays.stream(names.getNames())
+        .filter(n -> n.getTagNo() == GeneralName.uniformResourceIdentifier)
+        .map(n -> n.getName().toString())
+        .findFirst()
+        .orElse(null);
+  }
+
+  private static @Nullable Extensions requestedExtensions(PKCS10CertificationRequest csr) {
+    Attribute[] attributes = csr.getAttributes(PKCSObjectIdentifiers.pkcs_9_at_extensionRequest);
+
+    if (attributes.length == 0) {
+      return null;
+    }
+
+    return Extensions.getInstance(attributes[0].getAttrValues().getObjectAt(0));
+  }
+
+  private X509Certificate sign(PKCS10CertificationRequest csr) throws Exception {
+    var builder =
+        new X509v3CertificateBuilder(
+            X500Name.getInstance(caCertificate.getSubjectX500Principal().getEncoded()),
+            BigInteger.valueOf(System.nanoTime()),
+            new Date(System.currentTimeMillis() - 60_000),
+            new Date(System.currentTimeMillis() + 365L * 24 * 3_600_000),
+            csr.getSubject(),
+            csr.getSubjectPublicKeyInfo());
+
+    Extensions extensions = requestedExtensions(csr);
+    Extension san =
+        extensions != null ? extensions.getExtension(Extension.subjectAlternativeName) : null;
+    if (san != null) {
+      builder.addExtension(san);
+    }
+
+    return new JcaX509CertificateConverter()
+        .getCertificate(
+            builder.build(
+                new JcaContentSignerBuilder("SHA256withRSA").build(caKeyPair.getPrivate())));
+  }
+
+  static byte[] encodeBare(TrustListDataType trustList) {
+    ByteBuf buffer = Unpooled.buffer();
+    try {
+      var encoder = new OpcUaBinaryEncoder(DefaultEncodingContext.INSTANCE).setBuffer(buffer);
+      new TrustListDataType.Codec().encodeType(DefaultEncodingContext.INSTANCE, encoder, trustList);
+      return ByteBufUtil.getBytes(buffer);
+    } finally {
+      buffer.release();
+    }
+  }
+
+  /** The Directory's DefaultApplicationGroup id in the server's namespace table. */
+  public NodeId defaultApplicationGroupId() {
+    return nodeId(GdsNodeIds.Directory_CertificateGroups_DefaultApplicationGroup);
+  }
+
+  public NodeId defaultUserTokenGroupId() {
+    return nodeId(GdsNodeIds.Directory_CertificateGroups_DefaultUserTokenGroup);
+  }
+
+  public NodeId defaultApplicationGroupTrustListId() {
+    return nodeId(GdsNodeIds.Directory_CertificateGroups_DefaultApplicationGroup_TrustList);
+  }
+
+  public NodeId defaultUserTokenGroupTrustListId() {
+    return nodeId(GdsNodeIds.Directory_CertificateGroups_DefaultUserTokenGroup_TrustList);
+  }
+}

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/GdsClientTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/GdsClientTest.java
@@ -105,7 +105,7 @@ public class GdsClientTest extends AbstractGdsClientTest {
     void registerApplicationWithoutAdminRoleFailsWithBadUserAccessDenied() {
       gds.setRegistrationAllowed(false);
 
-      UaException e = assertThrows(UaException.class, () -> registerTestApplication());
+      UaException e = assertThrows(UaException.class, GdsClientTest.this::registerTestApplication);
 
       assertEquals(StatusCodes.Bad_UserAccessDenied, e.getStatusCode().value());
       assertInstanceOf(UaMethodException.class, e, "carries the method result");
@@ -424,7 +424,7 @@ public class GdsClientTest extends AbstractGdsClientTest {
       ApplicationRecordDataType[] found = gdsClient.findApplications(APPLICATION_URI);
       NodeId applicationId =
           found.length == 0
-              ? gdsClient.registerApplication(clientRecord(APPLICATION_URI))
+              ? gdsClient.registerApplication(clientRecord())
               : found[0].getApplicationId();
 
       NodeId groupId = gdsClient.getCertificateGroups(applicationId)[0];

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/GdsClientTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/GdsClientTest.java
@@ -1,0 +1,451 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.gds;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.security.KeyPair;
+import java.security.cert.X509Certificate;
+import java.util.List;
+import org.eclipse.milo.opcua.sdk.client.gds.GdsClient.CertificatesResult;
+import org.eclipse.milo.opcua.sdk.client.gds.GdsClient.FinishRequestResult;
+import org.eclipse.milo.opcua.sdk.client.gds.GdsClient.QueryApplicationsResult;
+import org.eclipse.milo.opcua.sdk.client.gds.GdsClient.QueryServersResult;
+import org.eclipse.milo.opcua.sdk.client.gds.GdsClient.RevocationStatus;
+import org.eclipse.milo.opcua.sdk.client.gds.GdsClient.TrustListInfo;
+import org.eclipse.milo.opcua.sdk.client.gds.model.objects.CertificateDirectoryTypeNode;
+import org.eclipse.milo.opcua.sdk.client.methods.UaMethodException;
+import org.eclipse.milo.opcua.sdk.client.nodes.UaObjectNode;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.gds.GdsNodeIds;
+import org.eclipse.milo.opcua.stack.core.gds.types.ApplicationRecordDataType;
+import org.eclipse.milo.opcua.stack.core.security.MemoryTrustListManager;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.ApplicationType;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.TrustListMasks;
+import org.eclipse.milo.opcua.stack.core.types.structured.TrustListDataType;
+import org.eclipse.milo.opcua.stack.core.util.CertificateUtil;
+import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class GdsClientTest extends AbstractGdsClientTest {
+
+  @Nested
+  class Creation {
+
+    @Test
+    void createResolvesTheNamespaceIndexAndDirectoryFromTheServer() {
+      assertEquals(gds.nodeId(GdsNodeIds.Directory), gdsClient.getDirectoryId());
+      assertEquals(gds.getNamespaceIndex(), gdsClient.getDirectoryId().getNamespaceIndex());
+    }
+
+    // The generated client model is only useful if create() registered it: the Directory must come
+    // back as the typed node class and its navigation must resolve the GDS-namespace browse names.
+    @Test
+    void createRegistersGdsObjectTypesSoDirectoryResolvesToCertificateDirectoryTypeNode()
+        throws Exception {
+
+      UaObjectNode directory = client.getAddressSpace().getObjectNode(gdsClient.getDirectoryId());
+
+      CertificateDirectoryTypeNode typed =
+          assertInstanceOf(CertificateDirectoryTypeNode.class, directory);
+      assertEquals(
+          gds.nodeId(GdsNodeIds.Directory_CertificateGroups),
+          typed.getCertificateGroupsNode().getNodeId());
+    }
+  }
+
+  @Nested
+  class Registration {
+
+    @Test
+    void findApplicationsReturnsEmptyForAnUnknownUri() throws Exception {
+      ApplicationRecordDataType[] found = gdsClient.findApplications("urn:nobody");
+
+      assertEquals(0, found.length);
+    }
+
+    // Part 12 §6.4: an application registers once and then finds itself by ApplicationUri; the
+    // record round-trips through the GDS-namespace codec in both directions.
+    @Test
+    void registerThenFindReturnsTheRecordWithTheAssignedId() throws Exception {
+      NodeId applicationId = registerTestApplication();
+
+      ApplicationRecordDataType[] found = gdsClient.findApplications(APPLICATION_URI);
+
+      assertEquals(1, found.length);
+      assertEquals(applicationId, found[0].getApplicationId());
+      assertEquals(APPLICATION_URI, found[0].getApplicationUri());
+      assertEquals(ApplicationType.Client, found[0].getApplicationType());
+      assertEquals(found[0], gdsClient.getApplication(applicationId));
+    }
+
+    @Test
+    void registerApplicationWithoutAdminRoleFailsWithBadUserAccessDenied() {
+      gds.setRegistrationAllowed(false);
+
+      UaException e = assertThrows(UaException.class, () -> registerTestApplication());
+
+      assertEquals(StatusCodes.Bad_UserAccessDenied, e.getStatusCode().value());
+      assertInstanceOf(UaMethodException.class, e, "carries the method result");
+    }
+
+    @Test
+    void getApplicationOfUnknownIdFailsWithBadNotFound() {
+      UaException e =
+          assertThrows(UaException.class, () -> gdsClient.getApplication(newNodeId("nope")));
+
+      assertEquals(StatusCodes.Bad_NotFound, e.getStatusCode().value());
+    }
+
+    @Test
+    void updateApplicationReplacesTheStoredRecord() throws Exception {
+      NodeId applicationId = registerTestApplication();
+      var updated =
+          new ApplicationRecordDataType(
+              applicationId,
+              APPLICATION_URI,
+              ApplicationType.ClientAndServer,
+              new LocalizedText[] {LocalizedText.english("Renamed")},
+              "urn:eclipse:milo:test:product:2",
+              new String[] {"opc.tcp://localhost:4840"},
+              new String[] {"NA"});
+
+      gdsClient.updateApplication(updated);
+
+      assertEquals(updated, gdsClient.getApplication(applicationId));
+    }
+
+    @Test
+    void unregisterApplicationRemovesTheRecord() throws Exception {
+      NodeId applicationId = registerTestApplication();
+
+      gdsClient.unregisterApplication(applicationId);
+
+      assertEquals(0, gdsClient.findApplications(APPLICATION_URI).length);
+    }
+
+    @Test
+    void queryApplicationsDecodesApplicationDescriptions() throws Exception {
+      registerTestApplication();
+
+      QueryApplicationsResult result =
+          gdsClient.queryApplications(uint(0), uint(0), null, null, uint(0), null, null);
+
+      assertEquals(1, result.applications().length);
+      assertEquals(APPLICATION_URI, result.applications()[0].getApplicationUri());
+      assertNotNull(result.lastCounterResetTime());
+      assertEquals(uint(0), result.nextRecordId());
+    }
+
+    @Test
+    void queryServersDecodesServerOnNetworkRecords() throws Exception {
+      registerTestApplication();
+
+      QueryServersResult result = gdsClient.queryServers(uint(0), uint(0), null, null, null, null);
+
+      assertEquals(1, result.servers().length);
+      assertEquals("Milo GDS Test Client", result.servers()[0].getServerName());
+    }
+  }
+
+  @Nested
+  class CertificateGroups {
+
+    @Test
+    void getCertificateGroupsReturnsTheGroupsAndReadCertificateTypesReadsEachGroupsProperty()
+        throws Exception {
+
+      NodeId applicationId = registerTestApplication();
+
+      NodeId[] groups = gdsClient.getCertificateGroups(applicationId);
+
+      assertArrayEquals(
+          new NodeId[] {gds.defaultApplicationGroupId(), gds.defaultUserTokenGroupId()}, groups);
+      assertArrayEquals(
+          new NodeId[] {
+            NodeIds.RsaSha256ApplicationCertificateType,
+            NodeIds.EccNistP256ApplicationCertificateType
+          },
+          gdsClient.readCertificateTypes(groups[0]));
+      assertArrayEquals(
+          new NodeId[] {NodeIds.RsaSha256ApplicationCertificateType},
+          gdsClient.readCertificateTypes(groups[1]));
+    }
+
+    @Test
+    void readCertificateTypesOfAnObjectWithoutThePropertyFailsWithBadNotFound() {
+      UaException e =
+          assertThrows(
+              UaException.class, () -> gdsClient.readCertificateTypes(gdsClient.getDirectoryId()));
+
+      assertEquals(StatusCodes.Bad_NotFound, e.getStatusCode().value());
+    }
+
+    @Test
+    void getCertificateStatusReportsWhetherAnUpdateIsRequired() throws Exception {
+      NodeId applicationId = registerTestApplication();
+
+      gds.setUpdateRequired(true);
+      assertTrue(gdsClient.getCertificateStatus(applicationId, null, null));
+
+      gds.setUpdateRequired(false);
+      assertFalse(gdsClient.getCertificateStatus(applicationId, null, null));
+    }
+
+    @Test
+    void getTrustListReturnsTheGroupsTrustListAndReadTrustListInfoReadsItsProperties()
+        throws Exception {
+
+      NodeId applicationId = registerTestApplication();
+
+      NodeId trustListId = gdsClient.getTrustList(applicationId, gds.defaultApplicationGroupId());
+      TrustListInfo info = gdsClient.readTrustListInfo(trustListId);
+
+      assertEquals(gds.defaultApplicationGroupTrustListId(), trustListId);
+      assertEquals(gds.getApplicationGroupTrustList().lastUpdateTime(), info.lastUpdateTime());
+      assertEquals(60_000.0, info.updateFrequency());
+    }
+
+    // UpdateFrequency is optional on TrustListType; a GDS that omits it must not make the whole
+    // read fail, the Pull client just has no server-suggested cycle period.
+    @Test
+    void readTrustListInfoReturnsNullUpdateFrequencyWhenTheGdsOmitsIt() throws Exception {
+      NodeId applicationId = registerTestApplication();
+
+      NodeId trustListId = gdsClient.getTrustList(applicationId, gds.defaultUserTokenGroupId());
+      TrustListInfo info = gdsClient.readTrustListInfo(trustListId);
+
+      assertEquals(gds.defaultUserTokenGroupTrustListId(), trustListId);
+      assertNull(info.updateFrequency());
+    }
+
+    @Test
+    void getTrustListOfUnknownGroupFailsWithBadNotFound() throws Exception {
+      NodeId applicationId = registerTestApplication();
+
+      UaException e =
+          assertThrows(
+              UaException.class, () -> gdsClient.getTrustList(applicationId, newNodeId("nope")));
+
+      assertEquals(StatusCodes.Bad_NotFound, e.getStatusCode().value());
+    }
+  }
+
+  @Nested
+  class CertificateRequests {
+
+    // Part 12 §7.9.3: the CSR's ApplicationUri must match the record, and the GDS's rejection code
+    // must reach the caller unchanged so it can tell a bad request from a pending one.
+    @Test
+    void startSigningRequestWithMismatchedApplicationUriFailsWithBadCertificateUriInvalid()
+        throws Exception {
+
+      NodeId applicationId = registerTestApplication();
+      KeyPair keyPair = SelfSignedCertificateGenerator.generateRsaKeyPair(2048);
+
+      UaException e =
+          assertThrows(
+              UaException.class,
+              () ->
+                  gdsClient.startSigningRequest(
+                      applicationId, null, null, csr(keyPair, "urn:someone:else")));
+
+      assertEquals(StatusCodes.Bad_CertificateUriInvalid, e.getStatusCode().value());
+    }
+
+    // Part 12 §7.6: FinishRequest answers Bad_NothingToDo until the request is approved; the
+    // caller polls on that code and must not treat it as a rejection.
+    @Test
+    void finishRequestFailsWithBadNothingToDoUntilTheCertificateIsIssued() throws Exception {
+      gds.setPollsBeforeIssued(2);
+      NodeId applicationId = registerTestApplication();
+      KeyPair keyPair = SelfSignedCertificateGenerator.generateRsaKeyPair(2048);
+
+      NodeId requestId =
+          gdsClient.startSigningRequest(
+              applicationId,
+              gds.defaultApplicationGroupId(),
+              NodeIds.RsaSha256ApplicationCertificateType,
+              csr(keyPair, APPLICATION_URI));
+
+      UaException first =
+          assertThrows(UaException.class, () -> gdsClient.finishRequest(applicationId, requestId));
+      UaException second =
+          assertThrows(UaException.class, () -> gdsClient.finishRequest(applicationId, requestId));
+      FinishRequestResult issued = gdsClient.finishRequest(applicationId, requestId);
+
+      assertEquals(StatusCodes.Bad_NothingToDo, first.getStatusCode().value());
+      assertEquals(StatusCodes.Bad_NothingToDo, second.getStatusCode().value());
+
+      X509Certificate certificate =
+          CertificateUtil.decodeCertificate(issued.certificate().bytesOrEmpty());
+      assertEquals(keyPair.getPublic(), certificate.getPublicKey());
+      assertEquals(APPLICATION_URI, CertificateUtil.getSanUri(certificate).orElse(null));
+      certificate.verify(gds.getCaCertificate().getPublicKey());
+      assertNull(issued.privateKey(), "signing requests never return a private key");
+      assertEquals(
+          List.of(gds.getCaCertificate()),
+          CertificateUtil.decodeCertificates(issued.issuerCertificates()[0].bytesOrEmpty()));
+    }
+
+    @Test
+    void finishRequestOfARejectedRequestFailsWithBadRequestNotAllowed() throws Exception {
+      gds.setRejectRequests(true);
+      NodeId applicationId = registerTestApplication();
+      KeyPair keyPair = SelfSignedCertificateGenerator.generateRsaKeyPair(2048);
+      NodeId requestId =
+          gdsClient.startSigningRequest(applicationId, null, null, csr(keyPair, APPLICATION_URI));
+
+      UaException e =
+          assertThrows(UaException.class, () -> gdsClient.finishRequest(applicationId, requestId));
+
+      assertEquals(StatusCodes.Bad_RequestNotAllowed, e.getStatusCode().value());
+    }
+
+    @Test
+    void startNewKeyPairRequestIsFinishedWithACertificateAndPrivateKey() throws Exception {
+      NodeId applicationId = registerTestApplication();
+
+      NodeId requestId =
+          gdsClient.startNewKeyPairRequest(
+              applicationId, null, null, "CN=Test", new String[] {"localhost"}, "PEM", null);
+      FinishRequestResult issued = gdsClient.finishRequest(applicationId, requestId);
+
+      ByteString privateKey = issued.privateKey();
+      assertNotNull(privateKey);
+      assertFalse(privateKey.isNullOrEmpty(), "key pair requests return a private key");
+      assertEquals(
+          APPLICATION_URI,
+          CertificateUtil.getSanUri(
+                  CertificateUtil.decodeCertificate(issued.certificate().bytesOrEmpty()))
+              .orElse(null));
+    }
+
+    @Test
+    void getCertificatesListsTheCertificatesIssuedToTheApplication() throws Exception {
+      NodeId applicationId = registerTestApplication();
+      KeyPair keyPair = SelfSignedCertificateGenerator.generateRsaKeyPair(2048);
+      NodeId requestId =
+          gdsClient.startSigningRequest(applicationId, null, null, csr(keyPair, APPLICATION_URI));
+      FinishRequestResult issued = gdsClient.finishRequest(applicationId, requestId);
+
+      CertificatesResult certificates = gdsClient.getCertificates(applicationId, null);
+
+      assertArrayEquals(
+          new NodeId[] {NodeIds.RsaSha256ApplicationCertificateType},
+          certificates.certificateTypeIds());
+      assertArrayEquals(new ByteString[] {issued.certificate()}, certificates.certificates());
+    }
+
+    @Test
+    void revokeCertificateIsReflectedByCheckRevocationStatus() throws Exception {
+      NodeId applicationId = registerTestApplication();
+      KeyPair keyPair = SelfSignedCertificateGenerator.generateRsaKeyPair(2048);
+      NodeId requestId =
+          gdsClient.startSigningRequest(applicationId, null, null, csr(keyPair, APPLICATION_URI));
+      ByteString certificate = gdsClient.finishRequest(applicationId, requestId).certificate();
+
+      RevocationStatus before = gdsClient.checkRevocationStatus(certificate);
+      gdsClient.revokeCertificate(applicationId, certificate);
+      RevocationStatus after = gdsClient.checkRevocationStatus(certificate);
+
+      assertTrue(before.certificateStatus().isGood());
+      assertEquals(StatusCodes.Bad_CertificateRevoked, after.certificateStatus().value());
+      assertNotNull(after.validityTime());
+    }
+
+    @Test
+    void verifyIssuedCertificateRejectsAKeyOrUriMismatch() throws Exception {
+      KeyPair requested = SelfSignedCertificateGenerator.generateRsaKeyPair(2048);
+      KeyPair other = SelfSignedCertificateGenerator.generateRsaKeyPair(2048);
+      NodeId applicationId = registerTestApplication();
+      NodeId requestId =
+          gdsClient.startSigningRequest(applicationId, null, null, csr(requested, APPLICATION_URI));
+      X509Certificate issued =
+          CertificateUtil.decodeCertificate(
+              gdsClient.finishRequest(applicationId, requestId).certificate().bytesOrEmpty());
+
+      GdsClient.verifyIssuedCertificate(issued, requested.getPublic(), APPLICATION_URI);
+
+      UaException wrongKey =
+          assertThrows(
+              UaException.class,
+              () -> GdsClient.verifyIssuedCertificate(issued, other.getPublic(), APPLICATION_URI));
+      UaException wrongUri =
+          assertThrows(
+              UaException.class,
+              () -> GdsClient.verifyIssuedCertificate(issued, requested.getPublic(), "urn:other"));
+
+      assertEquals(StatusCodes.Bad_CertificateInvalid, wrongKey.getStatusCode().value());
+      assertEquals(StatusCodes.Bad_CertificateUriInvalid, wrongUri.getStatusCode().value());
+    }
+  }
+
+  @Nested
+  class PullSequence {
+
+    // G1: the whole Part 12 §7.6 Pull sequence against the fake GDS ends with the CA that signed
+    // the issued certificate installed in the client's trust list manager.
+    @Test
+    void fullPullSequenceEndsWithTheGdsCaInTheTrustListManager() throws Exception {
+      gds.getApplicationGroupTrustList()
+          .setTrustList(
+              new TrustListDataType(
+                  uint(TrustListMasks.TrustedCertificates.getValue()),
+                  new ByteString[] {ByteString.of(gds.getCaCertificate().getEncoded())},
+                  null,
+                  null,
+                  null));
+      var trustListManager = new MemoryTrustListManager();
+      KeyPair keyPair = SelfSignedCertificateGenerator.generateRsaKeyPair(2048);
+
+      ApplicationRecordDataType[] found = gdsClient.findApplications(APPLICATION_URI);
+      NodeId applicationId =
+          found.length == 0
+              ? gdsClient.registerApplication(clientRecord(APPLICATION_URI))
+              : found[0].getApplicationId();
+
+      NodeId groupId = gdsClient.getCertificateGroups(applicationId)[0];
+      NodeId typeId = gdsClient.readCertificateTypes(groupId)[0];
+      assertTrue(gdsClient.getCertificateStatus(applicationId, groupId, typeId));
+
+      NodeId requestId =
+          gdsClient.startSigningRequest(
+              applicationId, groupId, typeId, csr(keyPair, APPLICATION_URI));
+      FinishRequestResult issued = gdsClient.finishRequest(applicationId, requestId);
+      X509Certificate certificate =
+          CertificateUtil.decodeCertificate(issued.certificate().bytesOrEmpty());
+      GdsClient.verifyIssuedCertificate(certificate, keyPair.getPublic(), APPLICATION_URI);
+
+      NodeId trustListId = gdsClient.getTrustList(applicationId, groupId);
+      TrustListDataType trustList = TrustListReader.read(client, trustListId);
+      TrustListApplier.apply(trustList, trustListManager);
+
+      assertEquals(List.of(gds.getCaCertificate()), trustListManager.getTrustedCertificates());
+      assertEquals(
+          certificate.getIssuerX500Principal(), gds.getCaCertificate().getSubjectX500Principal());
+    }
+  }
+}

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/GdsClientWithoutGdsNamespaceTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/GdsClientWithoutGdsNamespaceTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.gds;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.milo.opcua.sdk.test.AbstractClientServerTest;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.junit.jupiter.api.Test;
+
+public class GdsClientWithoutGdsNamespaceTest extends AbstractClientServerTest {
+
+  // Pointing a GDS client at an ordinary server must fail up front with a clear reason, and must
+  // not disturb the client, which may still be wanted for other work.
+  @Test
+  void createFailsWithBadNotFoundWhenTheServerDoesNotHostTheGdsNamespace() throws Exception {
+    UaException e = assertThrows(UaException.class, () -> GdsClient.create(client));
+
+    assertEquals(StatusCodes.Bad_NotFound, e.getStatusCode().value());
+    assertTrue(e.getMessage().contains(GdsClient.NAMESPACE_URI), e.getMessage());
+    assertTrue(client.readNamespaceTable().toArray().length > 0, "client still usable");
+  }
+}

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/TrustListReaderTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/TrustListReaderTest.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.gds;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ubyte;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.eclipse.milo.opcua.sdk.client.gds.FakeGdsNamespace.TrustListFile;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.OpenFileMode;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.TrustListMasks;
+import org.eclipse.milo.opcua.stack.core.types.structured.CallMethodRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.CallMethodResult;
+import org.eclipse.milo.opcua.stack.core.types.structured.TrustListDataType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class TrustListReaderTest extends AbstractGdsClientTest {
+
+  /** A body of a few hundred bytes so chunk sizes above and below it are both interesting. */
+  private static final TrustListDataType TRUST_LIST =
+      new TrustListDataType(
+          uint(TrustListMasks.All.getValue()),
+          new ByteString[] {ByteString.of(new byte[200]), ByteString.of(new byte[50])},
+          new ByteString[] {ByteString.of(new byte[30])},
+          new ByteString[] {ByteString.of(new byte[70])},
+          new ByteString[0]);
+
+  private TrustListFile file;
+  private NodeId trustListId;
+
+  @BeforeEach
+  void serveTrustList() {
+    file = gds.getApplicationGroupTrustList();
+    file.setTrustList(TRUST_LIST);
+    trustListId = gds.defaultApplicationGroupTrustListId();
+  }
+
+  // The FileType read loop must reassemble the body regardless of how many Read calls it takes:
+  // one byte at a time, the reference client's 4096, or a single read larger than the file.
+  @ParameterizedTest(name = "chunkSize={0}")
+  @ValueSource(ints = {1, 4096, 1_000_000})
+  void readsTheWholeBodyInChunksThenClosesTheFile(int chunkSize) throws Exception {
+    TrustListDataType read = TrustListReader.read(client, trustListId, chunkSize);
+
+    List<String> calls = file.calls();
+    assertEquals(TRUST_LIST, read);
+    assertEquals("Open", calls.get(0));
+    assertEquals("Close", calls.get(calls.size() - 1));
+    assertEquals(1, calls.stream().filter("Close"::equals).count(), "closed exactly once");
+    assertTrue(
+        calls.subList(1, calls.size() - 1).stream().allMatch(("Read(" + chunkSize + ")")::equals),
+        "every Read requested chunkSize bytes: " + calls);
+    assertEquals(0, file.openHandles(), "no handle left open");
+  }
+
+  // Part 5 C.2.1: MaxByteStringLength is the server's per-call limit; honouring it avoids a
+  // Bad_ResponseTooLarge from a server with a small limit.
+  @Test
+  void readUsesMaxByteStringLengthAsTheChunkSizeWhenTheFileExposesIt() throws Exception {
+    TrustListDataType read = TrustListReader.read(client, trustListId);
+
+    assertEquals(TRUST_LIST, read);
+    assertTrue(file.calls().contains("Read(100)"), file.calls().toString());
+  }
+
+  @Test
+  void readFallsBackToTheDefaultChunkSizeWhenMaxByteStringLengthIsAbsent() throws Exception {
+    TrustListFile userTokenFile = gds.getUserTokenGroupTrustList();
+    userTokenFile.setTrustList(TRUST_LIST);
+
+    TrustListDataType read = TrustListReader.read(client, gds.defaultUserTokenGroupTrustListId());
+
+    assertEquals(TRUST_LIST, read);
+    assertTrue(
+        userTokenFile.calls().contains("Read(" + TrustListReader.DEFAULT_CHUNK_SIZE + ")"),
+        userTokenFile.calls().toString());
+  }
+
+  // A lost handle counts against the server's OpenCount until it times out; Close must run even
+  // when a Read fails, and the Read's error is what the caller sees.
+  @Test
+  void closeIsStillCalledWhenAReadFailsMidway() {
+    file.failReadAfter(1);
+
+    UaException e =
+        assertThrows(UaException.class, () -> TrustListReader.read(client, trustListId, 100));
+
+    assertEquals(StatusCodes.Bad_UnexpectedError, e.getStatusCode().value());
+    assertEquals(List.of("Open", "Read(100)", "Read(100)", "Close"), file.calls());
+    assertEquals(0, file.openHandles());
+  }
+
+  @Test
+  void malformedBodyFailsWithBadDecodingErrorAfterClosingTheFile() {
+    file.setBody(new byte[] {1, 2, 3});
+
+    UaException e =
+        assertThrows(UaException.class, () -> TrustListReader.read(client, trustListId));
+
+    assertEquals(StatusCodes.Bad_DecodingError, e.getStatusCode().value());
+    assertEquals("Close", file.calls().get(file.calls().size() - 1));
+  }
+
+  // Part 4 §5.12.2.2 lets a caller name a Method by its declaration on the ObjectType that
+  // defines it. The reference GDS client and TrustListReader both call FileType_Open on
+  // TrustListType instances, so the server must resolve a declaration inherited from a supertype.
+  @Test
+  void serverResolvesFileTypeDeclarationIdsOnATrustListTypeInstance() throws Exception {
+    CallMethodResult open =
+        call(
+            NodeIds.FileType_Open,
+            new Variant[] {Variant.ofByte(ubyte(OpenFileMode.Read.getValue()))});
+    CallMethodResult unrelatedMethod =
+        call(NodeIds.FileType_GetPosition, new Variant[] {Variant.ofUInt32(uint(1))});
+
+    assertTrue(open.getStatusCode().isGood(), "FileType_Open: " + open);
+    assertEquals(StatusCodes.Bad_MethodInvalid, unrelatedMethod.getStatusCode().value());
+
+    UInteger handle = (UInteger) open.getOutputArguments()[0].value();
+    CallMethodResult close = call(NodeIds.FileType_Close, new Variant[] {Variant.ofUInt32(handle)});
+
+    assertTrue(close.getStatusCode().isGood(), "FileType_Close: " + close);
+    assertEquals(0, file.openHandles());
+  }
+
+  private CallMethodResult call(NodeId methodId, Variant[] inputs) throws UaException {
+    return client.call(List.of(new CallMethodRequest(trustListId, methodId, inputs)))
+        .getResults()[0];
+  }
+}

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/TrustListReaderTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/TrustListReaderTest.java
@@ -10,6 +10,7 @@
 
 package org.eclipse.milo.opcua.sdk.client.gds;
 
+import static java.util.Objects.requireNonNull;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ubyte;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -137,7 +138,8 @@ public class TrustListReaderTest extends AbstractGdsClientTest {
     assertTrue(open.getStatusCode().isGood(), "FileType_Open: " + open);
     assertEquals(StatusCodes.Bad_MethodInvalid, unrelatedMethod.getStatusCode().value());
 
-    UInteger handle = (UInteger) open.getOutputArguments()[0].value();
+    Variant[] outputs = requireNonNull(open.getOutputArguments());
+    UInteger handle = requireNonNull((UInteger) outputs[0].value());
     CallMethodResult close = call(NodeIds.FileType_Close, new Variant[] {Variant.ofUInt32(handle)});
 
     assertTrue(close.getStatusCode().isGood(), "FileType_Close: " + close);
@@ -145,7 +147,9 @@ public class TrustListReaderTest extends AbstractGdsClientTest {
   }
 
   private CallMethodResult call(NodeId methodId, Variant[] inputs) throws UaException {
-    return client.call(List.of(new CallMethodRequest(trustListId, methodId, inputs)))
-        .getResults()[0];
+    CallMethodResult[] results =
+        client.call(List.of(new CallMethodRequest(trustListId, methodId, inputs))).getResults();
+
+    return requireNonNull(results)[0];
   }
 }

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/gds/GdsServerModelTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/gds/GdsServerModelTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.gds;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.stream.Stream;
+import org.eclipse.milo.opcua.sdk.client.gds.GdsClient;
+import org.eclipse.milo.opcua.sdk.server.ObjectTypeManager;
+import org.eclipse.milo.opcua.sdk.server.gds.model.objects.AccessTokenIssuedAuditEventTypeNode;
+import org.eclipse.milo.opcua.sdk.server.gds.model.objects.AccessTokenRequestedAuditEventTypeNode;
+import org.eclipse.milo.opcua.sdk.server.gds.model.objects.ApplicationRegistrationChangedAuditEventTypeNode;
+import org.eclipse.milo.opcua.sdk.server.gds.model.objects.AuthorizationServiceTypeNode;
+import org.eclipse.milo.opcua.sdk.server.gds.model.objects.AuthorizationServicesFolderTypeNode;
+import org.eclipse.milo.opcua.sdk.server.gds.model.objects.CertificateDeliveredAuditEventTypeNode;
+import org.eclipse.milo.opcua.sdk.server.gds.model.objects.CertificateDirectoryTypeNode;
+import org.eclipse.milo.opcua.sdk.server.gds.model.objects.CertificateRequestedAuditEventTypeNode;
+import org.eclipse.milo.opcua.sdk.server.gds.model.objects.CertificateRevokedAuditEventTypeNode;
+import org.eclipse.milo.opcua.sdk.server.gds.model.objects.DirectoryTypeNode;
+import org.eclipse.milo.opcua.sdk.server.gds.model.objects.KeyCredentialDeliveredAuditEventTypeNode;
+import org.eclipse.milo.opcua.sdk.server.gds.model.objects.KeyCredentialManagementFolderTypeNode;
+import org.eclipse.milo.opcua.sdk.server.gds.model.objects.KeyCredentialRequestedAuditEventTypeNode;
+import org.eclipse.milo.opcua.sdk.server.gds.model.objects.KeyCredentialRevokedAuditEventTypeNode;
+import org.eclipse.milo.opcua.sdk.server.gds.model.objects.KeyCredentialServiceTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectNode;
+import org.eclipse.milo.opcua.stack.core.NamespaceTable;
+import org.eclipse.milo.opcua.stack.core.gds.GdsNodeIds;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * The generated server model registers through a {@link NamespaceTable} because the GDS namespace
+ * index is assigned by whichever server hosts it; each registration must land on the table's actual
+ * index for the GDS URI, not on the {@code ns=1} the generator wrote.
+ */
+public class GdsServerModelTest {
+
+  private static final String GDS_URI = GdsClient.NAMESPACE_URI;
+
+  static Stream<Arguments> objectTypes() {
+    return Stream.of(
+        Arguments.of(GdsNodeIds.DirectoryType, DirectoryTypeNode.class),
+        Arguments.of(GdsNodeIds.CertificateDirectoryType, CertificateDirectoryTypeNode.class),
+        Arguments.of(
+            GdsNodeIds.KeyCredentialManagementFolderType,
+            KeyCredentialManagementFolderTypeNode.class),
+        Arguments.of(GdsNodeIds.KeyCredentialServiceType, KeyCredentialServiceTypeNode.class),
+        Arguments.of(
+            GdsNodeIds.AuthorizationServicesFolderType, AuthorizationServicesFolderTypeNode.class),
+        Arguments.of(GdsNodeIds.AuthorizationServiceType, AuthorizationServiceTypeNode.class),
+        Arguments.of(
+            GdsNodeIds.ApplicationRegistrationChangedAuditEventType,
+            ApplicationRegistrationChangedAuditEventTypeNode.class),
+        Arguments.of(
+            GdsNodeIds.CertificateRequestedAuditEventType,
+            CertificateRequestedAuditEventTypeNode.class),
+        Arguments.of(
+            GdsNodeIds.CertificateDeliveredAuditEventType,
+            CertificateDeliveredAuditEventTypeNode.class),
+        Arguments.of(
+            GdsNodeIds.CertificateRevokedAuditEventType,
+            CertificateRevokedAuditEventTypeNode.class),
+        Arguments.of(
+            GdsNodeIds.KeyCredentialRequestedAuditEventType,
+            KeyCredentialRequestedAuditEventTypeNode.class),
+        Arguments.of(
+            GdsNodeIds.KeyCredentialDeliveredAuditEventType,
+            KeyCredentialDeliveredAuditEventTypeNode.class),
+        Arguments.of(
+            GdsNodeIds.KeyCredentialRevokedAuditEventType,
+            KeyCredentialRevokedAuditEventTypeNode.class),
+        Arguments.of(
+            GdsNodeIds.AccessTokenRequestedAuditEventType,
+            AccessTokenRequestedAuditEventTypeNode.class),
+        Arguments.of(
+            GdsNodeIds.AccessTokenIssuedAuditEventType, AccessTokenIssuedAuditEventTypeNode.class));
+  }
+
+  @ParameterizedTest(name = "{1}")
+  @MethodSource("objectTypes")
+  void objectTypeInitializerRegistersEachGdsTypeOnTheTablesIndexForTheGdsUri(
+      ExpandedNodeId typeId, Class<? extends UaObjectNode> nodeClass) throws Exception {
+
+    var namespaceTable = new NamespaceTable("urn:eclipse:milo:test:some-other-namespace", GDS_URI);
+    var objectTypeManager = new ObjectTypeManager();
+
+    ObjectTypeInitializer.initialize(namespaceTable, objectTypeManager);
+
+    NodeId localTypeId = typeId.toNodeIdOrThrow(namespaceTable);
+    assertTrue(localTypeId.getNamespaceIndex().intValue() > 1, "GDS is not at ns=1 here");
+    assertEquals(
+        nodeClass,
+        objectTypeManager
+            .getRegisteredType(localTypeId)
+            .orElseThrow(() -> new AssertionError("not registered: " + typeId))
+            .nodeClass());
+  }
+}

--- a/opc-ua-sdk/pom.xml
+++ b/opc-ua-sdk/pom.xml
@@ -31,6 +31,7 @@
     <module>dtd-manager</module>
     <module>dtd-reader</module>
     <module>sdk-client</module>
+    <module>sdk-client-gds</module>
     <module>sdk-core</module>
     <module>sdk-server</module>
     <module>integration-tests</module>

--- a/opc-ua-sdk/sdk-client-gds/pom.xml
+++ b/opc-ua-sdk/sdk-client-gds/pom.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2026 the Eclipse Milo Authors
+  ~
+  ~ This program and the accompanying materials are made
+  ~ available under the terms of the Eclipse Public License 2.0
+  ~ which is available at https://www.eclipse.org/legal/epl-2.0/
+  ~
+  ~ SPDX-License-Identifier: EPL-2.0
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.eclipse.milo</groupId>
+    <artifactId>milo-opc-ua-sdk</artifactId>
+    <version>1.2.0-SNAPSHOT</version>
+  </parent>
+
+  <name>Milo :: SDK Client GDS</name>
+
+  <artifactId>milo-sdk-client-gds</artifactId>
+
+  <properties>
+    <javaModuleName>org.eclipse.milo.opcua.sdk.client.gds</javaModuleName>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.milo</groupId>
+      <artifactId>milo-sdk-client</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+      <version>${jspecify.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>${slf4j.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/opc-ua-sdk/sdk-client-gds/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/ClientCalls.java
+++ b/opc-ua-sdk/sdk-client-gds/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/ClientCalls.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.gds;
+
+import static java.util.Objects.requireNonNullElse;
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.client.methods.UaMethodException;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.TimestampsToReturn;
+import org.eclipse.milo.opcua.stack.core.types.structured.BrowsePath;
+import org.eclipse.milo.opcua.stack.core.types.structured.BrowsePathResult;
+import org.eclipse.milo.opcua.stack.core.types.structured.BrowsePathTarget;
+import org.eclipse.milo.opcua.stack.core.types.structured.CallMethodRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.CallMethodResult;
+import org.eclipse.milo.opcua.stack.core.types.structured.RelativePath;
+import org.eclipse.milo.opcua.stack.core.types.structured.RelativePathElement;
+import org.jspecify.annotations.Nullable;
+
+/** Shared service-call plumbing for {@link GdsClient} and {@link TrustListReader}. */
+final class ClientCalls {
+
+  private ClientCalls() {}
+
+  /** Decodes a method's output arguments into a typed result. */
+  @FunctionalInterface
+  interface OutputDecoder<T> {
+    T decode(MethodOutputs outputs) throws UaException;
+  }
+
+  /**
+   * Invoke one method with a single Call request.
+   *
+   * <p>A Bad operation-level result fails the future with a {@link UaMethodException} carrying the
+   * server's {@link StatusCode}; a Good result with at least {@code requiredOutputs} output
+   * arguments is decoded by {@code decoder}.
+   */
+  static <T> CompletableFuture<T> call(
+      OpcUaClient client,
+      NodeId objectId,
+      NodeId methodId,
+      String methodName,
+      Variant[] inputs,
+      int requiredOutputs,
+      OutputDecoder<T> decoder) {
+
+    var request = new CallMethodRequest(objectId, methodId, inputs);
+
+    return client
+        .callAsync(List.of(request))
+        .thenCompose(
+            response -> {
+              CallMethodResult[] results =
+                  requireNonNullElse(response.getResults(), new CallMethodResult[0]);
+
+              if (results.length != 1) {
+                return failedFuture(
+                    new UaException(
+                        StatusCodes.Bad_UnexpectedError,
+                        methodName + ": expected 1 result, received " + results.length));
+              }
+
+              CallMethodResult result = results[0];
+              StatusCode statusCode = result.getStatusCode();
+
+              if (!statusCode.isGood()) {
+                return failedFuture(
+                    new UaMethodException(
+                        statusCode,
+                        result.getInputArgumentResults(),
+                        result.getInputArgumentDiagnosticInfos()));
+              }
+
+              try {
+                Variant[] outputs = requireNonNullElse(result.getOutputArguments(), new Variant[0]);
+
+                return completedFuture(
+                    decoder.decode(MethodOutputs.of(methodName, outputs, requiredOutputs)));
+              } catch (UaException e) {
+                return failedFuture(e);
+              }
+            });
+  }
+
+  /**
+   * Read the Value attribute of the namespace 0 Properties named {@code propertyNames} under {@code
+   * objectId}, using one TranslateBrowsePaths request and one Read request.
+   *
+   * @return a list aligned with {@code propertyNames}; an entry is {@code null} when the Property
+   *     does not exist on the object.
+   */
+  static CompletableFuture<List<@Nullable DataValue>> readProperties(
+      OpcUaClient client, NodeId objectId, List<String> propertyNames) {
+
+    List<BrowsePath> browsePaths =
+        propertyNames.stream()
+            .map(
+                name ->
+                    new BrowsePath(
+                        objectId,
+                        new RelativePath(
+                            new RelativePathElement[] {
+                              new RelativePathElement(
+                                  NodeIds.HasProperty, false, false, new QualifiedName(0, name))
+                            })))
+            .toList();
+
+    return client
+        .translateBrowsePathsAsync(browsePaths)
+        .thenCompose(
+            response -> {
+              BrowsePathResult[] results =
+                  requireNonNullElse(response.getResults(), new BrowsePathResult[0]);
+
+              if (results.length != propertyNames.size()) {
+                return failedFuture(
+                    new UaException(
+                        StatusCodes.Bad_UnexpectedError,
+                        "TranslateBrowsePaths: expected "
+                            + propertyNames.size()
+                            + " results, received "
+                            + results.length));
+              }
+
+              List<@Nullable NodeId> propertyIds = new ArrayList<>();
+              List<NodeId> idsToRead = new ArrayList<>();
+
+              for (BrowsePathResult result : results) {
+                NodeId propertyId = null;
+
+                if (result.getStatusCode().isGood()) {
+                  BrowsePathTarget[] targets =
+                      requireNonNullElse(result.getTargets(), new BrowsePathTarget[0]);
+
+                  if (targets.length > 0) {
+                    propertyId =
+                        targets[0].getTargetId().toNodeId(client.getNamespaceTable()).orElse(null);
+                  }
+                }
+
+                propertyIds.add(propertyId);
+
+                if (propertyId != null) {
+                  idsToRead.add(propertyId);
+                }
+              }
+
+              if (idsToRead.isEmpty()) {
+                return completedFuture(Arrays.asList(new DataValue[propertyNames.size()]));
+              }
+
+              return client
+                  .readValuesAsync(0.0, TimestampsToReturn.Neither, idsToRead)
+                  .thenApply(
+                      values -> {
+                        List<@Nullable DataValue> aligned = new ArrayList<>();
+                        int next = 0;
+
+                        for (NodeId propertyId : propertyIds) {
+                          aligned.add(propertyId != null ? values.get(next++) : null);
+                        }
+
+                        return aligned;
+                      });
+            });
+  }
+
+  /**
+   * Wait for {@code future}, rethrowing a failed {@link UaException} (including {@link
+   * UaMethodException}) as is and wrapping any other failure.
+   */
+  static <T> T await(CompletableFuture<T> future) throws UaException {
+    try {
+      return future.get();
+    } catch (ExecutionException e) {
+      Throwable cause = e.getCause();
+
+      if (cause instanceof UaException ux) {
+        throw ux;
+      } else {
+        throw new UaException(cause);
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
+    }
+  }
+}

--- a/opc-ua-sdk/sdk-client-gds/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/GdsClient.java
+++ b/opc-ua-sdk/sdk-client-gds/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/GdsClient.java
@@ -1,0 +1,1028 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.gds;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
+
+import java.security.PublicKey;
+import java.security.cert.X509Certificate;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.client.methods.UaMethodException;
+import org.eclipse.milo.opcua.stack.core.NamespaceTable;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.gds.DataTypeInitializer;
+import org.eclipse.milo.opcua.stack.core.gds.GdsNodeIds;
+import org.eclipse.milo.opcua.stack.core.gds.types.ApplicationRecordDataType;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
+import org.eclipse.milo.opcua.stack.core.types.structured.ApplicationDescription;
+import org.eclipse.milo.opcua.stack.core.types.structured.ServerOnNetwork;
+import org.eclipse.milo.opcua.stack.core.util.CertificateUtil;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Typed access to the {@code Directory} object of an OPC UA Global Discovery Server (OPC 10000-12).
+ *
+ * <p>A {@link GdsClient} wraps an {@link OpcUaClient} that is already connected to a GDS. {@link
+ * #create(OpcUaClient)} resolves the GDS namespace index, registers the GDS DataType and ObjectType
+ * model with the client, and locates the {@code Directory} object; every method wrapper then issues
+ * a single Call request. Each wrapper has a blocking form and an {@code ...Async} twin returning a
+ * {@link CompletableFuture}.
+ *
+ * <p>Wrappers do not interpret results. A Bad operation-level result surfaces as a {@link
+ * UaMethodException} (a {@link UaException}) carrying the GDS's {@link StatusCode}, so callers
+ * branch on it directly, for example {@link StatusCodes#Bad_NothingToDo} from {@link
+ * #finishRequest} means "poll again later" and {@link StatusCodes#Bad_RequestNotAllowed} means the
+ * request was rejected.
+ *
+ * <p>The Pull Model sequence (Part 12 §7.6) is:
+ *
+ * <pre>{@code
+ * GdsClient gds = GdsClient.create(client);
+ *
+ * ApplicationRecordDataType[] found = gds.findApplications(applicationUri);
+ * NodeId applicationId =
+ *     found.length == 0 ? gds.registerApplication(record) : found[0].getApplicationId();
+ *
+ * for (NodeId groupId : gds.getCertificateGroups(applicationId)) {
+ *   for (NodeId typeId : gds.readCertificateTypes(groupId)) {
+ *     if (gds.getCertificateStatus(applicationId, groupId, typeId)) {
+ *       NodeId requestId = gds.startSigningRequest(applicationId, groupId, typeId, csr);
+ *       // later, repeat until it no longer fails with Bad_NothingToDo:
+ *       FinishRequestResult issued = gds.finishRequest(applicationId, requestId);
+ *     }
+ *   }
+ *   NodeId trustListId = gds.getTrustList(applicationId, groupId);
+ *   TrustListDataType trustList = TrustListReader.read(client, trustListId);
+ *   TrustListApplier.apply(trustList, trustListManager);
+ * }
+ * }</pre>
+ *
+ * <p>The {@code Directory} NodeId is resolved when the client is created and is valid for the GDS
+ * the {@link OpcUaClient} was connected to; create a new {@link GdsClient} if the client is pointed
+ * at a different server. Instances are safe to share between threads.
+ */
+public final class GdsClient {
+
+  /** The URI of the GDS namespace, {@code http://opcfoundation.org/UA/GDS/}. */
+  public static final String NAMESPACE_URI = "http://opcfoundation.org/UA/GDS/";
+
+  private final OpcUaClient client;
+  private final NodeId directoryId;
+
+  private GdsClient(OpcUaClient client, NodeId directoryId) {
+    this.client = client;
+    this.directoryId = directoryId;
+  }
+
+  /**
+   * Create a {@link GdsClient} for a connected {@link OpcUaClient}.
+   *
+   * <p>Registers the {@code ApplicationRecordDataType} codec with the client's static {@link
+   * org.eclipse.milo.opcua.stack.core.types.DataTypeManager} and the GDS ObjectTypes with its
+   * {@link org.eclipse.milo.opcua.sdk.client.ObjectTypeManager}. If the client's local copy of the
+   * namespace array does not contain the GDS namespace it is re-read from the server once.
+   *
+   * @param client an {@link OpcUaClient} connected to a GDS.
+   * @return a new {@link GdsClient}.
+   * @throws UaException with {@link StatusCodes#Bad_NotFound} if the server's namespace array does
+   *     not contain {@link #NAMESPACE_URI}, or if reading the namespace array fails.
+   */
+  public static GdsClient create(OpcUaClient client) throws UaException {
+    NamespaceTable namespaceTable = client.getNamespaceTable();
+    UShort namespaceIndex = namespaceTable.getIndex(NAMESPACE_URI);
+
+    if (namespaceIndex == null) {
+      namespaceTable = client.readNamespaceTable();
+      namespaceIndex = namespaceTable.getIndex(NAMESPACE_URI);
+    }
+
+    if (namespaceIndex == null) {
+      throw new UaException(
+          StatusCodes.Bad_NotFound, "GDS namespace not found in NamespaceArray: " + NAMESPACE_URI);
+    }
+
+    DataTypeInitializer.initialize(namespaceTable, client.getStaticDataTypeManager());
+    ObjectTypeInitializer.initialize(namespaceTable, client.getObjectTypeManager());
+    VariableTypeInitializer.initialize(namespaceTable, client.getVariableTypeManager());
+
+    NodeId directoryId = GdsNodeIds.Directory.toNodeIdOrThrow(namespaceTable);
+
+    return new GdsClient(client, directoryId);
+  }
+
+  /**
+   * @return the {@link OpcUaClient} this GDS client wraps.
+   */
+  public OpcUaClient getClient() {
+    return client;
+  }
+
+  /**
+   * @return the {@link NodeId} of the GDS {@code Directory} object.
+   */
+  public NodeId getDirectoryId() {
+    return directoryId;
+  }
+
+  // region Directory (Part 12 §6.5)
+
+  /**
+   * Find the applications registered with {@code applicationUri} (Part 12 §6.5.7).
+   *
+   * @param applicationUri the ApplicationUri to search for.
+   * @return the matching records, empty if none are registered.
+   * @throws UaException if the call fails.
+   */
+  public ApplicationRecordDataType[] findApplications(String applicationUri) throws UaException {
+    return ClientCalls.await(findApplicationsAsync(applicationUri));
+  }
+
+  /**
+   * Asynchronous form of {@link #findApplications(String)}.
+   *
+   * @param applicationUri the ApplicationUri to search for.
+   * @return a future completing with the matching records.
+   */
+  public CompletableFuture<ApplicationRecordDataType[]> findApplicationsAsync(
+      String applicationUri) {
+
+    return call(
+        GdsNodeIds.Directory_FindApplications,
+        "FindApplications",
+        new Variant[] {Variant.ofString(applicationUri)},
+        1,
+        outputs ->
+            outputs.structArray(
+                0, ApplicationRecordDataType.class, client.getStaticEncodingContext()));
+  }
+
+  /**
+   * Register an application (Part 12 §6.5.6).
+   *
+   * <p>Requires the DiscoveryAdmin or ApplicationAdmin role on most servers; Part 12 §6.4 says to
+   * call {@link #findApplications(String)} first and register only when it returns nothing. The
+   * {@code applicationId} of {@code application} is ignored and assigned by the GDS.
+   *
+   * @param application the record to register.
+   * @return the ApplicationId assigned by the GDS.
+   * @throws UaException if the call fails, e.g. {@link StatusCodes#Bad_UserAccessDenied}.
+   */
+  public NodeId registerApplication(ApplicationRecordDataType application) throws UaException {
+    return ClientCalls.await(registerApplicationAsync(application));
+  }
+
+  /**
+   * Asynchronous form of {@link #registerApplication(ApplicationRecordDataType)}.
+   *
+   * @param application the record to register.
+   * @return a future completing with the assigned ApplicationId.
+   */
+  public CompletableFuture<NodeId> registerApplicationAsync(ApplicationRecordDataType application) {
+    return call(
+        GdsNodeIds.Directory_RegisterApplication,
+        "RegisterApplication",
+        new Variant[] {Variant.ofStruct(application)},
+        1,
+        outputs -> outputs.scalar(0, NodeId.class));
+  }
+
+  /**
+   * Update an existing registration (Part 12 §6.5.8).
+   *
+   * @param application the record to store; its {@code applicationId} identifies the registration.
+   * @throws UaException if the call fails.
+   */
+  public void updateApplication(ApplicationRecordDataType application) throws UaException {
+    ClientCalls.await(updateApplicationAsync(application));
+  }
+
+  /**
+   * Asynchronous form of {@link #updateApplication(ApplicationRecordDataType)}.
+   *
+   * @param application the record to store.
+   * @return a future completing when the update is done.
+   */
+  public CompletableFuture<Void> updateApplicationAsync(ApplicationRecordDataType application) {
+    return call(
+        GdsNodeIds.Directory_UpdateApplication,
+        "UpdateApplication",
+        new Variant[] {Variant.ofStruct(application)},
+        0,
+        outputs -> null);
+  }
+
+  /**
+   * Remove a registration (Part 12 §6.5.9).
+   *
+   * @param applicationId the ApplicationId returned by registration.
+   * @throws UaException if the call fails.
+   */
+  public void unregisterApplication(NodeId applicationId) throws UaException {
+    ClientCalls.await(unregisterApplicationAsync(applicationId));
+  }
+
+  /**
+   * Asynchronous form of {@link #unregisterApplication(NodeId)}.
+   *
+   * @param applicationId the ApplicationId returned by registration.
+   * @return a future completing when the registration is removed.
+   */
+  public CompletableFuture<Void> unregisterApplicationAsync(NodeId applicationId) {
+    return call(
+        GdsNodeIds.Directory_UnregisterApplication,
+        "UnregisterApplication",
+        new Variant[] {Variant.ofNodeId(applicationId)},
+        0,
+        outputs -> null);
+  }
+
+  /**
+   * Get a registration (Part 12 §6.5.10).
+   *
+   * @param applicationId the ApplicationId returned by registration.
+   * @return the stored record.
+   * @throws UaException if the call fails, e.g. {@link StatusCodes#Bad_NotFound}.
+   */
+  public ApplicationRecordDataType getApplication(NodeId applicationId) throws UaException {
+    return ClientCalls.await(getApplicationAsync(applicationId));
+  }
+
+  /**
+   * Asynchronous form of {@link #getApplication(NodeId)}.
+   *
+   * @param applicationId the ApplicationId returned by registration.
+   * @return a future completing with the stored record.
+   */
+  public CompletableFuture<ApplicationRecordDataType> getApplicationAsync(NodeId applicationId) {
+    return call(
+        GdsNodeIds.Directory_GetApplication,
+        "GetApplication",
+        new Variant[] {Variant.ofNodeId(applicationId)},
+        1,
+        outputs ->
+            outputs.struct(0, ApplicationRecordDataType.class, client.getStaticEncodingContext()));
+  }
+
+  /**
+   * Query registered applications (Part 12 §6.5.11).
+   *
+   * <p>String filters accept the wildcards defined for the query, and a null or empty value means
+   * "any". {@code applicationType} is the numeric filter defined by the spec, e.g. 0 for any.
+   *
+   * @param startingRecordId the record id to start at, 0 for the first.
+   * @param maxRecordsToReturn the maximum number of records, 0 for no limit.
+   * @param applicationName the ApplicationName filter.
+   * @param applicationUri the ApplicationUri filter.
+   * @param applicationType the ApplicationType filter.
+   * @param productUri the ProductUri filter.
+   * @param serverCapabilities the ServerCapabilities filter.
+   * @return the matching applications and paging information.
+   * @throws UaException if the call fails.
+   */
+  public QueryApplicationsResult queryApplications(
+      UInteger startingRecordId,
+      UInteger maxRecordsToReturn,
+      @Nullable String applicationName,
+      @Nullable String applicationUri,
+      UInteger applicationType,
+      @Nullable String productUri,
+      String @Nullable [] serverCapabilities)
+      throws UaException {
+
+    return ClientCalls.await(
+        queryApplicationsAsync(
+            startingRecordId,
+            maxRecordsToReturn,
+            applicationName,
+            applicationUri,
+            applicationType,
+            productUri,
+            serverCapabilities));
+  }
+
+  /**
+   * Asynchronous form of {@link #queryApplications}.
+   *
+   * @return a future completing with the matching applications and paging information.
+   */
+  public CompletableFuture<QueryApplicationsResult> queryApplicationsAsync(
+      UInteger startingRecordId,
+      UInteger maxRecordsToReturn,
+      @Nullable String applicationName,
+      @Nullable String applicationUri,
+      UInteger applicationType,
+      @Nullable String productUri,
+      String @Nullable [] serverCapabilities) {
+
+    return call(
+        GdsNodeIds.Directory_QueryApplications,
+        "QueryApplications",
+        new Variant[] {
+          Variant.ofUInt32(startingRecordId),
+          Variant.ofUInt32(maxRecordsToReturn),
+          Variant.of(applicationName),
+          Variant.of(applicationUri),
+          Variant.ofUInt32(applicationType),
+          Variant.of(productUri),
+          Variant.of(serverCapabilities)
+        },
+        3,
+        outputs ->
+            new QueryApplicationsResult(
+                outputs.scalar(0, DateTime.class),
+                outputs.scalar(1, UInteger.class),
+                outputs.structArray(
+                    2, ApplicationDescription.class, client.getStaticEncodingContext())));
+  }
+
+  /**
+   * Query registered servers (Part 12 §6.5.12).
+   *
+   * <p>String filters accept the wildcards defined for the query, and a null or empty value means
+   * "any".
+   *
+   * @param startingRecordId the record id to start at, 0 for the first.
+   * @param maxRecordsToReturn the maximum number of records, 0 for no limit.
+   * @param applicationName the ApplicationName filter.
+   * @param applicationUri the ApplicationUri filter.
+   * @param productUri the ProductUri filter.
+   * @param serverCapabilities the ServerCapabilities filter.
+   * @return the matching servers and the last counter reset time.
+   * @throws UaException if the call fails.
+   */
+  public QueryServersResult queryServers(
+      UInteger startingRecordId,
+      UInteger maxRecordsToReturn,
+      @Nullable String applicationName,
+      @Nullable String applicationUri,
+      @Nullable String productUri,
+      String @Nullable [] serverCapabilities)
+      throws UaException {
+
+    return ClientCalls.await(
+        queryServersAsync(
+            startingRecordId,
+            maxRecordsToReturn,
+            applicationName,
+            applicationUri,
+            productUri,
+            serverCapabilities));
+  }
+
+  /**
+   * Asynchronous form of {@link #queryServers}.
+   *
+   * @return a future completing with the matching servers and the last counter reset time.
+   */
+  public CompletableFuture<QueryServersResult> queryServersAsync(
+      UInteger startingRecordId,
+      UInteger maxRecordsToReturn,
+      @Nullable String applicationName,
+      @Nullable String applicationUri,
+      @Nullable String productUri,
+      String @Nullable [] serverCapabilities) {
+
+    return call(
+        GdsNodeIds.Directory_QueryServers,
+        "QueryServers",
+        new Variant[] {
+          Variant.ofUInt32(startingRecordId),
+          Variant.ofUInt32(maxRecordsToReturn),
+          Variant.of(applicationName),
+          Variant.of(applicationUri),
+          Variant.of(productUri),
+          Variant.of(serverCapabilities)
+        },
+        2,
+        outputs ->
+            new QueryServersResult(
+                outputs.scalar(0, DateTime.class),
+                outputs.structArray(1, ServerOnNetwork.class, client.getStaticEncodingContext())));
+  }
+
+  // endregion
+
+  // region CertificateDirectory (Part 12 §7.9)
+
+  /**
+   * Submit a PKCS#10 certificate signing request (Part 12 §7.9.3).
+   *
+   * <p>The request's ApplicationUri must match the application record, or the GDS rejects it with
+   * {@link StatusCodes#Bad_CertificateUriInvalid}; server applications also carry their domain
+   * names. Requires an encrypted channel. Poll {@link #finishRequest(NodeId, NodeId)} for the
+   * result.
+   *
+   * @param applicationId the ApplicationId returned by registration.
+   * @param certificateGroupId the CertificateGroup the certificate belongs to, or null for the
+   *     default group.
+   * @param certificateTypeId the CertificateType to issue, or null for the group's default.
+   * @param certificateRequest the DER-encoded PKCS#10 request.
+   * @return the RequestId to pass to {@link #finishRequest(NodeId, NodeId)}.
+   * @throws UaException if the call fails.
+   */
+  public NodeId startSigningRequest(
+      NodeId applicationId,
+      @Nullable NodeId certificateGroupId,
+      @Nullable NodeId certificateTypeId,
+      ByteString certificateRequest)
+      throws UaException {
+
+    return ClientCalls.await(
+        startSigningRequestAsync(
+            applicationId, certificateGroupId, certificateTypeId, certificateRequest));
+  }
+
+  /**
+   * Asynchronous form of {@link #startSigningRequest}.
+   *
+   * @return a future completing with the RequestId.
+   */
+  public CompletableFuture<NodeId> startSigningRequestAsync(
+      NodeId applicationId,
+      @Nullable NodeId certificateGroupId,
+      @Nullable NodeId certificateTypeId,
+      ByteString certificateRequest) {
+
+    return call(
+        GdsNodeIds.Directory_StartSigningRequest,
+        "StartSigningRequest",
+        new Variant[] {
+          Variant.ofNodeId(applicationId),
+          Variant.ofNodeId(orNull(certificateGroupId)),
+          Variant.ofNodeId(orNull(certificateTypeId)),
+          Variant.ofByteString(certificateRequest)
+        },
+        1,
+        outputs -> outputs.scalar(0, NodeId.class));
+  }
+
+  /**
+   * Ask the GDS to generate a key pair and certificate (Part 12 §7.9.4).
+   *
+   * <p>The private key is transported from the GDS to the caller in {@link
+   * FinishRequestResult#privateKey()}; prefer {@link #startSigningRequest} whenever the key pair
+   * can be generated locally, and protect the returned key material when it cannot. No helper is
+   * provided for decoding the PFX or PEM formats. Requires an encrypted channel.
+   *
+   * @param applicationId the ApplicationId returned by registration.
+   * @param certificateGroupId the CertificateGroup the certificate belongs to, or null for the
+   *     default group.
+   * @param certificateTypeId the CertificateType to issue, or null for the group's default.
+   * @param subjectName the subject name to put in the certificate, or null to let the GDS choose.
+   * @param domainNames the domain names to put in the certificate, or null to let the GDS choose.
+   * @param privateKeyFormat {@code "PFX"} or {@code "PEM"}, or null for the GDS default.
+   * @param privateKeyPassword the password to protect the private key with, or null for none.
+   * @return the RequestId to pass to {@link #finishRequest(NodeId, NodeId)}.
+   * @throws UaException if the call fails.
+   */
+  public NodeId startNewKeyPairRequest(
+      NodeId applicationId,
+      @Nullable NodeId certificateGroupId,
+      @Nullable NodeId certificateTypeId,
+      @Nullable String subjectName,
+      String @Nullable [] domainNames,
+      @Nullable String privateKeyFormat,
+      @Nullable String privateKeyPassword)
+      throws UaException {
+
+    return ClientCalls.await(
+        startNewKeyPairRequestAsync(
+            applicationId,
+            certificateGroupId,
+            certificateTypeId,
+            subjectName,
+            domainNames,
+            privateKeyFormat,
+            privateKeyPassword));
+  }
+
+  /**
+   * Asynchronous form of {@link #startNewKeyPairRequest}.
+   *
+   * @return a future completing with the RequestId.
+   */
+  public CompletableFuture<NodeId> startNewKeyPairRequestAsync(
+      NodeId applicationId,
+      @Nullable NodeId certificateGroupId,
+      @Nullable NodeId certificateTypeId,
+      @Nullable String subjectName,
+      String @Nullable [] domainNames,
+      @Nullable String privateKeyFormat,
+      @Nullable String privateKeyPassword) {
+
+    return call(
+        GdsNodeIds.Directory_StartNewKeyPairRequest,
+        "StartNewKeyPairRequest",
+        new Variant[] {
+          Variant.ofNodeId(applicationId),
+          Variant.ofNodeId(orNull(certificateGroupId)),
+          Variant.ofNodeId(orNull(certificateTypeId)),
+          Variant.of(subjectName),
+          Variant.of(domainNames),
+          Variant.of(privateKeyFormat),
+          Variant.of(privateKeyPassword)
+        },
+        1,
+        outputs -> outputs.scalar(0, NodeId.class));
+  }
+
+  /**
+   * Fetch the result of a signing or key pair request (Part 12 §7.9.5).
+   *
+   * <p>Fails with {@link StatusCodes#Bad_NothingToDo} while the request is still pending, in which
+   * case the caller polls again later; any other Bad code means the request was rejected and a new
+   * one must be submitted. Should be called on a channel using the same certificate as the matching
+   * start request. The returned certificate is not checked against anything; use {@link
+   * #verifyIssuedCertificate(X509Certificate, PublicKey, String)} before installing it.
+   *
+   * @param applicationId the ApplicationId returned by registration.
+   * @param requestId the RequestId returned by the start request.
+   * @return the issued certificate, the private key for key pair requests, and the issuer chain.
+   * @throws UaException if the call fails or the request is not complete.
+   */
+  public FinishRequestResult finishRequest(NodeId applicationId, NodeId requestId)
+      throws UaException {
+
+    return ClientCalls.await(finishRequestAsync(applicationId, requestId));
+  }
+
+  /**
+   * Asynchronous form of {@link #finishRequest(NodeId, NodeId)}.
+   *
+   * @return a future completing with the issued material.
+   */
+  public CompletableFuture<FinishRequestResult> finishRequestAsync(
+      NodeId applicationId, NodeId requestId) {
+
+    // Only the certificate is required; a GDS may omit the optional trailing outputs entirely.
+    return call(
+        GdsNodeIds.Directory_FinishRequest,
+        "FinishRequest",
+        new Variant[] {Variant.ofNodeId(applicationId), Variant.ofNodeId(requestId)},
+        1,
+        outputs -> {
+          ByteString privateKey = outputs.nullableScalar(1, ByteString.class);
+
+          return new FinishRequestResult(
+              outputs.scalar(0, ByteString.class),
+              privateKey != null && !privateKey.isNullOrEmpty() ? privateKey : null,
+              outputs.array(2, ByteString.class));
+        });
+  }
+
+  /**
+   * Get the CertificateGroups the GDS manages for an application (Part 12 §7.9.7).
+   *
+   * <p>The returned ids identify {@code CertificateGroupType} instances on the GDS; read their
+   * {@code CertificateTypes} with {@link #readCertificateTypes(NodeId)}.
+   *
+   * @param applicationId the ApplicationId returned by registration.
+   * @return the CertificateGroup ids.
+   * @throws UaException if the call fails.
+   */
+  public NodeId[] getCertificateGroups(NodeId applicationId) throws UaException {
+    return ClientCalls.await(getCertificateGroupsAsync(applicationId));
+  }
+
+  /**
+   * Asynchronous form of {@link #getCertificateGroups(NodeId)}.
+   *
+   * @return a future completing with the CertificateGroup ids.
+   */
+  public CompletableFuture<NodeId[]> getCertificateGroupsAsync(NodeId applicationId) {
+    return call(
+        GdsNodeIds.Directory_GetCertificateGroups,
+        "GetCertificateGroups",
+        new Variant[] {Variant.ofNodeId(applicationId)},
+        1,
+        outputs -> outputs.array(0, NodeId.class));
+  }
+
+  /**
+   * Get the certificates the GDS has issued to an application in a group (Part 12 §7.9.8).
+   *
+   * <p>Defined from GDS NodeSet 1.05.07; older servers fail with {@link
+   * StatusCodes#Bad_MethodInvalid} or {@link StatusCodes#Bad_NodeIdUnknown}.
+   *
+   * @param applicationId the ApplicationId returned by registration.
+   * @param certificateGroupId the CertificateGroup, or null for all groups.
+   * @return the CertificateType of each certificate and the certificates themselves.
+   * @throws UaException if the call fails.
+   */
+  public CertificatesResult getCertificates(
+      NodeId applicationId, @Nullable NodeId certificateGroupId) throws UaException {
+
+    return ClientCalls.await(getCertificatesAsync(applicationId, certificateGroupId));
+  }
+
+  /**
+   * Asynchronous form of {@link #getCertificates(NodeId, NodeId)}.
+   *
+   * @return a future completing with the certificates.
+   */
+  public CompletableFuture<CertificatesResult> getCertificatesAsync(
+      NodeId applicationId, @Nullable NodeId certificateGroupId) {
+
+    return call(
+        GdsNodeIds.Directory_GetCertificates,
+        "GetCertificates",
+        new Variant[] {
+          Variant.ofNodeId(applicationId), Variant.ofNodeId(orNull(certificateGroupId))
+        },
+        2,
+        outputs ->
+            new CertificatesResult(
+                outputs.array(0, NodeId.class), outputs.array(1, ByteString.class)));
+  }
+
+  /**
+   * Get the TrustList object for an application's CertificateGroup (Part 12 §7.9.9).
+   *
+   * <p>The returned id identifies a {@code TrustListType} instance on the GDS; read its contents
+   * with {@link TrustListReader} and its {@code LastUpdateTime} and {@code UpdateFrequency} with
+   * {@link #readTrustListInfo(NodeId)}.
+   *
+   * @param applicationId the ApplicationId returned by registration.
+   * @param certificateGroupId the CertificateGroup, or null for the default group.
+   * @return the TrustList id.
+   * @throws UaException if the call fails.
+   */
+  public NodeId getTrustList(NodeId applicationId, @Nullable NodeId certificateGroupId)
+      throws UaException {
+
+    return ClientCalls.await(getTrustListAsync(applicationId, certificateGroupId));
+  }
+
+  /**
+   * Asynchronous form of {@link #getTrustList(NodeId, NodeId)}.
+   *
+   * @return a future completing with the TrustList id.
+   */
+  public CompletableFuture<NodeId> getTrustListAsync(
+      NodeId applicationId, @Nullable NodeId certificateGroupId) {
+
+    return call(
+        GdsNodeIds.Directory_GetTrustList,
+        "GetTrustList",
+        new Variant[] {
+          Variant.ofNodeId(applicationId), Variant.ofNodeId(orNull(certificateGroupId))
+        },
+        1,
+        outputs -> outputs.scalar(0, NodeId.class));
+  }
+
+  /**
+   * Ask whether the GDS wants the application to request a new certificate (Part 12 §7.9.10).
+   *
+   * @param applicationId the ApplicationId returned by registration.
+   * @param certificateGroupId the CertificateGroup, or null for the default group.
+   * @param certificateTypeId the CertificateType, or null for the group's default.
+   * @return {@code true} if a new certificate should be requested.
+   * @throws UaException if the call fails.
+   */
+  public boolean getCertificateStatus(
+      NodeId applicationId, @Nullable NodeId certificateGroupId, @Nullable NodeId certificateTypeId)
+      throws UaException {
+
+    return ClientCalls.await(
+        getCertificateStatusAsync(applicationId, certificateGroupId, certificateTypeId));
+  }
+
+  /**
+   * Asynchronous form of {@link #getCertificateStatus(NodeId, NodeId, NodeId)}.
+   *
+   * @return a future completing with {@code true} if a new certificate should be requested.
+   */
+  public CompletableFuture<Boolean> getCertificateStatusAsync(
+      NodeId applicationId,
+      @Nullable NodeId certificateGroupId,
+      @Nullable NodeId certificateTypeId) {
+
+    return call(
+        GdsNodeIds.Directory_GetCertificateStatus,
+        "GetCertificateStatus",
+        new Variant[] {
+          Variant.ofNodeId(applicationId),
+          Variant.ofNodeId(orNull(certificateGroupId)),
+          Variant.ofNodeId(orNull(certificateTypeId))
+        },
+        1,
+        outputs -> outputs.scalar(0, Boolean.class));
+  }
+
+  /**
+   * Revoke a certificate the GDS issued to an application (Part 12 §7.9.6).
+   *
+   * <p>Defined from GDS NodeSet 1.05.07; older servers fail with {@link
+   * StatusCodes#Bad_MethodInvalid} or {@link StatusCodes#Bad_NodeIdUnknown}.
+   *
+   * @param applicationId the ApplicationId returned by registration.
+   * @param certificate the DER-encoded certificate to revoke.
+   * @throws UaException if the call fails.
+   */
+  public void revokeCertificate(NodeId applicationId, ByteString certificate) throws UaException {
+    ClientCalls.await(revokeCertificateAsync(applicationId, certificate));
+  }
+
+  /**
+   * Asynchronous form of {@link #revokeCertificate(NodeId, ByteString)}.
+   *
+   * @return a future completing when the certificate is revoked.
+   */
+  public CompletableFuture<Void> revokeCertificateAsync(
+      NodeId applicationId, ByteString certificate) {
+
+    return call(
+        GdsNodeIds.Directory_RevokeCertificate,
+        "RevokeCertificate",
+        new Variant[] {Variant.ofNodeId(applicationId), Variant.ofByteString(certificate)},
+        0,
+        outputs -> null);
+  }
+
+  /**
+   * Check the revocation status of a certificate (Part 12 §7.9.11).
+   *
+   * <p>Defined from GDS NodeSet 1.05.07; older servers fail with {@link
+   * StatusCodes#Bad_MethodInvalid} or {@link StatusCodes#Bad_NodeIdUnknown}.
+   *
+   * @param certificate the DER-encoded certificate to check.
+   * @return the certificate's status and how long the answer is valid for.
+   * @throws UaException if the call fails.
+   */
+  public RevocationStatus checkRevocationStatus(ByteString certificate) throws UaException {
+    return ClientCalls.await(checkRevocationStatusAsync(certificate));
+  }
+
+  /**
+   * Asynchronous form of {@link #checkRevocationStatus(ByteString)}.
+   *
+   * @return a future completing with the certificate's status.
+   */
+  public CompletableFuture<RevocationStatus> checkRevocationStatusAsync(ByteString certificate) {
+    return call(
+        GdsNodeIds.Directory_CheckRevocationStatus,
+        "CheckRevocationStatus",
+        new Variant[] {Variant.ofByteString(certificate)},
+        2,
+        outputs ->
+            new RevocationStatus(
+                outputs.scalar(0, StatusCode.class), outputs.scalar(1, DateTime.class)));
+  }
+
+  // endregion
+
+  // region Convenience reads
+
+  /**
+   * Read the {@code CertificateTypes} property of a CertificateGroup on the GDS.
+   *
+   * @param certificateGroupId a group id returned by {@link #getCertificateGroups(NodeId)}.
+   * @return the CertificateType ids the group issues, e.g. {@code
+   *     RsaSha256ApplicationCertificateType}.
+   * @throws UaException if the property does not exist or cannot be read.
+   */
+  public NodeId[] readCertificateTypes(NodeId certificateGroupId) throws UaException {
+    return ClientCalls.await(readCertificateTypesAsync(certificateGroupId));
+  }
+
+  /**
+   * Asynchronous form of {@link #readCertificateTypes(NodeId)}.
+   *
+   * @return a future completing with the CertificateType ids.
+   */
+  public CompletableFuture<NodeId[]> readCertificateTypesAsync(NodeId certificateGroupId) {
+    return ClientCalls.readProperties(client, certificateGroupId, List.of("CertificateTypes"))
+        .thenCompose(
+            values -> {
+              try {
+                NodeId[] certificateTypes =
+                    requiredProperty(
+                        "CertificateTypes", certificateGroupId, values.get(0), NodeId[].class);
+
+                return completedFuture(certificateTypes != null ? certificateTypes : new NodeId[0]);
+              } catch (UaException e) {
+                return failedFuture(e);
+              }
+            });
+  }
+
+  /**
+   * Read the {@code LastUpdateTime} and optional {@code UpdateFrequency} properties of a TrustList
+   * on the GDS.
+   *
+   * <p>A Pull client compares {@code lastUpdateTime} against the time it last applied the list to
+   * decide whether to read it again, and uses {@code updateFrequency} (milliseconds) as its cycle
+   * period; Part 12 §7.8.2.1 says to check within twice that value.
+   *
+   * @param trustListId a TrustList id returned by {@link #getTrustList(NodeId, NodeId)}.
+   * @return the property values; {@code updateFrequency} is null when the property is absent.
+   * @throws UaException if {@code LastUpdateTime} does not exist or cannot be read.
+   */
+  public TrustListInfo readTrustListInfo(NodeId trustListId) throws UaException {
+    return ClientCalls.await(readTrustListInfoAsync(trustListId));
+  }
+
+  /**
+   * Asynchronous form of {@link #readTrustListInfo(NodeId)}.
+   *
+   * @return a future completing with the property values.
+   */
+  public CompletableFuture<TrustListInfo> readTrustListInfoAsync(NodeId trustListId) {
+    return ClientCalls.readProperties(
+            client, trustListId, List.of("LastUpdateTime", "UpdateFrequency"))
+        .thenCompose(
+            values -> {
+              try {
+                DateTime lastUpdateTime =
+                    requiredProperty("LastUpdateTime", trustListId, values.get(0), DateTime.class);
+
+                if (lastUpdateTime == null) {
+                  throw new UaException(
+                      StatusCodes.Bad_UnexpectedError, "LastUpdateTime: value is null");
+                }
+
+                DataValue updateFrequency = values.get(1);
+                Double frequency = null;
+
+                if (updateFrequency != null
+                    && updateFrequency.getStatusCode().isGood()
+                    && updateFrequency.value().value() instanceof Double d) {
+                  frequency = d;
+                }
+
+                return completedFuture(new TrustListInfo(lastUpdateTime, frequency));
+              } catch (UaException e) {
+                return failedFuture(e);
+              }
+            });
+  }
+
+  /**
+   * Validate a required Property read by {@link ClientCalls#readProperties}.
+   *
+   * @return the value, or null when the Property exists and reads Good but holds a null value.
+   * @throws UaException if the Property is missing, read with a Bad status, or holds another type.
+   */
+  private static <T> @Nullable T requiredProperty(
+      String name, NodeId objectId, @Nullable DataValue value, Class<T> type) throws UaException {
+
+    if (value == null) {
+      throw new UaException(StatusCodes.Bad_NotFound, name + " property not found on " + objectId);
+    } else if (!value.getStatusCode().isGood()) {
+      throw new UaException(value.getStatusCode());
+    }
+
+    Object v = value.value().value();
+
+    if (v == null || type.isInstance(v)) {
+      return type.cast(v);
+    } else {
+      throw new UaException(
+          StatusCodes.Bad_UnexpectedError,
+          String.format(
+              "%s: expected %s, received %s",
+              name, type.getSimpleName(), v.getClass().getSimpleName()));
+    }
+  }
+
+  // endregion
+
+  /**
+   * Check that a certificate returned by {@link #finishRequest(NodeId, NodeId)} was issued for the
+   * caller's key pair and application.
+   *
+   * <p>The GDS is trusted to sign, not to be infallible: a certificate for the wrong key cannot be
+   * used for the channel, and one with the wrong ApplicationUri is rejected by every peer (Part 12
+   * §7.9.3). Neither problem is visible until a connection fails, so check before installing.
+   *
+   * @param issued the certificate from {@link FinishRequestResult#certificate()}.
+   * @param publicKey the public key of the key pair the signing request was created for.
+   * @param applicationUri the ApplicationUri of the application record.
+   * @throws UaException {@link StatusCodes#Bad_CertificateInvalid} if the public key differs, or
+   *     {@link StatusCodes#Bad_CertificateUriInvalid} if the ApplicationUri SAN differs.
+   */
+  public static void verifyIssuedCertificate(
+      X509Certificate issued, PublicKey publicKey, String applicationUri) throws UaException {
+
+    if (!issued.getPublicKey().equals(publicKey)) {
+      throw new UaException(
+          StatusCodes.Bad_CertificateInvalid,
+          "issued certificate public key does not match the requested key pair");
+    }
+
+    String sanUri = CertificateUtil.getSanUri(issued).orElse(null);
+
+    if (!Objects.equals(applicationUri, sanUri)) {
+      throw new UaException(
+          StatusCodes.Bad_CertificateUriInvalid,
+          String.format(
+              "issued certificate ApplicationUri '%s' does not match '%s'",
+              sanUri, applicationUri));
+    }
+  }
+
+  private <T> CompletableFuture<T> call(
+      ExpandedNodeId methodId,
+      String methodName,
+      Variant[] inputs,
+      int requiredOutputs,
+      ClientCalls.OutputDecoder<T> decoder) {
+
+    NodeId localMethodId;
+    try {
+      localMethodId = methodId.toNodeIdOrThrow(client.getNamespaceTable());
+    } catch (UaException e) {
+      return failedFuture(e);
+    }
+
+    return ClientCalls.call(
+        client, directoryId, localMethodId, methodName, inputs, requiredOutputs, decoder);
+  }
+
+  private static NodeId orNull(@Nullable NodeId nodeId) {
+    return nodeId != null ? nodeId : NodeId.NULL_VALUE;
+  }
+
+  /**
+   * The outputs of {@link GdsClient#finishRequest(NodeId, NodeId)}.
+   *
+   * <p>A GDS with nothing to return for an optional output may send a null Variant or a value with
+   * no content; both are normalized here, so {@code privateKey} is null exactly when no key was
+   * returned and {@code issuerCertificates} is empty exactly when no chain was returned.
+   *
+   * @param certificate the DER-encoded issued certificate.
+   * @param privateKey the private key in the requested format for a key pair request; null for a
+   *     signing request.
+   * @param issuerCertificates the DER-encoded issuer chain; empty when the GDS provides the chain
+   *     through the TrustList instead.
+   */
+  public record FinishRequestResult(
+      ByteString certificate, @Nullable ByteString privateKey, ByteString[] issuerCertificates) {}
+
+  /**
+   * The outputs of {@link GdsClient#getCertificates(NodeId, NodeId)}; the arrays are parallel.
+   *
+   * @param certificateTypeIds the CertificateType of each certificate.
+   * @param certificates the DER-encoded certificates.
+   */
+  public record CertificatesResult(NodeId[] certificateTypeIds, ByteString[] certificates) {}
+
+  /**
+   * The outputs of {@link GdsClient#checkRevocationStatus(ByteString)}.
+   *
+   * @param certificateStatus Good if the certificate is not revoked, otherwise the reason.
+   * @param validityTime the time until which the answer can be cached.
+   */
+  public record RevocationStatus(StatusCode certificateStatus, DateTime validityTime) {}
+
+  /**
+   * The outputs of {@link GdsClient#queryApplications}.
+   *
+   * @param lastCounterResetTime the last time the record id counter was reset.
+   * @param nextRecordId the record id to continue paging from, 0 when there are no more.
+   * @param applications the matching applications.
+   */
+  public record QueryApplicationsResult(
+      DateTime lastCounterResetTime,
+      UInteger nextRecordId,
+      ApplicationDescription[] applications) {}
+
+  /**
+   * The outputs of {@link GdsClient#queryServers}.
+   *
+   * @param lastCounterResetTime the last time the record id counter was reset.
+   * @param servers the matching servers.
+   */
+  public record QueryServersResult(DateTime lastCounterResetTime, ServerOnNetwork[] servers) {}
+
+  /**
+   * The TrustList properties read by {@link GdsClient#readTrustListInfo(NodeId)}.
+   *
+   * @param lastUpdateTime the last time the TrustList changed.
+   * @param updateFrequency the interval, in milliseconds, at which the GDS expects the list to be
+   *     re-read; null when the GDS does not expose the property.
+   */
+  public record TrustListInfo(DateTime lastUpdateTime, @Nullable Double updateFrequency) {}
+}

--- a/opc-ua-sdk/sdk-client-gds/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/GdsClient.java
+++ b/opc-ua-sdk/sdk-client-gds/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/GdsClient.java
@@ -38,6 +38,7 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
 import org.eclipse.milo.opcua.stack.core.types.structured.ApplicationDescription;
 import org.eclipse.milo.opcua.stack.core.types.structured.ServerOnNetwork;
 import org.eclipse.milo.opcua.stack.core.util.CertificateUtil;
+import org.eclipse.milo.opcua.stack.core.util.Unit;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -223,13 +224,13 @@ public final class GdsClient {
    * @param application the record to store.
    * @return a future completing when the update is done.
    */
-  public CompletableFuture<Void> updateApplicationAsync(ApplicationRecordDataType application) {
+  public CompletableFuture<Unit> updateApplicationAsync(ApplicationRecordDataType application) {
     return call(
         GdsNodeIds.Directory_UpdateApplication,
         "UpdateApplication",
         new Variant[] {Variant.ofStruct(application)},
         0,
-        outputs -> null);
+        outputs -> Unit.VALUE);
   }
 
   /**
@@ -248,13 +249,13 @@ public final class GdsClient {
    * @param applicationId the ApplicationId returned by registration.
    * @return a future completing when the registration is removed.
    */
-  public CompletableFuture<Void> unregisterApplicationAsync(NodeId applicationId) {
+  public CompletableFuture<Unit> unregisterApplicationAsync(NodeId applicationId) {
     return call(
         GdsNodeIds.Directory_UnregisterApplication,
         "UnregisterApplication",
         new Variant[] {Variant.ofNodeId(applicationId)},
         0,
-        outputs -> null);
+        outputs -> Unit.VALUE);
   }
 
   /**
@@ -750,7 +751,7 @@ public final class GdsClient {
    *
    * @return a future completing when the certificate is revoked.
    */
-  public CompletableFuture<Void> revokeCertificateAsync(
+  public CompletableFuture<Unit> revokeCertificateAsync(
       NodeId applicationId, ByteString certificate) {
 
     return call(
@@ -758,7 +759,7 @@ public final class GdsClient {
         "RevokeCertificate",
         new Variant[] {Variant.ofNodeId(applicationId), Variant.ofByteString(certificate)},
         0,
-        outputs -> null);
+        outputs -> Unit.VALUE);
   }
 
   /**
@@ -896,7 +897,9 @@ public final class GdsClient {
 
     Object v = value.value().value();
 
-    if (v == null || type.isInstance(v)) {
+    if (v == null) {
+      return null;
+    } else if (type.isInstance(v)) {
       return type.cast(v);
     } else {
       throw new UaException(

--- a/opc-ua-sdk/sdk-client-gds/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/MethodOutputs.java
+++ b/opc-ua-sdk/sdk-client-gds/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/MethodOutputs.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.gds;
+
+import java.lang.reflect.Array;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.UaSerializationException;
+import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
+import org.eclipse.milo.opcua.stack.core.types.UaStructuredType;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Typed access to the output arguments of a method call.
+ *
+ * <p>Every accessor validates the value it returns and reports a mismatch as {@link
+ * StatusCodes#Bad_UnexpectedError} naming the method, the argument index, the expected type, and
+ * the types actually received, so a server that deviates from the spec's argument list fails with a
+ * diagnosable error rather than a {@link ClassCastException}.
+ */
+final class MethodOutputs {
+
+  private final String methodName;
+  private final Variant[] outputs;
+
+  private MethodOutputs(String methodName, Variant[] outputs) {
+    this.methodName = methodName;
+    this.outputs = outputs;
+  }
+
+  /**
+   * Wrap {@code outputs}, requiring at least {@code requiredCount} values.
+   *
+   * <p>Surplus trailing outputs are tolerated; accessors only read the indexes a decoder asks for.
+   */
+  static MethodOutputs of(String methodName, Variant[] outputs, int requiredCount)
+      throws UaException {
+
+    if (outputs.length < requiredCount) {
+      throw new UaException(
+          StatusCodes.Bad_UnexpectedError,
+          String.format(
+              "%s: expected %d output argument(s) but received %d: %s",
+              methodName, requiredCount, outputs.length, describe(outputs)));
+    }
+
+    return new MethodOutputs(methodName, outputs);
+  }
+
+  /** Get the scalar output at {@code index}, which must be present and of type {@code type}. */
+  <T> T scalar(int index, Class<T> type) throws UaException {
+    T value = nullableScalar(index, type);
+
+    if (value == null) {
+      throw mismatch(index, type.getSimpleName());
+    }
+
+    return value;
+  }
+
+  /**
+   * Get the scalar output at {@code index}, which may be null but otherwise must be {@code type}.
+   */
+  <T> @Nullable T nullableScalar(int index, Class<T> type) throws UaException {
+    Object value = value(index);
+
+    if (value == null) {
+      return null;
+    } else if (type.isInstance(value)) {
+      return type.cast(value);
+    } else {
+      throw mismatch(index, type.getSimpleName());
+    }
+  }
+
+  /** Get the array output at {@code index}; a null array is returned as an empty one. */
+  <T> T[] array(int index, Class<T> componentType) throws UaException {
+    Object value = value(index);
+
+    if (value == null) {
+      @SuppressWarnings("unchecked")
+      T[] empty = (T[]) Array.newInstance(componentType, 0);
+      return empty;
+    } else if (componentType.arrayType().isInstance(value)) {
+      @SuppressWarnings("unchecked")
+      T[] array = (T[]) value;
+      return array;
+    } else {
+      throw mismatch(index, componentType.getSimpleName() + "[]");
+    }
+  }
+
+  /**
+   * Get the structure output at {@code index}, decoding it with {@code context} if it arrived as an
+   * {@link ExtensionObject}.
+   */
+  <T extends UaStructuredType> T struct(int index, Class<T> type, EncodingContext context)
+      throws UaException {
+
+    Object value = value(index);
+
+    if (value == null) {
+      throw mismatch(index, type.getSimpleName());
+    }
+
+    return decodeStruct(index, value, type, context);
+  }
+
+  /**
+   * Get the structure array output at {@code index}, decoding elements with {@code context} if they
+   * arrived as {@link ExtensionObject}s. A null array is returned as an empty one.
+   */
+  <T extends UaStructuredType> T[] structArray(int index, Class<T> type, EncodingContext context)
+      throws UaException {
+
+    Object value = value(index);
+
+    if (value != null && !(value instanceof Object[])) {
+      throw mismatch(index, type.getSimpleName() + "[]");
+    }
+
+    Object[] elements = value != null ? (Object[]) value : new Object[0];
+
+    @SuppressWarnings("unchecked")
+    T[] decoded = (T[]) Array.newInstance(type, elements.length);
+
+    for (int i = 0; i < elements.length; i++) {
+      if (elements[i] == null) {
+        throw mismatch(index, type.getSimpleName() + "[]");
+      }
+      decoded[i] = decodeStruct(index, elements[i], type, context);
+    }
+
+    return decoded;
+  }
+
+  private <T extends UaStructuredType> T decodeStruct(
+      int index, Object value, Class<T> type, EncodingContext context) throws UaException {
+
+    Object struct = value;
+
+    if (value instanceof ExtensionObject xo) {
+      try {
+        struct = xo.decode(context);
+      } catch (UaSerializationException e) {
+        throw new UaException(
+            StatusCodes.Bad_DecodingError,
+            String.format(
+                "%s: output %d could not be decoded as %s",
+                methodName, index, type.getSimpleName()),
+            e);
+      }
+    }
+
+    if (type.isInstance(struct)) {
+      return type.cast(struct);
+    } else {
+      throw mismatch(index, type.getSimpleName());
+    }
+  }
+
+  private @Nullable Object value(int index) {
+    return index < outputs.length ? outputs[index].value() : null;
+  }
+
+  private UaException mismatch(int index, String expectedType) {
+    return new UaException(
+        StatusCodes.Bad_UnexpectedError,
+        String.format(
+            "%s: expected output %d to be %s, received %s",
+            methodName, index, expectedType, describe(outputs)));
+  }
+
+  private static String describe(Variant[] outputs) {
+    return Arrays.stream(outputs)
+        .map(
+            v -> {
+              Object value = v.value();
+              if (value == null) {
+                return "null";
+              } else if (value instanceof ExtensionObject xo) {
+                return "ExtensionObject(" + xo.getEncodingOrTypeId().toParseableString() + ")";
+              } else {
+                return value.getClass().getSimpleName();
+              }
+            })
+        .collect(Collectors.joining(", ", "[", "]"));
+  }
+}

--- a/opc-ua-sdk/sdk-client-gds/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/MethodOutputs.java
+++ b/opc-ua-sdk/sdk-client-gds/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/MethodOutputs.java
@@ -131,16 +131,17 @@ final class MethodOutputs {
       throw mismatch(index, type.getSimpleName() + "[]");
     }
 
-    Object[] elements = value != null ? (Object[]) value : new Object[0];
+    @Nullable Object[] elements = value != null ? (@Nullable Object[]) value : new Object[0];
 
     @SuppressWarnings("unchecked")
     T[] decoded = (T[]) Array.newInstance(type, elements.length);
 
     for (int i = 0; i < elements.length; i++) {
-      if (elements[i] == null) {
+      Object element = elements[i];
+      if (element == null) {
         throw mismatch(index, type.getSimpleName() + "[]");
       }
-      decoded[i] = decodeStruct(index, elements[i], type, context);
+      decoded[i] = decodeStruct(index, element, type, context);
     }
 
     return decoded;

--- a/opc-ua-sdk/sdk-client-gds/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/TrustListApplier.java
+++ b/opc-ua-sdk/sdk-client-gds/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/TrustListApplier.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.gds;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+
+import java.security.GeneralSecurityException;
+import java.security.cert.X509CRL;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.List;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.security.TrustListManager;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.TrustListMasks;
+import org.eclipse.milo.opcua.stack.core.types.structured.TrustListDataType;
+import org.eclipse.milo.opcua.stack.core.util.CertificateUtil;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Converts between {@link TrustListDataType} and {@link TrustListManager}.
+ *
+ * <p>{@link #apply} installs a list pulled from a GDS: each list whose bit is set in {@code
+ * SpecifiedLists} replaces the manager's corresponding list in full, and lists whose bit is clear
+ * are left untouched, which is what Part 12 §7.8.2 defines the masks to mean. {@link
+ * #toTrustListDataType} is the inverse, for a server exposing its trust list through the Push Model
+ * or for tests.
+ */
+public final class TrustListApplier {
+
+  private TrustListApplier() {}
+
+  /**
+   * Replace the lists of {@code manager} named by {@code trustList}'s {@code SpecifiedLists} with
+   * the certificates and CRLs it carries.
+   *
+   * <p>All entries are decoded before anything is replaced, so a malformed entry rejects the whole
+   * update and the manager is unchanged. Lists are replaced in the order issuer certificates,
+   * trusted certificates, issuer CRLs, trusted CRLs. The replacements are separate operations on
+   * the manager, so a validation running concurrently may briefly see a mix of old and new lists.
+   *
+   * @param trustList the list to apply.
+   * @param manager the {@link TrustListManager} to update.
+   * @throws UaException if an entry cannot be decoded; {@link StatusCodes#Bad_CertificateInvalid}
+   *     for a certificate, {@link StatusCodes#Bad_DecodingError} for a CRL.
+   */
+  public static void apply(TrustListDataType trustList, TrustListManager manager)
+      throws UaException {
+
+    int masks = trustList.getSpecifiedLists().intValue();
+
+    List<X509Certificate> issuerCertificates =
+        isSet(masks, TrustListMasks.IssuerCertificates)
+            ? decodeCertificates("IssuerCertificates", trustList.getIssuerCertificates())
+            : null;
+    List<X509Certificate> trustedCertificates =
+        isSet(masks, TrustListMasks.TrustedCertificates)
+            ? decodeCertificates("TrustedCertificates", trustList.getTrustedCertificates())
+            : null;
+    List<X509CRL> issuerCrls =
+        isSet(masks, TrustListMasks.IssuerCrls)
+            ? decodeCrls("IssuerCrls", trustList.getIssuerCrls())
+            : null;
+    List<X509CRL> trustedCrls =
+        isSet(masks, TrustListMasks.TrustedCrls)
+            ? decodeCrls("TrustedCrls", trustList.getTrustedCrls())
+            : null;
+
+    if (issuerCertificates != null) {
+      manager.setIssuerCertificates(issuerCertificates);
+    }
+    if (trustedCertificates != null) {
+      manager.setTrustedCertificates(trustedCertificates);
+    }
+    if (issuerCrls != null) {
+      manager.setIssuerCrls(issuerCrls);
+    }
+    if (trustedCrls != null) {
+      manager.setTrustedCrls(trustedCrls);
+    }
+  }
+
+  /**
+   * Build a {@link TrustListDataType} from the lists of {@code manager} selected by {@code masks}.
+   *
+   * @param manager the {@link TrustListManager} to read.
+   * @param masks a bit set of {@link TrustListMasks} values selecting the lists to include; lists
+   *     not selected are left null.
+   * @return the encoded lists with {@code SpecifiedLists} set to {@code masks}.
+   * @throws UaException {@link StatusCodes#Bad_EncodingError} if a certificate or CRL cannot be
+   *     DER-encoded.
+   */
+  public static TrustListDataType toTrustListDataType(TrustListManager manager, int masks)
+      throws UaException {
+
+    return new TrustListDataType(
+        uint(masks),
+        isSet(masks, TrustListMasks.TrustedCertificates)
+            ? encodeCertificates(manager.getTrustedCertificates())
+            : null,
+        isSet(masks, TrustListMasks.TrustedCrls) ? encodeCrls(manager.getTrustedCrls()) : null,
+        isSet(masks, TrustListMasks.IssuerCertificates)
+            ? encodeCertificates(manager.getIssuerCertificates())
+            : null,
+        isSet(masks, TrustListMasks.IssuerCrls) ? encodeCrls(manager.getIssuerCrls()) : null);
+  }
+
+  private static boolean isSet(int masks, TrustListMasks mask) {
+    return (masks & mask.getValue()) != 0;
+  }
+
+  private static List<X509Certificate> decodeCertificates(
+      String listName, ByteString @Nullable [] entries) throws UaException {
+    return decodeAll(listName, entries, CertificateUtil::decodeCertificate);
+  }
+
+  private static List<X509CRL> decodeCrls(String listName, ByteString @Nullable [] entries)
+      throws UaException {
+    return decodeAll(listName, entries, CertificateUtil::decodeCrl);
+  }
+
+  private static <T> List<T> decodeAll(
+      String listName, ByteString @Nullable [] entries, Decoder<T> decoder) throws UaException {
+
+    var decoded = new ArrayList<T>();
+
+    if (entries != null) {
+      for (int i = 0; i < entries.length; i++) {
+        try {
+          decoded.add(decoder.decode(entries[i].bytesOrEmpty()));
+        } catch (UaException e) {
+          throw new UaException(
+              e.getStatusCode().value(), listName + "[" + i + "]: " + e.getMessage(), e);
+        }
+      }
+    }
+
+    return decoded;
+  }
+
+  private static ByteString[] encodeCertificates(List<X509Certificate> certificates)
+      throws UaException {
+    return encodeAll(certificates, X509Certificate::getEncoded);
+  }
+
+  private static ByteString[] encodeCrls(List<X509CRL> crls) throws UaException {
+    return encodeAll(crls, X509CRL::getEncoded);
+  }
+
+  private static <T> ByteString[] encodeAll(List<T> items, Encoder<T> encoder) throws UaException {
+
+    var encoded = new ByteString[items.size()];
+
+    for (int i = 0; i < encoded.length; i++) {
+      try {
+        encoded[i] = ByteString.of(encoder.encode(items.get(i)));
+      } catch (GeneralSecurityException e) {
+        throw new UaException(StatusCodes.Bad_EncodingError, e);
+      }
+    }
+
+    return encoded;
+  }
+
+  @FunctionalInterface
+  private interface Decoder<T> {
+    T decode(byte[] der) throws UaException;
+  }
+
+  @FunctionalInterface
+  private interface Encoder<T> {
+    byte[] encode(T item) throws GeneralSecurityException;
+  }
+}

--- a/opc-ua-sdk/sdk-client-gds/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/TrustListReader.java
+++ b/opc-ua-sdk/sdk-client-gds/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/TrustListReader.java
@@ -10,6 +10,7 @@
 
 package org.eclipse.milo.opcua.sdk.client.gds;
 
+import static java.util.Objects.requireNonNullElse;
 import static java.util.concurrent.CompletableFuture.completedFuture;
 import static java.util.concurrent.CompletableFuture.failedFuture;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ubyte;
@@ -33,6 +34,7 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.OpenFileMode;
 import org.eclipse.milo.opcua.stack.core.types.structured.TrustListDataType;
+import org.eclipse.milo.opcua.stack.core.util.Unit;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -243,10 +245,12 @@ public final class TrustListReader {
             "Read",
             new Variant[] {Variant.ofUInt32(fileHandle), Variant.ofInt32(chunkSize)},
             1,
-            outputs -> outputs.nullableScalar(0, ByteString.class))
+            outputs ->
+                requireNonNullElse(
+                    outputs.nullableScalar(0, ByteString.class), ByteString.NULL_VALUE))
         .thenCompose(
             data -> {
-              byte[] chunk = data != null ? data.bytesOrEmpty() : new byte[0];
+              byte[] chunk = data.bytesOrEmpty();
 
               body.writeBytes(chunk);
 
@@ -258,7 +262,7 @@ public final class TrustListReader {
             });
   }
 
-  private static CompletableFuture<Void> close(
+  private static CompletableFuture<Unit> close(
       OpcUaClient client, NodeId trustListId, UInteger fileHandle) {
 
     return ClientCalls.call(
@@ -268,6 +272,6 @@ public final class TrustListReader {
         "Close",
         new Variant[] {Variant.ofUInt32(fileHandle)},
         0,
-        outputs -> null);
+        outputs -> Unit.VALUE);
   }
 }

--- a/opc-ua-sdk/sdk-client-gds/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/TrustListReader.java
+++ b/opc-ua-sdk/sdk-client-gds/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/TrustListReader.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.gds;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+import static java.util.concurrent.CompletableFuture.failedFuture;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ubyte;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
+import org.eclipse.milo.opcua.stack.core.encoding.binary.OpcUaBinaryDecoder;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.OpenFileMode;
+import org.eclipse.milo.opcua.stack.core.types.structured.TrustListDataType;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Reads the contents of a {@code TrustListType} object into a {@link TrustListDataType}.
+ *
+ * <p>A TrustList is a {@code FileType} whose body is the OPC UA Binary encoding of a bare {@link
+ * TrustListDataType} (Part 12 §7.8.2). {@link #read} opens the file for reading, reads it in
+ * chunks, closes it, and decodes the body; the caller supplies the TrustList id, typically from
+ * {@link GdsClient#getTrustList(NodeId, NodeId)}, and then hands the result to {@link
+ * TrustListApplier}. The FileType methods are invoked through the {@code FileType} declaration ids
+ * ({@code FileType_Open} and so on), which Part 4 §5.12.2.2 allows for any FileType subtype
+ * instance.
+ *
+ * <p>Chunk size defaults to the object's optional {@code MaxByteStringLength} property, else {@link
+ * #DEFAULT_CHUNK_SIZE}, in both cases capped so a chunk fits in a message the client is willing to
+ * receive. Use the explicit-size overloads for servers that need something else.
+ */
+public final class TrustListReader {
+
+  /** Chunk size used when the TrustList does not expose {@code MaxByteStringLength}: 64 KiB. */
+  public static final int DEFAULT_CHUNK_SIZE = 64 * 1024;
+
+  // Headroom for the response headers and the Read result wrapping a chunk of data.
+  private static final int MESSAGE_OVERHEAD = 4096;
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(TrustListReader.class);
+
+  private TrustListReader() {}
+
+  /**
+   * Read and decode a TrustList, choosing the chunk size from the object's {@code
+   * MaxByteStringLength} property or {@link #DEFAULT_CHUNK_SIZE}.
+   *
+   * @param client a connected {@link OpcUaClient}.
+   * @param trustListId the {@link NodeId} of a {@code TrustListType} object.
+   * @return the decoded {@link TrustListDataType}.
+   * @throws UaException if opening, reading, or closing the file fails, or with {@link
+   *     StatusCodes#Bad_DecodingError} if the body is not a valid {@link TrustListDataType}.
+   */
+  public static TrustListDataType read(OpcUaClient client, NodeId trustListId) throws UaException {
+    return ClientCalls.await(readAsync(client, trustListId));
+  }
+
+  /**
+   * Read and decode a TrustList using {@code chunkSize}-byte Read calls.
+   *
+   * @param client a connected {@link OpcUaClient}.
+   * @param trustListId the {@link NodeId} of a {@code TrustListType} object.
+   * @param chunkSize the number of bytes to request per Read call; must be positive.
+   * @return the decoded {@link TrustListDataType}.
+   * @throws UaException if opening, reading, or closing the file fails, or with {@link
+   *     StatusCodes#Bad_DecodingError} if the body is not a valid {@link TrustListDataType}.
+   */
+  public static TrustListDataType read(OpcUaClient client, NodeId trustListId, int chunkSize)
+      throws UaException {
+
+    return ClientCalls.await(readAsync(client, trustListId, chunkSize));
+  }
+
+  /**
+   * Asynchronous form of {@link #read(OpcUaClient, NodeId)}.
+   *
+   * @return a future completing with the decoded {@link TrustListDataType}.
+   */
+  public static CompletableFuture<TrustListDataType> readAsync(
+      OpcUaClient client, NodeId trustListId) {
+
+    return ClientCalls.readProperties(client, trustListId, List.of("MaxByteStringLength"))
+        .thenCompose(values -> readAsync(client, trustListId, chunkSize(client, values.get(0))));
+  }
+
+  /**
+   * Asynchronous form of {@link #read(OpcUaClient, NodeId, int)}.
+   *
+   * @return a future completing with the decoded {@link TrustListDataType}.
+   */
+  public static CompletableFuture<TrustListDataType> readAsync(
+      OpcUaClient client, NodeId trustListId, int chunkSize) {
+
+    if (chunkSize <= 0) {
+      return failedFuture(new IllegalArgumentException("chunkSize must be positive: " + chunkSize));
+    }
+
+    return open(client, trustListId)
+        .thenCompose(fileHandle -> readThenClose(client, trustListId, fileHandle, chunkSize))
+        .thenCompose(
+            body -> {
+              try {
+                return completedFuture(decode(client.getStaticEncodingContext(), body));
+              } catch (UaException e) {
+                return failedFuture(e);
+              }
+            });
+  }
+
+  /**
+   * Read the whole file, then close it whether or not the read succeeded. A read failure wins over
+   * a close failure; a close failure after a successful read is logged, since the data is complete
+   * and the server reclaims an unclosed handle on its own.
+   */
+  private static CompletableFuture<byte[]> readThenClose(
+      OpcUaClient client, NodeId trustListId, UInteger fileHandle, int chunkSize) {
+
+    var result = new CompletableFuture<byte[]>();
+
+    readAll(client, trustListId, fileHandle, chunkSize, new ByteArrayOutputStream())
+        .whenComplete(
+            (body, readError) ->
+                close(client, trustListId, fileHandle)
+                    .whenComplete(
+                        (ignored, closeError) -> {
+                          if (readError != null) {
+                            Throwable cause = unwrap(readError);
+                            if (closeError != null) {
+                              cause.addSuppressed(unwrap(closeError));
+                            }
+                            result.completeExceptionally(cause);
+                          } else {
+                            if (closeError != null) {
+                              LOGGER.warn(
+                                  "Close failed after reading TrustList {}: {}",
+                                  trustListId,
+                                  unwrap(closeError).toString());
+                            }
+                            result.complete(body);
+                          }
+                        }));
+
+    return result;
+  }
+
+  private static Throwable unwrap(Throwable t) {
+    return t instanceof CompletionException && t.getCause() != null ? t.getCause() : t;
+  }
+
+  /**
+   * Decode the body of a TrustList file, which is a bare {@link TrustListDataType} in OPC UA Binary
+   * encoding (Part 12 §7.8.2), not an ExtensionObject.
+   *
+   * @param context the {@link EncodingContext} to decode with.
+   * @param body the file contents.
+   * @return the decoded {@link TrustListDataType}.
+   * @throws UaException {@link StatusCodes#Bad_DecodingError} if the body is malformed or has
+   *     trailing bytes.
+   */
+  public static TrustListDataType decode(EncodingContext context, byte[] body) throws UaException {
+
+    ByteBuf buffer = Unpooled.wrappedBuffer(body);
+
+    try {
+      var decoder = new OpcUaBinaryDecoder(context).setBuffer(buffer);
+
+      TrustListDataType trustList = new TrustListDataType.Codec().decodeType(context, decoder);
+
+      if (buffer.isReadable()) {
+        throw new UaException(
+            StatusCodes.Bad_DecodingError,
+            "TrustList body has " + buffer.readableBytes() + " trailing bytes");
+      }
+
+      return trustList;
+    } catch (RuntimeException e) {
+      throw new UaException(StatusCodes.Bad_DecodingError, "TrustList body is malformed", e);
+    } finally {
+      buffer.release();
+    }
+  }
+
+  private static int chunkSize(OpcUaClient client, @Nullable DataValue maxByteStringLength) {
+    int cap = client.getConfig().getEncodingLimits().getMaxMessageSize() - MESSAGE_OVERHEAD;
+
+    int preferred = DEFAULT_CHUNK_SIZE;
+
+    if (maxByteStringLength != null
+        && maxByteStringLength.getStatusCode().isGood()
+        && maxByteStringLength.value().value() instanceof UInteger max
+        && max.longValue() > 0) {
+      preferred = (int) Math.min(max.longValue(), Integer.MAX_VALUE);
+    }
+
+    return Math.max(1, Math.min(preferred, cap));
+  }
+
+  private static CompletableFuture<UInteger> open(OpcUaClient client, NodeId trustListId) {
+    return ClientCalls.call(
+        client,
+        trustListId,
+        NodeIds.FileType_Open,
+        "Open",
+        new Variant[] {Variant.ofByte(ubyte(OpenFileMode.Read.getValue()))},
+        1,
+        outputs -> outputs.scalar(0, UInteger.class));
+  }
+
+  private static CompletableFuture<byte[]> readAll(
+      OpcUaClient client,
+      NodeId trustListId,
+      UInteger fileHandle,
+      int chunkSize,
+      ByteArrayOutputStream body) {
+
+    return ClientCalls.call(
+            client,
+            trustListId,
+            NodeIds.FileType_Read,
+            "Read",
+            new Variant[] {Variant.ofUInt32(fileHandle), Variant.ofInt32(chunkSize)},
+            1,
+            outputs -> outputs.nullableScalar(0, ByteString.class))
+        .thenCompose(
+            data -> {
+              byte[] chunk = data != null ? data.bytesOrEmpty() : new byte[0];
+
+              body.writeBytes(chunk);
+
+              if (chunk.length < chunkSize) {
+                return completedFuture(body.toByteArray());
+              } else {
+                return readAll(client, trustListId, fileHandle, chunkSize, body);
+              }
+            });
+  }
+
+  private static CompletableFuture<Void> close(
+      OpcUaClient client, NodeId trustListId, UInteger fileHandle) {
+
+    return ClientCalls.call(
+        client,
+        trustListId,
+        NodeIds.FileType_Close,
+        "Close",
+        new Variant[] {Variant.ofUInt32(fileHandle)},
+        0,
+        outputs -> null);
+  }
+}

--- a/opc-ua-sdk/sdk-client-gds/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/package-info.java
+++ b/opc-ua-sdk/sdk-client-gds/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/package-info.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/**
+ * Client support for the OPC UA Global Discovery Server (GDS, OPC 10000-12): application
+ * registration, certificate requests through the Pull Model, and trust list retrieval.
+ *
+ * <p>This package spans two modules. {@code milo-sdk-client} contributes the generated GDS model:
+ * {@link org.eclipse.milo.opcua.sdk.client.gds.ObjectTypeInitializer}, {@link
+ * org.eclipse.milo.opcua.sdk.client.gds.VariableTypeInitializer}, and the typed node classes in
+ * {@code org.eclipse.milo.opcua.sdk.client.gds.model.objects}. {@code milo-sdk-client-gds}
+ * contributes the hand-written layer described here, which an application opts into by adding that
+ * module as a dependency.
+ *
+ * <h2>Entry points</h2>
+ *
+ * <p>{@link org.eclipse.milo.opcua.sdk.client.gds.GdsClient} wraps a connected {@link
+ * org.eclipse.milo.opcua.sdk.client.OpcUaClient}. Creating it resolves the GDS namespace index,
+ * registers the {@code ApplicationRecordDataType} codec and the GDS ObjectTypes with the client,
+ * and locates the {@code Directory} object. It then exposes every {@code DirectoryType} and {@code
+ * CertificateDirectoryType} method as a typed Java method with a blocking and an asynchronous form,
+ * plus two reads every workflow needs next: the {@code CertificateTypes} of a CertificateGroup and
+ * the {@code LastUpdateTime} and {@code UpdateFrequency} of a TrustList.
+ *
+ * <p>{@link org.eclipse.milo.opcua.sdk.client.gds.TrustListReader} reads a TrustList object with
+ * the FileType Open, Read, and Close methods and decodes the body into a {@link
+ * org.eclipse.milo.opcua.stack.core.types.structured.TrustListDataType}. {@link
+ * org.eclipse.milo.opcua.sdk.client.gds.TrustListApplier} installs that structure into a {@link
+ * org.eclipse.milo.opcua.stack.core.security.TrustListManager}, replacing each list the structure
+ * marks as specified, and can build the structure back from a manager.
+ *
+ * <h2>Data flow</h2>
+ *
+ * <p>The Pull Model (Part 12 §7.6) runs against the {@code Directory} object: find or register the
+ * application record, list the certificate groups the GDS manages for it, and for each group and
+ * certificate type ask whether an update is required, submit a signing request, and poll {@code
+ * FinishRequest} until it stops failing with {@code Bad_NothingToDo}. The group's TrustList is read
+ * whenever its {@code LastUpdateTime} moves past the time the application last applied it, and is
+ * applied to the {@code TrustListManager} of the matching local certificate group.
+ *
+ * <h2>Boundaries</h2>
+ *
+ * <p>The package is protocol code only. It makes no trust decisions and holds no state beyond the
+ * namespace index: the application chooses the identity and {@link
+ * org.eclipse.milo.opcua.stack.core.security.CertificateValidator} of the client that connects to
+ * the GDS, decides when to run each step and how to handle rejections, stores the {@code
+ * ApplicationId} and pending {@code RequestId}s across restarts, verifies issued certificates
+ * against its own key pairs, and decides which {@code TrustListManager} receives a pulled list.
+ * Method results are returned as the GDS reports them; a Bad status is thrown as a {@link
+ * org.eclipse.milo.opcua.stack.core.UaException} carrying the original code and is never
+ * interpreted or retried here.
+ *
+ * <p>Nothing in this package runs during namespace 0 startup. The GDS namespace index is only known
+ * once a client has read a server's namespace array, so the model registrations happen in {@code
+ * GdsClient.create} against that client's live {@link
+ * org.eclipse.milo.opcua.stack.core.NamespaceTable}.
+ */
+@NullMarked
+package org.eclipse.milo.opcua.sdk.client.gds;
+
+import org.jspecify.annotations.NullMarked;

--- a/opc-ua-sdk/sdk-client-gds/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/MethodOutputsTest.java
+++ b/opc-ua-sdk/sdk-client-gds/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/MethodOutputsTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.gds;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.ApplicationType;
+import org.eclipse.milo.opcua.stack.core.types.structured.ApplicationDescription;
+import org.eclipse.milo.opcua.stack.core.types.structured.ServerOnNetwork;
+import org.junit.jupiter.api.Test;
+
+/**
+ * A GDS that deviates from the spec's output argument list must produce a diagnosable {@code
+ * Bad_UnexpectedError} rather than a {@link ClassCastException} escaping from a wrapper.
+ */
+public class MethodOutputsTest {
+
+  @Test
+  void wrongOutputTypeIsReportedAsBadUnexpectedErrorNamingMethodAndTypes() throws Exception {
+    MethodOutputs outputs =
+        MethodOutputs.of("GetTrustList", new Variant[] {Variant.ofString("not a NodeId")}, 1);
+
+    UaException e = assertThrows(UaException.class, () -> outputs.scalar(0, NodeId.class));
+
+    assertEquals(StatusCodes.Bad_UnexpectedError, e.getStatusCode().value());
+    assertTrue(e.getMessage().contains("GetTrustList"), e.getMessage());
+    assertTrue(e.getMessage().contains("NodeId"), e.getMessage());
+    assertTrue(e.getMessage().contains("String"), e.getMessage());
+  }
+
+  @Test
+  void wrongOutputCountIsReportedAsBadUnexpectedError() {
+    UaException e =
+        assertThrows(
+            UaException.class, () -> MethodOutputs.of("GetCertificateStatus", new Variant[0], 1));
+
+    assertEquals(StatusCodes.Bad_UnexpectedError, e.getStatusCode().value());
+    assertTrue(e.getMessage().contains("GetCertificateStatus"), e.getMessage());
+  }
+
+  @Test
+  void missingRequiredScalarIsReportedAsBadUnexpectedError() throws Exception {
+    MethodOutputs outputs =
+        MethodOutputs.of("RegisterApplication", new Variant[] {Variant.ofNull()}, 1);
+
+    UaException e = assertThrows(UaException.class, () -> outputs.scalar(0, NodeId.class));
+
+    assertEquals(StatusCodes.Bad_UnexpectedError, e.getStatusCode().value());
+  }
+
+  // Servers encode an empty array as null on the wire; callers should not have to null-check.
+  @Test
+  void nullArrayOutputDecodesAsEmptyArray() throws Exception {
+    MethodOutputs outputs =
+        MethodOutputs.of("GetCertificateGroups", new Variant[] {Variant.ofNull()}, 1);
+
+    assertArrayEquals(new NodeId[0], outputs.array(0, NodeId.class));
+  }
+
+  // Structure outputs arrive as ExtensionObjects and must be decoded through the encoding context
+  // into the typed class the wrapper promises.
+  @Test
+  void extensionObjectArrayDecodesToTypedStructures() throws Exception {
+    var description =
+        new ApplicationDescription(
+            "urn:app",
+            "urn:product",
+            LocalizedText.english("App"),
+            ApplicationType.Server,
+            null,
+            null,
+            new String[] {"opc.tcp://localhost:4840"});
+    ExtensionObject encoded = ExtensionObject.encode(DefaultEncodingContext.INSTANCE, description);
+
+    MethodOutputs outputs =
+        MethodOutputs.of(
+            "QueryApplications", new Variant[] {new Variant(new ExtensionObject[] {encoded})}, 1);
+
+    ApplicationDescription[] decoded =
+        outputs.structArray(0, ApplicationDescription.class, DefaultEncodingContext.INSTANCE);
+
+    assertArrayEquals(new ApplicationDescription[] {description}, decoded);
+  }
+
+  @Test
+  void structureOfWrongTypeIsReportedAsBadUnexpectedError() {
+    var description =
+        new ApplicationDescription(
+            "urn:app", null, LocalizedText.NULL_VALUE, ApplicationType.Server, null, null, null);
+    ExtensionObject encoded = ExtensionObject.encode(DefaultEncodingContext.INSTANCE, description);
+
+    UaException e =
+        assertThrows(
+            UaException.class,
+            () ->
+                MethodOutputs.of("GetApplication", new Variant[] {new Variant(encoded)}, 1)
+                    .struct(0, ServerOnNetwork.class, DefaultEncodingContext.INSTANCE));
+
+    assertEquals(StatusCodes.Bad_UnexpectedError, e.getStatusCode().value());
+  }
+}

--- a/opc-ua-sdk/sdk-client-gds/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/TestPki.java
+++ b/opc-ua-sdk/sdk-client-gds/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/TestPki.java
@@ -14,6 +14,7 @@ import java.security.KeyPair;
 import java.security.cert.X509CRL;
 import java.security.cert.X509Certificate;
 import java.util.Date;
+import java.util.concurrent.Callable;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.cert.X509CRLHolder;
 import org.bouncycastle.cert.X509v2CRLBuilder;
@@ -23,51 +24,70 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateBuilder;
 import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateGenerator;
 
-/** Self-signed certificates and CRLs for exercising trust list code with real DER material. */
+/**
+ * Self-signed certificates and CRLs for exercising trust list code with real DER material.
+ *
+ * <p>Failures are rethrown unchecked so tests can hold the material in {@code static final} fields.
+ */
 final class TestPki {
 
   private TestPki() {}
 
-  static KeyPair keyPair() throws Exception {
-    return SelfSignedCertificateGenerator.generateRsaKeyPair(2048);
+  static KeyPair keyPair() {
+    return unchecked(() -> SelfSignedCertificateGenerator.generateRsaKeyPair(2048));
   }
 
-  static X509Certificate certificate(KeyPair keyPair, String commonName) throws Exception {
-    return new SelfSignedCertificateBuilder(keyPair)
-        .setCommonName(commonName)
-        .setApplicationUri("urn:eclipse:milo:test:" + commonName)
-        .build();
+  static X509Certificate certificate(KeyPair keyPair, String commonName) {
+    return unchecked(
+        () ->
+            new SelfSignedCertificateBuilder(keyPair)
+                .setCommonName(commonName)
+                .setApplicationUri("urn:eclipse:milo:test:" + commonName)
+                .build());
   }
 
-  static X509Certificate certificate(String commonName) throws Exception {
+  static X509Certificate certificate(String commonName) {
     return certificate(keyPair(), commonName);
   }
 
-  static X509CRL crl(X509Certificate issuer, KeyPair issuerKeyPair) throws Exception {
-    var builder =
-        new X509v2CRLBuilder(
-            X500Name.getInstance(issuer.getSubjectX500Principal().getEncoded()), new Date());
+  static X509CRL crl(X509Certificate issuer, KeyPair issuerKeyPair) {
+    return unchecked(
+        () -> {
+          var builder =
+              new X509v2CRLBuilder(
+                  X500Name.getInstance(issuer.getSubjectX500Principal().getEncoded()), new Date());
 
-    builder.setNextUpdate(new Date(System.currentTimeMillis() + 60_000));
+          builder.setNextUpdate(new Date(System.currentTimeMillis() + 60_000));
 
-    X509CRLHolder holder =
-        builder.build(
-            new JcaContentSignerBuilder("SHA256WithRSAEncryption")
-                .build(issuerKeyPair.getPrivate()));
+          X509CRLHolder holder =
+              builder.build(
+                  new JcaContentSignerBuilder("SHA256WithRSAEncryption")
+                      .build(issuerKeyPair.getPrivate()));
 
-    return new JcaX509CRLConverter().getCRL(holder);
+          return new JcaX509CRLConverter().getCRL(holder);
+        });
   }
 
-  static X509CRL crl() throws Exception {
+  static X509CRL crl() {
     KeyPair keyPair = keyPair();
     return crl(certificate(keyPair, "crl-issuer"), keyPair);
   }
 
-  static ByteString der(X509Certificate certificate) throws Exception {
-    return ByteString.of(certificate.getEncoded());
+  static ByteString der(X509Certificate certificate) {
+    return unchecked(() -> ByteString.of(certificate.getEncoded()));
   }
 
-  static ByteString der(X509CRL crl) throws Exception {
-    return ByteString.of(crl.getEncoded());
+  static ByteString der(X509CRL crl) {
+    return unchecked(() -> ByteString.of(crl.getEncoded()));
+  }
+
+  private static <T> T unchecked(Callable<T> action) {
+    try {
+      return action.call();
+    } catch (RuntimeException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new IllegalStateException(e);
+    }
   }
 }

--- a/opc-ua-sdk/sdk-client-gds/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/TestPki.java
+++ b/opc-ua-sdk/sdk-client-gds/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/TestPki.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.gds;
+
+import java.security.KeyPair;
+import java.security.cert.X509CRL;
+import java.security.cert.X509Certificate;
+import java.util.Date;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.cert.X509CRLHolder;
+import org.bouncycastle.cert.X509v2CRLBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509CRLConverter;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateBuilder;
+import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateGenerator;
+
+/** Self-signed certificates and CRLs for exercising trust list code with real DER material. */
+final class TestPki {
+
+  private TestPki() {}
+
+  static KeyPair keyPair() throws Exception {
+    return SelfSignedCertificateGenerator.generateRsaKeyPair(2048);
+  }
+
+  static X509Certificate certificate(KeyPair keyPair, String commonName) throws Exception {
+    return new SelfSignedCertificateBuilder(keyPair)
+        .setCommonName(commonName)
+        .setApplicationUri("urn:eclipse:milo:test:" + commonName)
+        .build();
+  }
+
+  static X509Certificate certificate(String commonName) throws Exception {
+    return certificate(keyPair(), commonName);
+  }
+
+  static X509CRL crl(X509Certificate issuer, KeyPair issuerKeyPair) throws Exception {
+    var builder =
+        new X509v2CRLBuilder(
+            X500Name.getInstance(issuer.getSubjectX500Principal().getEncoded()), new Date());
+
+    builder.setNextUpdate(new Date(System.currentTimeMillis() + 60_000));
+
+    X509CRLHolder holder =
+        builder.build(
+            new JcaContentSignerBuilder("SHA256WithRSAEncryption")
+                .build(issuerKeyPair.getPrivate()));
+
+    return new JcaX509CRLConverter().getCRL(holder);
+  }
+
+  static X509CRL crl() throws Exception {
+    KeyPair keyPair = keyPair();
+    return crl(certificate(keyPair, "crl-issuer"), keyPair);
+  }
+
+  static ByteString der(X509Certificate certificate) throws Exception {
+    return ByteString.of(certificate.getEncoded());
+  }
+
+  static ByteString der(X509CRL crl) throws Exception {
+    return ByteString.of(crl.getEncoded());
+  }
+}

--- a/opc-ua-sdk/sdk-client-gds/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/TrustListApplierTest.java
+++ b/opc-ua-sdk/sdk-client-gds/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/TrustListApplierTest.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.gds;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.security.cert.X509CRL;
+import java.security.cert.X509Certificate;
+import java.util.List;
+import java.util.Set;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.security.MemoryTrustListManager;
+import org.eclipse.milo.opcua.stack.core.security.TrustListManager;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.TrustListMasks;
+import org.eclipse.milo.opcua.stack.core.types.structured.TrustListDataType;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+public class TrustListApplierTest {
+
+  private static X509Certificate oldTrusted;
+  private static X509Certificate oldIssuer;
+  private static X509CRL oldTrustedCrl;
+  private static X509CRL oldIssuerCrl;
+
+  private static X509Certificate newTrusted;
+  private static X509Certificate newIssuer;
+  private static X509CRL newTrustedCrl;
+  private static X509CRL newIssuerCrl;
+
+  private MemoryTrustListManager manager;
+
+  @BeforeAll
+  static void generateMaterial() throws Exception {
+    oldTrusted = TestPki.certificate("old-trusted");
+    oldIssuer = TestPki.certificate("old-issuer");
+    oldTrustedCrl = TestPki.crl();
+    oldIssuerCrl = TestPki.crl();
+
+    newTrusted = TestPki.certificate("new-trusted");
+    newIssuer = TestPki.certificate("new-issuer");
+    newTrustedCrl = TestPki.crl();
+    newIssuerCrl = TestPki.crl();
+  }
+
+  @BeforeEach
+  void populateManagerWithOldLists() {
+    manager = new MemoryTrustListManager();
+    manager.setTrustedCertificates(List.of(oldTrusted));
+    manager.setIssuerCertificates(List.of(oldIssuer));
+    manager.setTrustedCrls(List.of(oldTrustedCrl));
+    manager.setIssuerCrls(List.of(oldIssuerCrl));
+  }
+
+  /** A trust list carrying the "new" material in every field, specified by {@code masks}. */
+  private static TrustListDataType newTrustList(int masks) throws Exception {
+    return new TrustListDataType(
+        uint(masks),
+        new ByteString[] {TestPki.der(newTrusted)},
+        new ByteString[] {TestPki.der(newTrustedCrl)},
+        new ByteString[] {TestPki.der(newIssuer)},
+        new ByteString[] {TestPki.der(newIssuerCrl)});
+  }
+
+  @Nested
+  class Apply {
+
+    // Part 12 §7.8.2: SpecifiedLists tells the receiver which fields carry meaning. A list whose
+    // bit is clear must be left alone even if the field happens to contain data.
+    @ParameterizedTest
+    @EnumSource(
+        value = TrustListMasks.class,
+        names = {"TrustedCertificates", "TrustedCrls", "IssuerCertificates", "IssuerCrls"})
+    void applyReplacesOnlyTheSpecifiedList(TrustListMasks mask) throws Exception {
+      TrustListApplier.apply(newTrustList(mask.getValue()), manager);
+
+      boolean trustedCerts = mask == TrustListMasks.TrustedCertificates;
+      boolean trustedCrls = mask == TrustListMasks.TrustedCrls;
+      boolean issuerCerts = mask == TrustListMasks.IssuerCertificates;
+      boolean issuerCrls = mask == TrustListMasks.IssuerCrls;
+
+      assertEquals(
+          List.of(trustedCerts ? newTrusted : oldTrusted), manager.getTrustedCertificates());
+      assertEquals(List.of(trustedCrls ? newTrustedCrl : oldTrustedCrl), manager.getTrustedCrls());
+      assertEquals(List.of(issuerCerts ? newIssuer : oldIssuer), manager.getIssuerCertificates());
+      assertEquals(List.of(issuerCrls ? newIssuerCrl : oldIssuerCrl), manager.getIssuerCrls());
+    }
+
+    @Test
+    void applyWithAllMasksReplacesEveryList() throws Exception {
+      TrustListApplier.apply(newTrustList(TrustListMasks.All.getValue()), manager);
+
+      assertEquals(List.of(newTrusted), manager.getTrustedCertificates());
+      assertEquals(List.of(newTrustedCrl), manager.getTrustedCrls());
+      assertEquals(List.of(newIssuer), manager.getIssuerCertificates());
+      assertEquals(List.of(newIssuerCrl), manager.getIssuerCrls());
+    }
+
+    // The GDS delivers the complete authoritative list; a certificate it dropped must disappear
+    // locally, which is why replacement rather than merging is required.
+    @Test
+    void applyWithSpecifiedButEmptyListClearsIt() throws Exception {
+      var trustList =
+          new TrustListDataType(
+              uint(TrustListMasks.TrustedCertificates.getValue()),
+              new ByteString[0],
+              null,
+              null,
+              null);
+
+      TrustListApplier.apply(trustList, manager);
+
+      assertEquals(List.of(), manager.getTrustedCertificates());
+      assertEquals(List.of(oldIssuer), manager.getIssuerCertificates(), "unspecified, untouched");
+    }
+
+    // A half-applied update would leave the manager trusting a new certificate set without the
+    // CRLs that revoke members of it; decoding must complete before anything is replaced.
+    @Test
+    void malformedCrlRejectsTheWholeUpdateAndLeavesManagerUnchanged() throws Exception {
+      var trustList =
+          new TrustListDataType(
+              uint(TrustListMasks.All.getValue()),
+              new ByteString[] {TestPki.der(newTrusted)},
+              new ByteString[] {ByteString.of(new byte[] {0x30, 0x03, 0x02, 0x01})},
+              new ByteString[] {TestPki.der(newIssuer)},
+              new ByteString[] {TestPki.der(newIssuerCrl)});
+
+      UaException e =
+          assertThrows(UaException.class, () -> TrustListApplier.apply(trustList, manager));
+
+      assertEquals(StatusCodes.Bad_DecodingError, e.getStatusCode().value());
+      assertEquals(List.of(oldTrusted), manager.getTrustedCertificates());
+      assertEquals(List.of(oldIssuer), manager.getIssuerCertificates());
+      assertEquals(List.of(oldIssuerCrl), manager.getIssuerCrls());
+    }
+
+    @Test
+    void malformedCertificateRejectsTheWholeUpdateWithBadCertificateInvalid() throws Exception {
+      var trustList =
+          new TrustListDataType(
+              uint(TrustListMasks.All.getValue()),
+              new ByteString[] {ByteString.of(new byte[] {1, 2, 3})},
+              new ByteString[] {TestPki.der(newTrustedCrl)},
+              new ByteString[] {TestPki.der(newIssuer)},
+              new ByteString[] {TestPki.der(newIssuerCrl)});
+
+      UaException e =
+          assertThrows(UaException.class, () -> TrustListApplier.apply(trustList, manager));
+
+      assertEquals(StatusCodes.Bad_CertificateInvalid, e.getStatusCode().value());
+      assertEquals(List.of(oldTrustedCrl), manager.getTrustedCrls());
+    }
+  }
+
+  @Nested
+  class ToTrustListDataType {
+
+    // What a Push server hands out must be exactly what a Pull client would install.
+    @Test
+    void roundTripsThroughApply() throws Exception {
+      TrustListDataType trustList =
+          TrustListApplier.toTrustListDataType(manager, TrustListMasks.All.getValue());
+
+      TrustListManager copy = new MemoryTrustListManager();
+      TrustListApplier.apply(trustList, copy);
+
+      assertEquals(uint(TrustListMasks.All.getValue()), trustList.getSpecifiedLists());
+      assertEquals(
+          Set.copyOf(manager.getTrustedCertificates()), Set.copyOf(copy.getTrustedCertificates()));
+      assertEquals(
+          Set.copyOf(manager.getIssuerCertificates()), Set.copyOf(copy.getIssuerCertificates()));
+      assertEquals(Set.copyOf(manager.getTrustedCrls()), Set.copyOf(copy.getTrustedCrls()));
+      assertEquals(Set.copyOf(manager.getIssuerCrls()), Set.copyOf(copy.getIssuerCrls()));
+    }
+
+    @Test
+    void leavesUnselectedListsNull() throws Exception {
+      int masks =
+          TrustListMasks.TrustedCertificates.getValue() | TrustListMasks.IssuerCrls.getValue();
+
+      TrustListDataType trustList = TrustListApplier.toTrustListDataType(manager, masks);
+
+      assertEquals(uint(masks), trustList.getSpecifiedLists());
+      assertEquals(1, trustList.getTrustedCertificates().length);
+      assertEquals(1, trustList.getIssuerCrls().length);
+      assertNull(trustList.getTrustedCrls());
+      assertNull(trustList.getIssuerCertificates());
+    }
+  }
+}

--- a/opc-ua-sdk/sdk-client-gds/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/TrustListApplierTest.java
+++ b/opc-ua-sdk/sdk-client-gds/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/TrustListApplierTest.java
@@ -12,6 +12,7 @@ package org.eclipse.milo.opcua.sdk.client.gds;
 
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -26,7 +27,6 @@ import org.eclipse.milo.opcua.stack.core.security.TrustListManager;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.TrustListMasks;
 import org.eclipse.milo.opcua.stack.core.types.structured.TrustListDataType;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -35,48 +35,35 @@ import org.junit.jupiter.params.provider.EnumSource;
 
 public class TrustListApplierTest {
 
-  private static X509Certificate oldTrusted;
-  private static X509Certificate oldIssuer;
-  private static X509CRL oldTrustedCrl;
-  private static X509CRL oldIssuerCrl;
+  private static final X509Certificate OLD_TRUSTED = TestPki.certificate("old-trusted");
+  private static final X509Certificate OLD_ISSUER = TestPki.certificate("old-issuer");
+  private static final X509CRL OLD_TRUSTED_CRL = TestPki.crl();
+  private static final X509CRL OLD_ISSUER_CRL = TestPki.crl();
 
-  private static X509Certificate newTrusted;
-  private static X509Certificate newIssuer;
-  private static X509CRL newTrustedCrl;
-  private static X509CRL newIssuerCrl;
+  private static final X509Certificate NEW_TRUSTED = TestPki.certificate("new-trusted");
+  private static final X509Certificate NEW_ISSUER = TestPki.certificate("new-issuer");
+  private static final X509CRL NEW_TRUSTED_CRL = TestPki.crl();
+  private static final X509CRL NEW_ISSUER_CRL = TestPki.crl();
 
   private MemoryTrustListManager manager;
-
-  @BeforeAll
-  static void generateMaterial() throws Exception {
-    oldTrusted = TestPki.certificate("old-trusted");
-    oldIssuer = TestPki.certificate("old-issuer");
-    oldTrustedCrl = TestPki.crl();
-    oldIssuerCrl = TestPki.crl();
-
-    newTrusted = TestPki.certificate("new-trusted");
-    newIssuer = TestPki.certificate("new-issuer");
-    newTrustedCrl = TestPki.crl();
-    newIssuerCrl = TestPki.crl();
-  }
 
   @BeforeEach
   void populateManagerWithOldLists() {
     manager = new MemoryTrustListManager();
-    manager.setTrustedCertificates(List.of(oldTrusted));
-    manager.setIssuerCertificates(List.of(oldIssuer));
-    manager.setTrustedCrls(List.of(oldTrustedCrl));
-    manager.setIssuerCrls(List.of(oldIssuerCrl));
+    manager.setTrustedCertificates(List.of(OLD_TRUSTED));
+    manager.setIssuerCertificates(List.of(OLD_ISSUER));
+    manager.setTrustedCrls(List.of(OLD_TRUSTED_CRL));
+    manager.setIssuerCrls(List.of(OLD_ISSUER_CRL));
   }
 
   /** A trust list carrying the "new" material in every field, specified by {@code masks}. */
-  private static TrustListDataType newTrustList(int masks) throws Exception {
+  private static TrustListDataType newTrustList(int masks) {
     return new TrustListDataType(
         uint(masks),
-        new ByteString[] {TestPki.der(newTrusted)},
-        new ByteString[] {TestPki.der(newTrustedCrl)},
-        new ByteString[] {TestPki.der(newIssuer)},
-        new ByteString[] {TestPki.der(newIssuerCrl)});
+        new ByteString[] {TestPki.der(NEW_TRUSTED)},
+        new ByteString[] {TestPki.der(NEW_TRUSTED_CRL)},
+        new ByteString[] {TestPki.der(NEW_ISSUER)},
+        new ByteString[] {TestPki.der(NEW_ISSUER_CRL)});
   }
 
   @Nested
@@ -97,20 +84,21 @@ public class TrustListApplierTest {
       boolean issuerCrls = mask == TrustListMasks.IssuerCrls;
 
       assertEquals(
-          List.of(trustedCerts ? newTrusted : oldTrusted), manager.getTrustedCertificates());
-      assertEquals(List.of(trustedCrls ? newTrustedCrl : oldTrustedCrl), manager.getTrustedCrls());
-      assertEquals(List.of(issuerCerts ? newIssuer : oldIssuer), manager.getIssuerCertificates());
-      assertEquals(List.of(issuerCrls ? newIssuerCrl : oldIssuerCrl), manager.getIssuerCrls());
+          List.of(trustedCerts ? NEW_TRUSTED : OLD_TRUSTED), manager.getTrustedCertificates());
+      assertEquals(
+          List.of(trustedCrls ? NEW_TRUSTED_CRL : OLD_TRUSTED_CRL), manager.getTrustedCrls());
+      assertEquals(List.of(issuerCerts ? NEW_ISSUER : OLD_ISSUER), manager.getIssuerCertificates());
+      assertEquals(List.of(issuerCrls ? NEW_ISSUER_CRL : OLD_ISSUER_CRL), manager.getIssuerCrls());
     }
 
     @Test
     void applyWithAllMasksReplacesEveryList() throws Exception {
       TrustListApplier.apply(newTrustList(TrustListMasks.All.getValue()), manager);
 
-      assertEquals(List.of(newTrusted), manager.getTrustedCertificates());
-      assertEquals(List.of(newTrustedCrl), manager.getTrustedCrls());
-      assertEquals(List.of(newIssuer), manager.getIssuerCertificates());
-      assertEquals(List.of(newIssuerCrl), manager.getIssuerCrls());
+      assertEquals(List.of(NEW_TRUSTED), manager.getTrustedCertificates());
+      assertEquals(List.of(NEW_TRUSTED_CRL), manager.getTrustedCrls());
+      assertEquals(List.of(NEW_ISSUER), manager.getIssuerCertificates());
+      assertEquals(List.of(NEW_ISSUER_CRL), manager.getIssuerCrls());
     }
 
     // The GDS delivers the complete authoritative list; a certificate it dropped must disappear
@@ -128,45 +116,45 @@ public class TrustListApplierTest {
       TrustListApplier.apply(trustList, manager);
 
       assertEquals(List.of(), manager.getTrustedCertificates());
-      assertEquals(List.of(oldIssuer), manager.getIssuerCertificates(), "unspecified, untouched");
+      assertEquals(List.of(OLD_ISSUER), manager.getIssuerCertificates(), "unspecified, untouched");
     }
 
     // A half-applied update would leave the manager trusting a new certificate set without the
     // CRLs that revoke members of it; decoding must complete before anything is replaced.
     @Test
-    void malformedCrlRejectsTheWholeUpdateAndLeavesManagerUnchanged() throws Exception {
+    void malformedCrlRejectsTheWholeUpdateAndLeavesManagerUnchanged() {
       var trustList =
           new TrustListDataType(
               uint(TrustListMasks.All.getValue()),
-              new ByteString[] {TestPki.der(newTrusted)},
+              new ByteString[] {TestPki.der(NEW_TRUSTED)},
               new ByteString[] {ByteString.of(new byte[] {0x30, 0x03, 0x02, 0x01})},
-              new ByteString[] {TestPki.der(newIssuer)},
-              new ByteString[] {TestPki.der(newIssuerCrl)});
+              new ByteString[] {TestPki.der(NEW_ISSUER)},
+              new ByteString[] {TestPki.der(NEW_ISSUER_CRL)});
 
       UaException e =
           assertThrows(UaException.class, () -> TrustListApplier.apply(trustList, manager));
 
       assertEquals(StatusCodes.Bad_DecodingError, e.getStatusCode().value());
-      assertEquals(List.of(oldTrusted), manager.getTrustedCertificates());
-      assertEquals(List.of(oldIssuer), manager.getIssuerCertificates());
-      assertEquals(List.of(oldIssuerCrl), manager.getIssuerCrls());
+      assertEquals(List.of(OLD_TRUSTED), manager.getTrustedCertificates());
+      assertEquals(List.of(OLD_ISSUER), manager.getIssuerCertificates());
+      assertEquals(List.of(OLD_ISSUER_CRL), manager.getIssuerCrls());
     }
 
     @Test
-    void malformedCertificateRejectsTheWholeUpdateWithBadCertificateInvalid() throws Exception {
+    void malformedCertificateRejectsTheWholeUpdateWithBadCertificateInvalid() {
       var trustList =
           new TrustListDataType(
               uint(TrustListMasks.All.getValue()),
               new ByteString[] {ByteString.of(new byte[] {1, 2, 3})},
-              new ByteString[] {TestPki.der(newTrustedCrl)},
-              new ByteString[] {TestPki.der(newIssuer)},
-              new ByteString[] {TestPki.der(newIssuerCrl)});
+              new ByteString[] {TestPki.der(NEW_TRUSTED_CRL)},
+              new ByteString[] {TestPki.der(NEW_ISSUER)},
+              new ByteString[] {TestPki.der(NEW_ISSUER_CRL)});
 
       UaException e =
           assertThrows(UaException.class, () -> TrustListApplier.apply(trustList, manager));
 
       assertEquals(StatusCodes.Bad_CertificateInvalid, e.getStatusCode().value());
-      assertEquals(List.of(oldTrustedCrl), manager.getTrustedCrls());
+      assertEquals(List.of(OLD_TRUSTED_CRL), manager.getTrustedCrls());
     }
   }
 
@@ -199,6 +187,8 @@ public class TrustListApplierTest {
       TrustListDataType trustList = TrustListApplier.toTrustListDataType(manager, masks);
 
       assertEquals(uint(masks), trustList.getSpecifiedLists());
+      assertNotNull(trustList.getTrustedCertificates());
+      assertNotNull(trustList.getIssuerCrls());
       assertEquals(1, trustList.getTrustedCertificates().length);
       assertEquals(1, trustList.getIssuerCrls().length);
       assertNull(trustList.getTrustedCrls());

--- a/opc-ua-sdk/sdk-client-gds/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/TrustListReaderDecodeTest.java
+++ b/opc-ua-sdk/sdk-client-gds/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/TrustListReaderDecodeTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.gds;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
+import java.util.Arrays;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
+import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
+import org.eclipse.milo.opcua.stack.core.encoding.binary.OpcUaBinaryEncoder;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.TrustListMasks;
+import org.eclipse.milo.opcua.stack.core.types.structured.TrustListDataType;
+import org.junit.jupiter.api.Test;
+
+public class TrustListReaderDecodeTest {
+
+  private static final EncodingContext CONTEXT = DefaultEncodingContext.INSTANCE;
+
+  private static final TrustListDataType TRUST_LIST =
+      new TrustListDataType(
+          uint(
+              TrustListMasks.TrustedCertificates.getValue() | TrustListMasks.IssuerCrls.getValue()),
+          new ByteString[] {ByteString.of(new byte[] {1, 2, 3}), ByteString.of(new byte[] {4})},
+          null,
+          null,
+          new ByteString[] {ByteString.of(new byte[] {5, 6})});
+
+  /** Encode {@code trustList} the way a TrustList file body is encoded (Part 12 §7.8.2). */
+  static byte[] bareBody(TrustListDataType trustList) {
+    ByteBuf buffer = Unpooled.buffer();
+    try {
+      var encoder = new OpcUaBinaryEncoder(CONTEXT).setBuffer(buffer);
+      new TrustListDataType.Codec().encodeType(CONTEXT, encoder, trustList);
+      return ByteBufUtil.getBytes(buffer);
+    } finally {
+      buffer.release();
+    }
+  }
+
+  // Part 12 §7.8.2 says the file contains the structure itself, not an ExtensionObject; the
+  // reference server and Milo-based Push servers both write it that way.
+  @Test
+  void decodeReadsBareTrustListDataTypeBody() throws Exception {
+    TrustListDataType decoded = TrustListReader.decode(CONTEXT, bareBody(TRUST_LIST));
+
+    assertEquals(TRUST_LIST, decoded);
+  }
+
+  // An ExtensionObject-wrapped body starts with the encoding NodeId, which would be mistaken for
+  // SpecifiedLists; the reader must not silently accept that framing.
+  @Test
+  void decodeRejectsExtensionObjectWrappedBody() {
+    ExtensionObject wrapped = ExtensionObject.encode(CONTEXT, TRUST_LIST);
+    ByteBuf buffer = Unpooled.buffer();
+    byte[] body;
+    try {
+      new OpcUaBinaryEncoder(CONTEXT).setBuffer(buffer).encodeExtensionObject(null, wrapped);
+      body = ByteBufUtil.getBytes(buffer);
+    } finally {
+      buffer.release();
+    }
+
+    UaException e = assertThrows(UaException.class, () -> TrustListReader.decode(CONTEXT, body));
+
+    assertEquals(StatusCodes.Bad_DecodingError, e.getStatusCode().value());
+  }
+
+  // Leftover bytes mean the chunked read reassembled something other than one structure.
+  @Test
+  void decodeRejectsTrailingBytes() {
+    byte[] full = bareBody(TRUST_LIST);
+    byte[] body = Arrays.copyOf(full, full.length + 1);
+
+    UaException e = assertThrows(UaException.class, () -> TrustListReader.decode(CONTEXT, body));
+
+    assertEquals(StatusCodes.Bad_DecodingError, e.getStatusCode().value());
+  }
+
+  @Test
+  void decodeRejectsTruncatedBody() {
+    byte[] full = bareBody(TRUST_LIST);
+    byte[] body = Arrays.copyOf(full, full.length - 3);
+
+    UaException e = assertThrows(UaException.class, () -> TrustListReader.decode(CONTEXT, body));
+
+    assertEquals(StatusCodes.Bad_DecodingError, e.getStatusCode().value());
+  }
+}

--- a/opc-ua-sdk/sdk-client-gds/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/TrustListReaderDecodeTest.java
+++ b/opc-ua-sdk/sdk-client-gds/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/TrustListReaderDecodeTest.java
@@ -42,12 +42,12 @@ public class TrustListReaderDecodeTest {
           null,
           new ByteString[] {ByteString.of(new byte[] {5, 6})});
 
-  /** Encode {@code trustList} the way a TrustList file body is encoded (Part 12 §7.8.2). */
-  static byte[] bareBody(TrustListDataType trustList) {
+  /** Encode {@link #TRUST_LIST} the way a TrustList file body is encoded (Part 12 §7.8.2). */
+  static byte[] bareBody() {
     ByteBuf buffer = Unpooled.buffer();
     try {
       var encoder = new OpcUaBinaryEncoder(CONTEXT).setBuffer(buffer);
-      new TrustListDataType.Codec().encodeType(CONTEXT, encoder, trustList);
+      new TrustListDataType.Codec().encodeType(CONTEXT, encoder, TRUST_LIST);
       return ByteBufUtil.getBytes(buffer);
     } finally {
       buffer.release();
@@ -58,7 +58,7 @@ public class TrustListReaderDecodeTest {
   // reference server and Milo-based Push servers both write it that way.
   @Test
   void decodeReadsBareTrustListDataTypeBody() throws Exception {
-    TrustListDataType decoded = TrustListReader.decode(CONTEXT, bareBody(TRUST_LIST));
+    TrustListDataType decoded = TrustListReader.decode(CONTEXT, bareBody());
 
     assertEquals(TRUST_LIST, decoded);
   }
@@ -85,7 +85,7 @@ public class TrustListReaderDecodeTest {
   // Leftover bytes mean the chunked read reassembled something other than one structure.
   @Test
   void decodeRejectsTrailingBytes() {
-    byte[] full = bareBody(TRUST_LIST);
+    byte[] full = bareBody();
     byte[] body = Arrays.copyOf(full, full.length + 1);
 
     UaException e = assertThrows(UaException.class, () -> TrustListReader.decode(CONTEXT, body));
@@ -95,7 +95,7 @@ public class TrustListReaderDecodeTest {
 
   @Test
   void decodeRejectsTruncatedBody() {
-    byte[] full = bareBody(TRUST_LIST);
+    byte[] full = bareBody();
     byte[] body = Arrays.copyOf(full, full.length - 3);
 
     UaException e = assertThrows(UaException.class, () -> TrustListReader.decode(CONTEXT, body));

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/ObjectTypeInitializer.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/ObjectTypeInitializer.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.gds;
+
+import org.eclipse.milo.opcua.sdk.client.ObjectTypeManager;
+import org.eclipse.milo.opcua.sdk.client.gds.model.objects.AccessTokenIssuedAuditEventTypeNode;
+import org.eclipse.milo.opcua.sdk.client.gds.model.objects.AccessTokenRequestedAuditEventTypeNode;
+import org.eclipse.milo.opcua.sdk.client.gds.model.objects.ApplicationRegistrationChangedAuditEventTypeNode;
+import org.eclipse.milo.opcua.sdk.client.gds.model.objects.AuthorizationServiceTypeNode;
+import org.eclipse.milo.opcua.sdk.client.gds.model.objects.AuthorizationServicesFolderTypeNode;
+import org.eclipse.milo.opcua.sdk.client.gds.model.objects.CertificateDeliveredAuditEventTypeNode;
+import org.eclipse.milo.opcua.sdk.client.gds.model.objects.CertificateDirectoryTypeNode;
+import org.eclipse.milo.opcua.sdk.client.gds.model.objects.CertificateRequestedAuditEventTypeNode;
+import org.eclipse.milo.opcua.sdk.client.gds.model.objects.CertificateRevokedAuditEventTypeNode;
+import org.eclipse.milo.opcua.sdk.client.gds.model.objects.DirectoryTypeNode;
+import org.eclipse.milo.opcua.sdk.client.gds.model.objects.KeyCredentialDeliveredAuditEventTypeNode;
+import org.eclipse.milo.opcua.sdk.client.gds.model.objects.KeyCredentialManagementFolderTypeNode;
+import org.eclipse.milo.opcua.sdk.client.gds.model.objects.KeyCredentialRequestedAuditEventTypeNode;
+import org.eclipse.milo.opcua.sdk.client.gds.model.objects.KeyCredentialRevokedAuditEventTypeNode;
+import org.eclipse.milo.opcua.sdk.client.gds.model.objects.KeyCredentialServiceTypeNode;
+import org.eclipse.milo.opcua.stack.core.NamespaceTable;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+
+public class ObjectTypeInitializer {
+  public static void initialize(
+      NamespaceTable namespaceTable, ObjectTypeManager objectTypeManager) {
+    objectTypeManager.registerObjectType(
+        NodeId.parse("ns=1;i=13").reindex(namespaceTable, "http://opcfoundation.org/UA/GDS/"),
+        DirectoryTypeNode.class,
+        DirectoryTypeNode::new);
+    objectTypeManager.registerObjectType(
+        NodeId.parse("ns=1;i=63").reindex(namespaceTable, "http://opcfoundation.org/UA/GDS/"),
+        CertificateDirectoryTypeNode.class,
+        CertificateDirectoryTypeNode::new);
+    objectTypeManager.registerObjectType(
+        NodeId.parse("ns=1;i=55").reindex(namespaceTable, "http://opcfoundation.org/UA/GDS/"),
+        KeyCredentialManagementFolderTypeNode.class,
+        KeyCredentialManagementFolderTypeNode::new);
+    objectTypeManager.registerObjectType(
+        NodeId.parse("ns=1;i=233").reindex(namespaceTable, "http://opcfoundation.org/UA/GDS/"),
+        AuthorizationServicesFolderTypeNode.class,
+        AuthorizationServicesFolderTypeNode::new);
+    objectTypeManager.registerObjectType(
+        NodeId.parse("ns=1;i=1039").reindex(namespaceTable, "http://opcfoundation.org/UA/GDS/"),
+        KeyCredentialRequestedAuditEventTypeNode.class,
+        KeyCredentialRequestedAuditEventTypeNode::new);
+    objectTypeManager.registerObjectType(
+        NodeId.parse("ns=1;i=1057").reindex(namespaceTable, "http://opcfoundation.org/UA/GDS/"),
+        KeyCredentialDeliveredAuditEventTypeNode.class,
+        KeyCredentialDeliveredAuditEventTypeNode::new);
+    objectTypeManager.registerObjectType(
+        NodeId.parse("ns=1;i=1075").reindex(namespaceTable, "http://opcfoundation.org/UA/GDS/"),
+        KeyCredentialRevokedAuditEventTypeNode.class,
+        KeyCredentialRevokedAuditEventTypeNode::new);
+    objectTypeManager.registerObjectType(
+        NodeId.parse("ns=1;i=26").reindex(namespaceTable, "http://opcfoundation.org/UA/GDS/"),
+        ApplicationRegistrationChangedAuditEventTypeNode.class,
+        ApplicationRegistrationChangedAuditEventTypeNode::new);
+    objectTypeManager.registerObjectType(
+        NodeId.parse("ns=1;i=91").reindex(namespaceTable, "http://opcfoundation.org/UA/GDS/"),
+        CertificateRequestedAuditEventTypeNode.class,
+        CertificateRequestedAuditEventTypeNode::new);
+    objectTypeManager.registerObjectType(
+        NodeId.parse("ns=1;i=109").reindex(namespaceTable, "http://opcfoundation.org/UA/GDS/"),
+        CertificateDeliveredAuditEventTypeNode.class,
+        CertificateDeliveredAuditEventTypeNode::new);
+    objectTypeManager.registerObjectType(
+        NodeId.parse("ns=1;i=27").reindex(namespaceTable, "http://opcfoundation.org/UA/GDS/"),
+        CertificateRevokedAuditEventTypeNode.class,
+        CertificateRevokedAuditEventTypeNode::new);
+    objectTypeManager.registerObjectType(
+        NodeId.parse("ns=1;i=111").reindex(namespaceTable, "http://opcfoundation.org/UA/GDS/"),
+        AccessTokenRequestedAuditEventTypeNode.class,
+        AccessTokenRequestedAuditEventTypeNode::new);
+    objectTypeManager.registerObjectType(
+        NodeId.parse("ns=1;i=975").reindex(namespaceTable, "http://opcfoundation.org/UA/GDS/"),
+        AccessTokenIssuedAuditEventTypeNode.class,
+        AccessTokenIssuedAuditEventTypeNode::new);
+    objectTypeManager.registerObjectType(
+        NodeId.parse("ns=1;i=1020").reindex(namespaceTable, "http://opcfoundation.org/UA/GDS/"),
+        KeyCredentialServiceTypeNode.class,
+        KeyCredentialServiceTypeNode::new);
+    objectTypeManager.registerObjectType(
+        NodeId.parse("ns=1;i=966").reindex(namespaceTable, "http://opcfoundation.org/UA/GDS/"),
+        AuthorizationServiceTypeNode.class,
+        AuthorizationServiceTypeNode::new);
+  }
+}

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/VariableTypeInitializer.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/VariableTypeInitializer.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.gds;
+
+import org.eclipse.milo.opcua.sdk.client.VariableTypeManager;
+import org.eclipse.milo.opcua.stack.core.NamespaceTable;
+
+public class VariableTypeInitializer {
+  public static void initialize(
+      NamespaceTable namespaceTable, VariableTypeManager variableTypeManager) {}
+}

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/AccessTokenIssuedAuditEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/AccessTokenIssuedAuditEventType.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.gds.model.objects;
+
+import org.eclipse.milo.opcua.sdk.client.model.objects.AuditUpdateMethodEventType;
+
+/**
+ * @see <a
+ *     href="https://reference.opcfoundation.org/GDS/docs/9.6.11">https://reference.opcfoundation.org/GDS/docs/9.6.11</a>
+ */
+public interface AccessTokenIssuedAuditEventType extends AuditUpdateMethodEventType {}

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/AccessTokenIssuedAuditEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/AccessTokenIssuedAuditEventTypeNode.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.gds.model.objects;
+
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.client.model.objects.AuditUpdateMethodEventTypeNode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
+import org.eclipse.milo.opcua.stack.core.types.structured.AccessRestrictionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.RolePermissionType;
+
+public class AccessTokenIssuedAuditEventTypeNode extends AuditUpdateMethodEventTypeNode
+    implements AccessTokenIssuedAuditEventType {
+  public AccessTokenIssuedAuditEventTypeNode(
+      OpcUaClient client,
+      NodeId nodeId,
+      NodeClass nodeClass,
+      QualifiedName browseName,
+      LocalizedText displayName,
+      LocalizedText description,
+      UInteger writeMask,
+      UInteger userWriteMask,
+      RolePermissionType[] rolePermissions,
+      RolePermissionType[] userRolePermissions,
+      AccessRestrictionType accessRestrictions,
+      UByte eventNotifier) {
+    super(
+        client,
+        nodeId,
+        nodeClass,
+        browseName,
+        displayName,
+        description,
+        writeMask,
+        userWriteMask,
+        rolePermissions,
+        userRolePermissions,
+        accessRestrictions,
+        eventNotifier);
+  }
+}

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/AccessTokenRequestedAuditEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/AccessTokenRequestedAuditEventType.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.gds.model.objects;
+
+import org.eclipse.milo.opcua.sdk.client.model.objects.AuditUpdateMethodEventType;
+
+/**
+ * @see <a
+ *     href="https://reference.opcfoundation.org/GDS/docs/9.6.10">https://reference.opcfoundation.org/GDS/docs/9.6.10</a>
+ */
+public interface AccessTokenRequestedAuditEventType extends AuditUpdateMethodEventType {}

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/AccessTokenRequestedAuditEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/AccessTokenRequestedAuditEventTypeNode.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.gds.model.objects;
+
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.client.model.objects.AuditUpdateMethodEventTypeNode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
+import org.eclipse.milo.opcua.stack.core.types.structured.AccessRestrictionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.RolePermissionType;
+
+public class AccessTokenRequestedAuditEventTypeNode extends AuditUpdateMethodEventTypeNode
+    implements AccessTokenRequestedAuditEventType {
+  public AccessTokenRequestedAuditEventTypeNode(
+      OpcUaClient client,
+      NodeId nodeId,
+      NodeClass nodeClass,
+      QualifiedName browseName,
+      LocalizedText displayName,
+      LocalizedText description,
+      UInteger writeMask,
+      UInteger userWriteMask,
+      RolePermissionType[] rolePermissions,
+      RolePermissionType[] userRolePermissions,
+      AccessRestrictionType accessRestrictions,
+      UByte eventNotifier) {
+    super(
+        client,
+        nodeId,
+        nodeClass,
+        browseName,
+        displayName,
+        description,
+        writeMask,
+        userWriteMask,
+        rolePermissions,
+        userRolePermissions,
+        accessRestrictions,
+        eventNotifier);
+  }
+}

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/ApplicationRegistrationChangedAuditEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/ApplicationRegistrationChangedAuditEventType.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.gds.model.objects;
+
+import org.eclipse.milo.opcua.sdk.client.model.objects.AuditUpdateMethodEventType;
+
+/**
+ * @see <a
+ *     href="https://reference.opcfoundation.org/GDS/docs/6.5.12">https://reference.opcfoundation.org/GDS/docs/6.5.12</a>
+ */
+public interface ApplicationRegistrationChangedAuditEventType extends AuditUpdateMethodEventType {}

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/ApplicationRegistrationChangedAuditEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/ApplicationRegistrationChangedAuditEventTypeNode.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.gds.model.objects;
+
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.client.model.objects.AuditUpdateMethodEventTypeNode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
+import org.eclipse.milo.opcua.stack.core.types.structured.AccessRestrictionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.RolePermissionType;
+
+public class ApplicationRegistrationChangedAuditEventTypeNode extends AuditUpdateMethodEventTypeNode
+    implements ApplicationRegistrationChangedAuditEventType {
+  public ApplicationRegistrationChangedAuditEventTypeNode(
+      OpcUaClient client,
+      NodeId nodeId,
+      NodeClass nodeClass,
+      QualifiedName browseName,
+      LocalizedText displayName,
+      LocalizedText description,
+      UInteger writeMask,
+      UInteger userWriteMask,
+      RolePermissionType[] rolePermissions,
+      RolePermissionType[] userRolePermissions,
+      AccessRestrictionType accessRestrictions,
+      UByte eventNotifier) {
+    super(
+        client,
+        nodeId,
+        nodeClass,
+        browseName,
+        displayName,
+        description,
+        writeMask,
+        userWriteMask,
+        rolePermissions,
+        userRolePermissions,
+        accessRestrictions,
+        eventNotifier);
+  }
+}

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/AuthorizationServiceType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/AuthorizationServiceType.java
@@ -1,0 +1,347 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.gds.model.objects;
+
+import java.util.concurrent.CompletableFuture;
+import org.eclipse.milo.opcua.sdk.client.model.objects.BaseObjectType;
+import org.eclipse.milo.opcua.sdk.client.model.variables.PropertyType;
+import org.eclipse.milo.opcua.sdk.core.QualifiedProperty;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
+
+/**
+ * @see <a
+ *     href="https://reference.opcfoundation.org/GDS/docs/9.6.4">https://reference.opcfoundation.org/GDS/docs/9.6.4</a>
+ */
+public interface AuthorizationServiceType extends BaseObjectType {
+  QualifiedProperty<String> SERVICE_URI =
+      new QualifiedProperty<>(
+          "http://opcfoundation.org/UA/GDS/",
+          "ServiceUri",
+          ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=12"),
+          -1,
+          String.class);
+
+  QualifiedProperty<ByteString> SERVICE_CERTIFICATE =
+      new QualifiedProperty<>(
+          "http://opcfoundation.org/UA/GDS/",
+          "ServiceCertificate",
+          ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=15"),
+          -1,
+          ByteString.class);
+
+  QualifiedProperty<UserTokenPolicy[]> USER_TOKEN_POLICIES =
+      new QualifiedProperty<>(
+          "http://opcfoundation.org/UA/GDS/",
+          "UserTokenPolicies",
+          ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=304"),
+          1,
+          UserTokenPolicy[].class);
+
+  QualifiedProperty<String[]> SUPPORTED_ROLES =
+      new QualifiedProperty<>(
+          "http://opcfoundation.org/UA/GDS/",
+          "SupportedRoles",
+          ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=12"),
+          1,
+          String[].class);
+
+  /**
+   * Get the local value of the ServiceUri Node.
+   *
+   * <p>The returned value is the last seen; it is not read live from the server.
+   *
+   * @return the local value of the ServiceUri Node.
+   * @throws UaException if an error occurs creating or getting the ServiceUri Node.
+   */
+  String getServiceUri() throws UaException;
+
+  /**
+   * Set the local value of the ServiceUri Node.
+   *
+   * <p>The value is only updated locally; it is not written to the server.
+   *
+   * @param value the local value to set for the ServiceUri Node.
+   * @throws UaException if an error occurs creating or getting the ServiceUri Node.
+   */
+  void setServiceUri(String value) throws UaException;
+
+  /**
+   * Read the value of the ServiceUri Node from the server and update the local value if the
+   * operation succeeds.
+   *
+   * @return the {@link String} value read from the server.
+   * @throws UaException if a service- or operation-level error occurs.
+   */
+  String readServiceUri() throws UaException;
+
+  /**
+   * Write a new value for the ServiceUri Node to the server and update the local value if the
+   * operation succeeds.
+   *
+   * @param value the {@link String} value to write to the server.
+   * @throws UaException if a service- or operation-level error occurs.
+   */
+  void writeServiceUri(String value) throws UaException;
+
+  /**
+   * An asynchronous implementation of {@link #readServiceUri}.
+   *
+   * @return a CompletableFuture that completes successfully with the value or completes
+   *     exceptionally if an operation- or service-level error occurs.
+   */
+  CompletableFuture<? extends String> readServiceUriAsync();
+
+  /**
+   * An asynchronous implementation of {@link #writeServiceUri}.
+   *
+   * @return a CompletableFuture that completes successfully with the operation result or completes
+   *     exceptionally if a service-level error occurs.
+   */
+  CompletableFuture<StatusCode> writeServiceUriAsync(String value);
+
+  /**
+   * Get the ServiceUri {@link PropertyType} Node, or {@code null} if it does not exist.
+   *
+   * <p>The Node is created when first accessed and cached for subsequent calls.
+   *
+   * @return the ServiceUri {@link PropertyType} Node, or {@code null} if it does not exist.
+   * @throws UaException if an error occurs creating or getting the Node.
+   */
+  PropertyType getServiceUriNode() throws UaException;
+
+  /**
+   * Asynchronous implementation of {@link #getServiceUriNode()}.
+   *
+   * @return a CompletableFuture that completes successfully with the PropertyType Node or completes
+   *     exceptionally if an error occurs creating or getting the Node.
+   */
+  CompletableFuture<? extends PropertyType> getServiceUriNodeAsync();
+
+  /**
+   * Get the local value of the ServiceCertificate Node.
+   *
+   * <p>The returned value is the last seen; it is not read live from the server.
+   *
+   * @return the local value of the ServiceCertificate Node.
+   * @throws UaException if an error occurs creating or getting the ServiceCertificate Node.
+   */
+  ByteString getServiceCertificate() throws UaException;
+
+  /**
+   * Set the local value of the ServiceCertificate Node.
+   *
+   * <p>The value is only updated locally; it is not written to the server.
+   *
+   * @param value the local value to set for the ServiceCertificate Node.
+   * @throws UaException if an error occurs creating or getting the ServiceCertificate Node.
+   */
+  void setServiceCertificate(ByteString value) throws UaException;
+
+  /**
+   * Read the value of the ServiceCertificate Node from the server and update the local value if the
+   * operation succeeds.
+   *
+   * @return the {@link ByteString} value read from the server.
+   * @throws UaException if a service- or operation-level error occurs.
+   */
+  ByteString readServiceCertificate() throws UaException;
+
+  /**
+   * Write a new value for the ServiceCertificate Node to the server and update the local value if
+   * the operation succeeds.
+   *
+   * @param value the {@link ByteString} value to write to the server.
+   * @throws UaException if a service- or operation-level error occurs.
+   */
+  void writeServiceCertificate(ByteString value) throws UaException;
+
+  /**
+   * An asynchronous implementation of {@link #readServiceCertificate}.
+   *
+   * @return a CompletableFuture that completes successfully with the value or completes
+   *     exceptionally if an operation- or service-level error occurs.
+   */
+  CompletableFuture<? extends ByteString> readServiceCertificateAsync();
+
+  /**
+   * An asynchronous implementation of {@link #writeServiceCertificate}.
+   *
+   * @return a CompletableFuture that completes successfully with the operation result or completes
+   *     exceptionally if a service-level error occurs.
+   */
+  CompletableFuture<StatusCode> writeServiceCertificateAsync(ByteString value);
+
+  /**
+   * Get the ServiceCertificate {@link PropertyType} Node, or {@code null} if it does not exist.
+   *
+   * <p>The Node is created when first accessed and cached for subsequent calls.
+   *
+   * @return the ServiceCertificate {@link PropertyType} Node, or {@code null} if it does not exist.
+   * @throws UaException if an error occurs creating or getting the Node.
+   */
+  PropertyType getServiceCertificateNode() throws UaException;
+
+  /**
+   * Asynchronous implementation of {@link #getServiceCertificateNode()}.
+   *
+   * @return a CompletableFuture that completes successfully with the PropertyType Node or completes
+   *     exceptionally if an error occurs creating or getting the Node.
+   */
+  CompletableFuture<? extends PropertyType> getServiceCertificateNodeAsync();
+
+  /**
+   * Get the local value of the UserTokenPolicies Node.
+   *
+   * <p>The returned value is the last seen; it is not read live from the server.
+   *
+   * @return the local value of the UserTokenPolicies Node.
+   * @throws UaException if an error occurs creating or getting the UserTokenPolicies Node.
+   */
+  UserTokenPolicy[] getUserTokenPolicies() throws UaException;
+
+  /**
+   * Set the local value of the UserTokenPolicies Node.
+   *
+   * <p>The value is only updated locally; it is not written to the server.
+   *
+   * @param value the local value to set for the UserTokenPolicies Node.
+   * @throws UaException if an error occurs creating or getting the UserTokenPolicies Node.
+   */
+  void setUserTokenPolicies(UserTokenPolicy[] value) throws UaException;
+
+  /**
+   * Read the value of the UserTokenPolicies Node from the server and update the local value if the
+   * operation succeeds.
+   *
+   * @return the {@link UserTokenPolicy[]} value read from the server.
+   * @throws UaException if a service- or operation-level error occurs.
+   */
+  UserTokenPolicy[] readUserTokenPolicies() throws UaException;
+
+  /**
+   * Write a new value for the UserTokenPolicies Node to the server and update the local value if
+   * the operation succeeds.
+   *
+   * @param value the {@link UserTokenPolicy[]} value to write to the server.
+   * @throws UaException if a service- or operation-level error occurs.
+   */
+  void writeUserTokenPolicies(UserTokenPolicy[] value) throws UaException;
+
+  /**
+   * An asynchronous implementation of {@link #readUserTokenPolicies}.
+   *
+   * @return a CompletableFuture that completes successfully with the value or completes
+   *     exceptionally if an operation- or service-level error occurs.
+   */
+  CompletableFuture<? extends UserTokenPolicy[]> readUserTokenPoliciesAsync();
+
+  /**
+   * An asynchronous implementation of {@link #writeUserTokenPolicies}.
+   *
+   * @return a CompletableFuture that completes successfully with the operation result or completes
+   *     exceptionally if a service-level error occurs.
+   */
+  CompletableFuture<StatusCode> writeUserTokenPoliciesAsync(UserTokenPolicy[] value);
+
+  /**
+   * Get the UserTokenPolicies {@link PropertyType} Node, or {@code null} if it does not exist.
+   *
+   * <p>The Node is created when first accessed and cached for subsequent calls.
+   *
+   * @return the UserTokenPolicies {@link PropertyType} Node, or {@code null} if it does not exist.
+   * @throws UaException if an error occurs creating or getting the Node.
+   */
+  PropertyType getUserTokenPoliciesNode() throws UaException;
+
+  /**
+   * Asynchronous implementation of {@link #getUserTokenPoliciesNode()}.
+   *
+   * @return a CompletableFuture that completes successfully with the PropertyType Node or completes
+   *     exceptionally if an error occurs creating or getting the Node.
+   */
+  CompletableFuture<? extends PropertyType> getUserTokenPoliciesNodeAsync();
+
+  /**
+   * Get the local value of the SupportedRoles Node.
+   *
+   * <p>The returned value is the last seen; it is not read live from the server.
+   *
+   * @return the local value of the SupportedRoles Node.
+   * @throws UaException if an error occurs creating or getting the SupportedRoles Node.
+   */
+  String[] getSupportedRoles() throws UaException;
+
+  /**
+   * Set the local value of the SupportedRoles Node.
+   *
+   * <p>The value is only updated locally; it is not written to the server.
+   *
+   * @param value the local value to set for the SupportedRoles Node.
+   * @throws UaException if an error occurs creating or getting the SupportedRoles Node.
+   */
+  void setSupportedRoles(String[] value) throws UaException;
+
+  /**
+   * Read the value of the SupportedRoles Node from the server and update the local value if the
+   * operation succeeds.
+   *
+   * @return the {@link String[]} value read from the server.
+   * @throws UaException if a service- or operation-level error occurs.
+   */
+  String[] readSupportedRoles() throws UaException;
+
+  /**
+   * Write a new value for the SupportedRoles Node to the server and update the local value if the
+   * operation succeeds.
+   *
+   * @param value the {@link String[]} value to write to the server.
+   * @throws UaException if a service- or operation-level error occurs.
+   */
+  void writeSupportedRoles(String[] value) throws UaException;
+
+  /**
+   * An asynchronous implementation of {@link #readSupportedRoles}.
+   *
+   * @return a CompletableFuture that completes successfully with the value or completes
+   *     exceptionally if an operation- or service-level error occurs.
+   */
+  CompletableFuture<? extends String[]> readSupportedRolesAsync();
+
+  /**
+   * An asynchronous implementation of {@link #writeSupportedRoles}.
+   *
+   * @return a CompletableFuture that completes successfully with the operation result or completes
+   *     exceptionally if a service-level error occurs.
+   */
+  CompletableFuture<StatusCode> writeSupportedRolesAsync(String[] value);
+
+  /**
+   * Get the SupportedRoles {@link PropertyType} Node, or {@code null} if it does not exist.
+   *
+   * <p>The Node is created when first accessed and cached for subsequent calls.
+   *
+   * @return the SupportedRoles {@link PropertyType} Node, or {@code null} if it does not exist.
+   * @throws UaException if an error occurs creating or getting the Node.
+   */
+  PropertyType getSupportedRolesNode() throws UaException;
+
+  /**
+   * Asynchronous implementation of {@link #getSupportedRolesNode()}.
+   *
+   * @return a CompletableFuture that completes successfully with the PropertyType Node or completes
+   *     exceptionally if an error occurs creating or getting the Node.
+   */
+  CompletableFuture<? extends PropertyType> getSupportedRolesNodeAsync();
+}

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/AuthorizationServiceTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/AuthorizationServiceTypeNode.java
@@ -1,0 +1,361 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.gds.model.objects;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.client.model.objects.BaseObjectTypeNode;
+import org.eclipse.milo.opcua.sdk.client.model.variables.PropertyTypeNode;
+import org.eclipse.milo.opcua.sdk.client.nodes.UaNode;
+import org.eclipse.milo.opcua.stack.core.AttributeId;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
+import org.eclipse.milo.opcua.stack.core.types.structured.AccessRestrictionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.RolePermissionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
+
+public class AuthorizationServiceTypeNode extends BaseObjectTypeNode
+    implements AuthorizationServiceType {
+  public AuthorizationServiceTypeNode(
+      OpcUaClient client,
+      NodeId nodeId,
+      NodeClass nodeClass,
+      QualifiedName browseName,
+      LocalizedText displayName,
+      LocalizedText description,
+      UInteger writeMask,
+      UInteger userWriteMask,
+      RolePermissionType[] rolePermissions,
+      RolePermissionType[] userRolePermissions,
+      AccessRestrictionType accessRestrictions,
+      UByte eventNotifier) {
+    super(
+        client,
+        nodeId,
+        nodeClass,
+        browseName,
+        displayName,
+        description,
+        writeMask,
+        userWriteMask,
+        rolePermissions,
+        userRolePermissions,
+        accessRestrictions,
+        eventNotifier);
+  }
+
+  @Override
+  public String getServiceUri() throws UaException {
+    PropertyTypeNode node = getServiceUriNode();
+    return (String) node.getValue().getValue().getValue();
+  }
+
+  @Override
+  public void setServiceUri(String value) throws UaException {
+    PropertyTypeNode node = getServiceUriNode();
+    node.setValue(new Variant(value));
+  }
+
+  @Override
+  public String readServiceUri() throws UaException {
+    try {
+      return readServiceUriAsync().get();
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
+    }
+  }
+
+  @Override
+  public void writeServiceUri(String value) throws UaException {
+    try {
+      writeServiceUriAsync(value).get();
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
+    }
+  }
+
+  @Override
+  public CompletableFuture<? extends String> readServiceUriAsync() {
+    return getServiceUriNodeAsync()
+        .thenCompose(node -> node.readAttributeAsync(AttributeId.Value))
+        .thenApply(v -> (String) v.getValue().getValue());
+  }
+
+  @Override
+  public CompletableFuture<StatusCode> writeServiceUriAsync(String serviceUri) {
+    DataValue value = DataValue.valueOnly(new Variant(serviceUri));
+    return getServiceUriNodeAsync()
+        .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
+  }
+
+  @Override
+  public PropertyTypeNode getServiceUriNode() throws UaException {
+    try {
+      return getServiceUriNodeAsync().get();
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
+    }
+  }
+
+  @Override
+  public CompletableFuture<? extends PropertyTypeNode> getServiceUriNodeAsync() {
+    CompletableFuture<UaNode> future =
+        getMemberNodeAsync(
+            "http://opcfoundation.org/UA/GDS/", "ServiceUri", ExpandedNodeId.parse("i=46"), false);
+    return future.thenApply(node -> (PropertyTypeNode) node);
+  }
+
+  @Override
+  public ByteString getServiceCertificate() throws UaException {
+    PropertyTypeNode node = getServiceCertificateNode();
+    return (ByteString) node.getValue().getValue().getValue();
+  }
+
+  @Override
+  public void setServiceCertificate(ByteString value) throws UaException {
+    PropertyTypeNode node = getServiceCertificateNode();
+    node.setValue(new Variant(value));
+  }
+
+  @Override
+  public ByteString readServiceCertificate() throws UaException {
+    try {
+      return readServiceCertificateAsync().get();
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
+    }
+  }
+
+  @Override
+  public void writeServiceCertificate(ByteString value) throws UaException {
+    try {
+      writeServiceCertificateAsync(value).get();
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
+    }
+  }
+
+  @Override
+  public CompletableFuture<? extends ByteString> readServiceCertificateAsync() {
+    return getServiceCertificateNodeAsync()
+        .thenCompose(node -> node.readAttributeAsync(AttributeId.Value))
+        .thenApply(v -> (ByteString) v.getValue().getValue());
+  }
+
+  @Override
+  public CompletableFuture<StatusCode> writeServiceCertificateAsync(ByteString serviceCertificate) {
+    DataValue value = DataValue.valueOnly(new Variant(serviceCertificate));
+    return getServiceCertificateNodeAsync()
+        .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
+  }
+
+  @Override
+  public PropertyTypeNode getServiceCertificateNode() throws UaException {
+    try {
+      return getServiceCertificateNodeAsync().get();
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
+    }
+  }
+
+  @Override
+  public CompletableFuture<? extends PropertyTypeNode> getServiceCertificateNodeAsync() {
+    CompletableFuture<UaNode> future =
+        getMemberNodeAsync(
+            "http://opcfoundation.org/UA/GDS/",
+            "ServiceCertificate",
+            ExpandedNodeId.parse("i=46"),
+            false);
+    return future.thenApply(node -> (PropertyTypeNode) node);
+  }
+
+  @Override
+  public UserTokenPolicy[] getUserTokenPolicies() throws UaException {
+    PropertyTypeNode node = getUserTokenPoliciesNode();
+    return cast(node.getValue().getValue().getValue(), UserTokenPolicy[].class);
+  }
+
+  @Override
+  public void setUserTokenPolicies(UserTokenPolicy[] value) throws UaException {
+    PropertyTypeNode node = getUserTokenPoliciesNode();
+    ExtensionObject[] encoded =
+        ExtensionObject.encodeArray(client.getStaticEncodingContext(), value);
+    node.setValue(new Variant(encoded));
+  }
+
+  @Override
+  public UserTokenPolicy[] readUserTokenPolicies() throws UaException {
+    try {
+      return readUserTokenPoliciesAsync().get();
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
+    }
+  }
+
+  @Override
+  public void writeUserTokenPolicies(UserTokenPolicy[] value) throws UaException {
+    try {
+      writeUserTokenPoliciesAsync(value).get();
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
+    }
+  }
+
+  @Override
+  public CompletableFuture<? extends UserTokenPolicy[]> readUserTokenPoliciesAsync() {
+    return getUserTokenPoliciesNodeAsync()
+        .thenCompose(node -> node.readAttributeAsync(AttributeId.Value))
+        .thenApply(v -> cast(v.getValue().getValue(), UserTokenPolicy[].class));
+  }
+
+  @Override
+  public CompletableFuture<StatusCode> writeUserTokenPoliciesAsync(
+      UserTokenPolicy[] userTokenPolicies) {
+    ExtensionObject[] encoded =
+        ExtensionObject.encodeArray(client.getStaticEncodingContext(), userTokenPolicies);
+    DataValue value = DataValue.valueOnly(new Variant(encoded));
+    return getUserTokenPoliciesNodeAsync()
+        .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
+  }
+
+  @Override
+  public PropertyTypeNode getUserTokenPoliciesNode() throws UaException {
+    try {
+      return getUserTokenPoliciesNodeAsync().get();
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
+    }
+  }
+
+  @Override
+  public CompletableFuture<? extends PropertyTypeNode> getUserTokenPoliciesNodeAsync() {
+    CompletableFuture<UaNode> future =
+        getMemberNodeAsync(
+            "http://opcfoundation.org/UA/GDS/",
+            "UserTokenPolicies",
+            ExpandedNodeId.parse("i=46"),
+            false);
+    return future.thenApply(node -> (PropertyTypeNode) node);
+  }
+
+  @Override
+  public String[] getSupportedRoles() throws UaException {
+    PropertyTypeNode node = getSupportedRolesNode();
+    return (String[]) node.getValue().getValue().getValue();
+  }
+
+  @Override
+  public void setSupportedRoles(String[] value) throws UaException {
+    PropertyTypeNode node = getSupportedRolesNode();
+    node.setValue(new Variant(value));
+  }
+
+  @Override
+  public String[] readSupportedRoles() throws UaException {
+    try {
+      return readSupportedRolesAsync().get();
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
+    }
+  }
+
+  @Override
+  public void writeSupportedRoles(String[] value) throws UaException {
+    try {
+      writeSupportedRolesAsync(value).get();
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
+    }
+  }
+
+  @Override
+  public CompletableFuture<? extends String[]> readSupportedRolesAsync() {
+    return getSupportedRolesNodeAsync()
+        .thenCompose(node -> node.readAttributeAsync(AttributeId.Value))
+        .thenApply(v -> (String[]) v.getValue().getValue());
+  }
+
+  @Override
+  public CompletableFuture<StatusCode> writeSupportedRolesAsync(String[] supportedRoles) {
+    DataValue value = DataValue.valueOnly(new Variant(supportedRoles));
+    return getSupportedRolesNodeAsync()
+        .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
+  }
+
+  @Override
+  public PropertyTypeNode getSupportedRolesNode() throws UaException {
+    try {
+      return getSupportedRolesNodeAsync().get();
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
+    }
+  }
+
+  @Override
+  public CompletableFuture<? extends PropertyTypeNode> getSupportedRolesNodeAsync() {
+    CompletableFuture<UaNode> future =
+        getMemberNodeAsync(
+            "http://opcfoundation.org/UA/GDS/",
+            "SupportedRoles",
+            ExpandedNodeId.parse("i=46"),
+            false);
+    return future.thenApply(node -> (PropertyTypeNode) node);
+  }
+}

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/AuthorizationServicesFolderType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/AuthorizationServicesFolderType.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.gds.model.objects;
+
+import org.eclipse.milo.opcua.sdk.client.model.objects.FolderType;
+
+/**
+ * @see <a
+ *     href="https://reference.opcfoundation.org/GDS/docs/9.6.2">https://reference.opcfoundation.org/GDS/docs/9.6.2</a>
+ */
+public interface AuthorizationServicesFolderType extends FolderType {}

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/AuthorizationServicesFolderTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/AuthorizationServicesFolderTypeNode.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.gds.model.objects;
+
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.client.model.objects.FolderTypeNode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
+import org.eclipse.milo.opcua.stack.core.types.structured.AccessRestrictionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.RolePermissionType;
+
+public class AuthorizationServicesFolderTypeNode extends FolderTypeNode
+    implements AuthorizationServicesFolderType {
+  public AuthorizationServicesFolderTypeNode(
+      OpcUaClient client,
+      NodeId nodeId,
+      NodeClass nodeClass,
+      QualifiedName browseName,
+      LocalizedText displayName,
+      LocalizedText description,
+      UInteger writeMask,
+      UInteger userWriteMask,
+      RolePermissionType[] rolePermissions,
+      RolePermissionType[] userRolePermissions,
+      AccessRestrictionType accessRestrictions,
+      UByte eventNotifier) {
+    super(
+        client,
+        nodeId,
+        nodeClass,
+        browseName,
+        displayName,
+        description,
+        writeMask,
+        userWriteMask,
+        rolePermissions,
+        userRolePermissions,
+        accessRestrictions,
+        eventNotifier);
+  }
+}

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/CertificateDeliveredAuditEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/CertificateDeliveredAuditEventType.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.gds.model.objects;
+
+import java.util.concurrent.CompletableFuture;
+import org.eclipse.milo.opcua.sdk.client.model.objects.AuditUpdateMethodEventType;
+import org.eclipse.milo.opcua.sdk.client.model.variables.PropertyType;
+import org.eclipse.milo.opcua.sdk.core.QualifiedProperty;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+
+/**
+ * @see <a
+ *     href="https://reference.opcfoundation.org/GDS/docs/7.9.13">https://reference.opcfoundation.org/GDS/docs/7.9.13</a>
+ */
+public interface CertificateDeliveredAuditEventType extends AuditUpdateMethodEventType {
+  QualifiedProperty<NodeId> CERTIFICATE_GROUP =
+      new QualifiedProperty<>(
+          "http://opcfoundation.org/UA/GDS/",
+          "CertificateGroup",
+          ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=17"),
+          -1,
+          NodeId.class);
+
+  QualifiedProperty<NodeId> CERTIFICATE_TYPE =
+      new QualifiedProperty<>(
+          "http://opcfoundation.org/UA/GDS/",
+          "CertificateType",
+          ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=17"),
+          -1,
+          NodeId.class);
+
+  /**
+   * Get the local value of the CertificateGroup Node.
+   *
+   * <p>The returned value is the last seen; it is not read live from the server.
+   *
+   * @return the local value of the CertificateGroup Node.
+   * @throws UaException if an error occurs creating or getting the CertificateGroup Node.
+   */
+  NodeId getCertificateGroup() throws UaException;
+
+  /**
+   * Set the local value of the CertificateGroup Node.
+   *
+   * <p>The value is only updated locally; it is not written to the server.
+   *
+   * @param value the local value to set for the CertificateGroup Node.
+   * @throws UaException if an error occurs creating or getting the CertificateGroup Node.
+   */
+  void setCertificateGroup(NodeId value) throws UaException;
+
+  /**
+   * Read the value of the CertificateGroup Node from the server and update the local value if the
+   * operation succeeds.
+   *
+   * @return the {@link NodeId} value read from the server.
+   * @throws UaException if a service- or operation-level error occurs.
+   */
+  NodeId readCertificateGroup() throws UaException;
+
+  /**
+   * Write a new value for the CertificateGroup Node to the server and update the local value if the
+   * operation succeeds.
+   *
+   * @param value the {@link NodeId} value to write to the server.
+   * @throws UaException if a service- or operation-level error occurs.
+   */
+  void writeCertificateGroup(NodeId value) throws UaException;
+
+  /**
+   * An asynchronous implementation of {@link #readCertificateGroup}.
+   *
+   * @return a CompletableFuture that completes successfully with the value or completes
+   *     exceptionally if an operation- or service-level error occurs.
+   */
+  CompletableFuture<? extends NodeId> readCertificateGroupAsync();
+
+  /**
+   * An asynchronous implementation of {@link #writeCertificateGroup}.
+   *
+   * @return a CompletableFuture that completes successfully with the operation result or completes
+   *     exceptionally if a service-level error occurs.
+   */
+  CompletableFuture<StatusCode> writeCertificateGroupAsync(NodeId value);
+
+  /**
+   * Get the CertificateGroup {@link PropertyType} Node, or {@code null} if it does not exist.
+   *
+   * <p>The Node is created when first accessed and cached for subsequent calls.
+   *
+   * @return the CertificateGroup {@link PropertyType} Node, or {@code null} if it does not exist.
+   * @throws UaException if an error occurs creating or getting the Node.
+   */
+  PropertyType getCertificateGroupNode() throws UaException;
+
+  /**
+   * Asynchronous implementation of {@link #getCertificateGroupNode()}.
+   *
+   * @return a CompletableFuture that completes successfully with the PropertyType Node or completes
+   *     exceptionally if an error occurs creating or getting the Node.
+   */
+  CompletableFuture<? extends PropertyType> getCertificateGroupNodeAsync();
+
+  /**
+   * Get the local value of the CertificateType Node.
+   *
+   * <p>The returned value is the last seen; it is not read live from the server.
+   *
+   * @return the local value of the CertificateType Node.
+   * @throws UaException if an error occurs creating or getting the CertificateType Node.
+   */
+  NodeId getCertificateType() throws UaException;
+
+  /**
+   * Set the local value of the CertificateType Node.
+   *
+   * <p>The value is only updated locally; it is not written to the server.
+   *
+   * @param value the local value to set for the CertificateType Node.
+   * @throws UaException if an error occurs creating or getting the CertificateType Node.
+   */
+  void setCertificateType(NodeId value) throws UaException;
+
+  /**
+   * Read the value of the CertificateType Node from the server and update the local value if the
+   * operation succeeds.
+   *
+   * @return the {@link NodeId} value read from the server.
+   * @throws UaException if a service- or operation-level error occurs.
+   */
+  NodeId readCertificateType() throws UaException;
+
+  /**
+   * Write a new value for the CertificateType Node to the server and update the local value if the
+   * operation succeeds.
+   *
+   * @param value the {@link NodeId} value to write to the server.
+   * @throws UaException if a service- or operation-level error occurs.
+   */
+  void writeCertificateType(NodeId value) throws UaException;
+
+  /**
+   * An asynchronous implementation of {@link #readCertificateType}.
+   *
+   * @return a CompletableFuture that completes successfully with the value or completes
+   *     exceptionally if an operation- or service-level error occurs.
+   */
+  CompletableFuture<? extends NodeId> readCertificateTypeAsync();
+
+  /**
+   * An asynchronous implementation of {@link #writeCertificateType}.
+   *
+   * @return a CompletableFuture that completes successfully with the operation result or completes
+   *     exceptionally if a service-level error occurs.
+   */
+  CompletableFuture<StatusCode> writeCertificateTypeAsync(NodeId value);
+
+  /**
+   * Get the CertificateType {@link PropertyType} Node, or {@code null} if it does not exist.
+   *
+   * <p>The Node is created when first accessed and cached for subsequent calls.
+   *
+   * @return the CertificateType {@link PropertyType} Node, or {@code null} if it does not exist.
+   * @throws UaException if an error occurs creating or getting the Node.
+   */
+  PropertyType getCertificateTypeNode() throws UaException;
+
+  /**
+   * Asynchronous implementation of {@link #getCertificateTypeNode()}.
+   *
+   * @return a CompletableFuture that completes successfully with the PropertyType Node or completes
+   *     exceptionally if an error occurs creating or getting the Node.
+   */
+  CompletableFuture<? extends PropertyType> getCertificateTypeNodeAsync();
+}

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/CertificateDeliveredAuditEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/CertificateDeliveredAuditEventTypeNode.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.gds.model.objects;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.client.model.objects.AuditUpdateMethodEventTypeNode;
+import org.eclipse.milo.opcua.sdk.client.model.variables.PropertyTypeNode;
+import org.eclipse.milo.opcua.sdk.client.nodes.UaNode;
+import org.eclipse.milo.opcua.stack.core.AttributeId;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
+import org.eclipse.milo.opcua.stack.core.types.structured.AccessRestrictionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.RolePermissionType;
+
+public class CertificateDeliveredAuditEventTypeNode extends AuditUpdateMethodEventTypeNode
+    implements CertificateDeliveredAuditEventType {
+  public CertificateDeliveredAuditEventTypeNode(
+      OpcUaClient client,
+      NodeId nodeId,
+      NodeClass nodeClass,
+      QualifiedName browseName,
+      LocalizedText displayName,
+      LocalizedText description,
+      UInteger writeMask,
+      UInteger userWriteMask,
+      RolePermissionType[] rolePermissions,
+      RolePermissionType[] userRolePermissions,
+      AccessRestrictionType accessRestrictions,
+      UByte eventNotifier) {
+    super(
+        client,
+        nodeId,
+        nodeClass,
+        browseName,
+        displayName,
+        description,
+        writeMask,
+        userWriteMask,
+        rolePermissions,
+        userRolePermissions,
+        accessRestrictions,
+        eventNotifier);
+  }
+
+  @Override
+  public NodeId getCertificateGroup() throws UaException {
+    PropertyTypeNode node = getCertificateGroupNode();
+    return (NodeId) node.getValue().getValue().getValue();
+  }
+
+  @Override
+  public void setCertificateGroup(NodeId value) throws UaException {
+    PropertyTypeNode node = getCertificateGroupNode();
+    node.setValue(new Variant(value));
+  }
+
+  @Override
+  public NodeId readCertificateGroup() throws UaException {
+    try {
+      return readCertificateGroupAsync().get();
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
+    }
+  }
+
+  @Override
+  public void writeCertificateGroup(NodeId value) throws UaException {
+    try {
+      writeCertificateGroupAsync(value).get();
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
+    }
+  }
+
+  @Override
+  public CompletableFuture<? extends NodeId> readCertificateGroupAsync() {
+    return getCertificateGroupNodeAsync()
+        .thenCompose(node -> node.readAttributeAsync(AttributeId.Value))
+        .thenApply(v -> (NodeId) v.getValue().getValue());
+  }
+
+  @Override
+  public CompletableFuture<StatusCode> writeCertificateGroupAsync(NodeId certificateGroup) {
+    DataValue value = DataValue.valueOnly(new Variant(certificateGroup));
+    return getCertificateGroupNodeAsync()
+        .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
+  }
+
+  @Override
+  public PropertyTypeNode getCertificateGroupNode() throws UaException {
+    try {
+      return getCertificateGroupNodeAsync().get();
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
+    }
+  }
+
+  @Override
+  public CompletableFuture<? extends PropertyTypeNode> getCertificateGroupNodeAsync() {
+    CompletableFuture<UaNode> future =
+        getMemberNodeAsync(
+            "http://opcfoundation.org/UA/GDS/",
+            "CertificateGroup",
+            ExpandedNodeId.parse("i=46"),
+            false);
+    return future.thenApply(node -> (PropertyTypeNode) node);
+  }
+
+  @Override
+  public NodeId getCertificateType() throws UaException {
+    PropertyTypeNode node = getCertificateTypeNode();
+    return (NodeId) node.getValue().getValue().getValue();
+  }
+
+  @Override
+  public void setCertificateType(NodeId value) throws UaException {
+    PropertyTypeNode node = getCertificateTypeNode();
+    node.setValue(new Variant(value));
+  }
+
+  @Override
+  public NodeId readCertificateType() throws UaException {
+    try {
+      return readCertificateTypeAsync().get();
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
+    }
+  }
+
+  @Override
+  public void writeCertificateType(NodeId value) throws UaException {
+    try {
+      writeCertificateTypeAsync(value).get();
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
+    }
+  }
+
+  @Override
+  public CompletableFuture<? extends NodeId> readCertificateTypeAsync() {
+    return getCertificateTypeNodeAsync()
+        .thenCompose(node -> node.readAttributeAsync(AttributeId.Value))
+        .thenApply(v -> (NodeId) v.getValue().getValue());
+  }
+
+  @Override
+  public CompletableFuture<StatusCode> writeCertificateTypeAsync(NodeId certificateType) {
+    DataValue value = DataValue.valueOnly(new Variant(certificateType));
+    return getCertificateTypeNodeAsync()
+        .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
+  }
+
+  @Override
+  public PropertyTypeNode getCertificateTypeNode() throws UaException {
+    try {
+      return getCertificateTypeNodeAsync().get();
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
+    }
+  }
+
+  @Override
+  public CompletableFuture<? extends PropertyTypeNode> getCertificateTypeNodeAsync() {
+    CompletableFuture<UaNode> future =
+        getMemberNodeAsync(
+            "http://opcfoundation.org/UA/GDS/",
+            "CertificateType",
+            ExpandedNodeId.parse("i=46"),
+            false);
+    return future.thenApply(node -> (PropertyTypeNode) node);
+  }
+}

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/CertificateDirectoryType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/CertificateDirectoryType.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.gds.model.objects;
+
+import java.util.concurrent.CompletableFuture;
+import org.eclipse.milo.opcua.sdk.client.model.objects.CertificateGroupFolderType;
+import org.eclipse.milo.opcua.stack.core.UaException;
+
+/**
+ * @see <a
+ *     href="https://reference.opcfoundation.org/GDS/docs/7.9.2">https://reference.opcfoundation.org/GDS/docs/7.9.2</a>
+ */
+public interface CertificateDirectoryType extends DirectoryType {
+  /**
+   * Get the CertificateGroups {@link CertificateGroupFolderType} Node, or {@code null} if it does
+   * not exist.
+   *
+   * <p>The Node is created when first accessed and cached for subsequent calls.
+   *
+   * @return the CertificateGroups {@link CertificateGroupFolderType} Node, or {@code null} if it
+   *     does not exist.
+   * @throws UaException if an error occurs creating or getting the Node.
+   */
+  CertificateGroupFolderType getCertificateGroupsNode() throws UaException;
+
+  /**
+   * Asynchronous implementation of {@link #getCertificateGroupsNode()}.
+   *
+   * @return a CompletableFuture that completes successfully with the CertificateGroupFolderType
+   *     Node or completes exceptionally if an error occurs creating or getting the Node.
+   */
+  CompletableFuture<? extends CertificateGroupFolderType> getCertificateGroupsNodeAsync();
+}

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/CertificateDirectoryTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/CertificateDirectoryTypeNode.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.gds.model.objects;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.client.model.objects.CertificateGroupFolderTypeNode;
+import org.eclipse.milo.opcua.sdk.client.nodes.UaNode;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
+import org.eclipse.milo.opcua.stack.core.types.structured.AccessRestrictionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.RolePermissionType;
+
+public class CertificateDirectoryTypeNode extends DirectoryTypeNode
+    implements CertificateDirectoryType {
+  public CertificateDirectoryTypeNode(
+      OpcUaClient client,
+      NodeId nodeId,
+      NodeClass nodeClass,
+      QualifiedName browseName,
+      LocalizedText displayName,
+      LocalizedText description,
+      UInteger writeMask,
+      UInteger userWriteMask,
+      RolePermissionType[] rolePermissions,
+      RolePermissionType[] userRolePermissions,
+      AccessRestrictionType accessRestrictions,
+      UByte eventNotifier) {
+    super(
+        client,
+        nodeId,
+        nodeClass,
+        browseName,
+        displayName,
+        description,
+        writeMask,
+        userWriteMask,
+        rolePermissions,
+        userRolePermissions,
+        accessRestrictions,
+        eventNotifier);
+  }
+
+  @Override
+  public CertificateGroupFolderTypeNode getCertificateGroupsNode() throws UaException {
+    try {
+      return getCertificateGroupsNodeAsync().get();
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
+    }
+  }
+
+  @Override
+  public CompletableFuture<? extends CertificateGroupFolderTypeNode>
+      getCertificateGroupsNodeAsync() {
+    CompletableFuture<UaNode> future =
+        getMemberNodeAsync(
+            "http://opcfoundation.org/UA/GDS/",
+            "CertificateGroups",
+            ExpandedNodeId.parse("i=35"),
+            false);
+    return future.thenApply(node -> (CertificateGroupFolderTypeNode) node);
+  }
+}

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/CertificateRequestedAuditEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/CertificateRequestedAuditEventType.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.gds.model.objects;
+
+import java.util.concurrent.CompletableFuture;
+import org.eclipse.milo.opcua.sdk.client.model.objects.AuditUpdateMethodEventType;
+import org.eclipse.milo.opcua.sdk.client.model.variables.PropertyType;
+import org.eclipse.milo.opcua.sdk.core.QualifiedProperty;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+
+/**
+ * @see <a
+ *     href="https://reference.opcfoundation.org/GDS/docs/7.9.12">https://reference.opcfoundation.org/GDS/docs/7.9.12</a>
+ */
+public interface CertificateRequestedAuditEventType extends AuditUpdateMethodEventType {
+  QualifiedProperty<NodeId> CERTIFICATE_GROUP =
+      new QualifiedProperty<>(
+          "http://opcfoundation.org/UA/GDS/",
+          "CertificateGroup",
+          ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=17"),
+          -1,
+          NodeId.class);
+
+  QualifiedProperty<NodeId> CERTIFICATE_TYPE =
+      new QualifiedProperty<>(
+          "http://opcfoundation.org/UA/GDS/",
+          "CertificateType",
+          ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=17"),
+          -1,
+          NodeId.class);
+
+  /**
+   * Get the local value of the CertificateGroup Node.
+   *
+   * <p>The returned value is the last seen; it is not read live from the server.
+   *
+   * @return the local value of the CertificateGroup Node.
+   * @throws UaException if an error occurs creating or getting the CertificateGroup Node.
+   */
+  NodeId getCertificateGroup() throws UaException;
+
+  /**
+   * Set the local value of the CertificateGroup Node.
+   *
+   * <p>The value is only updated locally; it is not written to the server.
+   *
+   * @param value the local value to set for the CertificateGroup Node.
+   * @throws UaException if an error occurs creating or getting the CertificateGroup Node.
+   */
+  void setCertificateGroup(NodeId value) throws UaException;
+
+  /**
+   * Read the value of the CertificateGroup Node from the server and update the local value if the
+   * operation succeeds.
+   *
+   * @return the {@link NodeId} value read from the server.
+   * @throws UaException if a service- or operation-level error occurs.
+   */
+  NodeId readCertificateGroup() throws UaException;
+
+  /**
+   * Write a new value for the CertificateGroup Node to the server and update the local value if the
+   * operation succeeds.
+   *
+   * @param value the {@link NodeId} value to write to the server.
+   * @throws UaException if a service- or operation-level error occurs.
+   */
+  void writeCertificateGroup(NodeId value) throws UaException;
+
+  /**
+   * An asynchronous implementation of {@link #readCertificateGroup}.
+   *
+   * @return a CompletableFuture that completes successfully with the value or completes
+   *     exceptionally if an operation- or service-level error occurs.
+   */
+  CompletableFuture<? extends NodeId> readCertificateGroupAsync();
+
+  /**
+   * An asynchronous implementation of {@link #writeCertificateGroup}.
+   *
+   * @return a CompletableFuture that completes successfully with the operation result or completes
+   *     exceptionally if a service-level error occurs.
+   */
+  CompletableFuture<StatusCode> writeCertificateGroupAsync(NodeId value);
+
+  /**
+   * Get the CertificateGroup {@link PropertyType} Node, or {@code null} if it does not exist.
+   *
+   * <p>The Node is created when first accessed and cached for subsequent calls.
+   *
+   * @return the CertificateGroup {@link PropertyType} Node, or {@code null} if it does not exist.
+   * @throws UaException if an error occurs creating or getting the Node.
+   */
+  PropertyType getCertificateGroupNode() throws UaException;
+
+  /**
+   * Asynchronous implementation of {@link #getCertificateGroupNode()}.
+   *
+   * @return a CompletableFuture that completes successfully with the PropertyType Node or completes
+   *     exceptionally if an error occurs creating or getting the Node.
+   */
+  CompletableFuture<? extends PropertyType> getCertificateGroupNodeAsync();
+
+  /**
+   * Get the local value of the CertificateType Node.
+   *
+   * <p>The returned value is the last seen; it is not read live from the server.
+   *
+   * @return the local value of the CertificateType Node.
+   * @throws UaException if an error occurs creating or getting the CertificateType Node.
+   */
+  NodeId getCertificateType() throws UaException;
+
+  /**
+   * Set the local value of the CertificateType Node.
+   *
+   * <p>The value is only updated locally; it is not written to the server.
+   *
+   * @param value the local value to set for the CertificateType Node.
+   * @throws UaException if an error occurs creating or getting the CertificateType Node.
+   */
+  void setCertificateType(NodeId value) throws UaException;
+
+  /**
+   * Read the value of the CertificateType Node from the server and update the local value if the
+   * operation succeeds.
+   *
+   * @return the {@link NodeId} value read from the server.
+   * @throws UaException if a service- or operation-level error occurs.
+   */
+  NodeId readCertificateType() throws UaException;
+
+  /**
+   * Write a new value for the CertificateType Node to the server and update the local value if the
+   * operation succeeds.
+   *
+   * @param value the {@link NodeId} value to write to the server.
+   * @throws UaException if a service- or operation-level error occurs.
+   */
+  void writeCertificateType(NodeId value) throws UaException;
+
+  /**
+   * An asynchronous implementation of {@link #readCertificateType}.
+   *
+   * @return a CompletableFuture that completes successfully with the value or completes
+   *     exceptionally if an operation- or service-level error occurs.
+   */
+  CompletableFuture<? extends NodeId> readCertificateTypeAsync();
+
+  /**
+   * An asynchronous implementation of {@link #writeCertificateType}.
+   *
+   * @return a CompletableFuture that completes successfully with the operation result or completes
+   *     exceptionally if a service-level error occurs.
+   */
+  CompletableFuture<StatusCode> writeCertificateTypeAsync(NodeId value);
+
+  /**
+   * Get the CertificateType {@link PropertyType} Node, or {@code null} if it does not exist.
+   *
+   * <p>The Node is created when first accessed and cached for subsequent calls.
+   *
+   * @return the CertificateType {@link PropertyType} Node, or {@code null} if it does not exist.
+   * @throws UaException if an error occurs creating or getting the Node.
+   */
+  PropertyType getCertificateTypeNode() throws UaException;
+
+  /**
+   * Asynchronous implementation of {@link #getCertificateTypeNode()}.
+   *
+   * @return a CompletableFuture that completes successfully with the PropertyType Node or completes
+   *     exceptionally if an error occurs creating or getting the Node.
+   */
+  CompletableFuture<? extends PropertyType> getCertificateTypeNodeAsync();
+}

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/CertificateRequestedAuditEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/CertificateRequestedAuditEventTypeNode.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.gds.model.objects;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.client.model.objects.AuditUpdateMethodEventTypeNode;
+import org.eclipse.milo.opcua.sdk.client.model.variables.PropertyTypeNode;
+import org.eclipse.milo.opcua.sdk.client.nodes.UaNode;
+import org.eclipse.milo.opcua.stack.core.AttributeId;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
+import org.eclipse.milo.opcua.stack.core.types.structured.AccessRestrictionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.RolePermissionType;
+
+public class CertificateRequestedAuditEventTypeNode extends AuditUpdateMethodEventTypeNode
+    implements CertificateRequestedAuditEventType {
+  public CertificateRequestedAuditEventTypeNode(
+      OpcUaClient client,
+      NodeId nodeId,
+      NodeClass nodeClass,
+      QualifiedName browseName,
+      LocalizedText displayName,
+      LocalizedText description,
+      UInteger writeMask,
+      UInteger userWriteMask,
+      RolePermissionType[] rolePermissions,
+      RolePermissionType[] userRolePermissions,
+      AccessRestrictionType accessRestrictions,
+      UByte eventNotifier) {
+    super(
+        client,
+        nodeId,
+        nodeClass,
+        browseName,
+        displayName,
+        description,
+        writeMask,
+        userWriteMask,
+        rolePermissions,
+        userRolePermissions,
+        accessRestrictions,
+        eventNotifier);
+  }
+
+  @Override
+  public NodeId getCertificateGroup() throws UaException {
+    PropertyTypeNode node = getCertificateGroupNode();
+    return (NodeId) node.getValue().getValue().getValue();
+  }
+
+  @Override
+  public void setCertificateGroup(NodeId value) throws UaException {
+    PropertyTypeNode node = getCertificateGroupNode();
+    node.setValue(new Variant(value));
+  }
+
+  @Override
+  public NodeId readCertificateGroup() throws UaException {
+    try {
+      return readCertificateGroupAsync().get();
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
+    }
+  }
+
+  @Override
+  public void writeCertificateGroup(NodeId value) throws UaException {
+    try {
+      writeCertificateGroupAsync(value).get();
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
+    }
+  }
+
+  @Override
+  public CompletableFuture<? extends NodeId> readCertificateGroupAsync() {
+    return getCertificateGroupNodeAsync()
+        .thenCompose(node -> node.readAttributeAsync(AttributeId.Value))
+        .thenApply(v -> (NodeId) v.getValue().getValue());
+  }
+
+  @Override
+  public CompletableFuture<StatusCode> writeCertificateGroupAsync(NodeId certificateGroup) {
+    DataValue value = DataValue.valueOnly(new Variant(certificateGroup));
+    return getCertificateGroupNodeAsync()
+        .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
+  }
+
+  @Override
+  public PropertyTypeNode getCertificateGroupNode() throws UaException {
+    try {
+      return getCertificateGroupNodeAsync().get();
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
+    }
+  }
+
+  @Override
+  public CompletableFuture<? extends PropertyTypeNode> getCertificateGroupNodeAsync() {
+    CompletableFuture<UaNode> future =
+        getMemberNodeAsync(
+            "http://opcfoundation.org/UA/GDS/",
+            "CertificateGroup",
+            ExpandedNodeId.parse("i=46"),
+            false);
+    return future.thenApply(node -> (PropertyTypeNode) node);
+  }
+
+  @Override
+  public NodeId getCertificateType() throws UaException {
+    PropertyTypeNode node = getCertificateTypeNode();
+    return (NodeId) node.getValue().getValue().getValue();
+  }
+
+  @Override
+  public void setCertificateType(NodeId value) throws UaException {
+    PropertyTypeNode node = getCertificateTypeNode();
+    node.setValue(new Variant(value));
+  }
+
+  @Override
+  public NodeId readCertificateType() throws UaException {
+    try {
+      return readCertificateTypeAsync().get();
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
+    }
+  }
+
+  @Override
+  public void writeCertificateType(NodeId value) throws UaException {
+    try {
+      writeCertificateTypeAsync(value).get();
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
+    }
+  }
+
+  @Override
+  public CompletableFuture<? extends NodeId> readCertificateTypeAsync() {
+    return getCertificateTypeNodeAsync()
+        .thenCompose(node -> node.readAttributeAsync(AttributeId.Value))
+        .thenApply(v -> (NodeId) v.getValue().getValue());
+  }
+
+  @Override
+  public CompletableFuture<StatusCode> writeCertificateTypeAsync(NodeId certificateType) {
+    DataValue value = DataValue.valueOnly(new Variant(certificateType));
+    return getCertificateTypeNodeAsync()
+        .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
+  }
+
+  @Override
+  public PropertyTypeNode getCertificateTypeNode() throws UaException {
+    try {
+      return getCertificateTypeNodeAsync().get();
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
+    }
+  }
+
+  @Override
+  public CompletableFuture<? extends PropertyTypeNode> getCertificateTypeNodeAsync() {
+    CompletableFuture<UaNode> future =
+        getMemberNodeAsync(
+            "http://opcfoundation.org/UA/GDS/",
+            "CertificateType",
+            ExpandedNodeId.parse("i=46"),
+            false);
+    return future.thenApply(node -> (PropertyTypeNode) node);
+  }
+}

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/CertificateRevokedAuditEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/CertificateRevokedAuditEventType.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.gds.model.objects;
+
+import org.eclipse.milo.opcua.sdk.client.model.objects.AuditUpdateMethodEventType;
+
+/**
+ * @see <a
+ *     href="https://reference.opcfoundation.org/GDS/docs/7.9.14">https://reference.opcfoundation.org/GDS/docs/7.9.14</a>
+ */
+public interface CertificateRevokedAuditEventType extends AuditUpdateMethodEventType {}

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/CertificateRevokedAuditEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/CertificateRevokedAuditEventTypeNode.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.gds.model.objects;
+
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.client.model.objects.AuditUpdateMethodEventTypeNode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
+import org.eclipse.milo.opcua.stack.core.types.structured.AccessRestrictionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.RolePermissionType;
+
+public class CertificateRevokedAuditEventTypeNode extends AuditUpdateMethodEventTypeNode
+    implements CertificateRevokedAuditEventType {
+  public CertificateRevokedAuditEventTypeNode(
+      OpcUaClient client,
+      NodeId nodeId,
+      NodeClass nodeClass,
+      QualifiedName browseName,
+      LocalizedText displayName,
+      LocalizedText description,
+      UInteger writeMask,
+      UInteger userWriteMask,
+      RolePermissionType[] rolePermissions,
+      RolePermissionType[] userRolePermissions,
+      AccessRestrictionType accessRestrictions,
+      UByte eventNotifier) {
+    super(
+        client,
+        nodeId,
+        nodeClass,
+        browseName,
+        displayName,
+        description,
+        writeMask,
+        userWriteMask,
+        rolePermissions,
+        userRolePermissions,
+        accessRestrictions,
+        eventNotifier);
+  }
+}

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/DirectoryType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/DirectoryType.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.gds.model.objects;
+
+import java.util.concurrent.CompletableFuture;
+import org.eclipse.milo.opcua.sdk.client.model.objects.FolderType;
+import org.eclipse.milo.opcua.stack.core.UaException;
+
+/**
+ * @see <a
+ *     href="https://reference.opcfoundation.org/GDS/docs/6.5.3">https://reference.opcfoundation.org/GDS/docs/6.5.3</a>
+ */
+public interface DirectoryType extends FolderType {
+  /**
+   * Get the Applications {@link FolderType} Node, or {@code null} if it does not exist.
+   *
+   * <p>The Node is created when first accessed and cached for subsequent calls.
+   *
+   * @return the Applications {@link FolderType} Node, or {@code null} if it does not exist.
+   * @throws UaException if an error occurs creating or getting the Node.
+   */
+  FolderType getApplicationsNode() throws UaException;
+
+  /**
+   * Asynchronous implementation of {@link #getApplicationsNode()}.
+   *
+   * @return a CompletableFuture that completes successfully with the FolderType Node or completes
+   *     exceptionally if an error occurs creating or getting the Node.
+   */
+  CompletableFuture<? extends FolderType> getApplicationsNodeAsync();
+}

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/DirectoryTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/DirectoryTypeNode.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.gds.model.objects;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.client.model.objects.FolderTypeNode;
+import org.eclipse.milo.opcua.sdk.client.nodes.UaNode;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
+import org.eclipse.milo.opcua.stack.core.types.structured.AccessRestrictionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.RolePermissionType;
+
+public class DirectoryTypeNode extends FolderTypeNode implements DirectoryType {
+  public DirectoryTypeNode(
+      OpcUaClient client,
+      NodeId nodeId,
+      NodeClass nodeClass,
+      QualifiedName browseName,
+      LocalizedText displayName,
+      LocalizedText description,
+      UInteger writeMask,
+      UInteger userWriteMask,
+      RolePermissionType[] rolePermissions,
+      RolePermissionType[] userRolePermissions,
+      AccessRestrictionType accessRestrictions,
+      UByte eventNotifier) {
+    super(
+        client,
+        nodeId,
+        nodeClass,
+        browseName,
+        displayName,
+        description,
+        writeMask,
+        userWriteMask,
+        rolePermissions,
+        userRolePermissions,
+        accessRestrictions,
+        eventNotifier);
+  }
+
+  @Override
+  public FolderTypeNode getApplicationsNode() throws UaException {
+    try {
+      return getApplicationsNodeAsync().get();
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
+    }
+  }
+
+  @Override
+  public CompletableFuture<? extends FolderTypeNode> getApplicationsNodeAsync() {
+    CompletableFuture<UaNode> future =
+        getMemberNodeAsync(
+            "http://opcfoundation.org/UA/GDS/",
+            "Applications",
+            ExpandedNodeId.parse("i=47"),
+            false);
+    return future.thenApply(node -> (FolderTypeNode) node);
+  }
+}

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/KeyCredentialDeliveredAuditEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/KeyCredentialDeliveredAuditEventType.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.gds.model.objects;
+
+import org.eclipse.milo.opcua.sdk.client.model.objects.KeyCredentialAuditEventType;
+
+/**
+ * @see <a
+ *     href="https://reference.opcfoundation.org/GDS/docs/8.5.10">https://reference.opcfoundation.org/GDS/docs/8.5.10</a>
+ */
+public interface KeyCredentialDeliveredAuditEventType extends KeyCredentialAuditEventType {}

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/KeyCredentialDeliveredAuditEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/KeyCredentialDeliveredAuditEventTypeNode.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.gds.model.objects;
+
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.client.model.objects.KeyCredentialAuditEventTypeNode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
+import org.eclipse.milo.opcua.stack.core.types.structured.AccessRestrictionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.RolePermissionType;
+
+public class KeyCredentialDeliveredAuditEventTypeNode extends KeyCredentialAuditEventTypeNode
+    implements KeyCredentialDeliveredAuditEventType {
+  public KeyCredentialDeliveredAuditEventTypeNode(
+      OpcUaClient client,
+      NodeId nodeId,
+      NodeClass nodeClass,
+      QualifiedName browseName,
+      LocalizedText displayName,
+      LocalizedText description,
+      UInteger writeMask,
+      UInteger userWriteMask,
+      RolePermissionType[] rolePermissions,
+      RolePermissionType[] userRolePermissions,
+      AccessRestrictionType accessRestrictions,
+      UByte eventNotifier) {
+    super(
+        client,
+        nodeId,
+        nodeClass,
+        browseName,
+        displayName,
+        description,
+        writeMask,
+        userWriteMask,
+        rolePermissions,
+        userRolePermissions,
+        accessRestrictions,
+        eventNotifier);
+  }
+}

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/KeyCredentialManagementFolderType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/KeyCredentialManagementFolderType.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.gds.model.objects;
+
+import org.eclipse.milo.opcua.sdk.client.model.objects.FolderType;
+
+/**
+ * @see <a
+ *     href="https://reference.opcfoundation.org/GDS/docs/8.5.2">https://reference.opcfoundation.org/GDS/docs/8.5.2</a>
+ */
+public interface KeyCredentialManagementFolderType extends FolderType {}

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/KeyCredentialManagementFolderTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/KeyCredentialManagementFolderTypeNode.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.gds.model.objects;
+
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.client.model.objects.FolderTypeNode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
+import org.eclipse.milo.opcua.stack.core.types.structured.AccessRestrictionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.RolePermissionType;
+
+public class KeyCredentialManagementFolderTypeNode extends FolderTypeNode
+    implements KeyCredentialManagementFolderType {
+  public KeyCredentialManagementFolderTypeNode(
+      OpcUaClient client,
+      NodeId nodeId,
+      NodeClass nodeClass,
+      QualifiedName browseName,
+      LocalizedText displayName,
+      LocalizedText description,
+      UInteger writeMask,
+      UInteger userWriteMask,
+      RolePermissionType[] rolePermissions,
+      RolePermissionType[] userRolePermissions,
+      AccessRestrictionType accessRestrictions,
+      UByte eventNotifier) {
+    super(
+        client,
+        nodeId,
+        nodeClass,
+        browseName,
+        displayName,
+        description,
+        writeMask,
+        userWriteMask,
+        rolePermissions,
+        userRolePermissions,
+        accessRestrictions,
+        eventNotifier);
+  }
+}

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/KeyCredentialRequestedAuditEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/KeyCredentialRequestedAuditEventType.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.gds.model.objects;
+
+import org.eclipse.milo.opcua.sdk.client.model.objects.KeyCredentialAuditEventType;
+
+/**
+ * @see <a
+ *     href="https://reference.opcfoundation.org/GDS/docs/8.5.9">https://reference.opcfoundation.org/GDS/docs/8.5.9</a>
+ */
+public interface KeyCredentialRequestedAuditEventType extends KeyCredentialAuditEventType {}

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/KeyCredentialRequestedAuditEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/KeyCredentialRequestedAuditEventTypeNode.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.gds.model.objects;
+
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.client.model.objects.KeyCredentialAuditEventTypeNode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
+import org.eclipse.milo.opcua.stack.core.types.structured.AccessRestrictionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.RolePermissionType;
+
+public class KeyCredentialRequestedAuditEventTypeNode extends KeyCredentialAuditEventTypeNode
+    implements KeyCredentialRequestedAuditEventType {
+  public KeyCredentialRequestedAuditEventTypeNode(
+      OpcUaClient client,
+      NodeId nodeId,
+      NodeClass nodeClass,
+      QualifiedName browseName,
+      LocalizedText displayName,
+      LocalizedText description,
+      UInteger writeMask,
+      UInteger userWriteMask,
+      RolePermissionType[] rolePermissions,
+      RolePermissionType[] userRolePermissions,
+      AccessRestrictionType accessRestrictions,
+      UByte eventNotifier) {
+    super(
+        client,
+        nodeId,
+        nodeClass,
+        browseName,
+        displayName,
+        description,
+        writeMask,
+        userWriteMask,
+        rolePermissions,
+        userRolePermissions,
+        accessRestrictions,
+        eventNotifier);
+  }
+}

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/KeyCredentialRevokedAuditEventType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/KeyCredentialRevokedAuditEventType.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.gds.model.objects;
+
+import org.eclipse.milo.opcua.sdk.client.model.objects.KeyCredentialAuditEventType;
+
+/**
+ * @see <a
+ *     href="https://reference.opcfoundation.org/GDS/docs/8.5.11">https://reference.opcfoundation.org/GDS/docs/8.5.11</a>
+ */
+public interface KeyCredentialRevokedAuditEventType extends KeyCredentialAuditEventType {}

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/KeyCredentialRevokedAuditEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/KeyCredentialRevokedAuditEventTypeNode.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.gds.model.objects;
+
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.client.model.objects.KeyCredentialAuditEventTypeNode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
+import org.eclipse.milo.opcua.stack.core.types.structured.AccessRestrictionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.RolePermissionType;
+
+public class KeyCredentialRevokedAuditEventTypeNode extends KeyCredentialAuditEventTypeNode
+    implements KeyCredentialRevokedAuditEventType {
+  public KeyCredentialRevokedAuditEventTypeNode(
+      OpcUaClient client,
+      NodeId nodeId,
+      NodeClass nodeClass,
+      QualifiedName browseName,
+      LocalizedText displayName,
+      LocalizedText description,
+      UInteger writeMask,
+      UInteger userWriteMask,
+      RolePermissionType[] rolePermissions,
+      RolePermissionType[] userRolePermissions,
+      AccessRestrictionType accessRestrictions,
+      UByte eventNotifier) {
+    super(
+        client,
+        nodeId,
+        nodeClass,
+        browseName,
+        displayName,
+        description,
+        writeMask,
+        userWriteMask,
+        rolePermissions,
+        userRolePermissions,
+        accessRestrictions,
+        eventNotifier);
+  }
+}

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/KeyCredentialServiceType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/KeyCredentialServiceType.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.gds.model.objects;
+
+import java.util.concurrent.CompletableFuture;
+import org.eclipse.milo.opcua.sdk.client.model.objects.BaseObjectType;
+import org.eclipse.milo.opcua.sdk.client.model.variables.PropertyType;
+import org.eclipse.milo.opcua.sdk.core.QualifiedProperty;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+
+/**
+ * @see <a
+ *     href="https://reference.opcfoundation.org/GDS/docs/8.5.4">https://reference.opcfoundation.org/GDS/docs/8.5.4</a>
+ */
+public interface KeyCredentialServiceType extends BaseObjectType {
+  QualifiedProperty<String> RESOURCE_URI =
+      new QualifiedProperty<>(
+          "http://opcfoundation.org/UA/GDS/",
+          "ResourceUri",
+          ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=12"),
+          -1,
+          String.class);
+
+  QualifiedProperty<String[]> PROFILE_URIS =
+      new QualifiedProperty<>(
+          "http://opcfoundation.org/UA/GDS/",
+          "ProfileUris",
+          ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=12"),
+          1,
+          String[].class);
+
+  QualifiedProperty<String[]> SECURITY_POLICY_URIS =
+      new QualifiedProperty<>(
+          "http://opcfoundation.org/UA/GDS/",
+          "SecurityPolicyUris",
+          ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=12"),
+          1,
+          String[].class);
+
+  /**
+   * Get the local value of the ResourceUri Node.
+   *
+   * <p>The returned value is the last seen; it is not read live from the server.
+   *
+   * @return the local value of the ResourceUri Node.
+   * @throws UaException if an error occurs creating or getting the ResourceUri Node.
+   */
+  String getResourceUri() throws UaException;
+
+  /**
+   * Set the local value of the ResourceUri Node.
+   *
+   * <p>The value is only updated locally; it is not written to the server.
+   *
+   * @param value the local value to set for the ResourceUri Node.
+   * @throws UaException if an error occurs creating or getting the ResourceUri Node.
+   */
+  void setResourceUri(String value) throws UaException;
+
+  /**
+   * Read the value of the ResourceUri Node from the server and update the local value if the
+   * operation succeeds.
+   *
+   * @return the {@link String} value read from the server.
+   * @throws UaException if a service- or operation-level error occurs.
+   */
+  String readResourceUri() throws UaException;
+
+  /**
+   * Write a new value for the ResourceUri Node to the server and update the local value if the
+   * operation succeeds.
+   *
+   * @param value the {@link String} value to write to the server.
+   * @throws UaException if a service- or operation-level error occurs.
+   */
+  void writeResourceUri(String value) throws UaException;
+
+  /**
+   * An asynchronous implementation of {@link #readResourceUri}.
+   *
+   * @return a CompletableFuture that completes successfully with the value or completes
+   *     exceptionally if an operation- or service-level error occurs.
+   */
+  CompletableFuture<? extends String> readResourceUriAsync();
+
+  /**
+   * An asynchronous implementation of {@link #writeResourceUri}.
+   *
+   * @return a CompletableFuture that completes successfully with the operation result or completes
+   *     exceptionally if a service-level error occurs.
+   */
+  CompletableFuture<StatusCode> writeResourceUriAsync(String value);
+
+  /**
+   * Get the ResourceUri {@link PropertyType} Node, or {@code null} if it does not exist.
+   *
+   * <p>The Node is created when first accessed and cached for subsequent calls.
+   *
+   * @return the ResourceUri {@link PropertyType} Node, or {@code null} if it does not exist.
+   * @throws UaException if an error occurs creating or getting the Node.
+   */
+  PropertyType getResourceUriNode() throws UaException;
+
+  /**
+   * Asynchronous implementation of {@link #getResourceUriNode()}.
+   *
+   * @return a CompletableFuture that completes successfully with the PropertyType Node or completes
+   *     exceptionally if an error occurs creating or getting the Node.
+   */
+  CompletableFuture<? extends PropertyType> getResourceUriNodeAsync();
+
+  /**
+   * Get the local value of the ProfileUris Node.
+   *
+   * <p>The returned value is the last seen; it is not read live from the server.
+   *
+   * @return the local value of the ProfileUris Node.
+   * @throws UaException if an error occurs creating or getting the ProfileUris Node.
+   */
+  String[] getProfileUris() throws UaException;
+
+  /**
+   * Set the local value of the ProfileUris Node.
+   *
+   * <p>The value is only updated locally; it is not written to the server.
+   *
+   * @param value the local value to set for the ProfileUris Node.
+   * @throws UaException if an error occurs creating or getting the ProfileUris Node.
+   */
+  void setProfileUris(String[] value) throws UaException;
+
+  /**
+   * Read the value of the ProfileUris Node from the server and update the local value if the
+   * operation succeeds.
+   *
+   * @return the {@link String[]} value read from the server.
+   * @throws UaException if a service- or operation-level error occurs.
+   */
+  String[] readProfileUris() throws UaException;
+
+  /**
+   * Write a new value for the ProfileUris Node to the server and update the local value if the
+   * operation succeeds.
+   *
+   * @param value the {@link String[]} value to write to the server.
+   * @throws UaException if a service- or operation-level error occurs.
+   */
+  void writeProfileUris(String[] value) throws UaException;
+
+  /**
+   * An asynchronous implementation of {@link #readProfileUris}.
+   *
+   * @return a CompletableFuture that completes successfully with the value or completes
+   *     exceptionally if an operation- or service-level error occurs.
+   */
+  CompletableFuture<? extends String[]> readProfileUrisAsync();
+
+  /**
+   * An asynchronous implementation of {@link #writeProfileUris}.
+   *
+   * @return a CompletableFuture that completes successfully with the operation result or completes
+   *     exceptionally if a service-level error occurs.
+   */
+  CompletableFuture<StatusCode> writeProfileUrisAsync(String[] value);
+
+  /**
+   * Get the ProfileUris {@link PropertyType} Node, or {@code null} if it does not exist.
+   *
+   * <p>The Node is created when first accessed and cached for subsequent calls.
+   *
+   * @return the ProfileUris {@link PropertyType} Node, or {@code null} if it does not exist.
+   * @throws UaException if an error occurs creating or getting the Node.
+   */
+  PropertyType getProfileUrisNode() throws UaException;
+
+  /**
+   * Asynchronous implementation of {@link #getProfileUrisNode()}.
+   *
+   * @return a CompletableFuture that completes successfully with the PropertyType Node or completes
+   *     exceptionally if an error occurs creating or getting the Node.
+   */
+  CompletableFuture<? extends PropertyType> getProfileUrisNodeAsync();
+
+  /**
+   * Get the local value of the SecurityPolicyUris Node.
+   *
+   * <p>The returned value is the last seen; it is not read live from the server.
+   *
+   * @return the local value of the SecurityPolicyUris Node.
+   * @throws UaException if an error occurs creating or getting the SecurityPolicyUris Node.
+   */
+  String[] getSecurityPolicyUris() throws UaException;
+
+  /**
+   * Set the local value of the SecurityPolicyUris Node.
+   *
+   * <p>The value is only updated locally; it is not written to the server.
+   *
+   * @param value the local value to set for the SecurityPolicyUris Node.
+   * @throws UaException if an error occurs creating or getting the SecurityPolicyUris Node.
+   */
+  void setSecurityPolicyUris(String[] value) throws UaException;
+
+  /**
+   * Read the value of the SecurityPolicyUris Node from the server and update the local value if the
+   * operation succeeds.
+   *
+   * @return the {@link String[]} value read from the server.
+   * @throws UaException if a service- or operation-level error occurs.
+   */
+  String[] readSecurityPolicyUris() throws UaException;
+
+  /**
+   * Write a new value for the SecurityPolicyUris Node to the server and update the local value if
+   * the operation succeeds.
+   *
+   * @param value the {@link String[]} value to write to the server.
+   * @throws UaException if a service- or operation-level error occurs.
+   */
+  void writeSecurityPolicyUris(String[] value) throws UaException;
+
+  /**
+   * An asynchronous implementation of {@link #readSecurityPolicyUris}.
+   *
+   * @return a CompletableFuture that completes successfully with the value or completes
+   *     exceptionally if an operation- or service-level error occurs.
+   */
+  CompletableFuture<? extends String[]> readSecurityPolicyUrisAsync();
+
+  /**
+   * An asynchronous implementation of {@link #writeSecurityPolicyUris}.
+   *
+   * @return a CompletableFuture that completes successfully with the operation result or completes
+   *     exceptionally if a service-level error occurs.
+   */
+  CompletableFuture<StatusCode> writeSecurityPolicyUrisAsync(String[] value);
+
+  /**
+   * Get the SecurityPolicyUris {@link PropertyType} Node, or {@code null} if it does not exist.
+   *
+   * <p>The Node is created when first accessed and cached for subsequent calls.
+   *
+   * @return the SecurityPolicyUris {@link PropertyType} Node, or {@code null} if it does not exist.
+   * @throws UaException if an error occurs creating or getting the Node.
+   */
+  PropertyType getSecurityPolicyUrisNode() throws UaException;
+
+  /**
+   * Asynchronous implementation of {@link #getSecurityPolicyUrisNode()}.
+   *
+   * @return a CompletableFuture that completes successfully with the PropertyType Node or completes
+   *     exceptionally if an error occurs creating or getting the Node.
+   */
+  CompletableFuture<? extends PropertyType> getSecurityPolicyUrisNodeAsync();
+}

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/KeyCredentialServiceTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/KeyCredentialServiceTypeNode.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.gds.model.objects;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.client.model.objects.BaseObjectTypeNode;
+import org.eclipse.milo.opcua.sdk.client.model.variables.PropertyTypeNode;
+import org.eclipse.milo.opcua.sdk.client.nodes.UaNode;
+import org.eclipse.milo.opcua.stack.core.AttributeId;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
+import org.eclipse.milo.opcua.stack.core.types.structured.AccessRestrictionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.RolePermissionType;
+
+public class KeyCredentialServiceTypeNode extends BaseObjectTypeNode
+    implements KeyCredentialServiceType {
+  public KeyCredentialServiceTypeNode(
+      OpcUaClient client,
+      NodeId nodeId,
+      NodeClass nodeClass,
+      QualifiedName browseName,
+      LocalizedText displayName,
+      LocalizedText description,
+      UInteger writeMask,
+      UInteger userWriteMask,
+      RolePermissionType[] rolePermissions,
+      RolePermissionType[] userRolePermissions,
+      AccessRestrictionType accessRestrictions,
+      UByte eventNotifier) {
+    super(
+        client,
+        nodeId,
+        nodeClass,
+        browseName,
+        displayName,
+        description,
+        writeMask,
+        userWriteMask,
+        rolePermissions,
+        userRolePermissions,
+        accessRestrictions,
+        eventNotifier);
+  }
+
+  @Override
+  public String getResourceUri() throws UaException {
+    PropertyTypeNode node = getResourceUriNode();
+    return (String) node.getValue().getValue().getValue();
+  }
+
+  @Override
+  public void setResourceUri(String value) throws UaException {
+    PropertyTypeNode node = getResourceUriNode();
+    node.setValue(new Variant(value));
+  }
+
+  @Override
+  public String readResourceUri() throws UaException {
+    try {
+      return readResourceUriAsync().get();
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
+    }
+  }
+
+  @Override
+  public void writeResourceUri(String value) throws UaException {
+    try {
+      writeResourceUriAsync(value).get();
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
+    }
+  }
+
+  @Override
+  public CompletableFuture<? extends String> readResourceUriAsync() {
+    return getResourceUriNodeAsync()
+        .thenCompose(node -> node.readAttributeAsync(AttributeId.Value))
+        .thenApply(v -> (String) v.getValue().getValue());
+  }
+
+  @Override
+  public CompletableFuture<StatusCode> writeResourceUriAsync(String resourceUri) {
+    DataValue value = DataValue.valueOnly(new Variant(resourceUri));
+    return getResourceUriNodeAsync()
+        .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
+  }
+
+  @Override
+  public PropertyTypeNode getResourceUriNode() throws UaException {
+    try {
+      return getResourceUriNodeAsync().get();
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
+    }
+  }
+
+  @Override
+  public CompletableFuture<? extends PropertyTypeNode> getResourceUriNodeAsync() {
+    CompletableFuture<UaNode> future =
+        getMemberNodeAsync(
+            "http://opcfoundation.org/UA/GDS/", "ResourceUri", ExpandedNodeId.parse("i=46"), false);
+    return future.thenApply(node -> (PropertyTypeNode) node);
+  }
+
+  @Override
+  public String[] getProfileUris() throws UaException {
+    PropertyTypeNode node = getProfileUrisNode();
+    return (String[]) node.getValue().getValue().getValue();
+  }
+
+  @Override
+  public void setProfileUris(String[] value) throws UaException {
+    PropertyTypeNode node = getProfileUrisNode();
+    node.setValue(new Variant(value));
+  }
+
+  @Override
+  public String[] readProfileUris() throws UaException {
+    try {
+      return readProfileUrisAsync().get();
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
+    }
+  }
+
+  @Override
+  public void writeProfileUris(String[] value) throws UaException {
+    try {
+      writeProfileUrisAsync(value).get();
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
+    }
+  }
+
+  @Override
+  public CompletableFuture<? extends String[]> readProfileUrisAsync() {
+    return getProfileUrisNodeAsync()
+        .thenCompose(node -> node.readAttributeAsync(AttributeId.Value))
+        .thenApply(v -> (String[]) v.getValue().getValue());
+  }
+
+  @Override
+  public CompletableFuture<StatusCode> writeProfileUrisAsync(String[] profileUris) {
+    DataValue value = DataValue.valueOnly(new Variant(profileUris));
+    return getProfileUrisNodeAsync()
+        .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
+  }
+
+  @Override
+  public PropertyTypeNode getProfileUrisNode() throws UaException {
+    try {
+      return getProfileUrisNodeAsync().get();
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
+    }
+  }
+
+  @Override
+  public CompletableFuture<? extends PropertyTypeNode> getProfileUrisNodeAsync() {
+    CompletableFuture<UaNode> future =
+        getMemberNodeAsync(
+            "http://opcfoundation.org/UA/GDS/", "ProfileUris", ExpandedNodeId.parse("i=46"), false);
+    return future.thenApply(node -> (PropertyTypeNode) node);
+  }
+
+  @Override
+  public String[] getSecurityPolicyUris() throws UaException {
+    PropertyTypeNode node = getSecurityPolicyUrisNode();
+    return (String[]) node.getValue().getValue().getValue();
+  }
+
+  @Override
+  public void setSecurityPolicyUris(String[] value) throws UaException {
+    PropertyTypeNode node = getSecurityPolicyUrisNode();
+    node.setValue(new Variant(value));
+  }
+
+  @Override
+  public String[] readSecurityPolicyUris() throws UaException {
+    try {
+      return readSecurityPolicyUrisAsync().get();
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
+    }
+  }
+
+  @Override
+  public void writeSecurityPolicyUris(String[] value) throws UaException {
+    try {
+      writeSecurityPolicyUrisAsync(value).get();
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
+    }
+  }
+
+  @Override
+  public CompletableFuture<? extends String[]> readSecurityPolicyUrisAsync() {
+    return getSecurityPolicyUrisNodeAsync()
+        .thenCompose(node -> node.readAttributeAsync(AttributeId.Value))
+        .thenApply(v -> (String[]) v.getValue().getValue());
+  }
+
+  @Override
+  public CompletableFuture<StatusCode> writeSecurityPolicyUrisAsync(String[] securityPolicyUris) {
+    DataValue value = DataValue.valueOnly(new Variant(securityPolicyUris));
+    return getSecurityPolicyUrisNodeAsync()
+        .thenCompose(node -> node.writeAttributeAsync(AttributeId.Value, value));
+  }
+
+  @Override
+  public PropertyTypeNode getSecurityPolicyUrisNode() throws UaException {
+    try {
+      return getSecurityPolicyUrisNodeAsync().get();
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new UaException(StatusCodes.Bad_UnexpectedError, e);
+    }
+  }
+
+  @Override
+  public CompletableFuture<? extends PropertyTypeNode> getSecurityPolicyUrisNodeAsync() {
+    CompletableFuture<UaNode> future =
+        getMemberNodeAsync(
+            "http://opcfoundation.org/UA/GDS/",
+            "SecurityPolicyUris",
+            ExpandedNodeId.parse("i=46"),
+            false);
+    return future.thenApply(node -> (PropertyTypeNode) node);
+  }
+}

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/package-info.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/package-info.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/**
+ * Generated client-side model of the OPC UA Global Discovery Server ObjectTypes.
+ *
+ * <p>Each GDS ObjectType (OPC 10000-12) is represented by an interface and a {@code *Node}
+ * implementation, mirroring the namespace 0 model in {@code
+ * org.eclipse.milo.opcua.sdk.client.model.objects}: {@link
+ * org.eclipse.milo.opcua.sdk.client.gds.model.objects.DirectoryType} and {@link
+ * org.eclipse.milo.opcua.sdk.client.gds.model.objects.CertificateDirectoryType} for the {@code
+ * Directory} object, the KeyCredential and AuthorizationService folder and service types, and the
+ * GDS audit event types. The node classes navigate components and properties; they do not wrap the
+ * Directory methods. Typed method calls are provided by {@code
+ * org.eclipse.milo.opcua.sdk.client.gds.GdsClient} in the {@code milo-sdk-client-gds} module.
+ *
+ * <p>Instances of these classes are produced by {@link
+ * org.eclipse.milo.opcua.sdk.client.AddressSpace} once the types are registered with the client's
+ * {@link org.eclipse.milo.opcua.sdk.client.ObjectTypeManager} by {@link
+ * org.eclipse.milo.opcua.sdk.client.gds.ObjectTypeInitializer}. That initializer resolves the GDS
+ * namespace index through the client's live {@link
+ * org.eclipse.milo.opcua.stack.core.NamespaceTable}, so it can only run against a connected client
+ * and is not part of the namespace 0 startup path.
+ *
+ * <h2>Regeneration</h2>
+ *
+ * <p>Every class in this package, together with {@link
+ * org.eclipse.milo.opcua.sdk.client.gds.ObjectTypeInitializer} and {@link
+ * org.eclipse.milo.opcua.sdk.client.gds.VariableTypeInitializer}, is generated and must not be
+ * edited by hand. The source is the {@code gds-model-client} module of <a
+ * href="https://github.com/kevinherron/opc-ua-gds-model">opc-ua-gds-model</a> at commit {@code
+ * efa229d} (GDS NodeSet2 1.05.07), copied in with {@code com.digitalpetri.opcua.gds.client}
+ * rewritten to {@code org.eclipse.milo.opcua.sdk.client.gds} and {@code
+ * com.digitalpetri.opcua.gds.client.objects} rewritten to this package. See {@code
+ * docs/features/gds-client.md} for the procedure.
+ */
+package org.eclipse.milo.opcua.sdk.client.gds.model.objects;

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/ObjectTypeInitializer.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/ObjectTypeInitializer.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.gds;
+
+import org.eclipse.milo.opcua.sdk.server.ObjectTypeManager;
+import org.eclipse.milo.opcua.sdk.server.gds.model.objects.AccessTokenIssuedAuditEventTypeNode;
+import org.eclipse.milo.opcua.sdk.server.gds.model.objects.AccessTokenRequestedAuditEventTypeNode;
+import org.eclipse.milo.opcua.sdk.server.gds.model.objects.ApplicationRegistrationChangedAuditEventTypeNode;
+import org.eclipse.milo.opcua.sdk.server.gds.model.objects.AuthorizationServiceTypeNode;
+import org.eclipse.milo.opcua.sdk.server.gds.model.objects.AuthorizationServicesFolderTypeNode;
+import org.eclipse.milo.opcua.sdk.server.gds.model.objects.CertificateDeliveredAuditEventTypeNode;
+import org.eclipse.milo.opcua.sdk.server.gds.model.objects.CertificateDirectoryTypeNode;
+import org.eclipse.milo.opcua.sdk.server.gds.model.objects.CertificateRequestedAuditEventTypeNode;
+import org.eclipse.milo.opcua.sdk.server.gds.model.objects.CertificateRevokedAuditEventTypeNode;
+import org.eclipse.milo.opcua.sdk.server.gds.model.objects.DirectoryTypeNode;
+import org.eclipse.milo.opcua.sdk.server.gds.model.objects.KeyCredentialDeliveredAuditEventTypeNode;
+import org.eclipse.milo.opcua.sdk.server.gds.model.objects.KeyCredentialManagementFolderTypeNode;
+import org.eclipse.milo.opcua.sdk.server.gds.model.objects.KeyCredentialRequestedAuditEventTypeNode;
+import org.eclipse.milo.opcua.sdk.server.gds.model.objects.KeyCredentialRevokedAuditEventTypeNode;
+import org.eclipse.milo.opcua.sdk.server.gds.model.objects.KeyCredentialServiceTypeNode;
+import org.eclipse.milo.opcua.stack.core.NamespaceTable;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+
+public class ObjectTypeInitializer {
+  public static void initialize(
+      NamespaceTable namespaceTable, ObjectTypeManager objectTypeManager) {
+    objectTypeManager.registerObjectType(
+        NodeId.parse("ns=1;i=13").reindex(namespaceTable, "http://opcfoundation.org/UA/GDS/"),
+        DirectoryTypeNode.class,
+        DirectoryTypeNode::new);
+    objectTypeManager.registerObjectType(
+        NodeId.parse("ns=1;i=63").reindex(namespaceTable, "http://opcfoundation.org/UA/GDS/"),
+        CertificateDirectoryTypeNode.class,
+        CertificateDirectoryTypeNode::new);
+    objectTypeManager.registerObjectType(
+        NodeId.parse("ns=1;i=55").reindex(namespaceTable, "http://opcfoundation.org/UA/GDS/"),
+        KeyCredentialManagementFolderTypeNode.class,
+        KeyCredentialManagementFolderTypeNode::new);
+    objectTypeManager.registerObjectType(
+        NodeId.parse("ns=1;i=233").reindex(namespaceTable, "http://opcfoundation.org/UA/GDS/"),
+        AuthorizationServicesFolderTypeNode.class,
+        AuthorizationServicesFolderTypeNode::new);
+    objectTypeManager.registerObjectType(
+        NodeId.parse("ns=1;i=1039").reindex(namespaceTable, "http://opcfoundation.org/UA/GDS/"),
+        KeyCredentialRequestedAuditEventTypeNode.class,
+        KeyCredentialRequestedAuditEventTypeNode::new);
+    objectTypeManager.registerObjectType(
+        NodeId.parse("ns=1;i=1057").reindex(namespaceTable, "http://opcfoundation.org/UA/GDS/"),
+        KeyCredentialDeliveredAuditEventTypeNode.class,
+        KeyCredentialDeliveredAuditEventTypeNode::new);
+    objectTypeManager.registerObjectType(
+        NodeId.parse("ns=1;i=1075").reindex(namespaceTable, "http://opcfoundation.org/UA/GDS/"),
+        KeyCredentialRevokedAuditEventTypeNode.class,
+        KeyCredentialRevokedAuditEventTypeNode::new);
+    objectTypeManager.registerObjectType(
+        NodeId.parse("ns=1;i=26").reindex(namespaceTable, "http://opcfoundation.org/UA/GDS/"),
+        ApplicationRegistrationChangedAuditEventTypeNode.class,
+        ApplicationRegistrationChangedAuditEventTypeNode::new);
+    objectTypeManager.registerObjectType(
+        NodeId.parse("ns=1;i=91").reindex(namespaceTable, "http://opcfoundation.org/UA/GDS/"),
+        CertificateRequestedAuditEventTypeNode.class,
+        CertificateRequestedAuditEventTypeNode::new);
+    objectTypeManager.registerObjectType(
+        NodeId.parse("ns=1;i=109").reindex(namespaceTable, "http://opcfoundation.org/UA/GDS/"),
+        CertificateDeliveredAuditEventTypeNode.class,
+        CertificateDeliveredAuditEventTypeNode::new);
+    objectTypeManager.registerObjectType(
+        NodeId.parse("ns=1;i=27").reindex(namespaceTable, "http://opcfoundation.org/UA/GDS/"),
+        CertificateRevokedAuditEventTypeNode.class,
+        CertificateRevokedAuditEventTypeNode::new);
+    objectTypeManager.registerObjectType(
+        NodeId.parse("ns=1;i=111").reindex(namespaceTable, "http://opcfoundation.org/UA/GDS/"),
+        AccessTokenRequestedAuditEventTypeNode.class,
+        AccessTokenRequestedAuditEventTypeNode::new);
+    objectTypeManager.registerObjectType(
+        NodeId.parse("ns=1;i=975").reindex(namespaceTable, "http://opcfoundation.org/UA/GDS/"),
+        AccessTokenIssuedAuditEventTypeNode.class,
+        AccessTokenIssuedAuditEventTypeNode::new);
+    objectTypeManager.registerObjectType(
+        NodeId.parse("ns=1;i=1020").reindex(namespaceTable, "http://opcfoundation.org/UA/GDS/"),
+        KeyCredentialServiceTypeNode.class,
+        KeyCredentialServiceTypeNode::new);
+    objectTypeManager.registerObjectType(
+        NodeId.parse("ns=1;i=966").reindex(namespaceTable, "http://opcfoundation.org/UA/GDS/"),
+        AuthorizationServiceTypeNode.class,
+        AuthorizationServiceTypeNode::new);
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/VariableTypeInitializer.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/VariableTypeInitializer.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.gds;
+
+import org.eclipse.milo.opcua.sdk.server.VariableTypeManager;
+import org.eclipse.milo.opcua.stack.core.NamespaceTable;
+
+public class VariableTypeInitializer {
+  public static void initialize(
+      NamespaceTable namespaceTable, VariableTypeManager variableTypeManager) {}
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/AccessTokenIssuedAuditEventType.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/AccessTokenIssuedAuditEventType.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.gds.model.objects;
+
+import org.eclipse.milo.opcua.sdk.server.model.objects.AuditUpdateMethodEventType;
+
+/**
+ * @see <a
+ *     href="https://reference.opcfoundation.org/GDS/docs/9.6.11">https://reference.opcfoundation.org/GDS/docs/9.6.11</a>
+ */
+public interface AccessTokenIssuedAuditEventType extends AuditUpdateMethodEventType {}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/AccessTokenIssuedAuditEventTypeNode.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/AccessTokenIssuedAuditEventTypeNode.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.gds.model.objects;
+
+import org.eclipse.milo.opcua.sdk.server.model.objects.AuditUpdateMethodEventTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNodeContext;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.structured.AccessRestrictionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.RolePermissionType;
+
+public class AccessTokenIssuedAuditEventTypeNode extends AuditUpdateMethodEventTypeNode
+    implements AccessTokenIssuedAuditEventType {
+  public AccessTokenIssuedAuditEventTypeNode(
+      UaNodeContext context,
+      NodeId nodeId,
+      QualifiedName browseName,
+      LocalizedText displayName,
+      LocalizedText description,
+      UInteger writeMask,
+      UInteger userWriteMask,
+      RolePermissionType[] rolePermissions,
+      RolePermissionType[] userRolePermissions,
+      AccessRestrictionType accessRestrictions,
+      UByte eventNotifier) {
+    super(
+        context,
+        nodeId,
+        browseName,
+        displayName,
+        description,
+        writeMask,
+        userWriteMask,
+        rolePermissions,
+        userRolePermissions,
+        accessRestrictions,
+        eventNotifier);
+  }
+
+  public AccessTokenIssuedAuditEventTypeNode(
+      UaNodeContext context,
+      NodeId nodeId,
+      QualifiedName browseName,
+      LocalizedText displayName,
+      LocalizedText description,
+      UInteger writeMask,
+      UInteger userWriteMask,
+      RolePermissionType[] rolePermissions,
+      RolePermissionType[] userRolePermissions,
+      AccessRestrictionType accessRestrictions) {
+    super(
+        context,
+        nodeId,
+        browseName,
+        displayName,
+        description,
+        writeMask,
+        userWriteMask,
+        rolePermissions,
+        userRolePermissions,
+        accessRestrictions);
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/AccessTokenRequestedAuditEventType.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/AccessTokenRequestedAuditEventType.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.gds.model.objects;
+
+import org.eclipse.milo.opcua.sdk.server.model.objects.AuditUpdateMethodEventType;
+
+/**
+ * @see <a
+ *     href="https://reference.opcfoundation.org/GDS/docs/9.6.10">https://reference.opcfoundation.org/GDS/docs/9.6.10</a>
+ */
+public interface AccessTokenRequestedAuditEventType extends AuditUpdateMethodEventType {}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/AccessTokenRequestedAuditEventTypeNode.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/AccessTokenRequestedAuditEventTypeNode.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.gds.model.objects;
+
+import org.eclipse.milo.opcua.sdk.server.model.objects.AuditUpdateMethodEventTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNodeContext;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.structured.AccessRestrictionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.RolePermissionType;
+
+public class AccessTokenRequestedAuditEventTypeNode extends AuditUpdateMethodEventTypeNode
+    implements AccessTokenRequestedAuditEventType {
+  public AccessTokenRequestedAuditEventTypeNode(
+      UaNodeContext context,
+      NodeId nodeId,
+      QualifiedName browseName,
+      LocalizedText displayName,
+      LocalizedText description,
+      UInteger writeMask,
+      UInteger userWriteMask,
+      RolePermissionType[] rolePermissions,
+      RolePermissionType[] userRolePermissions,
+      AccessRestrictionType accessRestrictions,
+      UByte eventNotifier) {
+    super(
+        context,
+        nodeId,
+        browseName,
+        displayName,
+        description,
+        writeMask,
+        userWriteMask,
+        rolePermissions,
+        userRolePermissions,
+        accessRestrictions,
+        eventNotifier);
+  }
+
+  public AccessTokenRequestedAuditEventTypeNode(
+      UaNodeContext context,
+      NodeId nodeId,
+      QualifiedName browseName,
+      LocalizedText displayName,
+      LocalizedText description,
+      UInteger writeMask,
+      UInteger userWriteMask,
+      RolePermissionType[] rolePermissions,
+      RolePermissionType[] userRolePermissions,
+      AccessRestrictionType accessRestrictions) {
+    super(
+        context,
+        nodeId,
+        browseName,
+        displayName,
+        description,
+        writeMask,
+        userWriteMask,
+        rolePermissions,
+        userRolePermissions,
+        accessRestrictions);
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/ApplicationRegistrationChangedAuditEventType.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/ApplicationRegistrationChangedAuditEventType.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.gds.model.objects;
+
+import org.eclipse.milo.opcua.sdk.server.model.objects.AuditUpdateMethodEventType;
+
+/**
+ * @see <a
+ *     href="https://reference.opcfoundation.org/GDS/docs/6.5.12">https://reference.opcfoundation.org/GDS/docs/6.5.12</a>
+ */
+public interface ApplicationRegistrationChangedAuditEventType extends AuditUpdateMethodEventType {}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/ApplicationRegistrationChangedAuditEventTypeNode.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/ApplicationRegistrationChangedAuditEventTypeNode.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.gds.model.objects;
+
+import org.eclipse.milo.opcua.sdk.server.model.objects.AuditUpdateMethodEventTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNodeContext;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.structured.AccessRestrictionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.RolePermissionType;
+
+public class ApplicationRegistrationChangedAuditEventTypeNode extends AuditUpdateMethodEventTypeNode
+    implements ApplicationRegistrationChangedAuditEventType {
+  public ApplicationRegistrationChangedAuditEventTypeNode(
+      UaNodeContext context,
+      NodeId nodeId,
+      QualifiedName browseName,
+      LocalizedText displayName,
+      LocalizedText description,
+      UInteger writeMask,
+      UInteger userWriteMask,
+      RolePermissionType[] rolePermissions,
+      RolePermissionType[] userRolePermissions,
+      AccessRestrictionType accessRestrictions,
+      UByte eventNotifier) {
+    super(
+        context,
+        nodeId,
+        browseName,
+        displayName,
+        description,
+        writeMask,
+        userWriteMask,
+        rolePermissions,
+        userRolePermissions,
+        accessRestrictions,
+        eventNotifier);
+  }
+
+  public ApplicationRegistrationChangedAuditEventTypeNode(
+      UaNodeContext context,
+      NodeId nodeId,
+      QualifiedName browseName,
+      LocalizedText displayName,
+      LocalizedText description,
+      UInteger writeMask,
+      UInteger userWriteMask,
+      RolePermissionType[] rolePermissions,
+      RolePermissionType[] userRolePermissions,
+      AccessRestrictionType accessRestrictions) {
+    super(
+        context,
+        nodeId,
+        browseName,
+        displayName,
+        description,
+        writeMask,
+        userWriteMask,
+        rolePermissions,
+        userRolePermissions,
+        accessRestrictions);
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/AuthorizationServiceType.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/AuthorizationServiceType.java
@@ -1,0 +1,597 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.gds.model.objects;
+
+import java.util.UUID;
+import org.eclipse.milo.opcua.sdk.core.QualifiedProperty;
+import org.eclipse.milo.opcua.sdk.core.nodes.MethodNode;
+import org.eclipse.milo.opcua.sdk.server.methods.AbstractMethodInvocationHandler;
+import org.eclipse.milo.opcua.sdk.server.methods.Out;
+import org.eclipse.milo.opcua.sdk.server.model.objects.BaseObjectType;
+import org.eclipse.milo.opcua.sdk.server.model.variables.PropertyType;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaMethodNode;
+import org.eclipse.milo.opcua.stack.core.NamespaceTable;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.structured.Argument;
+import org.eclipse.milo.opcua.stack.core.types.structured.SignatureData;
+import org.eclipse.milo.opcua.stack.core.types.structured.UserIdentityToken;
+import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
+import org.eclipse.milo.opcua.stack.core.util.Lazy;
+
+/**
+ * @see <a
+ *     href="https://reference.opcfoundation.org/GDS/docs/9.6.4">https://reference.opcfoundation.org/GDS/docs/9.6.4</a>
+ */
+public interface AuthorizationServiceType extends BaseObjectType {
+  QualifiedProperty<String> SERVICE_URI =
+      new QualifiedProperty<>(
+          "http://opcfoundation.org/UA/GDS/",
+          "ServiceUri",
+          ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=12"),
+          -1,
+          String.class);
+
+  QualifiedProperty<ByteString> SERVICE_CERTIFICATE =
+      new QualifiedProperty<>(
+          "http://opcfoundation.org/UA/GDS/",
+          "ServiceCertificate",
+          ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=15"),
+          -1,
+          ByteString.class);
+
+  QualifiedProperty<UserTokenPolicy[]> USER_TOKEN_POLICIES =
+      new QualifiedProperty<>(
+          "http://opcfoundation.org/UA/GDS/",
+          "UserTokenPolicies",
+          ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=304"),
+          1,
+          UserTokenPolicy[].class);
+
+  QualifiedProperty<String[]> SUPPORTED_ROLES =
+      new QualifiedProperty<>(
+          "http://opcfoundation.org/UA/GDS/",
+          "SupportedRoles",
+          ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=12"),
+          1,
+          String[].class);
+
+  String getServiceUri();
+
+  void setServiceUri(String value);
+
+  PropertyType getServiceUriNode();
+
+  ByteString getServiceCertificate();
+
+  void setServiceCertificate(ByteString value);
+
+  PropertyType getServiceCertificateNode();
+
+  UserTokenPolicy[] getUserTokenPolicies();
+
+  void setUserTokenPolicies(UserTokenPolicy[] value);
+
+  PropertyType getUserTokenPoliciesNode();
+
+  String[] getSupportedRoles();
+
+  void setSupportedRoles(String[] value);
+
+  PropertyType getSupportedRolesNode();
+
+  MethodNode getGetServiceDescriptionMethodNode();
+
+  MethodNode getRequestAccessTokenMethodNode();
+
+  MethodNode getStartRequestTokenMethodNode();
+
+  MethodNode getFinishRequestTokenMethodNode();
+
+  MethodNode getRefreshTokenMethodNode();
+
+  abstract class GetServiceDescriptionMethod extends AbstractMethodInvocationHandler {
+    private final Lazy<Argument[]> outputArguments = new Lazy<>();
+
+    public GetServiceDescriptionMethod(UaMethodNode node) {
+      super(node);
+    }
+
+    @Override
+    public Argument[] getInputArguments() {
+      return new Argument[] {};
+    }
+
+    @Override
+    public Argument[] getOutputArguments() {
+      return outputArguments.get(
+          () -> {
+            NamespaceTable namespaceTable = getNode().getNodeContext().getNamespaceTable();
+
+            return new Argument[] {
+              new Argument(
+                  "ServiceUri",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=12")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "ServiceCertificate",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=15")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "UserTokenPolicies",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=304")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  1,
+                  new UInteger[] {UInteger.valueOf(0)},
+                  new LocalizedText("", ""))
+            };
+          });
+    }
+
+    @Override
+    protected Variant[] invoke(
+        AbstractMethodInvocationHandler.InvocationContext context, Variant[] inputValues)
+        throws UaException {
+      Out<String> serviceUri = new Out<>();
+      Out<ByteString> serviceCertificate = new Out<>();
+      Out<UserTokenPolicy[]> userTokenPolicies = new Out<>();
+      invoke(context, serviceUri, serviceCertificate, userTokenPolicies);
+      return new Variant[] {
+        new Variant(serviceUri.get()),
+        new Variant(serviceCertificate.get()),
+        new Variant(userTokenPolicies.get())
+      };
+    }
+
+    protected abstract void invoke(
+        AbstractMethodInvocationHandler.InvocationContext context,
+        Out<String> serviceUri,
+        Out<ByteString> serviceCertificate,
+        Out<UserTokenPolicy[]> userTokenPolicies)
+        throws UaException;
+  }
+
+  abstract class RequestAccessTokenMethod extends AbstractMethodInvocationHandler {
+    private final Lazy<Argument[]> inputArguments = new Lazy<>();
+
+    private final Lazy<Argument[]> outputArguments = new Lazy<>();
+
+    public RequestAccessTokenMethod(UaMethodNode node) {
+      super(node);
+    }
+
+    @Override
+    public Argument[] getInputArguments() {
+      return inputArguments.get(
+          () -> {
+            NamespaceTable namespaceTable = getNode().getNodeContext().getNamespaceTable();
+
+            return new Argument[] {
+              new Argument(
+                  "IdentityToken",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=316")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "ResourceId",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=12")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", ""))
+            };
+          });
+    }
+
+    @Override
+    public Argument[] getOutputArguments() {
+      return outputArguments.get(
+          () -> {
+            NamespaceTable namespaceTable = getNode().getNodeContext().getNamespaceTable();
+
+            return new Argument[] {
+              new Argument(
+                  "AccessToken",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=12")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", ""))
+            };
+          });
+    }
+
+    @Override
+    protected Variant[] invoke(
+        AbstractMethodInvocationHandler.InvocationContext context, Variant[] inputValues)
+        throws UaException {
+      UserIdentityToken identityToken = (UserIdentityToken) inputValues[0].getValue();
+      String resourceId = (String) inputValues[1].getValue();
+      Out<String> accessToken = new Out<>();
+      invoke(context, identityToken, resourceId, accessToken);
+      return new Variant[] {new Variant(accessToken.get())};
+    }
+
+    protected abstract void invoke(
+        AbstractMethodInvocationHandler.InvocationContext context,
+        UserIdentityToken identityToken,
+        String resourceId,
+        Out<String> accessToken)
+        throws UaException;
+  }
+
+  abstract class StartRequestTokenMethod extends AbstractMethodInvocationHandler {
+    private final Lazy<Argument[]> inputArguments = new Lazy<>();
+
+    private final Lazy<Argument[]> outputArguments = new Lazy<>();
+
+    public StartRequestTokenMethod(UaMethodNode node) {
+      super(node);
+    }
+
+    @Override
+    public Argument[] getInputArguments() {
+      return inputArguments.get(
+          () -> {
+            NamespaceTable namespaceTable = getNode().getNodeContext().getNamespaceTable();
+
+            return new Argument[] {
+              new Argument(
+                  "ResourceId",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=12")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "PolicyId",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=12")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "RequestorData",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=15")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", ""))
+            };
+          });
+    }
+
+    @Override
+    public Argument[] getOutputArguments() {
+      return outputArguments.get(
+          () -> {
+            NamespaceTable namespaceTable = getNode().getNodeContext().getNamespaceTable();
+
+            return new Argument[] {
+              new Argument(
+                  "ServiceData",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=15")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "RequestId",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=14")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", ""))
+            };
+          });
+    }
+
+    @Override
+    protected Variant[] invoke(
+        AbstractMethodInvocationHandler.InvocationContext context, Variant[] inputValues)
+        throws UaException {
+      String resourceId = (String) inputValues[0].getValue();
+      String policyId = (String) inputValues[1].getValue();
+      ByteString requestorData = (ByteString) inputValues[2].getValue();
+      Out<ByteString> serviceData = new Out<>();
+      Out<UUID> requestId = new Out<>();
+      invoke(context, resourceId, policyId, requestorData, serviceData, requestId);
+      return new Variant[] {new Variant(serviceData.get()), new Variant(requestId.get())};
+    }
+
+    protected abstract void invoke(
+        AbstractMethodInvocationHandler.InvocationContext context,
+        String resourceId,
+        String policyId,
+        ByteString requestorData,
+        Out<ByteString> serviceData,
+        Out<UUID> requestId)
+        throws UaException;
+  }
+
+  abstract class FinishRequestTokenMethod extends AbstractMethodInvocationHandler {
+    private final Lazy<Argument[]> inputArguments = new Lazy<>();
+
+    private final Lazy<Argument[]> outputArguments = new Lazy<>();
+
+    public FinishRequestTokenMethod(UaMethodNode node) {
+      super(node);
+    }
+
+    @Override
+    public Argument[] getInputArguments() {
+      return inputArguments.get(
+          () -> {
+            NamespaceTable namespaceTable = getNode().getNodeContext().getNamespaceTable();
+
+            return new Argument[] {
+              new Argument(
+                  "RequestId",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=14")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "RequestedRoles",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=12")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  1,
+                  new UInteger[] {UInteger.valueOf(0)},
+                  new LocalizedText("", "")),
+              new Argument(
+                  "UserIdentityToken",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=316")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "UserTokenSignature",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=456")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", ""))
+            };
+          });
+    }
+
+    @Override
+    public Argument[] getOutputArguments() {
+      return outputArguments.get(
+          () -> {
+            NamespaceTable namespaceTable = getNode().getNodeContext().getNamespaceTable();
+
+            return new Argument[] {
+              new Argument(
+                  "AccessToken",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=12")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "AccessTokenExpiryTime",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=13")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "RefreshToken",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=12")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "RefreshTokenExpiryTime",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=13")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", ""))
+            };
+          });
+    }
+
+    @Override
+    protected Variant[] invoke(
+        AbstractMethodInvocationHandler.InvocationContext context, Variant[] inputValues)
+        throws UaException {
+      UUID requestId = (UUID) inputValues[0].getValue();
+      String[] requestedRoles = (String[]) inputValues[1].getValue();
+      UserIdentityToken userIdentityToken = (UserIdentityToken) inputValues[2].getValue();
+      SignatureData userTokenSignature = (SignatureData) inputValues[3].getValue();
+      Out<String> accessToken = new Out<>();
+      Out<DateTime> accessTokenExpiryTime = new Out<>();
+      Out<String> refreshToken = new Out<>();
+      Out<DateTime> refreshTokenExpiryTime = new Out<>();
+      invoke(
+          context,
+          requestId,
+          requestedRoles,
+          userIdentityToken,
+          userTokenSignature,
+          accessToken,
+          accessTokenExpiryTime,
+          refreshToken,
+          refreshTokenExpiryTime);
+      return new Variant[] {
+        new Variant(accessToken.get()),
+        new Variant(accessTokenExpiryTime.get()),
+        new Variant(refreshToken.get()),
+        new Variant(refreshTokenExpiryTime.get())
+      };
+    }
+
+    protected abstract void invoke(
+        AbstractMethodInvocationHandler.InvocationContext context,
+        UUID requestId,
+        String[] requestedRoles,
+        UserIdentityToken userIdentityToken,
+        SignatureData userTokenSignature,
+        Out<String> accessToken,
+        Out<DateTime> accessTokenExpiryTime,
+        Out<String> refreshToken,
+        Out<DateTime> refreshTokenExpiryTime)
+        throws UaException;
+  }
+
+  abstract class RefreshTokenMethod extends AbstractMethodInvocationHandler {
+    private final Lazy<Argument[]> inputArguments = new Lazy<>();
+
+    private final Lazy<Argument[]> outputArguments = new Lazy<>();
+
+    public RefreshTokenMethod(UaMethodNode node) {
+      super(node);
+    }
+
+    @Override
+    public Argument[] getInputArguments() {
+      return inputArguments.get(
+          () -> {
+            NamespaceTable namespaceTable = getNode().getNodeContext().getNamespaceTable();
+
+            return new Argument[] {
+              new Argument(
+                  "ResourceId",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=12")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "CurrentRefreshToken",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=12")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", ""))
+            };
+          });
+    }
+
+    @Override
+    public Argument[] getOutputArguments() {
+      return outputArguments.get(
+          () -> {
+            NamespaceTable namespaceTable = getNode().getNodeContext().getNamespaceTable();
+
+            return new Argument[] {
+              new Argument(
+                  "AccessToken",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=12")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "AccessTokenExpiryTime",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=13")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "NewRefreshToken",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=12")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "NewRefreshTokenExpiryTime",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=13")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", ""))
+            };
+          });
+    }
+
+    @Override
+    protected Variant[] invoke(
+        AbstractMethodInvocationHandler.InvocationContext context, Variant[] inputValues)
+        throws UaException {
+      String resourceId = (String) inputValues[0].getValue();
+      String currentRefreshToken = (String) inputValues[1].getValue();
+      Out<String> accessToken = new Out<>();
+      Out<DateTime> accessTokenExpiryTime = new Out<>();
+      Out<String> newRefreshToken = new Out<>();
+      Out<DateTime> newRefreshTokenExpiryTime = new Out<>();
+      invoke(
+          context,
+          resourceId,
+          currentRefreshToken,
+          accessToken,
+          accessTokenExpiryTime,
+          newRefreshToken,
+          newRefreshTokenExpiryTime);
+      return new Variant[] {
+        new Variant(accessToken.get()),
+        new Variant(accessTokenExpiryTime.get()),
+        new Variant(newRefreshToken.get()),
+        new Variant(newRefreshTokenExpiryTime.get())
+      };
+    }
+
+    protected abstract void invoke(
+        AbstractMethodInvocationHandler.InvocationContext context,
+        String resourceId,
+        String currentRefreshToken,
+        Out<String> accessToken,
+        Out<DateTime> accessTokenExpiryTime,
+        Out<String> newRefreshToken,
+        Out<DateTime> newRefreshTokenExpiryTime)
+        throws UaException;
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/AuthorizationServiceTypeNode.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/AuthorizationServiceTypeNode.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.gds.model.objects;
+
+import java.util.Optional;
+import org.eclipse.milo.opcua.sdk.core.Reference;
+import org.eclipse.milo.opcua.sdk.core.nodes.VariableNode;
+import org.eclipse.milo.opcua.sdk.server.model.objects.BaseObjectTypeNode;
+import org.eclipse.milo.opcua.sdk.server.model.variables.PropertyTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaMethodNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNodeContext;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.structured.AccessRestrictionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.RolePermissionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
+
+public class AuthorizationServiceTypeNode extends BaseObjectTypeNode
+    implements AuthorizationServiceType {
+  public AuthorizationServiceTypeNode(
+      UaNodeContext context,
+      NodeId nodeId,
+      QualifiedName browseName,
+      LocalizedText displayName,
+      LocalizedText description,
+      UInteger writeMask,
+      UInteger userWriteMask,
+      RolePermissionType[] rolePermissions,
+      RolePermissionType[] userRolePermissions,
+      AccessRestrictionType accessRestrictions,
+      UByte eventNotifier) {
+    super(
+        context,
+        nodeId,
+        browseName,
+        displayName,
+        description,
+        writeMask,
+        userWriteMask,
+        rolePermissions,
+        userRolePermissions,
+        accessRestrictions,
+        eventNotifier);
+  }
+
+  public AuthorizationServiceTypeNode(
+      UaNodeContext context,
+      NodeId nodeId,
+      QualifiedName browseName,
+      LocalizedText displayName,
+      LocalizedText description,
+      UInteger writeMask,
+      UInteger userWriteMask,
+      RolePermissionType[] rolePermissions,
+      RolePermissionType[] userRolePermissions,
+      AccessRestrictionType accessRestrictions) {
+    super(
+        context,
+        nodeId,
+        browseName,
+        displayName,
+        description,
+        writeMask,
+        userWriteMask,
+        rolePermissions,
+        userRolePermissions,
+        accessRestrictions);
+  }
+
+  @Override
+  public PropertyTypeNode getServiceUriNode() {
+    Optional<VariableNode> propertyNode = getPropertyNode(AuthorizationServiceType.SERVICE_URI);
+    return (PropertyTypeNode) propertyNode.orElse(null);
+  }
+
+  @Override
+  public String getServiceUri() {
+    return getProperty(AuthorizationServiceType.SERVICE_URI).orElse(null);
+  }
+
+  @Override
+  public void setServiceUri(String value) {
+    setProperty(AuthorizationServiceType.SERVICE_URI, value);
+  }
+
+  @Override
+  public PropertyTypeNode getServiceCertificateNode() {
+    Optional<VariableNode> propertyNode =
+        getPropertyNode(AuthorizationServiceType.SERVICE_CERTIFICATE);
+    return (PropertyTypeNode) propertyNode.orElse(null);
+  }
+
+  @Override
+  public ByteString getServiceCertificate() {
+    return getProperty(AuthorizationServiceType.SERVICE_CERTIFICATE).orElse(null);
+  }
+
+  @Override
+  public void setServiceCertificate(ByteString value) {
+    setProperty(AuthorizationServiceType.SERVICE_CERTIFICATE, value);
+  }
+
+  @Override
+  public PropertyTypeNode getUserTokenPoliciesNode() {
+    Optional<VariableNode> propertyNode =
+        getPropertyNode(AuthorizationServiceType.USER_TOKEN_POLICIES);
+    return (PropertyTypeNode) propertyNode.orElse(null);
+  }
+
+  @Override
+  public UserTokenPolicy[] getUserTokenPolicies() {
+    return getProperty(AuthorizationServiceType.USER_TOKEN_POLICIES).orElse(null);
+  }
+
+  @Override
+  public void setUserTokenPolicies(UserTokenPolicy[] value) {
+    setProperty(AuthorizationServiceType.USER_TOKEN_POLICIES, value);
+  }
+
+  @Override
+  public PropertyTypeNode getSupportedRolesNode() {
+    Optional<VariableNode> propertyNode = getPropertyNode(AuthorizationServiceType.SUPPORTED_ROLES);
+    return (PropertyTypeNode) propertyNode.orElse(null);
+  }
+
+  @Override
+  public String[] getSupportedRoles() {
+    return getProperty(AuthorizationServiceType.SUPPORTED_ROLES).orElse(null);
+  }
+
+  @Override
+  public void setSupportedRoles(String[] value) {
+    setProperty(AuthorizationServiceType.SUPPORTED_ROLES, value);
+  }
+
+  @Override
+  public UaMethodNode getGetServiceDescriptionMethodNode() {
+    Optional<UaNode> methodNode =
+        findNode(
+            "http://opcfoundation.org/UA/GDS/",
+            "GetServiceDescription",
+            node -> node instanceof UaMethodNode,
+            Reference.HAS_COMPONENT_PREDICATE);
+    return (UaMethodNode) methodNode.orElse(null);
+  }
+
+  @Override
+  public UaMethodNode getRequestAccessTokenMethodNode() {
+    Optional<UaNode> methodNode =
+        findNode(
+            "http://opcfoundation.org/UA/GDS/",
+            "RequestAccessToken",
+            node -> node instanceof UaMethodNode,
+            Reference.HAS_COMPONENT_PREDICATE);
+    return (UaMethodNode) methodNode.orElse(null);
+  }
+
+  @Override
+  public UaMethodNode getStartRequestTokenMethodNode() {
+    Optional<UaNode> methodNode =
+        findNode(
+            "http://opcfoundation.org/UA/GDS/",
+            "StartRequestToken",
+            node -> node instanceof UaMethodNode,
+            Reference.HAS_COMPONENT_PREDICATE);
+    return (UaMethodNode) methodNode.orElse(null);
+  }
+
+  @Override
+  public UaMethodNode getFinishRequestTokenMethodNode() {
+    Optional<UaNode> methodNode =
+        findNode(
+            "http://opcfoundation.org/UA/GDS/",
+            "FinishRequestToken",
+            node -> node instanceof UaMethodNode,
+            Reference.HAS_COMPONENT_PREDICATE);
+    return (UaMethodNode) methodNode.orElse(null);
+  }
+
+  @Override
+  public UaMethodNode getRefreshTokenMethodNode() {
+    Optional<UaNode> methodNode =
+        findNode(
+            "http://opcfoundation.org/UA/GDS/",
+            "RefreshToken",
+            node -> node instanceof UaMethodNode,
+            Reference.HAS_COMPONENT_PREDICATE);
+    return (UaMethodNode) methodNode.orElse(null);
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/AuthorizationServicesFolderType.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/AuthorizationServicesFolderType.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.gds.model.objects;
+
+import org.eclipse.milo.opcua.sdk.server.model.objects.FolderType;
+
+/**
+ * @see <a
+ *     href="https://reference.opcfoundation.org/GDS/docs/9.6.2">https://reference.opcfoundation.org/GDS/docs/9.6.2</a>
+ */
+public interface AuthorizationServicesFolderType extends FolderType {}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/AuthorizationServicesFolderTypeNode.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/AuthorizationServicesFolderTypeNode.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.gds.model.objects;
+
+import org.eclipse.milo.opcua.sdk.server.model.objects.FolderTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNodeContext;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.structured.AccessRestrictionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.RolePermissionType;
+
+public class AuthorizationServicesFolderTypeNode extends FolderTypeNode
+    implements AuthorizationServicesFolderType {
+  public AuthorizationServicesFolderTypeNode(
+      UaNodeContext context,
+      NodeId nodeId,
+      QualifiedName browseName,
+      LocalizedText displayName,
+      LocalizedText description,
+      UInteger writeMask,
+      UInteger userWriteMask,
+      RolePermissionType[] rolePermissions,
+      RolePermissionType[] userRolePermissions,
+      AccessRestrictionType accessRestrictions,
+      UByte eventNotifier) {
+    super(
+        context,
+        nodeId,
+        browseName,
+        displayName,
+        description,
+        writeMask,
+        userWriteMask,
+        rolePermissions,
+        userRolePermissions,
+        accessRestrictions,
+        eventNotifier);
+  }
+
+  public AuthorizationServicesFolderTypeNode(
+      UaNodeContext context,
+      NodeId nodeId,
+      QualifiedName browseName,
+      LocalizedText displayName,
+      LocalizedText description,
+      UInteger writeMask,
+      UInteger userWriteMask,
+      RolePermissionType[] rolePermissions,
+      RolePermissionType[] userRolePermissions,
+      AccessRestrictionType accessRestrictions) {
+    super(
+        context,
+        nodeId,
+        browseName,
+        displayName,
+        description,
+        writeMask,
+        userWriteMask,
+        rolePermissions,
+        userRolePermissions,
+        accessRestrictions);
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/CertificateDeliveredAuditEventType.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/CertificateDeliveredAuditEventType.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.gds.model.objects;
+
+import org.eclipse.milo.opcua.sdk.core.QualifiedProperty;
+import org.eclipse.milo.opcua.sdk.server.model.objects.AuditUpdateMethodEventType;
+import org.eclipse.milo.opcua.sdk.server.model.variables.PropertyType;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+
+/**
+ * @see <a
+ *     href="https://reference.opcfoundation.org/GDS/docs/7.9.13">https://reference.opcfoundation.org/GDS/docs/7.9.13</a>
+ */
+public interface CertificateDeliveredAuditEventType extends AuditUpdateMethodEventType {
+  QualifiedProperty<NodeId> CERTIFICATE_GROUP =
+      new QualifiedProperty<>(
+          "http://opcfoundation.org/UA/GDS/",
+          "CertificateGroup",
+          ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=17"),
+          -1,
+          NodeId.class);
+
+  QualifiedProperty<NodeId> CERTIFICATE_TYPE =
+      new QualifiedProperty<>(
+          "http://opcfoundation.org/UA/GDS/",
+          "CertificateType",
+          ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=17"),
+          -1,
+          NodeId.class);
+
+  NodeId getCertificateGroup();
+
+  void setCertificateGroup(NodeId value);
+
+  PropertyType getCertificateGroupNode();
+
+  NodeId getCertificateType();
+
+  void setCertificateType(NodeId value);
+
+  PropertyType getCertificateTypeNode();
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/CertificateDeliveredAuditEventTypeNode.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/CertificateDeliveredAuditEventTypeNode.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.gds.model.objects;
+
+import java.util.Optional;
+import org.eclipse.milo.opcua.sdk.core.nodes.VariableNode;
+import org.eclipse.milo.opcua.sdk.server.model.objects.AuditUpdateMethodEventTypeNode;
+import org.eclipse.milo.opcua.sdk.server.model.variables.PropertyTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNodeContext;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.structured.AccessRestrictionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.RolePermissionType;
+
+public class CertificateDeliveredAuditEventTypeNode extends AuditUpdateMethodEventTypeNode
+    implements CertificateDeliveredAuditEventType {
+  public CertificateDeliveredAuditEventTypeNode(
+      UaNodeContext context,
+      NodeId nodeId,
+      QualifiedName browseName,
+      LocalizedText displayName,
+      LocalizedText description,
+      UInteger writeMask,
+      UInteger userWriteMask,
+      RolePermissionType[] rolePermissions,
+      RolePermissionType[] userRolePermissions,
+      AccessRestrictionType accessRestrictions,
+      UByte eventNotifier) {
+    super(
+        context,
+        nodeId,
+        browseName,
+        displayName,
+        description,
+        writeMask,
+        userWriteMask,
+        rolePermissions,
+        userRolePermissions,
+        accessRestrictions,
+        eventNotifier);
+  }
+
+  public CertificateDeliveredAuditEventTypeNode(
+      UaNodeContext context,
+      NodeId nodeId,
+      QualifiedName browseName,
+      LocalizedText displayName,
+      LocalizedText description,
+      UInteger writeMask,
+      UInteger userWriteMask,
+      RolePermissionType[] rolePermissions,
+      RolePermissionType[] userRolePermissions,
+      AccessRestrictionType accessRestrictions) {
+    super(
+        context,
+        nodeId,
+        browseName,
+        displayName,
+        description,
+        writeMask,
+        userWriteMask,
+        rolePermissions,
+        userRolePermissions,
+        accessRestrictions);
+  }
+
+  @Override
+  public PropertyTypeNode getCertificateGroupNode() {
+    Optional<VariableNode> propertyNode =
+        getPropertyNode(CertificateDeliveredAuditEventType.CERTIFICATE_GROUP);
+    return (PropertyTypeNode) propertyNode.orElse(null);
+  }
+
+  @Override
+  public NodeId getCertificateGroup() {
+    return getProperty(CertificateDeliveredAuditEventType.CERTIFICATE_GROUP).orElse(null);
+  }
+
+  @Override
+  public void setCertificateGroup(NodeId value) {
+    setProperty(CertificateDeliveredAuditEventType.CERTIFICATE_GROUP, value);
+  }
+
+  @Override
+  public PropertyTypeNode getCertificateTypeNode() {
+    Optional<VariableNode> propertyNode =
+        getPropertyNode(CertificateDeliveredAuditEventType.CERTIFICATE_TYPE);
+    return (PropertyTypeNode) propertyNode.orElse(null);
+  }
+
+  @Override
+  public NodeId getCertificateType() {
+    return getProperty(CertificateDeliveredAuditEventType.CERTIFICATE_TYPE).orElse(null);
+  }
+
+  @Override
+  public void setCertificateType(NodeId value) {
+    setProperty(CertificateDeliveredAuditEventType.CERTIFICATE_TYPE, value);
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/CertificateDirectoryType.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/CertificateDirectoryType.java
@@ -1,0 +1,822 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.gds.model.objects;
+
+import org.eclipse.milo.opcua.sdk.core.nodes.MethodNode;
+import org.eclipse.milo.opcua.sdk.server.methods.AbstractMethodInvocationHandler;
+import org.eclipse.milo.opcua.sdk.server.methods.Out;
+import org.eclipse.milo.opcua.sdk.server.model.objects.CertificateGroupFolderType;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaMethodNode;
+import org.eclipse.milo.opcua.stack.core.NamespaceTable;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.structured.Argument;
+import org.eclipse.milo.opcua.stack.core.util.Lazy;
+
+/**
+ * @see <a
+ *     href="https://reference.opcfoundation.org/GDS/docs/7.9.2">https://reference.opcfoundation.org/GDS/docs/7.9.2</a>
+ */
+public interface CertificateDirectoryType extends DirectoryType {
+  MethodNode getStartSigningRequestMethodNode();
+
+  MethodNode getStartNewKeyPairRequestMethodNode();
+
+  MethodNode getFinishRequestMethodNode();
+
+  MethodNode getRevokeCertificateMethodNode();
+
+  MethodNode getGetCertificateGroupsMethodNode();
+
+  MethodNode getGetCertificatesMethodNode();
+
+  MethodNode getGetTrustListMethodNode();
+
+  MethodNode getGetCertificateStatusMethodNode();
+
+  MethodNode getCheckRevocationStatusMethodNode();
+
+  CertificateGroupFolderType getCertificateGroupsNode();
+
+  abstract class StartSigningRequestMethod extends AbstractMethodInvocationHandler {
+    private final Lazy<Argument[]> inputArguments = new Lazy<>();
+
+    private final Lazy<Argument[]> outputArguments = new Lazy<>();
+
+    public StartSigningRequestMethod(UaMethodNode node) {
+      super(node);
+    }
+
+    @Override
+    public Argument[] getInputArguments() {
+      return inputArguments.get(
+          () -> {
+            NamespaceTable namespaceTable = getNode().getNodeContext().getNamespaceTable();
+
+            return new Argument[] {
+              new Argument(
+                  "ApplicationId",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=17")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "CertificateGroupId",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=17")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "CertificateTypeId",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=17")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "CertificateRequest",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=15")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", ""))
+            };
+          });
+    }
+
+    @Override
+    public Argument[] getOutputArguments() {
+      return outputArguments.get(
+          () -> {
+            NamespaceTable namespaceTable = getNode().getNodeContext().getNamespaceTable();
+
+            return new Argument[] {
+              new Argument(
+                  "RequestId",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=17")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", ""))
+            };
+          });
+    }
+
+    @Override
+    protected Variant[] invoke(
+        AbstractMethodInvocationHandler.InvocationContext context, Variant[] inputValues)
+        throws UaException {
+      NodeId applicationId = (NodeId) inputValues[0].getValue();
+      NodeId certificateGroupId = (NodeId) inputValues[1].getValue();
+      NodeId certificateTypeId = (NodeId) inputValues[2].getValue();
+      ByteString certificateRequest = (ByteString) inputValues[3].getValue();
+      Out<NodeId> requestId = new Out<>();
+      invoke(
+          context,
+          applicationId,
+          certificateGroupId,
+          certificateTypeId,
+          certificateRequest,
+          requestId);
+      return new Variant[] {new Variant(requestId.get())};
+    }
+
+    protected abstract void invoke(
+        AbstractMethodInvocationHandler.InvocationContext context,
+        NodeId applicationId,
+        NodeId certificateGroupId,
+        NodeId certificateTypeId,
+        ByteString certificateRequest,
+        Out<NodeId> requestId)
+        throws UaException;
+  }
+
+  abstract class StartNewKeyPairRequestMethod extends AbstractMethodInvocationHandler {
+    private final Lazy<Argument[]> inputArguments = new Lazy<>();
+
+    private final Lazy<Argument[]> outputArguments = new Lazy<>();
+
+    public StartNewKeyPairRequestMethod(UaMethodNode node) {
+      super(node);
+    }
+
+    @Override
+    public Argument[] getInputArguments() {
+      return inputArguments.get(
+          () -> {
+            NamespaceTable namespaceTable = getNode().getNodeContext().getNamespaceTable();
+
+            return new Argument[] {
+              new Argument(
+                  "ApplicationId",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=17")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "CertificateGroupId",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=17")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "CertificateTypeId",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=17")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "SubjectName",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=12")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "DomainNames",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=12")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  1,
+                  new UInteger[] {UInteger.valueOf(0)},
+                  new LocalizedText("", "")),
+              new Argument(
+                  "PrivateKeyFormat",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=12")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "PrivateKeyPassword",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=12")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", ""))
+            };
+          });
+    }
+
+    @Override
+    public Argument[] getOutputArguments() {
+      return outputArguments.get(
+          () -> {
+            NamespaceTable namespaceTable = getNode().getNodeContext().getNamespaceTable();
+
+            return new Argument[] {
+              new Argument(
+                  "RequestId",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=17")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", ""))
+            };
+          });
+    }
+
+    @Override
+    protected Variant[] invoke(
+        AbstractMethodInvocationHandler.InvocationContext context, Variant[] inputValues)
+        throws UaException {
+      NodeId applicationId = (NodeId) inputValues[0].getValue();
+      NodeId certificateGroupId = (NodeId) inputValues[1].getValue();
+      NodeId certificateTypeId = (NodeId) inputValues[2].getValue();
+      String subjectName = (String) inputValues[3].getValue();
+      String[] domainNames = (String[]) inputValues[4].getValue();
+      String privateKeyFormat = (String) inputValues[5].getValue();
+      String privateKeyPassword = (String) inputValues[6].getValue();
+      Out<NodeId> requestId = new Out<>();
+      invoke(
+          context,
+          applicationId,
+          certificateGroupId,
+          certificateTypeId,
+          subjectName,
+          domainNames,
+          privateKeyFormat,
+          privateKeyPassword,
+          requestId);
+      return new Variant[] {new Variant(requestId.get())};
+    }
+
+    protected abstract void invoke(
+        AbstractMethodInvocationHandler.InvocationContext context,
+        NodeId applicationId,
+        NodeId certificateGroupId,
+        NodeId certificateTypeId,
+        String subjectName,
+        String[] domainNames,
+        String privateKeyFormat,
+        String privateKeyPassword,
+        Out<NodeId> requestId)
+        throws UaException;
+  }
+
+  abstract class FinishRequestMethod extends AbstractMethodInvocationHandler {
+    private final Lazy<Argument[]> inputArguments = new Lazy<>();
+
+    private final Lazy<Argument[]> outputArguments = new Lazy<>();
+
+    public FinishRequestMethod(UaMethodNode node) {
+      super(node);
+    }
+
+    @Override
+    public Argument[] getInputArguments() {
+      return inputArguments.get(
+          () -> {
+            NamespaceTable namespaceTable = getNode().getNodeContext().getNamespaceTable();
+
+            return new Argument[] {
+              new Argument(
+                  "ApplicationId",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=17")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "RequestId",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=17")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", ""))
+            };
+          });
+    }
+
+    @Override
+    public Argument[] getOutputArguments() {
+      return outputArguments.get(
+          () -> {
+            NamespaceTable namespaceTable = getNode().getNodeContext().getNamespaceTable();
+
+            return new Argument[] {
+              new Argument(
+                  "Certificate",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=15")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "PrivateKey",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=15")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "IssuerCertificates",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=15")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  1,
+                  new UInteger[] {UInteger.valueOf(0)},
+                  new LocalizedText("", ""))
+            };
+          });
+    }
+
+    @Override
+    protected Variant[] invoke(
+        AbstractMethodInvocationHandler.InvocationContext context, Variant[] inputValues)
+        throws UaException {
+      NodeId applicationId = (NodeId) inputValues[0].getValue();
+      NodeId requestId = (NodeId) inputValues[1].getValue();
+      Out<ByteString> certificate = new Out<>();
+      Out<ByteString> privateKey = new Out<>();
+      Out<ByteString[]> issuerCertificates = new Out<>();
+      invoke(context, applicationId, requestId, certificate, privateKey, issuerCertificates);
+      return new Variant[] {
+        new Variant(certificate.get()),
+        new Variant(privateKey.get()),
+        new Variant(issuerCertificates.get())
+      };
+    }
+
+    protected abstract void invoke(
+        AbstractMethodInvocationHandler.InvocationContext context,
+        NodeId applicationId,
+        NodeId requestId,
+        Out<ByteString> certificate,
+        Out<ByteString> privateKey,
+        Out<ByteString[]> issuerCertificates)
+        throws UaException;
+  }
+
+  abstract class RevokeCertificateMethod extends AbstractMethodInvocationHandler {
+    private final Lazy<Argument[]> inputArguments = new Lazy<>();
+
+    public RevokeCertificateMethod(UaMethodNode node) {
+      super(node);
+    }
+
+    @Override
+    public Argument[] getInputArguments() {
+      return inputArguments.get(
+          () -> {
+            NamespaceTable namespaceTable = getNode().getNodeContext().getNamespaceTable();
+
+            return new Argument[] {
+              new Argument(
+                  "ApplicationId",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=17")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "Certificate",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=15")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", ""))
+            };
+          });
+    }
+
+    @Override
+    public Argument[] getOutputArguments() {
+      return new Argument[] {};
+    }
+
+    @Override
+    protected Variant[] invoke(
+        AbstractMethodInvocationHandler.InvocationContext context, Variant[] inputValues)
+        throws UaException {
+      NodeId applicationId = (NodeId) inputValues[0].getValue();
+      ByteString certificate = (ByteString) inputValues[1].getValue();
+      invoke(context, applicationId, certificate);
+      return new Variant[] {};
+    }
+
+    protected abstract void invoke(
+        AbstractMethodInvocationHandler.InvocationContext context,
+        NodeId applicationId,
+        ByteString certificate)
+        throws UaException;
+  }
+
+  abstract class GetCertificateGroupsMethod extends AbstractMethodInvocationHandler {
+    private final Lazy<Argument[]> inputArguments = new Lazy<>();
+
+    private final Lazy<Argument[]> outputArguments = new Lazy<>();
+
+    public GetCertificateGroupsMethod(UaMethodNode node) {
+      super(node);
+    }
+
+    @Override
+    public Argument[] getInputArguments() {
+      return inputArguments.get(
+          () -> {
+            NamespaceTable namespaceTable = getNode().getNodeContext().getNamespaceTable();
+
+            return new Argument[] {
+              new Argument(
+                  "ApplicationId",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=17")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", ""))
+            };
+          });
+    }
+
+    @Override
+    public Argument[] getOutputArguments() {
+      return outputArguments.get(
+          () -> {
+            NamespaceTable namespaceTable = getNode().getNodeContext().getNamespaceTable();
+
+            return new Argument[] {
+              new Argument(
+                  "CertificateGroupIds",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=17")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  1,
+                  new UInteger[] {UInteger.valueOf(0)},
+                  new LocalizedText("", ""))
+            };
+          });
+    }
+
+    @Override
+    protected Variant[] invoke(
+        AbstractMethodInvocationHandler.InvocationContext context, Variant[] inputValues)
+        throws UaException {
+      NodeId applicationId = (NodeId) inputValues[0].getValue();
+      Out<NodeId[]> certificateGroupIds = new Out<>();
+      invoke(context, applicationId, certificateGroupIds);
+      return new Variant[] {new Variant(certificateGroupIds.get())};
+    }
+
+    protected abstract void invoke(
+        AbstractMethodInvocationHandler.InvocationContext context,
+        NodeId applicationId,
+        Out<NodeId[]> certificateGroupIds)
+        throws UaException;
+  }
+
+  abstract class GetCertificatesMethod extends AbstractMethodInvocationHandler {
+    private final Lazy<Argument[]> inputArguments = new Lazy<>();
+
+    private final Lazy<Argument[]> outputArguments = new Lazy<>();
+
+    public GetCertificatesMethod(UaMethodNode node) {
+      super(node);
+    }
+
+    @Override
+    public Argument[] getInputArguments() {
+      return inputArguments.get(
+          () -> {
+            NamespaceTable namespaceTable = getNode().getNodeContext().getNamespaceTable();
+
+            return new Argument[] {
+              new Argument(
+                  "ApplicationId",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=17")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "CertificateGroupId",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=17")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", ""))
+            };
+          });
+    }
+
+    @Override
+    public Argument[] getOutputArguments() {
+      return outputArguments.get(
+          () -> {
+            NamespaceTable namespaceTable = getNode().getNodeContext().getNamespaceTable();
+
+            return new Argument[] {
+              new Argument(
+                  "CertificateTypeIds",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=17")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  1,
+                  new UInteger[] {UInteger.valueOf(0)},
+                  new LocalizedText("", "")),
+              new Argument(
+                  "Certificates",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=15")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  1,
+                  new UInteger[] {UInteger.valueOf(0)},
+                  new LocalizedText("", ""))
+            };
+          });
+    }
+
+    @Override
+    protected Variant[] invoke(
+        AbstractMethodInvocationHandler.InvocationContext context, Variant[] inputValues)
+        throws UaException {
+      NodeId applicationId = (NodeId) inputValues[0].getValue();
+      NodeId certificateGroupId = (NodeId) inputValues[1].getValue();
+      Out<NodeId[]> certificateTypeIds = new Out<>();
+      Out<ByteString[]> certificates = new Out<>();
+      invoke(context, applicationId, certificateGroupId, certificateTypeIds, certificates);
+      return new Variant[] {new Variant(certificateTypeIds.get()), new Variant(certificates.get())};
+    }
+
+    protected abstract void invoke(
+        AbstractMethodInvocationHandler.InvocationContext context,
+        NodeId applicationId,
+        NodeId certificateGroupId,
+        Out<NodeId[]> certificateTypeIds,
+        Out<ByteString[]> certificates)
+        throws UaException;
+  }
+
+  abstract class GetTrustListMethod extends AbstractMethodInvocationHandler {
+    private final Lazy<Argument[]> inputArguments = new Lazy<>();
+
+    private final Lazy<Argument[]> outputArguments = new Lazy<>();
+
+    public GetTrustListMethod(UaMethodNode node) {
+      super(node);
+    }
+
+    @Override
+    public Argument[] getInputArguments() {
+      return inputArguments.get(
+          () -> {
+            NamespaceTable namespaceTable = getNode().getNodeContext().getNamespaceTable();
+
+            return new Argument[] {
+              new Argument(
+                  "ApplicationId",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=17")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "CertificateGroupId",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=17")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", ""))
+            };
+          });
+    }
+
+    @Override
+    public Argument[] getOutputArguments() {
+      return outputArguments.get(
+          () -> {
+            NamespaceTable namespaceTable = getNode().getNodeContext().getNamespaceTable();
+
+            return new Argument[] {
+              new Argument(
+                  "TrustListId",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=17")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", ""))
+            };
+          });
+    }
+
+    @Override
+    protected Variant[] invoke(
+        AbstractMethodInvocationHandler.InvocationContext context, Variant[] inputValues)
+        throws UaException {
+      NodeId applicationId = (NodeId) inputValues[0].getValue();
+      NodeId certificateGroupId = (NodeId) inputValues[1].getValue();
+      Out<NodeId> trustListId = new Out<>();
+      invoke(context, applicationId, certificateGroupId, trustListId);
+      return new Variant[] {new Variant(trustListId.get())};
+    }
+
+    protected abstract void invoke(
+        AbstractMethodInvocationHandler.InvocationContext context,
+        NodeId applicationId,
+        NodeId certificateGroupId,
+        Out<NodeId> trustListId)
+        throws UaException;
+  }
+
+  abstract class GetCertificateStatusMethod extends AbstractMethodInvocationHandler {
+    private final Lazy<Argument[]> inputArguments = new Lazy<>();
+
+    private final Lazy<Argument[]> outputArguments = new Lazy<>();
+
+    public GetCertificateStatusMethod(UaMethodNode node) {
+      super(node);
+    }
+
+    @Override
+    public Argument[] getInputArguments() {
+      return inputArguments.get(
+          () -> {
+            NamespaceTable namespaceTable = getNode().getNodeContext().getNamespaceTable();
+
+            return new Argument[] {
+              new Argument(
+                  "ApplicationId",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=17")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "CertificateGroupId",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=17")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "CertificateTypeId",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=17")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", ""))
+            };
+          });
+    }
+
+    @Override
+    public Argument[] getOutputArguments() {
+      return outputArguments.get(
+          () -> {
+            NamespaceTable namespaceTable = getNode().getNodeContext().getNamespaceTable();
+
+            return new Argument[] {
+              new Argument(
+                  "UpdateRequired",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=1")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", ""))
+            };
+          });
+    }
+
+    @Override
+    protected Variant[] invoke(
+        AbstractMethodInvocationHandler.InvocationContext context, Variant[] inputValues)
+        throws UaException {
+      NodeId applicationId = (NodeId) inputValues[0].getValue();
+      NodeId certificateGroupId = (NodeId) inputValues[1].getValue();
+      NodeId certificateTypeId = (NodeId) inputValues[2].getValue();
+      Out<Boolean> updateRequired = new Out<>();
+      invoke(context, applicationId, certificateGroupId, certificateTypeId, updateRequired);
+      return new Variant[] {new Variant(updateRequired.get())};
+    }
+
+    protected abstract void invoke(
+        AbstractMethodInvocationHandler.InvocationContext context,
+        NodeId applicationId,
+        NodeId certificateGroupId,
+        NodeId certificateTypeId,
+        Out<Boolean> updateRequired)
+        throws UaException;
+  }
+
+  abstract class CheckRevocationStatusMethod extends AbstractMethodInvocationHandler {
+    private final Lazy<Argument[]> inputArguments = new Lazy<>();
+
+    private final Lazy<Argument[]> outputArguments = new Lazy<>();
+
+    public CheckRevocationStatusMethod(UaMethodNode node) {
+      super(node);
+    }
+
+    @Override
+    public Argument[] getInputArguments() {
+      return inputArguments.get(
+          () -> {
+            NamespaceTable namespaceTable = getNode().getNodeContext().getNamespaceTable();
+
+            return new Argument[] {
+              new Argument(
+                  "Certificate",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=15")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", ""))
+            };
+          });
+    }
+
+    @Override
+    public Argument[] getOutputArguments() {
+      return outputArguments.get(
+          () -> {
+            NamespaceTable namespaceTable = getNode().getNodeContext().getNamespaceTable();
+
+            return new Argument[] {
+              new Argument(
+                  "CertificateStatus",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=19")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "ValidityTime",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=294")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", ""))
+            };
+          });
+    }
+
+    @Override
+    protected Variant[] invoke(
+        AbstractMethodInvocationHandler.InvocationContext context, Variant[] inputValues)
+        throws UaException {
+      ByteString certificate = (ByteString) inputValues[0].getValue();
+      Out<StatusCode> certificateStatus = new Out<>();
+      Out<DateTime> validityTime = new Out<>();
+      invoke(context, certificate, certificateStatus, validityTime);
+      return new Variant[] {new Variant(certificateStatus.get()), new Variant(validityTime.get())};
+    }
+
+    protected abstract void invoke(
+        AbstractMethodInvocationHandler.InvocationContext context,
+        ByteString certificate,
+        Out<StatusCode> certificateStatus,
+        Out<DateTime> validityTime)
+        throws UaException;
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/CertificateDirectoryTypeNode.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/CertificateDirectoryTypeNode.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.gds.model.objects;
+
+import java.util.Optional;
+import org.eclipse.milo.opcua.sdk.core.Reference;
+import org.eclipse.milo.opcua.sdk.server.model.objects.CertificateGroupFolderTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaMethodNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNodeContext;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectNode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.structured.AccessRestrictionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.RolePermissionType;
+
+public class CertificateDirectoryTypeNode extends DirectoryTypeNode
+    implements CertificateDirectoryType {
+  public CertificateDirectoryTypeNode(
+      UaNodeContext context,
+      NodeId nodeId,
+      QualifiedName browseName,
+      LocalizedText displayName,
+      LocalizedText description,
+      UInteger writeMask,
+      UInteger userWriteMask,
+      RolePermissionType[] rolePermissions,
+      RolePermissionType[] userRolePermissions,
+      AccessRestrictionType accessRestrictions,
+      UByte eventNotifier) {
+    super(
+        context,
+        nodeId,
+        browseName,
+        displayName,
+        description,
+        writeMask,
+        userWriteMask,
+        rolePermissions,
+        userRolePermissions,
+        accessRestrictions,
+        eventNotifier);
+  }
+
+  public CertificateDirectoryTypeNode(
+      UaNodeContext context,
+      NodeId nodeId,
+      QualifiedName browseName,
+      LocalizedText displayName,
+      LocalizedText description,
+      UInteger writeMask,
+      UInteger userWriteMask,
+      RolePermissionType[] rolePermissions,
+      RolePermissionType[] userRolePermissions,
+      AccessRestrictionType accessRestrictions) {
+    super(
+        context,
+        nodeId,
+        browseName,
+        displayName,
+        description,
+        writeMask,
+        userWriteMask,
+        rolePermissions,
+        userRolePermissions,
+        accessRestrictions);
+  }
+
+  @Override
+  public UaMethodNode getStartSigningRequestMethodNode() {
+    Optional<UaNode> methodNode =
+        findNode(
+            "http://opcfoundation.org/UA/GDS/",
+            "StartSigningRequest",
+            node -> node instanceof UaMethodNode,
+            Reference.HAS_COMPONENT_PREDICATE);
+    return (UaMethodNode) methodNode.orElse(null);
+  }
+
+  @Override
+  public UaMethodNode getStartNewKeyPairRequestMethodNode() {
+    Optional<UaNode> methodNode =
+        findNode(
+            "http://opcfoundation.org/UA/GDS/",
+            "StartNewKeyPairRequest",
+            node -> node instanceof UaMethodNode,
+            Reference.HAS_COMPONENT_PREDICATE);
+    return (UaMethodNode) methodNode.orElse(null);
+  }
+
+  @Override
+  public UaMethodNode getFinishRequestMethodNode() {
+    Optional<UaNode> methodNode =
+        findNode(
+            "http://opcfoundation.org/UA/GDS/",
+            "FinishRequest",
+            node -> node instanceof UaMethodNode,
+            Reference.HAS_COMPONENT_PREDICATE);
+    return (UaMethodNode) methodNode.orElse(null);
+  }
+
+  @Override
+  public UaMethodNode getRevokeCertificateMethodNode() {
+    Optional<UaNode> methodNode =
+        findNode(
+            "http://opcfoundation.org/UA/GDS/",
+            "RevokeCertificate",
+            node -> node instanceof UaMethodNode,
+            Reference.HAS_COMPONENT_PREDICATE);
+    return (UaMethodNode) methodNode.orElse(null);
+  }
+
+  @Override
+  public UaMethodNode getGetCertificateGroupsMethodNode() {
+    Optional<UaNode> methodNode =
+        findNode(
+            "http://opcfoundation.org/UA/GDS/",
+            "GetCertificateGroups",
+            node -> node instanceof UaMethodNode,
+            Reference.HAS_COMPONENT_PREDICATE);
+    return (UaMethodNode) methodNode.orElse(null);
+  }
+
+  @Override
+  public UaMethodNode getGetCertificatesMethodNode() {
+    Optional<UaNode> methodNode =
+        findNode(
+            "http://opcfoundation.org/UA/GDS/",
+            "GetCertificates",
+            node -> node instanceof UaMethodNode,
+            Reference.HAS_COMPONENT_PREDICATE);
+    return (UaMethodNode) methodNode.orElse(null);
+  }
+
+  @Override
+  public UaMethodNode getGetTrustListMethodNode() {
+    Optional<UaNode> methodNode =
+        findNode(
+            "http://opcfoundation.org/UA/GDS/",
+            "GetTrustList",
+            node -> node instanceof UaMethodNode,
+            Reference.HAS_COMPONENT_PREDICATE);
+    return (UaMethodNode) methodNode.orElse(null);
+  }
+
+  @Override
+  public UaMethodNode getGetCertificateStatusMethodNode() {
+    Optional<UaNode> methodNode =
+        findNode(
+            "http://opcfoundation.org/UA/GDS/",
+            "GetCertificateStatus",
+            node -> node instanceof UaMethodNode,
+            Reference.HAS_COMPONENT_PREDICATE);
+    return (UaMethodNode) methodNode.orElse(null);
+  }
+
+  @Override
+  public UaMethodNode getCheckRevocationStatusMethodNode() {
+    Optional<UaNode> methodNode =
+        findNode(
+            "http://opcfoundation.org/UA/GDS/",
+            "CheckRevocationStatus",
+            node -> node instanceof UaMethodNode,
+            Reference.HAS_COMPONENT_PREDICATE);
+    return (UaMethodNode) methodNode.orElse(null);
+  }
+
+  @Override
+  public CertificateGroupFolderTypeNode getCertificateGroupsNode() {
+    Optional<UaNode> node =
+        findNode(
+            "http://opcfoundation.org/UA/GDS/",
+            "CertificateGroups",
+            n -> n instanceof UaObjectNode,
+            Reference.ORGANIZES_PREDICATE);
+    return (CertificateGroupFolderTypeNode) node.orElse(null);
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/CertificateRequestedAuditEventType.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/CertificateRequestedAuditEventType.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.gds.model.objects;
+
+import org.eclipse.milo.opcua.sdk.core.QualifiedProperty;
+import org.eclipse.milo.opcua.sdk.server.model.objects.AuditUpdateMethodEventType;
+import org.eclipse.milo.opcua.sdk.server.model.variables.PropertyType;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+
+/**
+ * @see <a
+ *     href="https://reference.opcfoundation.org/GDS/docs/7.9.12">https://reference.opcfoundation.org/GDS/docs/7.9.12</a>
+ */
+public interface CertificateRequestedAuditEventType extends AuditUpdateMethodEventType {
+  QualifiedProperty<NodeId> CERTIFICATE_GROUP =
+      new QualifiedProperty<>(
+          "http://opcfoundation.org/UA/GDS/",
+          "CertificateGroup",
+          ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=17"),
+          -1,
+          NodeId.class);
+
+  QualifiedProperty<NodeId> CERTIFICATE_TYPE =
+      new QualifiedProperty<>(
+          "http://opcfoundation.org/UA/GDS/",
+          "CertificateType",
+          ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=17"),
+          -1,
+          NodeId.class);
+
+  NodeId getCertificateGroup();
+
+  void setCertificateGroup(NodeId value);
+
+  PropertyType getCertificateGroupNode();
+
+  NodeId getCertificateType();
+
+  void setCertificateType(NodeId value);
+
+  PropertyType getCertificateTypeNode();
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/CertificateRequestedAuditEventTypeNode.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/CertificateRequestedAuditEventTypeNode.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.gds.model.objects;
+
+import java.util.Optional;
+import org.eclipse.milo.opcua.sdk.core.nodes.VariableNode;
+import org.eclipse.milo.opcua.sdk.server.model.objects.AuditUpdateMethodEventTypeNode;
+import org.eclipse.milo.opcua.sdk.server.model.variables.PropertyTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNodeContext;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.structured.AccessRestrictionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.RolePermissionType;
+
+public class CertificateRequestedAuditEventTypeNode extends AuditUpdateMethodEventTypeNode
+    implements CertificateRequestedAuditEventType {
+  public CertificateRequestedAuditEventTypeNode(
+      UaNodeContext context,
+      NodeId nodeId,
+      QualifiedName browseName,
+      LocalizedText displayName,
+      LocalizedText description,
+      UInteger writeMask,
+      UInteger userWriteMask,
+      RolePermissionType[] rolePermissions,
+      RolePermissionType[] userRolePermissions,
+      AccessRestrictionType accessRestrictions,
+      UByte eventNotifier) {
+    super(
+        context,
+        nodeId,
+        browseName,
+        displayName,
+        description,
+        writeMask,
+        userWriteMask,
+        rolePermissions,
+        userRolePermissions,
+        accessRestrictions,
+        eventNotifier);
+  }
+
+  public CertificateRequestedAuditEventTypeNode(
+      UaNodeContext context,
+      NodeId nodeId,
+      QualifiedName browseName,
+      LocalizedText displayName,
+      LocalizedText description,
+      UInteger writeMask,
+      UInteger userWriteMask,
+      RolePermissionType[] rolePermissions,
+      RolePermissionType[] userRolePermissions,
+      AccessRestrictionType accessRestrictions) {
+    super(
+        context,
+        nodeId,
+        browseName,
+        displayName,
+        description,
+        writeMask,
+        userWriteMask,
+        rolePermissions,
+        userRolePermissions,
+        accessRestrictions);
+  }
+
+  @Override
+  public PropertyTypeNode getCertificateGroupNode() {
+    Optional<VariableNode> propertyNode =
+        getPropertyNode(CertificateRequestedAuditEventType.CERTIFICATE_GROUP);
+    return (PropertyTypeNode) propertyNode.orElse(null);
+  }
+
+  @Override
+  public NodeId getCertificateGroup() {
+    return getProperty(CertificateRequestedAuditEventType.CERTIFICATE_GROUP).orElse(null);
+  }
+
+  @Override
+  public void setCertificateGroup(NodeId value) {
+    setProperty(CertificateRequestedAuditEventType.CERTIFICATE_GROUP, value);
+  }
+
+  @Override
+  public PropertyTypeNode getCertificateTypeNode() {
+    Optional<VariableNode> propertyNode =
+        getPropertyNode(CertificateRequestedAuditEventType.CERTIFICATE_TYPE);
+    return (PropertyTypeNode) propertyNode.orElse(null);
+  }
+
+  @Override
+  public NodeId getCertificateType() {
+    return getProperty(CertificateRequestedAuditEventType.CERTIFICATE_TYPE).orElse(null);
+  }
+
+  @Override
+  public void setCertificateType(NodeId value) {
+    setProperty(CertificateRequestedAuditEventType.CERTIFICATE_TYPE, value);
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/CertificateRevokedAuditEventType.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/CertificateRevokedAuditEventType.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.gds.model.objects;
+
+import org.eclipse.milo.opcua.sdk.server.model.objects.AuditUpdateMethodEventType;
+
+/**
+ * @see <a
+ *     href="https://reference.opcfoundation.org/GDS/docs/7.9.14">https://reference.opcfoundation.org/GDS/docs/7.9.14</a>
+ */
+public interface CertificateRevokedAuditEventType extends AuditUpdateMethodEventType {}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/CertificateRevokedAuditEventTypeNode.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/CertificateRevokedAuditEventTypeNode.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.gds.model.objects;
+
+import org.eclipse.milo.opcua.sdk.server.model.objects.AuditUpdateMethodEventTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNodeContext;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.structured.AccessRestrictionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.RolePermissionType;
+
+public class CertificateRevokedAuditEventTypeNode extends AuditUpdateMethodEventTypeNode
+    implements CertificateRevokedAuditEventType {
+  public CertificateRevokedAuditEventTypeNode(
+      UaNodeContext context,
+      NodeId nodeId,
+      QualifiedName browseName,
+      LocalizedText displayName,
+      LocalizedText description,
+      UInteger writeMask,
+      UInteger userWriteMask,
+      RolePermissionType[] rolePermissions,
+      RolePermissionType[] userRolePermissions,
+      AccessRestrictionType accessRestrictions,
+      UByte eventNotifier) {
+    super(
+        context,
+        nodeId,
+        browseName,
+        displayName,
+        description,
+        writeMask,
+        userWriteMask,
+        rolePermissions,
+        userRolePermissions,
+        accessRestrictions,
+        eventNotifier);
+  }
+
+  public CertificateRevokedAuditEventTypeNode(
+      UaNodeContext context,
+      NodeId nodeId,
+      QualifiedName browseName,
+      LocalizedText displayName,
+      LocalizedText description,
+      UInteger writeMask,
+      UInteger userWriteMask,
+      RolePermissionType[] rolePermissions,
+      RolePermissionType[] userRolePermissions,
+      AccessRestrictionType accessRestrictions) {
+    super(
+        context,
+        nodeId,
+        browseName,
+        displayName,
+        description,
+        writeMask,
+        userWriteMask,
+        rolePermissions,
+        userRolePermissions,
+        accessRestrictions);
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/DirectoryType.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/DirectoryType.java
@@ -1,0 +1,627 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.gds.model.objects;
+
+import org.eclipse.milo.opcua.sdk.core.nodes.MethodNode;
+import org.eclipse.milo.opcua.sdk.server.methods.AbstractMethodInvocationHandler;
+import org.eclipse.milo.opcua.sdk.server.methods.Out;
+import org.eclipse.milo.opcua.sdk.server.model.objects.FolderType;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaMethodNode;
+import org.eclipse.milo.opcua.stack.core.NamespaceTable;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.gds.types.ApplicationRecordDataType;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.structured.ApplicationDescription;
+import org.eclipse.milo.opcua.stack.core.types.structured.Argument;
+import org.eclipse.milo.opcua.stack.core.types.structured.ServerOnNetwork;
+import org.eclipse.milo.opcua.stack.core.util.Lazy;
+
+/**
+ * @see <a
+ *     href="https://reference.opcfoundation.org/GDS/docs/6.5.3">https://reference.opcfoundation.org/GDS/docs/6.5.3</a>
+ */
+public interface DirectoryType extends FolderType {
+  FolderType getApplicationsNode();
+
+  MethodNode getFindApplicationsMethodNode();
+
+  MethodNode getRegisterApplicationMethodNode();
+
+  MethodNode getUpdateApplicationMethodNode();
+
+  MethodNode getUnregisterApplicationMethodNode();
+
+  MethodNode getGetApplicationMethodNode();
+
+  MethodNode getQueryApplicationsMethodNode();
+
+  MethodNode getQueryServersMethodNode();
+
+  abstract class FindApplicationsMethod extends AbstractMethodInvocationHandler {
+    private final Lazy<Argument[]> inputArguments = new Lazy<>();
+
+    private final Lazy<Argument[]> outputArguments = new Lazy<>();
+
+    public FindApplicationsMethod(UaMethodNode node) {
+      super(node);
+    }
+
+    @Override
+    public Argument[] getInputArguments() {
+      return inputArguments.get(
+          () -> {
+            NamespaceTable namespaceTable = getNode().getNodeContext().getNamespaceTable();
+
+            return new Argument[] {
+              new Argument(
+                  "ApplicationUri",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=12")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", ""))
+            };
+          });
+    }
+
+    @Override
+    public Argument[] getOutputArguments() {
+      return outputArguments.get(
+          () -> {
+            NamespaceTable namespaceTable = getNode().getNodeContext().getNamespaceTable();
+
+            return new Argument[] {
+              new Argument(
+                  "Applications",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/GDS/;i=1")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  1,
+                  new UInteger[] {UInteger.valueOf(0)},
+                  new LocalizedText("", ""))
+            };
+          });
+    }
+
+    @Override
+    protected Variant[] invoke(
+        AbstractMethodInvocationHandler.InvocationContext context, Variant[] inputValues)
+        throws UaException {
+      String applicationUri = (String) inputValues[0].getValue();
+      Out<ApplicationRecordDataType[]> applications = new Out<>();
+      invoke(context, applicationUri, applications);
+      return new Variant[] {new Variant(applications.get())};
+    }
+
+    protected abstract void invoke(
+        AbstractMethodInvocationHandler.InvocationContext context,
+        String applicationUri,
+        Out<ApplicationRecordDataType[]> applications)
+        throws UaException;
+  }
+
+  abstract class RegisterApplicationMethod extends AbstractMethodInvocationHandler {
+    private final Lazy<Argument[]> inputArguments = new Lazy<>();
+
+    private final Lazy<Argument[]> outputArguments = new Lazy<>();
+
+    public RegisterApplicationMethod(UaMethodNode node) {
+      super(node);
+    }
+
+    @Override
+    public Argument[] getInputArguments() {
+      return inputArguments.get(
+          () -> {
+            NamespaceTable namespaceTable = getNode().getNodeContext().getNamespaceTable();
+
+            return new Argument[] {
+              new Argument(
+                  "Application",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/GDS/;i=1")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", ""))
+            };
+          });
+    }
+
+    @Override
+    public Argument[] getOutputArguments() {
+      return outputArguments.get(
+          () -> {
+            NamespaceTable namespaceTable = getNode().getNodeContext().getNamespaceTable();
+
+            return new Argument[] {
+              new Argument(
+                  "ApplicationId",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=17")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", ""))
+            };
+          });
+    }
+
+    @Override
+    protected Variant[] invoke(
+        AbstractMethodInvocationHandler.InvocationContext context, Variant[] inputValues)
+        throws UaException {
+      ApplicationRecordDataType application = (ApplicationRecordDataType) inputValues[0].getValue();
+      Out<NodeId> applicationId = new Out<>();
+      invoke(context, application, applicationId);
+      return new Variant[] {new Variant(applicationId.get())};
+    }
+
+    protected abstract void invoke(
+        AbstractMethodInvocationHandler.InvocationContext context,
+        ApplicationRecordDataType application,
+        Out<NodeId> applicationId)
+        throws UaException;
+  }
+
+  abstract class UpdateApplicationMethod extends AbstractMethodInvocationHandler {
+    private final Lazy<Argument[]> inputArguments = new Lazy<>();
+
+    public UpdateApplicationMethod(UaMethodNode node) {
+      super(node);
+    }
+
+    @Override
+    public Argument[] getInputArguments() {
+      return inputArguments.get(
+          () -> {
+            NamespaceTable namespaceTable = getNode().getNodeContext().getNamespaceTable();
+
+            return new Argument[] {
+              new Argument(
+                  "Application",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/GDS/;i=1")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", ""))
+            };
+          });
+    }
+
+    @Override
+    public Argument[] getOutputArguments() {
+      return new Argument[] {};
+    }
+
+    @Override
+    protected Variant[] invoke(
+        AbstractMethodInvocationHandler.InvocationContext context, Variant[] inputValues)
+        throws UaException {
+      ApplicationRecordDataType application = (ApplicationRecordDataType) inputValues[0].getValue();
+      invoke(context, application);
+      return new Variant[] {};
+    }
+
+    protected abstract void invoke(
+        AbstractMethodInvocationHandler.InvocationContext context,
+        ApplicationRecordDataType application)
+        throws UaException;
+  }
+
+  abstract class UnregisterApplicationMethod extends AbstractMethodInvocationHandler {
+    private final Lazy<Argument[]> inputArguments = new Lazy<>();
+
+    public UnregisterApplicationMethod(UaMethodNode node) {
+      super(node);
+    }
+
+    @Override
+    public Argument[] getInputArguments() {
+      return inputArguments.get(
+          () -> {
+            NamespaceTable namespaceTable = getNode().getNodeContext().getNamespaceTable();
+
+            return new Argument[] {
+              new Argument(
+                  "ApplicationId",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=17")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", ""))
+            };
+          });
+    }
+
+    @Override
+    public Argument[] getOutputArguments() {
+      return new Argument[] {};
+    }
+
+    @Override
+    protected Variant[] invoke(
+        AbstractMethodInvocationHandler.InvocationContext context, Variant[] inputValues)
+        throws UaException {
+      NodeId applicationId = (NodeId) inputValues[0].getValue();
+      invoke(context, applicationId);
+      return new Variant[] {};
+    }
+
+    protected abstract void invoke(
+        AbstractMethodInvocationHandler.InvocationContext context, NodeId applicationId)
+        throws UaException;
+  }
+
+  abstract class GetApplicationMethod extends AbstractMethodInvocationHandler {
+    private final Lazy<Argument[]> inputArguments = new Lazy<>();
+
+    private final Lazy<Argument[]> outputArguments = new Lazy<>();
+
+    public GetApplicationMethod(UaMethodNode node) {
+      super(node);
+    }
+
+    @Override
+    public Argument[] getInputArguments() {
+      return inputArguments.get(
+          () -> {
+            NamespaceTable namespaceTable = getNode().getNodeContext().getNamespaceTable();
+
+            return new Argument[] {
+              new Argument(
+                  "ApplicationId",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=17")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", ""))
+            };
+          });
+    }
+
+    @Override
+    public Argument[] getOutputArguments() {
+      return outputArguments.get(
+          () -> {
+            NamespaceTable namespaceTable = getNode().getNodeContext().getNamespaceTable();
+
+            return new Argument[] {
+              new Argument(
+                  "Application",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/GDS/;i=1")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", ""))
+            };
+          });
+    }
+
+    @Override
+    protected Variant[] invoke(
+        AbstractMethodInvocationHandler.InvocationContext context, Variant[] inputValues)
+        throws UaException {
+      NodeId applicationId = (NodeId) inputValues[0].getValue();
+      Out<ApplicationRecordDataType> application = new Out<>();
+      invoke(context, applicationId, application);
+      return new Variant[] {new Variant(application.get())};
+    }
+
+    protected abstract void invoke(
+        AbstractMethodInvocationHandler.InvocationContext context,
+        NodeId applicationId,
+        Out<ApplicationRecordDataType> application)
+        throws UaException;
+  }
+
+  abstract class QueryApplicationsMethod extends AbstractMethodInvocationHandler {
+    private final Lazy<Argument[]> inputArguments = new Lazy<>();
+
+    private final Lazy<Argument[]> outputArguments = new Lazy<>();
+
+    public QueryApplicationsMethod(UaMethodNode node) {
+      super(node);
+    }
+
+    @Override
+    public Argument[] getInputArguments() {
+      return inputArguments.get(
+          () -> {
+            NamespaceTable namespaceTable = getNode().getNodeContext().getNamespaceTable();
+
+            return new Argument[] {
+              new Argument(
+                  "StartingRecordId",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=7")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "MaxRecordsToReturn",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=7")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "ApplicationName",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=12")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "ApplicationUri",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=12")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "ApplicationType",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=7")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "ProductUri",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=12")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "Capabilities",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=12")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  1,
+                  new UInteger[] {UInteger.valueOf(0)},
+                  new LocalizedText("", ""))
+            };
+          });
+    }
+
+    @Override
+    public Argument[] getOutputArguments() {
+      return outputArguments.get(
+          () -> {
+            NamespaceTable namespaceTable = getNode().getNodeContext().getNamespaceTable();
+
+            return new Argument[] {
+              new Argument(
+                  "LastCounterResetTime",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=294")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "NextRecordId",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=7")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "Applications",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=308")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  1,
+                  new UInteger[] {UInteger.valueOf(0)},
+                  new LocalizedText("", ""))
+            };
+          });
+    }
+
+    @Override
+    protected Variant[] invoke(
+        AbstractMethodInvocationHandler.InvocationContext context, Variant[] inputValues)
+        throws UaException {
+      UInteger startingRecordId = (UInteger) inputValues[0].getValue();
+      UInteger maxRecordsToReturn = (UInteger) inputValues[1].getValue();
+      String applicationName = (String) inputValues[2].getValue();
+      String applicationUri = (String) inputValues[3].getValue();
+      UInteger applicationType = (UInteger) inputValues[4].getValue();
+      String productUri = (String) inputValues[5].getValue();
+      String[] capabilities = (String[]) inputValues[6].getValue();
+      Out<DateTime> lastCounterResetTime = new Out<>();
+      Out<UInteger> nextRecordId = new Out<>();
+      Out<ApplicationDescription[]> applications = new Out<>();
+      invoke(
+          context,
+          startingRecordId,
+          maxRecordsToReturn,
+          applicationName,
+          applicationUri,
+          applicationType,
+          productUri,
+          capabilities,
+          lastCounterResetTime,
+          nextRecordId,
+          applications);
+      return new Variant[] {
+        new Variant(lastCounterResetTime.get()),
+        new Variant(nextRecordId.get()),
+        new Variant(applications.get())
+      };
+    }
+
+    protected abstract void invoke(
+        AbstractMethodInvocationHandler.InvocationContext context,
+        UInteger startingRecordId,
+        UInteger maxRecordsToReturn,
+        String applicationName,
+        String applicationUri,
+        UInteger applicationType,
+        String productUri,
+        String[] capabilities,
+        Out<DateTime> lastCounterResetTime,
+        Out<UInteger> nextRecordId,
+        Out<ApplicationDescription[]> applications)
+        throws UaException;
+  }
+
+  abstract class QueryServersMethod extends AbstractMethodInvocationHandler {
+    private final Lazy<Argument[]> inputArguments = new Lazy<>();
+
+    private final Lazy<Argument[]> outputArguments = new Lazy<>();
+
+    public QueryServersMethod(UaMethodNode node) {
+      super(node);
+    }
+
+    @Override
+    public Argument[] getInputArguments() {
+      return inputArguments.get(
+          () -> {
+            NamespaceTable namespaceTable = getNode().getNodeContext().getNamespaceTable();
+
+            return new Argument[] {
+              new Argument(
+                  "StartingRecordId",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=7")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "MaxRecordsToReturn",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=7")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "ApplicationName",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=12")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "ApplicationUri",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=12")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "ProductUri",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=12")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "ServerCapabilities",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=12")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  1,
+                  new UInteger[] {UInteger.valueOf(0)},
+                  new LocalizedText("", ""))
+            };
+          });
+    }
+
+    @Override
+    public Argument[] getOutputArguments() {
+      return outputArguments.get(
+          () -> {
+            NamespaceTable namespaceTable = getNode().getNodeContext().getNamespaceTable();
+
+            return new Argument[] {
+              new Argument(
+                  "LastCounterResetTime",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=294")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "Servers",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=12189")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  1,
+                  new UInteger[] {UInteger.valueOf(0)},
+                  new LocalizedText("", ""))
+            };
+          });
+    }
+
+    @Override
+    protected Variant[] invoke(
+        AbstractMethodInvocationHandler.InvocationContext context, Variant[] inputValues)
+        throws UaException {
+      UInteger startingRecordId = (UInteger) inputValues[0].getValue();
+      UInteger maxRecordsToReturn = (UInteger) inputValues[1].getValue();
+      String applicationName = (String) inputValues[2].getValue();
+      String applicationUri = (String) inputValues[3].getValue();
+      String productUri = (String) inputValues[4].getValue();
+      String[] serverCapabilities = (String[]) inputValues[5].getValue();
+      Out<DateTime> lastCounterResetTime = new Out<>();
+      Out<ServerOnNetwork[]> servers = new Out<>();
+      invoke(
+          context,
+          startingRecordId,
+          maxRecordsToReturn,
+          applicationName,
+          applicationUri,
+          productUri,
+          serverCapabilities,
+          lastCounterResetTime,
+          servers);
+      return new Variant[] {new Variant(lastCounterResetTime.get()), new Variant(servers.get())};
+    }
+
+    protected abstract void invoke(
+        AbstractMethodInvocationHandler.InvocationContext context,
+        UInteger startingRecordId,
+        UInteger maxRecordsToReturn,
+        String applicationName,
+        String applicationUri,
+        String productUri,
+        String[] serverCapabilities,
+        Out<DateTime> lastCounterResetTime,
+        Out<ServerOnNetwork[]> servers)
+        throws UaException;
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/DirectoryTypeNode.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/DirectoryTypeNode.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.gds.model.objects;
+
+import java.util.Optional;
+import org.eclipse.milo.opcua.sdk.core.Reference;
+import org.eclipse.milo.opcua.sdk.core.nodes.ObjectNode;
+import org.eclipse.milo.opcua.sdk.server.model.objects.FolderTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaMethodNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNodeContext;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.structured.AccessRestrictionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.RolePermissionType;
+
+public class DirectoryTypeNode extends FolderTypeNode implements DirectoryType {
+  public DirectoryTypeNode(
+      UaNodeContext context,
+      NodeId nodeId,
+      QualifiedName browseName,
+      LocalizedText displayName,
+      LocalizedText description,
+      UInteger writeMask,
+      UInteger userWriteMask,
+      RolePermissionType[] rolePermissions,
+      RolePermissionType[] userRolePermissions,
+      AccessRestrictionType accessRestrictions,
+      UByte eventNotifier) {
+    super(
+        context,
+        nodeId,
+        browseName,
+        displayName,
+        description,
+        writeMask,
+        userWriteMask,
+        rolePermissions,
+        userRolePermissions,
+        accessRestrictions,
+        eventNotifier);
+  }
+
+  public DirectoryTypeNode(
+      UaNodeContext context,
+      NodeId nodeId,
+      QualifiedName browseName,
+      LocalizedText displayName,
+      LocalizedText description,
+      UInteger writeMask,
+      UInteger userWriteMask,
+      RolePermissionType[] rolePermissions,
+      RolePermissionType[] userRolePermissions,
+      AccessRestrictionType accessRestrictions) {
+    super(
+        context,
+        nodeId,
+        browseName,
+        displayName,
+        description,
+        writeMask,
+        userWriteMask,
+        rolePermissions,
+        userRolePermissions,
+        accessRestrictions);
+  }
+
+  @Override
+  public FolderTypeNode getApplicationsNode() {
+    Optional<ObjectNode> component =
+        getObjectComponent("http://opcfoundation.org/UA/GDS/", "Applications");
+    return (FolderTypeNode) component.orElse(null);
+  }
+
+  @Override
+  public UaMethodNode getFindApplicationsMethodNode() {
+    Optional<UaNode> methodNode =
+        findNode(
+            "http://opcfoundation.org/UA/GDS/",
+            "FindApplications",
+            node -> node instanceof UaMethodNode,
+            Reference.HAS_COMPONENT_PREDICATE);
+    return (UaMethodNode) methodNode.orElse(null);
+  }
+
+  @Override
+  public UaMethodNode getRegisterApplicationMethodNode() {
+    Optional<UaNode> methodNode =
+        findNode(
+            "http://opcfoundation.org/UA/GDS/",
+            "RegisterApplication",
+            node -> node instanceof UaMethodNode,
+            Reference.HAS_COMPONENT_PREDICATE);
+    return (UaMethodNode) methodNode.orElse(null);
+  }
+
+  @Override
+  public UaMethodNode getUpdateApplicationMethodNode() {
+    Optional<UaNode> methodNode =
+        findNode(
+            "http://opcfoundation.org/UA/GDS/",
+            "UpdateApplication",
+            node -> node instanceof UaMethodNode,
+            Reference.HAS_COMPONENT_PREDICATE);
+    return (UaMethodNode) methodNode.orElse(null);
+  }
+
+  @Override
+  public UaMethodNode getUnregisterApplicationMethodNode() {
+    Optional<UaNode> methodNode =
+        findNode(
+            "http://opcfoundation.org/UA/GDS/",
+            "UnregisterApplication",
+            node -> node instanceof UaMethodNode,
+            Reference.HAS_COMPONENT_PREDICATE);
+    return (UaMethodNode) methodNode.orElse(null);
+  }
+
+  @Override
+  public UaMethodNode getGetApplicationMethodNode() {
+    Optional<UaNode> methodNode =
+        findNode(
+            "http://opcfoundation.org/UA/GDS/",
+            "GetApplication",
+            node -> node instanceof UaMethodNode,
+            Reference.HAS_COMPONENT_PREDICATE);
+    return (UaMethodNode) methodNode.orElse(null);
+  }
+
+  @Override
+  public UaMethodNode getQueryApplicationsMethodNode() {
+    Optional<UaNode> methodNode =
+        findNode(
+            "http://opcfoundation.org/UA/GDS/",
+            "QueryApplications",
+            node -> node instanceof UaMethodNode,
+            Reference.HAS_COMPONENT_PREDICATE);
+    return (UaMethodNode) methodNode.orElse(null);
+  }
+
+  @Override
+  public UaMethodNode getQueryServersMethodNode() {
+    Optional<UaNode> methodNode =
+        findNode(
+            "http://opcfoundation.org/UA/GDS/",
+            "QueryServers",
+            node -> node instanceof UaMethodNode,
+            Reference.HAS_COMPONENT_PREDICATE);
+    return (UaMethodNode) methodNode.orElse(null);
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/KeyCredentialDeliveredAuditEventType.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/KeyCredentialDeliveredAuditEventType.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.gds.model.objects;
+
+import org.eclipse.milo.opcua.sdk.server.model.objects.KeyCredentialAuditEventType;
+
+/**
+ * @see <a
+ *     href="https://reference.opcfoundation.org/GDS/docs/8.5.10">https://reference.opcfoundation.org/GDS/docs/8.5.10</a>
+ */
+public interface KeyCredentialDeliveredAuditEventType extends KeyCredentialAuditEventType {}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/KeyCredentialDeliveredAuditEventTypeNode.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/KeyCredentialDeliveredAuditEventTypeNode.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.gds.model.objects;
+
+import org.eclipse.milo.opcua.sdk.server.model.objects.KeyCredentialAuditEventTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNodeContext;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.structured.AccessRestrictionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.RolePermissionType;
+
+public class KeyCredentialDeliveredAuditEventTypeNode extends KeyCredentialAuditEventTypeNode
+    implements KeyCredentialDeliveredAuditEventType {
+  public KeyCredentialDeliveredAuditEventTypeNode(
+      UaNodeContext context,
+      NodeId nodeId,
+      QualifiedName browseName,
+      LocalizedText displayName,
+      LocalizedText description,
+      UInteger writeMask,
+      UInteger userWriteMask,
+      RolePermissionType[] rolePermissions,
+      RolePermissionType[] userRolePermissions,
+      AccessRestrictionType accessRestrictions,
+      UByte eventNotifier) {
+    super(
+        context,
+        nodeId,
+        browseName,
+        displayName,
+        description,
+        writeMask,
+        userWriteMask,
+        rolePermissions,
+        userRolePermissions,
+        accessRestrictions,
+        eventNotifier);
+  }
+
+  public KeyCredentialDeliveredAuditEventTypeNode(
+      UaNodeContext context,
+      NodeId nodeId,
+      QualifiedName browseName,
+      LocalizedText displayName,
+      LocalizedText description,
+      UInteger writeMask,
+      UInteger userWriteMask,
+      RolePermissionType[] rolePermissions,
+      RolePermissionType[] userRolePermissions,
+      AccessRestrictionType accessRestrictions) {
+    super(
+        context,
+        nodeId,
+        browseName,
+        displayName,
+        description,
+        writeMask,
+        userWriteMask,
+        rolePermissions,
+        userRolePermissions,
+        accessRestrictions);
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/KeyCredentialManagementFolderType.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/KeyCredentialManagementFolderType.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.gds.model.objects;
+
+import org.eclipse.milo.opcua.sdk.server.model.objects.FolderType;
+
+/**
+ * @see <a
+ *     href="https://reference.opcfoundation.org/GDS/docs/8.5.2">https://reference.opcfoundation.org/GDS/docs/8.5.2</a>
+ */
+public interface KeyCredentialManagementFolderType extends FolderType {}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/KeyCredentialManagementFolderTypeNode.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/KeyCredentialManagementFolderTypeNode.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.gds.model.objects;
+
+import org.eclipse.milo.opcua.sdk.server.model.objects.FolderTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNodeContext;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.structured.AccessRestrictionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.RolePermissionType;
+
+public class KeyCredentialManagementFolderTypeNode extends FolderTypeNode
+    implements KeyCredentialManagementFolderType {
+  public KeyCredentialManagementFolderTypeNode(
+      UaNodeContext context,
+      NodeId nodeId,
+      QualifiedName browseName,
+      LocalizedText displayName,
+      LocalizedText description,
+      UInteger writeMask,
+      UInteger userWriteMask,
+      RolePermissionType[] rolePermissions,
+      RolePermissionType[] userRolePermissions,
+      AccessRestrictionType accessRestrictions,
+      UByte eventNotifier) {
+    super(
+        context,
+        nodeId,
+        browseName,
+        displayName,
+        description,
+        writeMask,
+        userWriteMask,
+        rolePermissions,
+        userRolePermissions,
+        accessRestrictions,
+        eventNotifier);
+  }
+
+  public KeyCredentialManagementFolderTypeNode(
+      UaNodeContext context,
+      NodeId nodeId,
+      QualifiedName browseName,
+      LocalizedText displayName,
+      LocalizedText description,
+      UInteger writeMask,
+      UInteger userWriteMask,
+      RolePermissionType[] rolePermissions,
+      RolePermissionType[] userRolePermissions,
+      AccessRestrictionType accessRestrictions) {
+    super(
+        context,
+        nodeId,
+        browseName,
+        displayName,
+        description,
+        writeMask,
+        userWriteMask,
+        rolePermissions,
+        userRolePermissions,
+        accessRestrictions);
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/KeyCredentialRequestedAuditEventType.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/KeyCredentialRequestedAuditEventType.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.gds.model.objects;
+
+import org.eclipse.milo.opcua.sdk.server.model.objects.KeyCredentialAuditEventType;
+
+/**
+ * @see <a
+ *     href="https://reference.opcfoundation.org/GDS/docs/8.5.9">https://reference.opcfoundation.org/GDS/docs/8.5.9</a>
+ */
+public interface KeyCredentialRequestedAuditEventType extends KeyCredentialAuditEventType {}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/KeyCredentialRequestedAuditEventTypeNode.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/KeyCredentialRequestedAuditEventTypeNode.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.gds.model.objects;
+
+import org.eclipse.milo.opcua.sdk.server.model.objects.KeyCredentialAuditEventTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNodeContext;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.structured.AccessRestrictionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.RolePermissionType;
+
+public class KeyCredentialRequestedAuditEventTypeNode extends KeyCredentialAuditEventTypeNode
+    implements KeyCredentialRequestedAuditEventType {
+  public KeyCredentialRequestedAuditEventTypeNode(
+      UaNodeContext context,
+      NodeId nodeId,
+      QualifiedName browseName,
+      LocalizedText displayName,
+      LocalizedText description,
+      UInteger writeMask,
+      UInteger userWriteMask,
+      RolePermissionType[] rolePermissions,
+      RolePermissionType[] userRolePermissions,
+      AccessRestrictionType accessRestrictions,
+      UByte eventNotifier) {
+    super(
+        context,
+        nodeId,
+        browseName,
+        displayName,
+        description,
+        writeMask,
+        userWriteMask,
+        rolePermissions,
+        userRolePermissions,
+        accessRestrictions,
+        eventNotifier);
+  }
+
+  public KeyCredentialRequestedAuditEventTypeNode(
+      UaNodeContext context,
+      NodeId nodeId,
+      QualifiedName browseName,
+      LocalizedText displayName,
+      LocalizedText description,
+      UInteger writeMask,
+      UInteger userWriteMask,
+      RolePermissionType[] rolePermissions,
+      RolePermissionType[] userRolePermissions,
+      AccessRestrictionType accessRestrictions) {
+    super(
+        context,
+        nodeId,
+        browseName,
+        displayName,
+        description,
+        writeMask,
+        userWriteMask,
+        rolePermissions,
+        userRolePermissions,
+        accessRestrictions);
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/KeyCredentialRevokedAuditEventType.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/KeyCredentialRevokedAuditEventType.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.gds.model.objects;
+
+import org.eclipse.milo.opcua.sdk.server.model.objects.KeyCredentialAuditEventType;
+
+/**
+ * @see <a
+ *     href="https://reference.opcfoundation.org/GDS/docs/8.5.11">https://reference.opcfoundation.org/GDS/docs/8.5.11</a>
+ */
+public interface KeyCredentialRevokedAuditEventType extends KeyCredentialAuditEventType {}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/KeyCredentialRevokedAuditEventTypeNode.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/KeyCredentialRevokedAuditEventTypeNode.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.gds.model.objects;
+
+import org.eclipse.milo.opcua.sdk.server.model.objects.KeyCredentialAuditEventTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNodeContext;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.structured.AccessRestrictionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.RolePermissionType;
+
+public class KeyCredentialRevokedAuditEventTypeNode extends KeyCredentialAuditEventTypeNode
+    implements KeyCredentialRevokedAuditEventType {
+  public KeyCredentialRevokedAuditEventTypeNode(
+      UaNodeContext context,
+      NodeId nodeId,
+      QualifiedName browseName,
+      LocalizedText displayName,
+      LocalizedText description,
+      UInteger writeMask,
+      UInteger userWriteMask,
+      RolePermissionType[] rolePermissions,
+      RolePermissionType[] userRolePermissions,
+      AccessRestrictionType accessRestrictions,
+      UByte eventNotifier) {
+    super(
+        context,
+        nodeId,
+        browseName,
+        displayName,
+        description,
+        writeMask,
+        userWriteMask,
+        rolePermissions,
+        userRolePermissions,
+        accessRestrictions,
+        eventNotifier);
+  }
+
+  public KeyCredentialRevokedAuditEventTypeNode(
+      UaNodeContext context,
+      NodeId nodeId,
+      QualifiedName browseName,
+      LocalizedText displayName,
+      LocalizedText description,
+      UInteger writeMask,
+      UInteger userWriteMask,
+      RolePermissionType[] rolePermissions,
+      RolePermissionType[] userRolePermissions,
+      AccessRestrictionType accessRestrictions) {
+    super(
+        context,
+        nodeId,
+        browseName,
+        displayName,
+        description,
+        writeMask,
+        userWriteMask,
+        rolePermissions,
+        userRolePermissions,
+        accessRestrictions);
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/KeyCredentialServiceType.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/KeyCredentialServiceType.java
@@ -1,0 +1,350 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.gds.model.objects;
+
+import org.eclipse.milo.opcua.sdk.core.QualifiedProperty;
+import org.eclipse.milo.opcua.sdk.core.nodes.MethodNode;
+import org.eclipse.milo.opcua.sdk.server.methods.AbstractMethodInvocationHandler;
+import org.eclipse.milo.opcua.sdk.server.methods.Out;
+import org.eclipse.milo.opcua.sdk.server.model.objects.BaseObjectType;
+import org.eclipse.milo.opcua.sdk.server.model.variables.PropertyType;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaMethodNode;
+import org.eclipse.milo.opcua.stack.core.NamespaceTable;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.structured.Argument;
+import org.eclipse.milo.opcua.stack.core.util.Lazy;
+
+/**
+ * @see <a
+ *     href="https://reference.opcfoundation.org/GDS/docs/8.5.4">https://reference.opcfoundation.org/GDS/docs/8.5.4</a>
+ */
+public interface KeyCredentialServiceType extends BaseObjectType {
+  QualifiedProperty<String> RESOURCE_URI =
+      new QualifiedProperty<>(
+          "http://opcfoundation.org/UA/GDS/",
+          "ResourceUri",
+          ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=12"),
+          -1,
+          String.class);
+
+  QualifiedProperty<String[]> PROFILE_URIS =
+      new QualifiedProperty<>(
+          "http://opcfoundation.org/UA/GDS/",
+          "ProfileUris",
+          ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=12"),
+          1,
+          String[].class);
+
+  QualifiedProperty<String[]> SECURITY_POLICY_URIS =
+      new QualifiedProperty<>(
+          "http://opcfoundation.org/UA/GDS/",
+          "SecurityPolicyUris",
+          ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=12"),
+          1,
+          String[].class);
+
+  String getResourceUri();
+
+  void setResourceUri(String value);
+
+  PropertyType getResourceUriNode();
+
+  String[] getProfileUris();
+
+  void setProfileUris(String[] value);
+
+  PropertyType getProfileUrisNode();
+
+  String[] getSecurityPolicyUris();
+
+  void setSecurityPolicyUris(String[] value);
+
+  PropertyType getSecurityPolicyUrisNode();
+
+  MethodNode getStartRequestMethodNode();
+
+  MethodNode getFinishRequestMethodNode();
+
+  MethodNode getRevokeMethodNode();
+
+  abstract class StartRequestMethod extends AbstractMethodInvocationHandler {
+    private final Lazy<Argument[]> inputArguments = new Lazy<>();
+
+    private final Lazy<Argument[]> outputArguments = new Lazy<>();
+
+    public StartRequestMethod(UaMethodNode node) {
+      super(node);
+    }
+
+    @Override
+    public Argument[] getInputArguments() {
+      return inputArguments.get(
+          () -> {
+            NamespaceTable namespaceTable = getNode().getNodeContext().getNamespaceTable();
+
+            return new Argument[] {
+              new Argument(
+                  "ApplicationUri",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=12")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "PublicKey",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=15")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "SecurityPolicyUri",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=12")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "RequestedRoles",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=17")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  1,
+                  new UInteger[] {UInteger.valueOf(0)},
+                  new LocalizedText("", ""))
+            };
+          });
+    }
+
+    @Override
+    public Argument[] getOutputArguments() {
+      return outputArguments.get(
+          () -> {
+            NamespaceTable namespaceTable = getNode().getNodeContext().getNamespaceTable();
+
+            return new Argument[] {
+              new Argument(
+                  "RequestId",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=17")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", ""))
+            };
+          });
+    }
+
+    @Override
+    protected Variant[] invoke(
+        AbstractMethodInvocationHandler.InvocationContext context, Variant[] inputValues)
+        throws UaException {
+      String applicationUri = (String) inputValues[0].getValue();
+      ByteString publicKey = (ByteString) inputValues[1].getValue();
+      String securityPolicyUri = (String) inputValues[2].getValue();
+      NodeId[] requestedRoles = (NodeId[]) inputValues[3].getValue();
+      Out<NodeId> requestId = new Out<>();
+      invoke(context, applicationUri, publicKey, securityPolicyUri, requestedRoles, requestId);
+      return new Variant[] {new Variant(requestId.get())};
+    }
+
+    protected abstract void invoke(
+        AbstractMethodInvocationHandler.InvocationContext context,
+        String applicationUri,
+        ByteString publicKey,
+        String securityPolicyUri,
+        NodeId[] requestedRoles,
+        Out<NodeId> requestId)
+        throws UaException;
+  }
+
+  abstract class FinishRequestMethod extends AbstractMethodInvocationHandler {
+    private final Lazy<Argument[]> inputArguments = new Lazy<>();
+
+    private final Lazy<Argument[]> outputArguments = new Lazy<>();
+
+    public FinishRequestMethod(UaMethodNode node) {
+      super(node);
+    }
+
+    @Override
+    public Argument[] getInputArguments() {
+      return inputArguments.get(
+          () -> {
+            NamespaceTable namespaceTable = getNode().getNodeContext().getNamespaceTable();
+
+            return new Argument[] {
+              new Argument(
+                  "RequestId",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=17")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "CancelRequest",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=1")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", ""))
+            };
+          });
+    }
+
+    @Override
+    public Argument[] getOutputArguments() {
+      return outputArguments.get(
+          () -> {
+            NamespaceTable namespaceTable = getNode().getNodeContext().getNamespaceTable();
+
+            return new Argument[] {
+              new Argument(
+                  "CredentialId",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=12")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "CredentialSecret",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=15")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "CertificateThumbprint",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=12")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "SecurityPolicyUri",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=12")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", "")),
+              new Argument(
+                  "GrantedRoles",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=17")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  1,
+                  new UInteger[] {UInteger.valueOf(0)},
+                  new LocalizedText("", ""))
+            };
+          });
+    }
+
+    @Override
+    protected Variant[] invoke(
+        AbstractMethodInvocationHandler.InvocationContext context, Variant[] inputValues)
+        throws UaException {
+      NodeId requestId = (NodeId) inputValues[0].getValue();
+      Boolean cancelRequest = (Boolean) inputValues[1].getValue();
+      Out<String> credentialId = new Out<>();
+      Out<ByteString> credentialSecret = new Out<>();
+      Out<String> certificateThumbprint = new Out<>();
+      Out<String> securityPolicyUri = new Out<>();
+      Out<NodeId[]> grantedRoles = new Out<>();
+      invoke(
+          context,
+          requestId,
+          cancelRequest,
+          credentialId,
+          credentialSecret,
+          certificateThumbprint,
+          securityPolicyUri,
+          grantedRoles);
+      return new Variant[] {
+        new Variant(credentialId.get()),
+        new Variant(credentialSecret.get()),
+        new Variant(certificateThumbprint.get()),
+        new Variant(securityPolicyUri.get()),
+        new Variant(grantedRoles.get())
+      };
+    }
+
+    protected abstract void invoke(
+        AbstractMethodInvocationHandler.InvocationContext context,
+        NodeId requestId,
+        Boolean cancelRequest,
+        Out<String> credentialId,
+        Out<ByteString> credentialSecret,
+        Out<String> certificateThumbprint,
+        Out<String> securityPolicyUri,
+        Out<NodeId[]> grantedRoles)
+        throws UaException;
+  }
+
+  abstract class RevokeMethod extends AbstractMethodInvocationHandler {
+    private final Lazy<Argument[]> inputArguments = new Lazy<>();
+
+    public RevokeMethod(UaMethodNode node) {
+      super(node);
+    }
+
+    @Override
+    public Argument[] getInputArguments() {
+      return inputArguments.get(
+          () -> {
+            NamespaceTable namespaceTable = getNode().getNodeContext().getNamespaceTable();
+
+            return new Argument[] {
+              new Argument(
+                  "CredentialId",
+                  ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=12")
+                      .toNodeId(namespaceTable)
+                      .orElseThrow(),
+                  -1,
+                  null,
+                  new LocalizedText("", ""))
+            };
+          });
+    }
+
+    @Override
+    public Argument[] getOutputArguments() {
+      return new Argument[] {};
+    }
+
+    @Override
+    protected Variant[] invoke(
+        AbstractMethodInvocationHandler.InvocationContext context, Variant[] inputValues)
+        throws UaException {
+      String credentialId = (String) inputValues[0].getValue();
+      invoke(context, credentialId);
+      return new Variant[] {};
+    }
+
+    protected abstract void invoke(
+        AbstractMethodInvocationHandler.InvocationContext context, String credentialId)
+        throws UaException;
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/KeyCredentialServiceTypeNode.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/objects/KeyCredentialServiceTypeNode.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.gds.model.objects;
+
+import java.util.Optional;
+import org.eclipse.milo.opcua.sdk.core.Reference;
+import org.eclipse.milo.opcua.sdk.core.nodes.VariableNode;
+import org.eclipse.milo.opcua.sdk.server.model.objects.BaseObjectTypeNode;
+import org.eclipse.milo.opcua.sdk.server.model.variables.PropertyTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaMethodNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNodeContext;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.structured.AccessRestrictionType;
+import org.eclipse.milo.opcua.stack.core.types.structured.RolePermissionType;
+
+public class KeyCredentialServiceTypeNode extends BaseObjectTypeNode
+    implements KeyCredentialServiceType {
+  public KeyCredentialServiceTypeNode(
+      UaNodeContext context,
+      NodeId nodeId,
+      QualifiedName browseName,
+      LocalizedText displayName,
+      LocalizedText description,
+      UInteger writeMask,
+      UInteger userWriteMask,
+      RolePermissionType[] rolePermissions,
+      RolePermissionType[] userRolePermissions,
+      AccessRestrictionType accessRestrictions,
+      UByte eventNotifier) {
+    super(
+        context,
+        nodeId,
+        browseName,
+        displayName,
+        description,
+        writeMask,
+        userWriteMask,
+        rolePermissions,
+        userRolePermissions,
+        accessRestrictions,
+        eventNotifier);
+  }
+
+  public KeyCredentialServiceTypeNode(
+      UaNodeContext context,
+      NodeId nodeId,
+      QualifiedName browseName,
+      LocalizedText displayName,
+      LocalizedText description,
+      UInteger writeMask,
+      UInteger userWriteMask,
+      RolePermissionType[] rolePermissions,
+      RolePermissionType[] userRolePermissions,
+      AccessRestrictionType accessRestrictions) {
+    super(
+        context,
+        nodeId,
+        browseName,
+        displayName,
+        description,
+        writeMask,
+        userWriteMask,
+        rolePermissions,
+        userRolePermissions,
+        accessRestrictions);
+  }
+
+  @Override
+  public PropertyTypeNode getResourceUriNode() {
+    Optional<VariableNode> propertyNode = getPropertyNode(KeyCredentialServiceType.RESOURCE_URI);
+    return (PropertyTypeNode) propertyNode.orElse(null);
+  }
+
+  @Override
+  public String getResourceUri() {
+    return getProperty(KeyCredentialServiceType.RESOURCE_URI).orElse(null);
+  }
+
+  @Override
+  public void setResourceUri(String value) {
+    setProperty(KeyCredentialServiceType.RESOURCE_URI, value);
+  }
+
+  @Override
+  public PropertyTypeNode getProfileUrisNode() {
+    Optional<VariableNode> propertyNode = getPropertyNode(KeyCredentialServiceType.PROFILE_URIS);
+    return (PropertyTypeNode) propertyNode.orElse(null);
+  }
+
+  @Override
+  public String[] getProfileUris() {
+    return getProperty(KeyCredentialServiceType.PROFILE_URIS).orElse(null);
+  }
+
+  @Override
+  public void setProfileUris(String[] value) {
+    setProperty(KeyCredentialServiceType.PROFILE_URIS, value);
+  }
+
+  @Override
+  public PropertyTypeNode getSecurityPolicyUrisNode() {
+    Optional<VariableNode> propertyNode =
+        getPropertyNode(KeyCredentialServiceType.SECURITY_POLICY_URIS);
+    return (PropertyTypeNode) propertyNode.orElse(null);
+  }
+
+  @Override
+  public String[] getSecurityPolicyUris() {
+    return getProperty(KeyCredentialServiceType.SECURITY_POLICY_URIS).orElse(null);
+  }
+
+  @Override
+  public void setSecurityPolicyUris(String[] value) {
+    setProperty(KeyCredentialServiceType.SECURITY_POLICY_URIS, value);
+  }
+
+  @Override
+  public UaMethodNode getStartRequestMethodNode() {
+    Optional<UaNode> methodNode =
+        findNode(
+            "http://opcfoundation.org/UA/GDS/",
+            "StartRequest",
+            node -> node instanceof UaMethodNode,
+            Reference.HAS_COMPONENT_PREDICATE);
+    return (UaMethodNode) methodNode.orElse(null);
+  }
+
+  @Override
+  public UaMethodNode getFinishRequestMethodNode() {
+    Optional<UaNode> methodNode =
+        findNode(
+            "http://opcfoundation.org/UA/GDS/",
+            "FinishRequest",
+            node -> node instanceof UaMethodNode,
+            Reference.HAS_COMPONENT_PREDICATE);
+    return (UaMethodNode) methodNode.orElse(null);
+  }
+
+  @Override
+  public UaMethodNode getRevokeMethodNode() {
+    Optional<UaNode> methodNode =
+        findNode(
+            "http://opcfoundation.org/UA/GDS/",
+            "Revoke",
+            node -> node instanceof UaMethodNode,
+            Reference.HAS_COMPONENT_PREDICATE);
+    return (UaMethodNode) methodNode.orElse(null);
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/package-info.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/**
+ * Generated server-side model of the OPC UA Global Discovery Server namespace.
+ *
+ * <p>This package gives a server that hosts the GDS namespace ({@code
+ * http://opcfoundation.org/UA/GDS/}, OPC 10000-12) typed node classes for its ObjectTypes; the
+ * classes themselves live in {@code org.eclipse.milo.opcua.sdk.server.gds.model.objects}. Milo does
+ * not implement a GDS: the Directory methods, application registry, certificate authority, and
+ * trust list storage are left to the hosting application. Nothing in the server SDK invokes this
+ * package on its own.
+ *
+ * <p>{@link org.eclipse.milo.opcua.sdk.server.gds.ObjectTypeInitializer} registers the node classes
+ * with the server's {@link org.eclipse.milo.opcua.sdk.server.ObjectTypeManager}. It resolves the
+ * GDS namespace index through the server's {@link
+ * org.eclipse.milo.opcua.stack.core.NamespaceTable}, so the hosting application must add the GDS
+ * namespace URI to the table before calling it, and the call is not part of the namespace 0 startup
+ * path. {@link org.eclipse.milo.opcua.sdk.server.gds.VariableTypeInitializer} is empty because the
+ * GDS namespace defines no VariableTypes. The {@code ApplicationRecordDataType} codec is registered
+ * separately with {@link org.eclipse.milo.opcua.stack.core.gds.DataTypeInitializer}.
+ *
+ * <h2>Regeneration</h2>
+ *
+ * <p>Every class in this package and its {@code model.objects} subpackage is generated and must not
+ * be edited by hand. The source is the {@code gds-model-server} module of <a
+ * href="https://github.com/kevinherron/opc-ua-gds-model">opc-ua-gds-model</a> at commit {@code
+ * efa229d} (GDS NodeSet2 1.05.07), copied in with {@code com.digitalpetri.opcua.gds.server}
+ * rewritten to this package and {@code com.digitalpetri.opcua.gds.server.objects} rewritten to
+ * {@code org.eclipse.milo.opcua.sdk.server.gds.model.objects}. See {@code
+ * docs/features/gds-client.md} for the procedure.
+ */
+package org.eclipse.milo.opcua.sdk.server.gds;

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/gds/DataTypeInitializer.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/gds/DataTypeInitializer.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.core.gds;
+
+import org.eclipse.milo.opcua.stack.core.NamespaceTable;
+import org.eclipse.milo.opcua.stack.core.gds.types.ApplicationRecordDataType;
+import org.eclipse.milo.opcua.stack.core.types.DataTypeManager;
+
+public class DataTypeInitializer {
+  public static void initialize(NamespaceTable namespaceTable, DataTypeManager dataTypeManager) {
+    try {
+      registerStructCodecs(namespaceTable, dataTypeManager);
+    } catch (Exception e) {
+      throw new RuntimeException("DataType initialization failed", e);
+    }
+  }
+
+  private static void registerStructCodecs(
+      NamespaceTable namespaceTable, DataTypeManager dataTypeManager) throws Exception {
+    dataTypeManager.registerType(
+        ApplicationRecordDataType.TYPE_ID.toNodeIdOrThrow(namespaceTable),
+        new ApplicationRecordDataType.Codec(),
+        ApplicationRecordDataType.BINARY_ENCODING_ID.toNodeIdOrThrow(namespaceTable),
+        ApplicationRecordDataType.XML_ENCODING_ID.toNodeIdOrThrow(namespaceTable),
+        ApplicationRecordDataType.JSON_ENCODING_ID.toNodeIdOrThrow(namespaceTable));
+  }
+}

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/gds/GdsNodeIds.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/gds/GdsNodeIds.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.core.gds;
+
+/** This file is intentionally empty. It serves as the entry point for IDE autocompletion. */
+public abstract class GdsNodeIds extends GdsNodeIds0 {}

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/gds/GdsNodeIds0.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/gds/GdsNodeIds0.java
@@ -1,0 +1,1389 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.core.gds;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+
+abstract class GdsNodeIds0 extends GdsNodeIdsBase {
+  public static final ExpandedNodeId ApplicationRecordDataType =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1));
+
+  public static final ExpandedNodeId DirectoryType = ExpandedNodeId.of(NAMESPACE_URI, uint(13));
+
+  public static final ExpandedNodeId DirectoryType_Applications =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(14));
+
+  public static final ExpandedNodeId DirectoryType_FindApplications =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(15));
+
+  public static final ExpandedNodeId DirectoryType_FindApplications_InputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(16));
+
+  public static final ExpandedNodeId DirectoryType_FindApplications_OutputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(17));
+
+  public static final ExpandedNodeId DirectoryType_RegisterApplication =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(18));
+
+  public static final ExpandedNodeId DirectoryType_RegisterApplication_InputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(19));
+
+  public static final ExpandedNodeId DirectoryType_RegisterApplication_OutputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(20));
+
+  public static final ExpandedNodeId DirectoryType_UnregisterApplication =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(21));
+
+  public static final ExpandedNodeId DirectoryType_UnregisterApplication_InputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(22));
+
+  public static final ExpandedNodeId DirectoryType_QueryServers =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(23));
+
+  public static final ExpandedNodeId DirectoryType_QueryServers_InputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(24));
+
+  public static final ExpandedNodeId DirectoryType_QueryServers_OutputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(25));
+
+  public static final ExpandedNodeId ApplicationRegistrationChangedAuditEventType =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(26));
+
+  public static final ExpandedNodeId CertificateRevokedAuditEventType =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(27));
+
+  public static final ExpandedNodeId KeyCredentialManagementFolderType =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(55));
+
+  public static final ExpandedNodeId KeyCredentialManagementFolderType_ServiceName_Placeholder =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(61));
+
+  public static final ExpandedNodeId CertificateDirectoryType =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(63));
+
+  public static final ExpandedNodeId AuthorizationServiceType_RefreshToken =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(64));
+
+  public static final ExpandedNodeId AuthorizationServiceType_RefreshToken_InputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(65));
+
+  public static final ExpandedNodeId AuthorizationServiceType_RefreshToken_OutputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(66));
+
+  public static final ExpandedNodeId CertificateDirectoryType_StartNewKeyPairRequest =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(76));
+
+  public static final ExpandedNodeId
+      CertificateDirectoryType_StartNewKeyPairRequest_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(77));
+
+  public static final ExpandedNodeId
+      CertificateDirectoryType_StartNewKeyPairRequest_OutputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(78));
+
+  public static final ExpandedNodeId CertificateDirectoryType_StartSigningRequest =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(79));
+
+  public static final ExpandedNodeId CertificateDirectoryType_StartSigningRequest_InputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(80));
+
+  public static final ExpandedNodeId CertificateDirectoryType_StartSigningRequest_OutputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(81));
+
+  public static final ExpandedNodeId
+      KeyCredentialManagementFolderType_ServiceName_Placeholder_ResourceUri =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(83));
+
+  public static final ExpandedNodeId CertificateDirectoryType_FinishRequest =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(85));
+
+  public static final ExpandedNodeId CertificateDirectoryType_FinishRequest_InputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(86));
+
+  public static final ExpandedNodeId CertificateDirectoryType_FinishRequest_OutputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(87));
+
+  public static final ExpandedNodeId CertificateDirectoryType_GetCertificates =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(89));
+
+  public static final ExpandedNodeId CertificateDirectoryType_GetCertificates_InputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(90));
+
+  public static final ExpandedNodeId CertificateRequestedAuditEventType =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(91));
+
+  public static final ExpandedNodeId AuthorizationServiceType_StartRequestToken =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(95));
+
+  public static final ExpandedNodeId AuthorizationServiceType_StartRequestToken_InputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(96));
+
+  public static final ExpandedNodeId AuthorizationServiceType_StartRequestToken_OutputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(97));
+
+  public static final ExpandedNodeId AuthorizationServiceType_FinishRequestToken =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(98));
+
+  public static final ExpandedNodeId AuthorizationServiceType_FinishRequestToken_InputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(99));
+
+  public static final ExpandedNodeId AuthorizationServiceType_FinishRequestToken_OutputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(100));
+
+  public static final ExpandedNodeId CertificateDirectoryType_GetCertificates_OutputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(108));
+
+  public static final ExpandedNodeId CertificateDeliveredAuditEventType =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(109));
+
+  public static final ExpandedNodeId AuthorizationServiceType_SupportedRoles =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(110));
+
+  public static final ExpandedNodeId AccessTokenRequestedAuditEventType =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(111));
+
+  public static final ExpandedNodeId CertificateDirectoryType_CheckRevocationStatus =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(126));
+
+  public static final ExpandedNodeId ApplicationRecordDataType_Encoding_DefaultXml =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(127));
+
+  public static final ExpandedNodeId OpcUaGds_XmlSchema =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(128));
+
+  public static final ExpandedNodeId OpcUaGds_XmlSchema_NamespaceUri =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(130));
+
+  public static final ExpandedNodeId OpcUaGds_XmlSchema_ApplicationRecordDataType =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(131));
+
+  public static final ExpandedNodeId ApplicationRecordDataType_Encoding_DefaultBinary =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(134));
+
+  public static final ExpandedNodeId OpcUaGds_BinarySchema =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(135));
+
+  public static final ExpandedNodeId OpcUaGds_BinarySchema_NamespaceUri =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(137));
+
+  public static final ExpandedNodeId OpcUaGds_BinarySchema_ApplicationRecordDataType =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(138));
+
+  public static final ExpandedNodeId Directory = ExpandedNodeId.of(NAMESPACE_URI, uint(141));
+
+  public static final ExpandedNodeId Directory_Applications =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(142));
+
+  public static final ExpandedNodeId Directory_FindApplications =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(143));
+
+  public static final ExpandedNodeId Directory_FindApplications_InputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(144));
+
+  public static final ExpandedNodeId Directory_FindApplications_OutputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(145));
+
+  public static final ExpandedNodeId Directory_RegisterApplication =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(146));
+
+  public static final ExpandedNodeId Directory_RegisterApplication_InputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(147));
+
+  public static final ExpandedNodeId Directory_RegisterApplication_OutputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(148));
+
+  public static final ExpandedNodeId Directory_UnregisterApplication =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(149));
+
+  public static final ExpandedNodeId Directory_UnregisterApplication_InputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(150));
+
+  public static final ExpandedNodeId Directory_QueryServers =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(151));
+
+  public static final ExpandedNodeId Directory_QueryServers_InputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(152));
+
+  public static final ExpandedNodeId Directory_QueryServers_OutputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(153));
+
+  public static final ExpandedNodeId Directory_StartNewKeyPairRequest =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(154));
+
+  public static final ExpandedNodeId Directory_StartNewKeyPairRequest_InputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(155));
+
+  public static final ExpandedNodeId Directory_StartNewKeyPairRequest_OutputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(156));
+
+  public static final ExpandedNodeId Directory_StartSigningRequest =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(157));
+
+  public static final ExpandedNodeId Directory_StartSigningRequest_InputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(158));
+
+  public static final ExpandedNodeId Directory_StartSigningRequest_OutputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(159));
+
+  public static final ExpandedNodeId CertificateDirectoryType_CheckRevocationStatus_InputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(160));
+
+  public static final ExpandedNodeId
+      CertificateDirectoryType_CheckRevocationStatus_OutputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(161));
+
+  public static final ExpandedNodeId
+      KeyCredentialManagementFolderType_ServiceName_Placeholder_ProfileUris =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(162));
+
+  public static final ExpandedNodeId Directory_FinishRequest =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(163));
+
+  public static final ExpandedNodeId Directory_FinishRequest_InputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(164));
+
+  public static final ExpandedNodeId Directory_FinishRequest_OutputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(165));
+
+  public static final ExpandedNodeId
+      KeyCredentialManagementFolderType_ServiceName_Placeholder_StartRequest =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(168));
+
+  public static final ExpandedNodeId
+      KeyCredentialManagementFolderType_ServiceName_Placeholder_StartRequest_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(171));
+
+  public static final ExpandedNodeId Directory_GetCertificates =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(174));
+
+  public static final ExpandedNodeId Directory_GetCertificates_InputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(175));
+
+  public static final ExpandedNodeId Directory_GetCertificates_OutputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(176));
+
+  public static final ExpandedNodeId Directory_CheckRevocationStatus =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(177));
+
+  public static final ExpandedNodeId Directory_CheckRevocationStatus_InputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(178));
+
+  public static final ExpandedNodeId Directory_CheckRevocationStatus_OutputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(179));
+
+  public static final ExpandedNodeId DirectoryType_UpdateApplication =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(188));
+
+  public static final ExpandedNodeId DirectoryType_UpdateApplication_InputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(189));
+
+  public static final ExpandedNodeId
+      KeyCredentialManagementFolderType_ServiceName_Placeholder_StartRequest_OutputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(195));
+
+  public static final ExpandedNodeId
+      KeyCredentialManagementFolderType_ServiceName_Placeholder_FinishRequest =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(196));
+
+  public static final ExpandedNodeId CertificateDirectoryType_GetTrustList =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(197));
+
+  public static final ExpandedNodeId CertificateDirectoryType_GetTrustList_InputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(198));
+
+  public static final ExpandedNodeId CertificateDirectoryType_GetTrustList_OutputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(199));
+
+  public static final ExpandedNodeId Directory_UpdateApplication =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(200));
+
+  public static final ExpandedNodeId Directory_UpdateApplication_InputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(201));
+
+  public static final ExpandedNodeId
+      KeyCredentialManagementFolderType_ServiceName_Placeholder_FinishRequest_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(202));
+
+  public static final ExpandedNodeId
+      KeyCredentialManagementFolderType_ServiceName_Placeholder_FinishRequest_OutputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(203));
+
+  public static final ExpandedNodeId Directory_GetTrustList =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(204));
+
+  public static final ExpandedNodeId Directory_GetTrustList_InputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(205));
+
+  public static final ExpandedNodeId Directory_GetTrustList_OutputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(206));
+
+  public static final ExpandedNodeId DirectoryType_GetApplication =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(210));
+
+  public static final ExpandedNodeId DirectoryType_GetApplication_InputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(211));
+
+  public static final ExpandedNodeId DirectoryType_GetApplication_OutputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(212));
+
+  public static final ExpandedNodeId Directory_GetApplication =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(216));
+
+  public static final ExpandedNodeId Directory_GetApplication_InputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(217));
+
+  public static final ExpandedNodeId Directory_GetApplication_OutputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(218));
+
+  public static final ExpandedNodeId CertificateDirectoryType_GetCertificateStatus =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(222));
+
+  public static final ExpandedNodeId CertificateDirectoryType_GetCertificateStatus_InputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(223));
+
+  public static final ExpandedNodeId CertificateDirectoryType_GetCertificateStatus_OutputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(224));
+
+  public static final ExpandedNodeId Directory_GetCertificateStatus =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(225));
+
+  public static final ExpandedNodeId Directory_GetCertificateStatus_InputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(226));
+
+  public static final ExpandedNodeId Directory_GetCertificateStatus_OutputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(227));
+
+  public static final ExpandedNodeId AuthorizationServicesFolderType =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(233));
+
+  public static final ExpandedNodeId AuthorizationServicesFolderType_ServiceName_Placeholder =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(234));
+
+  public static final ExpandedNodeId
+      AuthorizationServicesFolderType_ServiceName_Placeholder_ServiceUri =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(235));
+
+  public static final ExpandedNodeId
+      AuthorizationServicesFolderType_ServiceName_Placeholder_ServiceCertificate =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(236));
+
+  public static final ExpandedNodeId
+      AuthorizationServicesFolderType_ServiceName_Placeholder_GetServiceDescription =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(238));
+
+  public static final ExpandedNodeId
+      AuthorizationServicesFolderType_ServiceName_Placeholder_GetServiceDescription_OutputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(239));
+
+  public static final ExpandedNodeId CertificateDirectoryType_GetCertificateGroups =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(369));
+
+  public static final ExpandedNodeId CertificateDirectoryType_GetCertificateGroups_InputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(370));
+
+  public static final ExpandedNodeId CertificateDirectoryType_GetCertificateGroups_OutputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(371));
+
+  public static final ExpandedNodeId KeyCredentialServiceType_SecurityPolicyUris =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(495));
+
+  public static final ExpandedNodeId Directory_GetCertificateGroups =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(508));
+
+  public static final ExpandedNodeId Directory_GetCertificateGroups_InputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(509));
+
+  public static final ExpandedNodeId Directory_GetCertificateGroups_OutputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(510));
+
+  public static final ExpandedNodeId CertificateDirectoryType_CertificateGroups =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(511));
+
+  public static final ExpandedNodeId
+      CertificateDirectoryType_CertificateGroups_DefaultApplicationGroup =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(512));
+
+  public static final ExpandedNodeId
+      CertificateDirectoryType_CertificateGroups_DefaultApplicationGroup_TrustList =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(513));
+
+  public static final ExpandedNodeId
+      CertificateDirectoryType_CertificateGroups_DefaultApplicationGroup_TrustList_Size =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(514));
+
+  public static final ExpandedNodeId
+      CertificateDirectoryType_CertificateGroups_DefaultApplicationGroup_TrustList_Writable =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(515));
+
+  public static final ExpandedNodeId
+      CertificateDirectoryType_CertificateGroups_DefaultApplicationGroup_TrustList_UserWritable =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(516));
+
+  public static final ExpandedNodeId
+      CertificateDirectoryType_CertificateGroups_DefaultApplicationGroup_TrustList_OpenCount =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(517));
+
+  public static final ExpandedNodeId
+      CertificateDirectoryType_CertificateGroups_DefaultApplicationGroup_TrustList_Open =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(519));
+
+  public static final ExpandedNodeId
+      CertificateDirectoryType_CertificateGroups_DefaultApplicationGroup_TrustList_Open_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(520));
+
+  public static final ExpandedNodeId
+      CertificateDirectoryType_CertificateGroups_DefaultApplicationGroup_TrustList_Open_OutputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(521));
+
+  public static final ExpandedNodeId
+      CertificateDirectoryType_CertificateGroups_DefaultApplicationGroup_TrustList_Close =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(522));
+
+  public static final ExpandedNodeId
+      CertificateDirectoryType_CertificateGroups_DefaultApplicationGroup_TrustList_Close_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(523));
+
+  public static final ExpandedNodeId
+      CertificateDirectoryType_CertificateGroups_DefaultApplicationGroup_TrustList_Read =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(524));
+
+  public static final ExpandedNodeId
+      CertificateDirectoryType_CertificateGroups_DefaultApplicationGroup_TrustList_Read_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(525));
+
+  public static final ExpandedNodeId
+      CertificateDirectoryType_CertificateGroups_DefaultApplicationGroup_TrustList_Read_OutputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(526));
+
+  public static final ExpandedNodeId
+      CertificateDirectoryType_CertificateGroups_DefaultApplicationGroup_TrustList_Write =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(527));
+
+  public static final ExpandedNodeId
+      CertificateDirectoryType_CertificateGroups_DefaultApplicationGroup_TrustList_Write_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(528));
+
+  public static final ExpandedNodeId
+      CertificateDirectoryType_CertificateGroups_DefaultApplicationGroup_TrustList_GetPosition =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(529));
+
+  public static final ExpandedNodeId
+      CertificateDirectoryType_CertificateGroups_DefaultApplicationGroup_TrustList_GetPosition_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(530));
+
+  public static final ExpandedNodeId
+      CertificateDirectoryType_CertificateGroups_DefaultApplicationGroup_TrustList_GetPosition_OutputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(531));
+
+  public static final ExpandedNodeId
+      CertificateDirectoryType_CertificateGroups_DefaultApplicationGroup_TrustList_SetPosition =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(532));
+
+  public static final ExpandedNodeId
+      CertificateDirectoryType_CertificateGroups_DefaultApplicationGroup_TrustList_SetPosition_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(533));
+
+  public static final ExpandedNodeId
+      CertificateDirectoryType_CertificateGroups_DefaultApplicationGroup_TrustList_LastUpdateTime =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(534));
+
+  public static final ExpandedNodeId
+      CertificateDirectoryType_CertificateGroups_DefaultApplicationGroup_TrustList_OpenWithMasks =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(535));
+
+  public static final ExpandedNodeId
+      CertificateDirectoryType_CertificateGroups_DefaultApplicationGroup_TrustList_OpenWithMasks_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(536));
+
+  public static final ExpandedNodeId
+      CertificateDirectoryType_CertificateGroups_DefaultApplicationGroup_TrustList_OpenWithMasks_OutputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(537));
+
+  public static final ExpandedNodeId
+      CertificateDirectoryType_CertificateGroups_DefaultApplicationGroup_TrustList_CloseAndUpdate =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(538));
+
+  public static final ExpandedNodeId
+      CertificateDirectoryType_CertificateGroups_DefaultApplicationGroup_TrustList_CloseAndUpdate_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(539));
+
+  public static final ExpandedNodeId
+      CertificateDirectoryType_CertificateGroups_DefaultApplicationGroup_TrustList_CloseAndUpdate_OutputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(540));
+
+  public static final ExpandedNodeId
+      CertificateDirectoryType_CertificateGroups_DefaultApplicationGroup_TrustList_AddCertificate =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(541));
+
+  public static final ExpandedNodeId
+      CertificateDirectoryType_CertificateGroups_DefaultApplicationGroup_TrustList_AddCertificate_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(542));
+
+  public static final ExpandedNodeId
+      CertificateDirectoryType_CertificateGroups_DefaultApplicationGroup_TrustList_RemoveCertificate =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(543));
+
+  public static final ExpandedNodeId
+      CertificateDirectoryType_CertificateGroups_DefaultApplicationGroup_TrustList_RemoveCertificate_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(544));
+
+  public static final ExpandedNodeId
+      CertificateDirectoryType_CertificateGroups_DefaultApplicationGroup_CertificateTypes =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(545));
+
+  public static final ExpandedNodeId Directory_CertificateGroups =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(614));
+
+  public static final ExpandedNodeId Directory_CertificateGroups_DefaultApplicationGroup =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(615));
+
+  public static final ExpandedNodeId Directory_CertificateGroups_DefaultApplicationGroup_TrustList =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(616));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultApplicationGroup_TrustList_Size =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(617));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultApplicationGroup_TrustList_Writable =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(618));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultApplicationGroup_TrustList_UserWritable =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(619));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultApplicationGroup_TrustList_OpenCount =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(620));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultApplicationGroup_TrustList_Open =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(622));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultApplicationGroup_TrustList_Open_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(623));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultApplicationGroup_TrustList_Open_OutputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(624));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultApplicationGroup_TrustList_Close =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(625));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultApplicationGroup_TrustList_Close_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(626));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultApplicationGroup_TrustList_Read =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(627));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultApplicationGroup_TrustList_Read_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(628));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultApplicationGroup_TrustList_Read_OutputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(629));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultApplicationGroup_TrustList_Write =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(630));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultApplicationGroup_TrustList_Write_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(631));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultApplicationGroup_TrustList_GetPosition =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(632));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultApplicationGroup_TrustList_GetPosition_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(633));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultApplicationGroup_TrustList_GetPosition_OutputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(634));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultApplicationGroup_TrustList_SetPosition =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(635));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultApplicationGroup_TrustList_SetPosition_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(636));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultApplicationGroup_TrustList_LastUpdateTime =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(637));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultApplicationGroup_TrustList_OpenWithMasks =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(638));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultApplicationGroup_TrustList_OpenWithMasks_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(639));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultApplicationGroup_TrustList_OpenWithMasks_OutputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(640));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultApplicationGroup_TrustList_CloseAndUpdate =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(641));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultApplicationGroup_TrustList_CloseAndUpdate_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(642));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultApplicationGroup_TrustList_CloseAndUpdate_OutputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(643));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultApplicationGroup_TrustList_AddCertificate =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(644));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultApplicationGroup_TrustList_AddCertificate_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(645));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultApplicationGroup_TrustList_RemoveCertificate =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(646));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultApplicationGroup_TrustList_RemoveCertificate_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(647));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultApplicationGroup_CertificateTypes =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(648));
+
+  public static final ExpandedNodeId Directory_CertificateGroups_DefaultHttpsGroup =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(649));
+
+  public static final ExpandedNodeId Directory_CertificateGroups_DefaultHttpsGroup_TrustList =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(650));
+
+  public static final ExpandedNodeId Directory_CertificateGroups_DefaultHttpsGroup_TrustList_Size =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(651));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultHttpsGroup_TrustList_Writable =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(652));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultHttpsGroup_TrustList_UserWritable =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(653));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultHttpsGroup_TrustList_OpenCount =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(654));
+
+  public static final ExpandedNodeId Directory_CertificateGroups_DefaultHttpsGroup_TrustList_Open =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(656));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultHttpsGroup_TrustList_Open_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(657));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultHttpsGroup_TrustList_Open_OutputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(658));
+
+  public static final ExpandedNodeId Directory_CertificateGroups_DefaultHttpsGroup_TrustList_Close =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(659));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultHttpsGroup_TrustList_Close_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(660));
+
+  public static final ExpandedNodeId Directory_CertificateGroups_DefaultHttpsGroup_TrustList_Read =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(661));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultHttpsGroup_TrustList_Read_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(662));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultHttpsGroup_TrustList_Read_OutputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(663));
+
+  public static final ExpandedNodeId Directory_CertificateGroups_DefaultHttpsGroup_TrustList_Write =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(664));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultHttpsGroup_TrustList_Write_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(665));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultHttpsGroup_TrustList_GetPosition =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(666));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultHttpsGroup_TrustList_GetPosition_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(667));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultHttpsGroup_TrustList_GetPosition_OutputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(668));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultHttpsGroup_TrustList_SetPosition =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(669));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultHttpsGroup_TrustList_SetPosition_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(670));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultHttpsGroup_TrustList_LastUpdateTime =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(671));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultHttpsGroup_TrustList_OpenWithMasks =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(672));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultHttpsGroup_TrustList_OpenWithMasks_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(673));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultHttpsGroup_TrustList_OpenWithMasks_OutputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(674));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultHttpsGroup_TrustList_CloseAndUpdate =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(675));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultHttpsGroup_TrustList_CloseAndUpdate_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(676));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultHttpsGroup_TrustList_CloseAndUpdate_OutputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(677));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultHttpsGroup_TrustList_AddCertificate =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(678));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultHttpsGroup_TrustList_AddCertificate_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(679));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultHttpsGroup_TrustList_RemoveCertificate =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(680));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultHttpsGroup_TrustList_RemoveCertificate_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(681));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultHttpsGroup_CertificateTypes =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(682));
+
+  public static final ExpandedNodeId Directory_CertificateGroups_DefaultUserTokenGroup =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(683));
+
+  public static final ExpandedNodeId Directory_CertificateGroups_DefaultUserTokenGroup_TrustList =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(684));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultUserTokenGroup_TrustList_Size =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(685));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultUserTokenGroup_TrustList_Writable =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(686));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultUserTokenGroup_TrustList_UserWritable =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(687));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultUserTokenGroup_TrustList_OpenCount =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(688));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultUserTokenGroup_TrustList_Open =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(690));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultUserTokenGroup_TrustList_Open_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(691));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultUserTokenGroup_TrustList_Open_OutputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(692));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultUserTokenGroup_TrustList_Close =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(693));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultUserTokenGroup_TrustList_Close_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(694));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultUserTokenGroup_TrustList_Read =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(695));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultUserTokenGroup_TrustList_Read_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(696));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultUserTokenGroup_TrustList_Read_OutputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(697));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultUserTokenGroup_TrustList_Write =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(698));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultUserTokenGroup_TrustList_Write_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(699));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultUserTokenGroup_TrustList_GetPosition =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(700));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultUserTokenGroup_TrustList_GetPosition_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(701));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultUserTokenGroup_TrustList_GetPosition_OutputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(702));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultUserTokenGroup_TrustList_SetPosition =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(703));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultUserTokenGroup_TrustList_SetPosition_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(704));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultUserTokenGroup_TrustList_LastUpdateTime =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(705));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultUserTokenGroup_TrustList_OpenWithMasks =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(706));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultUserTokenGroup_TrustList_OpenWithMasks_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(707));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultUserTokenGroup_TrustList_OpenWithMasks_OutputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(708));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultUserTokenGroup_TrustList_CloseAndUpdate =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(709));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultUserTokenGroup_TrustList_CloseAndUpdate_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(710));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultUserTokenGroup_TrustList_CloseAndUpdate_OutputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(711));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultUserTokenGroup_TrustList_AddCertificate =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(712));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultUserTokenGroup_TrustList_AddCertificate_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(713));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultUserTokenGroup_TrustList_RemoveCertificate =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(714));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultUserTokenGroup_TrustList_RemoveCertificate_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(715));
+
+  public static final ExpandedNodeId
+      Directory_CertificateGroups_DefaultUserTokenGroup_CertificateTypes =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(716));
+
+  public static final ExpandedNodeId CertificateRequestedAuditEventType_CertificateGroup =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(717));
+
+  public static final ExpandedNodeId CertificateRequestedAuditEventType_CertificateType =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(718));
+
+  public static final ExpandedNodeId CertificateDeliveredAuditEventType_CertificateGroup =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(719));
+
+  public static final ExpandedNodeId CertificateDeliveredAuditEventType_CertificateType =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(720));
+
+  public static final ExpandedNodeId OPCUAGDSNamespaceMetadata =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(721));
+
+  public static final ExpandedNodeId OPCUAGDSNamespaceMetadata_NamespaceUri =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(722));
+
+  public static final ExpandedNodeId OPCUAGDSNamespaceMetadata_NamespaceVersion =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(723));
+
+  public static final ExpandedNodeId OPCUAGDSNamespaceMetadata_NamespacePublicationDate =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(724));
+
+  public static final ExpandedNodeId OPCUAGDSNamespaceMetadata_IsNamespaceSubset =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(725));
+
+  public static final ExpandedNodeId OPCUAGDSNamespaceMetadata_StaticNodeIdTypes =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(726));
+
+  public static final ExpandedNodeId OPCUAGDSNamespaceMetadata_StaticNumericNodeIdRange =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(727));
+
+  public static final ExpandedNodeId OPCUAGDSNamespaceMetadata_StaticStringNodeIdPattern =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(728));
+
+  public static final ExpandedNodeId OPCUAGDSNamespaceMetadata_DefaultRolePermissions =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(862));
+
+  public static final ExpandedNodeId OPCUAGDSNamespaceMetadata_DefaultUserRolePermissions =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(863));
+
+  public static final ExpandedNodeId OPCUAGDSNamespaceMetadata_DefaultAccessRestrictions =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(864));
+
+  public static final ExpandedNodeId DirectoryType_QueryApplications =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(868));
+
+  public static final ExpandedNodeId DirectoryType_QueryApplications_InputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(869));
+
+  public static final ExpandedNodeId DirectoryType_QueryApplications_OutputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(870));
+
+  public static final ExpandedNodeId AuthorizationServices =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(959));
+
+  public static final ExpandedNodeId AuthorizationServiceType =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(966));
+
+  public static final ExpandedNodeId AuthorizationServiceType_UserTokenPolicies =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(967));
+
+  public static final ExpandedNodeId AuthorizationServiceType_ServiceCertificate =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(968));
+
+  public static final ExpandedNodeId AuthorizationServiceType_RequestAccessToken =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(969));
+
+  public static final ExpandedNodeId AuthorizationServiceType_RequestAccessToken_InputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(970));
+
+  public static final ExpandedNodeId AuthorizationServiceType_RequestAccessToken_OutputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(971));
+
+  public static final ExpandedNodeId AccessTokenIssuedAuditEventType =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(975));
+
+  public static final ExpandedNodeId Directory_QueryApplications =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(992));
+
+  public static final ExpandedNodeId Directory_QueryApplications_InputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(993));
+
+  public static final ExpandedNodeId Directory_QueryApplications_OutputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(994));
+
+  public static final ExpandedNodeId AuthorizationServiceType_ServiceUri =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1003));
+
+  public static final ExpandedNodeId AuthorizationServiceType_GetServiceDescription =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1004));
+
+  public static final ExpandedNodeId
+      AuthorizationServiceType_GetServiceDescription_OutputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(1005));
+
+  public static final ExpandedNodeId KeyCredentialManagement =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1008));
+
+  public static final ExpandedNodeId KeyCredentialServiceType =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1020));
+
+  public static final ExpandedNodeId KeyCredentialServiceType_ResourceUri =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1021));
+
+  public static final ExpandedNodeId KeyCredentialServiceType_ProfileUris =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1022));
+
+  public static final ExpandedNodeId KeyCredentialServiceType_StartRequest =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1023));
+
+  public static final ExpandedNodeId KeyCredentialServiceType_StartRequest_InputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1024));
+
+  public static final ExpandedNodeId KeyCredentialServiceType_StartRequest_OutputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1025));
+
+  public static final ExpandedNodeId KeyCredentialServiceType_FinishRequest =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1026));
+
+  public static final ExpandedNodeId KeyCredentialServiceType_FinishRequest_InputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1027));
+
+  public static final ExpandedNodeId KeyCredentialServiceType_FinishRequest_OutputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1028));
+
+  public static final ExpandedNodeId KeyCredentialServiceType_Revoke =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1029));
+
+  public static final ExpandedNodeId KeyCredentialServiceType_Revoke_InputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1030));
+
+  public static final ExpandedNodeId KeyCredentialRequestedAuditEventType =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1039));
+
+  public static final ExpandedNodeId KeyCredentialDeliveredAuditEventType =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1057));
+
+  public static final ExpandedNodeId KeyCredentialRevokedAuditEventType =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1075));
+
+  public static final ExpandedNodeId WellKnownRole_DiscoveryAdmin =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1661));
+
+  public static final ExpandedNodeId WellKnownRole_DiscoveryAdmin_Identities =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1662));
+
+  public static final ExpandedNodeId WellKnownRole_DiscoveryAdmin_ApplicationsExclude =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1663));
+
+  public static final ExpandedNodeId WellKnownRole_DiscoveryAdmin_Applications =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1664));
+
+  public static final ExpandedNodeId WellKnownRole_DiscoveryAdmin_EndpointsExclude =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1665));
+
+  public static final ExpandedNodeId WellKnownRole_DiscoveryAdmin_Endpoints =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1666));
+
+  public static final ExpandedNodeId WellKnownRole_DiscoveryAdmin_AddIdentity =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1668));
+
+  public static final ExpandedNodeId WellKnownRole_DiscoveryAdmin_AddIdentity_InputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1669));
+
+  public static final ExpandedNodeId WellKnownRole_DiscoveryAdmin_RemoveIdentity =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1670));
+
+  public static final ExpandedNodeId WellKnownRole_DiscoveryAdmin_RemoveIdentity_InputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1671));
+
+  public static final ExpandedNodeId WellKnownRole_DiscoveryAdmin_AddApplication =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1672));
+
+  public static final ExpandedNodeId WellKnownRole_DiscoveryAdmin_AddApplication_InputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1673));
+
+  public static final ExpandedNodeId WellKnownRole_DiscoveryAdmin_RemoveApplication =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1674));
+
+  public static final ExpandedNodeId WellKnownRole_DiscoveryAdmin_RemoveApplication_InputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1675));
+
+  public static final ExpandedNodeId WellKnownRole_DiscoveryAdmin_AddEndpoint =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1676));
+
+  public static final ExpandedNodeId WellKnownRole_DiscoveryAdmin_AddEndpoint_InputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1677));
+
+  public static final ExpandedNodeId WellKnownRole_DiscoveryAdmin_RemoveEndpoint =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1678));
+
+  public static final ExpandedNodeId WellKnownRole_DiscoveryAdmin_RemoveEndpoint_InputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1679));
+
+  public static final ExpandedNodeId WellKnownRole_CertificateAuthorityAdmin =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1680));
+
+  public static final ExpandedNodeId WellKnownRole_CertificateAuthorityAdmin_Identities =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1681));
+
+  public static final ExpandedNodeId WellKnownRole_CertificateAuthorityAdmin_ApplicationsExclude =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1682));
+
+  public static final ExpandedNodeId WellKnownRole_CertificateAuthorityAdmin_Applications =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1683));
+
+  public static final ExpandedNodeId WellKnownRole_CertificateAuthorityAdmin_EndpointsExclude =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1684));
+
+  public static final ExpandedNodeId WellKnownRole_CertificateAuthorityAdmin_Endpoints =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1685));
+
+  public static final ExpandedNodeId WellKnownRole_CertificateAuthorityAdmin_AddIdentity =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1687));
+
+  public static final ExpandedNodeId
+      WellKnownRole_CertificateAuthorityAdmin_AddIdentity_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(1688));
+
+  public static final ExpandedNodeId WellKnownRole_CertificateAuthorityAdmin_RemoveIdentity =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1689));
+
+  public static final ExpandedNodeId
+      WellKnownRole_CertificateAuthorityAdmin_RemoveIdentity_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(1690));
+
+  public static final ExpandedNodeId WellKnownRole_CertificateAuthorityAdmin_AddApplication =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1691));
+
+  public static final ExpandedNodeId
+      WellKnownRole_CertificateAuthorityAdmin_AddApplication_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(1692));
+
+  public static final ExpandedNodeId WellKnownRole_CertificateAuthorityAdmin_RemoveApplication =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1693));
+
+  public static final ExpandedNodeId
+      WellKnownRole_CertificateAuthorityAdmin_RemoveApplication_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(1694));
+
+  public static final ExpandedNodeId WellKnownRole_CertificateAuthorityAdmin_AddEndpoint =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1695));
+
+  public static final ExpandedNodeId
+      WellKnownRole_CertificateAuthorityAdmin_AddEndpoint_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(1696));
+
+  public static final ExpandedNodeId WellKnownRole_CertificateAuthorityAdmin_RemoveEndpoint =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1697));
+
+  public static final ExpandedNodeId
+      WellKnownRole_CertificateAuthorityAdmin_RemoveEndpoint_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(1698));
+
+  public static final ExpandedNodeId WellKnownRole_RegistrationAuthorityAdmin =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1699));
+
+  public static final ExpandedNodeId WellKnownRole_RegistrationAuthorityAdmin_Identities =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1700));
+
+  public static final ExpandedNodeId WellKnownRole_RegistrationAuthorityAdmin_ApplicationsExclude =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1701));
+
+  public static final ExpandedNodeId WellKnownRole_RegistrationAuthorityAdmin_Applications =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1702));
+
+  public static final ExpandedNodeId WellKnownRole_RegistrationAuthorityAdmin_EndpointsExclude =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1703));
+
+  public static final ExpandedNodeId WellKnownRole_RegistrationAuthorityAdmin_Endpoints =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1704));
+
+  public static final ExpandedNodeId WellKnownRole_RegistrationAuthorityAdmin_AddIdentity =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1706));
+
+  public static final ExpandedNodeId
+      WellKnownRole_RegistrationAuthorityAdmin_AddIdentity_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(1707));
+
+  public static final ExpandedNodeId WellKnownRole_RegistrationAuthorityAdmin_RemoveIdentity =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1708));
+
+  public static final ExpandedNodeId
+      WellKnownRole_RegistrationAuthorityAdmin_RemoveIdentity_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(1709));
+
+  public static final ExpandedNodeId WellKnownRole_RegistrationAuthorityAdmin_AddApplication =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1710));
+
+  public static final ExpandedNodeId
+      WellKnownRole_RegistrationAuthorityAdmin_AddApplication_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(1711));
+
+  public static final ExpandedNodeId WellKnownRole_RegistrationAuthorityAdmin_RemoveApplication =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1712));
+
+  public static final ExpandedNodeId
+      WellKnownRole_RegistrationAuthorityAdmin_RemoveApplication_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(1713));
+
+  public static final ExpandedNodeId WellKnownRole_RegistrationAuthorityAdmin_AddEndpoint =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1714));
+
+  public static final ExpandedNodeId
+      WellKnownRole_RegistrationAuthorityAdmin_AddEndpoint_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(1715));
+
+  public static final ExpandedNodeId WellKnownRole_RegistrationAuthorityAdmin_RemoveEndpoint =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1716));
+
+  public static final ExpandedNodeId
+      WellKnownRole_RegistrationAuthorityAdmin_RemoveEndpoint_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(1717));
+
+  public static final ExpandedNodeId WellKnownRole_KeyCredentialAdmin =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1718));
+
+  public static final ExpandedNodeId WellKnownRole_KeyCredentialAdmin_Identities =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1719));
+
+  public static final ExpandedNodeId WellKnownRole_KeyCredentialAdmin_ApplicationsExclude =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1720));
+
+  public static final ExpandedNodeId WellKnownRole_KeyCredentialAdmin_Applications =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1721));
+
+  public static final ExpandedNodeId WellKnownRole_KeyCredentialAdmin_EndpointsExclude =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1722));
+
+  public static final ExpandedNodeId WellKnownRole_KeyCredentialAdmin_Endpoints =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1723));
+
+  public static final ExpandedNodeId WellKnownRole_KeyCredentialAdmin_AddIdentity =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1725));
+
+  public static final ExpandedNodeId WellKnownRole_KeyCredentialAdmin_AddIdentity_InputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1726));
+
+  public static final ExpandedNodeId WellKnownRole_KeyCredentialAdmin_RemoveIdentity =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1727));
+
+  public static final ExpandedNodeId
+      WellKnownRole_KeyCredentialAdmin_RemoveIdentity_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(1728));
+
+  public static final ExpandedNodeId WellKnownRole_KeyCredentialAdmin_AddApplication =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1729));
+
+  public static final ExpandedNodeId
+      WellKnownRole_KeyCredentialAdmin_AddApplication_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(1730));
+
+  public static final ExpandedNodeId WellKnownRole_KeyCredentialAdmin_RemoveApplication =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1731));
+
+  public static final ExpandedNodeId
+      WellKnownRole_KeyCredentialAdmin_RemoveApplication_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(1732));
+
+  public static final ExpandedNodeId WellKnownRole_KeyCredentialAdmin_AddEndpoint =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1733));
+
+  public static final ExpandedNodeId WellKnownRole_KeyCredentialAdmin_AddEndpoint_InputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1734));
+
+  public static final ExpandedNodeId WellKnownRole_KeyCredentialAdmin_RemoveEndpoint =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1735));
+
+  public static final ExpandedNodeId
+      WellKnownRole_KeyCredentialAdmin_RemoveEndpoint_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(1736));
+
+  public static final ExpandedNodeId WellKnownRole_AuthorizationServiceAdmin =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1737));
+
+  public static final ExpandedNodeId WellKnownRole_AuthorizationServiceAdmin_Identities =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1738));
+
+  public static final ExpandedNodeId WellKnownRole_AuthorizationServiceAdmin_ApplicationsExclude =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1739));
+
+  public static final ExpandedNodeId WellKnownRole_AuthorizationServiceAdmin_Applications =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1740));
+
+  public static final ExpandedNodeId WellKnownRole_AuthorizationServiceAdmin_EndpointsExclude =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1741));
+
+  public static final ExpandedNodeId WellKnownRole_AuthorizationServiceAdmin_Endpoints =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1742));
+
+  public static final ExpandedNodeId WellKnownRole_AuthorizationServiceAdmin_AddIdentity =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1744));
+
+  public static final ExpandedNodeId
+      WellKnownRole_AuthorizationServiceAdmin_AddIdentity_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(1745));
+
+  public static final ExpandedNodeId WellKnownRole_AuthorizationServiceAdmin_RemoveIdentity =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1746));
+
+  public static final ExpandedNodeId
+      WellKnownRole_AuthorizationServiceAdmin_RemoveIdentity_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(1747));
+
+  public static final ExpandedNodeId WellKnownRole_AuthorizationServiceAdmin_AddApplication =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1748));
+
+  public static final ExpandedNodeId
+      WellKnownRole_AuthorizationServiceAdmin_AddApplication_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(1749));
+
+  public static final ExpandedNodeId WellKnownRole_AuthorizationServiceAdmin_RemoveApplication =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1750));
+
+  public static final ExpandedNodeId
+      WellKnownRole_AuthorizationServiceAdmin_RemoveApplication_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(1751));
+
+  public static final ExpandedNodeId WellKnownRole_AuthorizationServiceAdmin_AddEndpoint =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1752));
+
+  public static final ExpandedNodeId
+      WellKnownRole_AuthorizationServiceAdmin_AddEndpoint_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(1753));
+
+  public static final ExpandedNodeId WellKnownRole_AuthorizationServiceAdmin_RemoveEndpoint =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1754));
+
+  public static final ExpandedNodeId
+      WellKnownRole_AuthorizationServiceAdmin_RemoveEndpoint_InputArguments =
+          ExpandedNodeId.of(NAMESPACE_URI, uint(1755));
+
+  public static final ExpandedNodeId OPCUAGDSNamespaceMetadata_ModelVersion =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(1756));
+
+  public static final ExpandedNodeId ApplicationRecordDataType_Encoding_DefaultJson =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(8001));
+
+  public static final ExpandedNodeId OpcUaGds_BinarySchema_Deprecated =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(8002));
+
+  public static final ExpandedNodeId OpcUaGds_XmlSchema_Deprecated =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(8004));
+
+  public static final ExpandedNodeId CertificateDirectoryType_RevokeCertificate =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(15003));
+
+  public static final ExpandedNodeId CertificateDirectoryType_RevokeCertificate_InputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(15004));
+
+  public static final ExpandedNodeId Directory_RevokeCertificate =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(15005));
+
+  public static final ExpandedNodeId Directory_RevokeCertificate_InputArguments =
+      ExpandedNodeId.of(NAMESPACE_URI, uint(15006));
+}

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/gds/GdsNodeIdsBase.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/gds/GdsNodeIdsBase.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.core.gds;
+
+abstract class GdsNodeIdsBase {
+  protected static final String NAMESPACE_URI = "http://opcfoundation.org/UA/GDS/";
+}

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/gds/package-info.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/gds/package-info.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/**
+ * Generated model for the OPC UA Global Discovery Server namespace, {@code
+ * http://opcfoundation.org/UA/GDS/} (OPC 10000-12).
+ *
+ * <p>{@link org.eclipse.milo.opcua.stack.core.gds.GdsNodeIds} holds one {@link
+ * org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId} constant per node in the GDS
+ * NodeSet, expressed against the namespace URI rather than an index. The GDS namespace index
+ * differs from server to server, so a constant must be resolved through the {@link
+ * org.eclipse.milo.opcua.stack.core.NamespaceTable} of the peer it will be used with, for example
+ * {@code GdsNodeIds.Directory.toNodeIdOrThrow(client.getNamespaceTable())}.
+ *
+ * <p>{@link org.eclipse.milo.opcua.stack.core.gds.DataTypeInitializer} registers the codec for the
+ * one structure the namespace defines, {@link
+ * org.eclipse.milo.opcua.stack.core.gds.types.ApplicationRecordDataType}, with a {@link
+ * org.eclipse.milo.opcua.stack.core.types.DataTypeManager}. It is not part of the namespace 0
+ * startup path and must be invoked explicitly, with a {@link
+ * org.eclipse.milo.opcua.stack.core.NamespaceTable} that already contains the GDS namespace URI. On
+ * the client side {@code org.eclipse.milo.opcua.sdk.client.gds.GdsClient} (module {@code
+ * milo-sdk-client-gds}) does this during creation; on the server side an application hosting the
+ * GDS namespace calls it after adding the URI to the server's table.
+ *
+ * <h2>Regeneration</h2>
+ *
+ * <p>Every class in this package and in {@code org.eclipse.milo.opcua.stack.core.gds.types} is
+ * generated and must not be edited by hand. The source is the {@code gds-model-core} module of <a
+ * href="https://github.com/kevinherron/opc-ua-gds-model">opc-ua-gds-model</a> at commit {@code
+ * efa229d} (GDS NodeSet2 1.05.07 on a 1.05.07 base model), copied in with the package prefix {@code
+ * com.digitalpetri.opcua.gds} rewritten to {@code org.eclipse.milo.opcua.stack.core.gds} and the
+ * Eclipse Milo license header prepended. To pick up a newer NodeSet, regenerate in that repository
+ * first, then recopy; the procedure is documented in {@code docs/features/gds-client.md}.
+ */
+package org.eclipse.milo.opcua.stack.core.gds;

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/gds/types/ApplicationRecordDataType.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/gds/types/ApplicationRecordDataType.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.core.gds.types;
+
+import java.util.StringJoiner;
+import org.eclipse.milo.opcua.stack.core.NamespaceTable;
+import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
+import org.eclipse.milo.opcua.stack.core.encoding.GenericDataTypeCodec;
+import org.eclipse.milo.opcua.stack.core.encoding.UaDecoder;
+import org.eclipse.milo.opcua.stack.core.encoding.UaEncoder;
+import org.eclipse.milo.opcua.stack.core.types.UaStructuredType;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.ApplicationType;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.StructureType;
+import org.eclipse.milo.opcua.stack.core.types.structured.Structure;
+import org.eclipse.milo.opcua.stack.core.types.structured.StructureDefinition;
+import org.eclipse.milo.opcua.stack.core.types.structured.StructureField;
+import org.eclipse.milo.opcua.stack.core.util.codegen.EqualsBuilder;
+import org.eclipse.milo.opcua.stack.core.util.codegen.HashCodeBuilder;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * @see <a
+ *     href="https://reference.opcfoundation.org/GDS/docs/6.5.5">https://reference.opcfoundation.org/GDS/docs/6.5.5</a>
+ */
+public class ApplicationRecordDataType extends Structure implements UaStructuredType {
+  public static final ExpandedNodeId TYPE_ID =
+      ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/GDS/;i=1");
+
+  public static final ExpandedNodeId BINARY_ENCODING_ID =
+      ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/GDS/;i=134");
+
+  public static final ExpandedNodeId XML_ENCODING_ID =
+      ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/GDS/;i=127");
+
+  public static final ExpandedNodeId JSON_ENCODING_ID =
+      ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/GDS/;i=8001");
+
+  private final NodeId applicationId;
+
+  private final @Nullable String applicationUri;
+
+  private final ApplicationType applicationType;
+
+  private final LocalizedText @Nullable [] applicationNames;
+
+  private final @Nullable String productUri;
+
+  private final String @Nullable [] discoveryUrls;
+
+  private final String @Nullable [] serverCapabilities;
+
+  public ApplicationRecordDataType(
+      NodeId applicationId,
+      @Nullable String applicationUri,
+      ApplicationType applicationType,
+      LocalizedText @Nullable [] applicationNames,
+      @Nullable String productUri,
+      String @Nullable [] discoveryUrls,
+      String @Nullable [] serverCapabilities) {
+    this.applicationId = applicationId;
+    this.applicationUri = applicationUri;
+    this.applicationType = applicationType;
+    this.applicationNames = applicationNames;
+    this.productUri = productUri;
+    this.discoveryUrls = discoveryUrls;
+    this.serverCapabilities = serverCapabilities;
+  }
+
+  @Override
+  public ExpandedNodeId getTypeId() {
+    return TYPE_ID;
+  }
+
+  @Override
+  public ExpandedNodeId getBinaryEncodingId() {
+    return BINARY_ENCODING_ID;
+  }
+
+  @Override
+  public ExpandedNodeId getXmlEncodingId() {
+    return XML_ENCODING_ID;
+  }
+
+  @Override
+  public ExpandedNodeId getJsonEncodingId() {
+    return JSON_ENCODING_ID;
+  }
+
+  public NodeId getApplicationId() {
+    return applicationId;
+  }
+
+  public @Nullable String getApplicationUri() {
+    return applicationUri;
+  }
+
+  public ApplicationType getApplicationType() {
+    return applicationType;
+  }
+
+  public LocalizedText @Nullable [] getApplicationNames() {
+    return applicationNames;
+  }
+
+  public @Nullable String getProductUri() {
+    return productUri;
+  }
+
+  public String @Nullable [] getDiscoveryUrls() {
+    return discoveryUrls;
+  }
+
+  public String @Nullable [] getServerCapabilities() {
+    return serverCapabilities;
+  }
+
+  @Override
+  public boolean equals(Object object) {
+    if (this == object) {
+      return true;
+    } else if (object == null || getClass() != object.getClass()) {
+      return false;
+    }
+    ApplicationRecordDataType that = (ApplicationRecordDataType) object;
+    var eqb = new EqualsBuilder();
+    eqb.append(getApplicationId(), that.getApplicationId());
+    eqb.append(getApplicationUri(), that.getApplicationUri());
+    eqb.append(getApplicationType(), that.getApplicationType());
+    eqb.append(getApplicationNames(), that.getApplicationNames());
+    eqb.append(getProductUri(), that.getProductUri());
+    eqb.append(getDiscoveryUrls(), that.getDiscoveryUrls());
+    eqb.append(getServerCapabilities(), that.getServerCapabilities());
+    return eqb.build();
+  }
+
+  @Override
+  public int hashCode() {
+    var hcb = new HashCodeBuilder();
+    hcb.append(getApplicationId());
+    hcb.append(getApplicationUri());
+    hcb.append(getApplicationType());
+    hcb.append(getApplicationNames());
+    hcb.append(getProductUri());
+    hcb.append(getDiscoveryUrls());
+    hcb.append(getServerCapabilities());
+    return hcb.build();
+  }
+
+  @Override
+  public String toString() {
+    var joiner = new StringJoiner(", ", ApplicationRecordDataType.class.getSimpleName() + "[", "]");
+    joiner.add("applicationId=" + getApplicationId());
+    joiner.add("applicationUri='" + getApplicationUri() + "'");
+    joiner.add("applicationType=" + getApplicationType());
+    joiner.add("applicationNames=" + java.util.Arrays.toString(getApplicationNames()));
+    joiner.add("productUri='" + getProductUri() + "'");
+    joiner.add("discoveryUrls=" + java.util.Arrays.toString(getDiscoveryUrls()));
+    joiner.add("serverCapabilities=" + java.util.Arrays.toString(getServerCapabilities()));
+    return joiner.toString();
+  }
+
+  public static StructureDefinition definition(NamespaceTable namespaceTable) {
+    return new StructureDefinition(
+        ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/GDS/;i=134")
+            .toNodeId(namespaceTable)
+            .orElseThrow(),
+        ExpandedNodeId.parse("nsu=http://opcfoundation.org/UA/;i=22")
+            .toNodeId(namespaceTable)
+            .orElseThrow(),
+        StructureType.Structure,
+        new StructureField[] {
+          new StructureField(
+              "ApplicationId",
+              LocalizedText.NULL_VALUE,
+              new NodeId(0, 17),
+              -1,
+              null,
+              UInteger.valueOf(0),
+              false),
+          new StructureField(
+              "ApplicationUri",
+              LocalizedText.NULL_VALUE,
+              new NodeId(0, 12),
+              -1,
+              null,
+              UInteger.valueOf(0),
+              false),
+          new StructureField(
+              "ApplicationType",
+              LocalizedText.NULL_VALUE,
+              new NodeId(0, 307),
+              -1,
+              null,
+              UInteger.valueOf(0),
+              false),
+          new StructureField(
+              "ApplicationNames",
+              LocalizedText.NULL_VALUE,
+              new NodeId(0, 21),
+              1,
+              null,
+              UInteger.valueOf(0),
+              false),
+          new StructureField(
+              "ProductUri",
+              LocalizedText.NULL_VALUE,
+              new NodeId(0, 12),
+              -1,
+              null,
+              UInteger.valueOf(0),
+              false),
+          new StructureField(
+              "DiscoveryUrls",
+              LocalizedText.NULL_VALUE,
+              new NodeId(0, 12),
+              1,
+              null,
+              UInteger.valueOf(0),
+              false),
+          new StructureField(
+              "ServerCapabilities",
+              LocalizedText.NULL_VALUE,
+              new NodeId(0, 12),
+              1,
+              null,
+              UInteger.valueOf(0),
+              false)
+        });
+  }
+
+  public static final class Codec extends GenericDataTypeCodec<ApplicationRecordDataType> {
+    @Override
+    public Class<ApplicationRecordDataType> getType() {
+      return ApplicationRecordDataType.class;
+    }
+
+    @Override
+    public ApplicationRecordDataType decodeType(EncodingContext context, UaDecoder decoder) {
+      final NodeId applicationId;
+      final String applicationUri;
+      final ApplicationType applicationType;
+      final LocalizedText[] applicationNames;
+      final String productUri;
+      final String[] discoveryUrls;
+      final String[] serverCapabilities;
+      applicationId = decoder.decodeNodeId("ApplicationId");
+      applicationUri = decoder.decodeString("ApplicationUri");
+      applicationType = ApplicationType.from(decoder.decodeEnum("ApplicationType"));
+      applicationNames = decoder.decodeLocalizedTextArray("ApplicationNames");
+      productUri = decoder.decodeString("ProductUri");
+      discoveryUrls = decoder.decodeStringArray("DiscoveryUrls");
+      serverCapabilities = decoder.decodeStringArray("ServerCapabilities");
+      return new ApplicationRecordDataType(
+          applicationId,
+          applicationUri,
+          applicationType,
+          applicationNames,
+          productUri,
+          discoveryUrls,
+          serverCapabilities);
+    }
+
+    @Override
+    public void encodeType(
+        EncodingContext context, UaEncoder encoder, ApplicationRecordDataType value) {
+      encoder.encodeNodeId("ApplicationId", value.getApplicationId());
+      encoder.encodeString("ApplicationUri", value.getApplicationUri());
+      encoder.encodeEnum("ApplicationType", value.getApplicationType());
+      encoder.encodeLocalizedTextArray("ApplicationNames", value.getApplicationNames());
+      encoder.encodeString("ProductUri", value.getProductUri());
+      encoder.encodeStringArray("DiscoveryUrls", value.getDiscoveryUrls());
+      encoder.encodeStringArray("ServerCapabilities", value.getServerCapabilities());
+    }
+  }
+}

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/gds/types/package-info.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/gds/types/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/**
+ * Generated structured DataTypes of the OPC UA Global Discovery Server namespace.
+ *
+ * <p>The GDS namespace defines a single structure, {@link
+ * org.eclipse.milo.opcua.stack.core.gds.types.ApplicationRecordDataType}, which describes an
+ * application registered with a GDS (OPC 10000-12 clause 6.5.5). It follows the same shape as the
+ * namespace 0 structures in {@code org.eclipse.milo.opcua.stack.core.types.structured}: an
+ * immutable value class with a nested {@code Codec} and namespace-URI-qualified type and encoding
+ * ids. Because the ids are URI-qualified, the codec can only be registered against a {@link
+ * org.eclipse.milo.opcua.stack.core.NamespaceTable} that already contains the GDS namespace; see
+ * {@link org.eclipse.milo.opcua.stack.core.gds.DataTypeInitializer}.
+ *
+ * <p>Generated code; see the regeneration notes in {@link org.eclipse.milo.opcua.stack.core.gds}.
+ */
+package org.eclipse.milo.opcua.stack.core.gds.types;

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/FileBasedTrustListManager.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/FileBasedTrustListManager.java
@@ -139,8 +139,6 @@ public class FileBasedTrustListManager implements TrustListManager, Closeable {
     synchronizeIssuerCrl();
     synchronizeTrustedCerts();
     synchronizeTrustedCrl();
-
-    lastUpdateTime.set(DateTime.now());
   }
 
   @Override
@@ -222,6 +220,8 @@ public class FileBasedTrustListManager implements TrustListManager, Closeable {
 
       toWrite.forEach(crl -> writeCrlToDir(crl, issuerCrlDir));
       toDelete.forEach(crl -> deleteCrlFromDir(crl, issuerCrlDir));
+
+      touchLastUpdateTime();
     } finally {
       readWriteLock.writeLock().unlock();
     }
@@ -241,6 +241,8 @@ public class FileBasedTrustListManager implements TrustListManager, Closeable {
 
       toWrite.forEach(crl -> writeCrlToDir(crl, trustedCrlDir));
       toDelete.forEach(crl -> deleteCrlFromDir(crl, trustedCrlDir));
+
+      touchLastUpdateTime();
     } finally {
       readWriteLock.writeLock().unlock();
     }
@@ -260,6 +262,8 @@ public class FileBasedTrustListManager implements TrustListManager, Closeable {
 
       toWrite.forEach(cert -> writeCertificateToDir(cert, issuerCertsDir));
       toDelete.forEach(cert -> deleteCertificateFromDir(cert, issuerCertsDir));
+
+      touchLastUpdateTime();
     } finally {
       readWriteLock.writeLock().unlock();
     }
@@ -279,6 +283,8 @@ public class FileBasedTrustListManager implements TrustListManager, Closeable {
 
       toWrite.forEach(cert -> writeCertificateToDir(cert, trustedCertsDir));
       toDelete.forEach(cert -> deleteCertificateFromDir(cert, trustedCertsDir));
+
+      touchLastUpdateTime();
     } finally {
       readWriteLock.writeLock().unlock();
     }
@@ -291,6 +297,8 @@ public class FileBasedTrustListManager implements TrustListManager, Closeable {
       issuerCertificates.add(certificate);
 
       writeCertificateToDir(certificate, issuerCertsDir);
+
+      touchLastUpdateTime();
     } finally {
       readWriteLock.writeLock().unlock();
     }
@@ -303,6 +311,8 @@ public class FileBasedTrustListManager implements TrustListManager, Closeable {
       trustedCertificates.add(certificate);
 
       writeCertificateToDir(certificate, trustedCertsDir);
+
+      touchLastUpdateTime();
     } finally {
       readWriteLock.writeLock().unlock();
     }
@@ -314,7 +324,13 @@ public class FileBasedTrustListManager implements TrustListManager, Closeable {
     try {
       deleteCertificateFromDir(thumbprint, issuerCertsDir);
 
-      return remove(thumbprint, issuerCertificates);
+      boolean removed = remove(thumbprint, issuerCertificates);
+
+      if (removed) {
+        touchLastUpdateTime();
+      }
+
+      return removed;
     } finally {
       readWriteLock.writeLock().unlock();
     }
@@ -326,7 +342,13 @@ public class FileBasedTrustListManager implements TrustListManager, Closeable {
     try {
       deleteCertificateFromDir(thumbprint, trustedCertsDir);
 
-      return remove(thumbprint, trustedCertificates);
+      boolean removed = remove(thumbprint, trustedCertificates);
+
+      if (removed) {
+        touchLastUpdateTime();
+      }
+
+      return removed;
     } finally {
       readWriteLock.writeLock().unlock();
     }
@@ -348,6 +370,10 @@ public class FileBasedTrustListManager implements TrustListManager, Closeable {
     return lastUpdateTime.get();
   }
 
+  private void touchLastUpdateTime() {
+    lastUpdateTime.set(DateTime.now());
+  }
+
   private void synchronizeIssuerCerts() {
     LOGGER.debug("Synchronizing issuer certs...");
 
@@ -358,6 +384,8 @@ public class FileBasedTrustListManager implements TrustListManager, Closeable {
       try (var files = Files.list(issuerCertsDir)) {
         files.flatMap(c -> decodeCertificateFile(c).stream()).forEach(issuerCertificates::add);
       }
+
+      touchLastUpdateTime();
     } catch (IOException e) {
       LOGGER.warn("Error synchronizing issuer certs", e);
     } finally {
@@ -375,6 +403,8 @@ public class FileBasedTrustListManager implements TrustListManager, Closeable {
       try (var files = Files.list(issuerCrlDir)) {
         files.flatMap(c -> decodeCrlFile(c).stream()).forEach(issuerCrls::addAll);
       }
+
+      touchLastUpdateTime();
     } catch (IOException e) {
       LOGGER.warn("Error synchronizing issuer CRLs", e);
     } finally {
@@ -392,6 +422,8 @@ public class FileBasedTrustListManager implements TrustListManager, Closeable {
       try (var files = Files.list(trustedCertsDir)) {
         files.flatMap(c -> decodeCertificateFile(c).stream()).forEach(trustedCertificates::add);
       }
+
+      touchLastUpdateTime();
     } catch (IOException e) {
       LOGGER.warn("Error synchronizing trusted certs", e);
     } finally {
@@ -409,6 +441,8 @@ public class FileBasedTrustListManager implements TrustListManager, Closeable {
       try (var files = Files.list(trustedCrlDir)) {
         files.flatMap(c -> decodeCrlFile(c).stream()).forEach(trustedCrls::addAll);
       }
+
+      touchLastUpdateTime();
     } catch (IOException e) {
       LOGGER.warn("Error synchronizing trusted CRLs", e);
     } finally {

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/FileBasedTrustListManager.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/FileBasedTrustListManager.java
@@ -26,13 +26,8 @@ import java.nio.file.Path;
 import java.nio.file.StandardWatchEventKinds;
 import java.nio.file.WatchKey;
 import java.nio.file.WatchService;
-import java.security.cert.CRL;
-import java.security.cert.CRLException;
-import java.security.cert.CertificateException;
-import java.security.cert.CertificateFactory;
 import java.security.cert.X509CRL;
 import java.security.cert.X509Certificate;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -42,7 +37,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.stream.Collectors;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
@@ -435,18 +429,9 @@ public class FileBasedTrustListManager implements TrustListManager, Closeable {
   }
 
   private static Optional<List<X509CRL>> decodeCrlFile(Path path) {
-    try {
-      CertificateFactory factory = CertificateFactory.getInstance("X.509");
-      try (FileInputStream inputStream = new FileInputStream(path.toFile())) {
-        Collection<? extends CRL> crls = factory.generateCRLs(inputStream);
-
-        return Optional.of(
-            crls.stream()
-                .filter(crl -> crl instanceof X509CRL)
-                .map(X509CRL.class::cast)
-                .collect(Collectors.toList()));
-      }
-    } catch (CertificateException | CRLException | IOException e) {
+    try (FileInputStream inputStream = new FileInputStream(path.toFile())) {
+      return Optional.of(CertificateUtil.decodeCrls(inputStream));
+    } catch (UaException | IOException e) {
       LOGGER.warn("Error decoding CRL file: {}", path, e);
 
       return Optional.empty();

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/CertificateUtil.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/CertificateUtil.java
@@ -20,11 +20,14 @@ import java.io.InputStream;
 import java.io.StringWriter;
 import java.security.KeyPair;
 import java.security.Provider;
+import java.security.cert.CRL;
+import java.security.cert.CRLException;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.CertificateParsingException;
+import java.security.cert.X509CRL;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -125,6 +128,79 @@ public class CertificateUtil {
       return certificates.stream().map(X509Certificate.class::cast).collect(Collectors.toList());
     } catch (CertificateException e) {
       throw new UaException(StatusCodes.Bad_CertificateInvalid, e);
+    }
+  }
+
+  /**
+   * Decode a DER-encoded X.509 CRL.
+   *
+   * @param crlBytes the DER-encoded CRL bytes.
+   * @return an {@link X509CRL}.
+   * @throws UaException if decoding the CRL fails or the bytes contain no CRL.
+   */
+  public static X509CRL decodeCrl(byte[] crlBytes) throws UaException {
+    Preconditions.checkNotNull(crlBytes, "crlBytes cannot be null");
+
+    return decodeCrl(new ByteArrayInputStream(crlBytes));
+  }
+
+  /**
+   * Decode a DER-encoded X.509 CRL.
+   *
+   * @param inputStream the {@link InputStream} containing DER-encoded CRL bytes.
+   * @return an {@link X509CRL}.
+   * @throws UaException if decoding the CRL fails or the stream contains no CRL.
+   */
+  public static X509CRL decodeCrl(InputStream inputStream) throws UaException {
+    List<X509CRL> crls = decodeCrls(inputStream);
+
+    if (crls.isEmpty()) {
+      throw new UaException(StatusCodes.Bad_DecodingError, "no CRL found");
+    }
+
+    return crls.get(0);
+  }
+
+  /**
+   * Decode either a sequence of DER-encoded X.509 CRLs or a PKCS#7 CRL set.
+   *
+   * @param crlBytes the byte[] to decode from.
+   * @return a {@link List} of CRLs decoded from {@code crlBytes}.
+   * @throws UaException if decoding fails.
+   */
+  public static List<X509CRL> decodeCrls(byte[] crlBytes) throws UaException {
+    Preconditions.checkNotNull(crlBytes, "crlBytes cannot be null");
+
+    return decodeCrls(new ByteArrayInputStream(crlBytes));
+  }
+
+  /**
+   * Decode either a sequence of DER-encoded X.509 CRLs or a PKCS#7 CRL set.
+   *
+   * @param inputStream the {@link InputStream} to decode from.
+   * @return a {@link List} of CRLs decoded from {@code inputStream}.
+   * @throws UaException if decoding fails.
+   */
+  public static List<X509CRL> decodeCrls(InputStream inputStream) throws UaException {
+    Preconditions.checkNotNull(inputStream, "inputStream cannot be null");
+
+    CertificateFactory factory;
+
+    try {
+      factory = CertificateFactory.getInstance("X.509");
+    } catch (CertificateException e) {
+      throw new UaException(StatusCodes.Bad_InternalError, e);
+    }
+
+    try {
+      Collection<? extends CRL> crls = factory.generateCRLs(inputStream);
+
+      return crls.stream()
+          .filter(X509CRL.class::isInstance)
+          .map(X509CRL.class::cast)
+          .collect(Collectors.toList());
+    } catch (CRLException e) {
+      throw new UaException(StatusCodes.Bad_DecodingError, e);
     }
   }
 

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/gds/types/ApplicationRecordDataTypeTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/gds/types/ApplicationRecordDataTypeTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.core.gds.types;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.stream.Stream;
+import org.eclipse.milo.opcua.stack.core.NamespaceTable;
+import org.eclipse.milo.opcua.stack.core.ServerTable;
+import org.eclipse.milo.opcua.stack.core.channel.EncodingLimits;
+import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
+import org.eclipse.milo.opcua.stack.core.encoding.EncodingManager;
+import org.eclipse.milo.opcua.stack.core.encoding.OpcUaEncodingManager;
+import org.eclipse.milo.opcua.stack.core.gds.DataTypeInitializer;
+import org.eclipse.milo.opcua.stack.core.gds.GdsNodeIds;
+import org.eclipse.milo.opcua.stack.core.types.DataTypeManager;
+import org.eclipse.milo.opcua.stack.core.types.DefaultDataTypeManager;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.ApplicationType;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class ApplicationRecordDataTypeTest {
+
+  private static final String GDS_URI = "http://opcfoundation.org/UA/GDS/";
+
+  static Stream<Arguments> records() {
+    return Stream.of(
+        Arguments.of(
+            "all optional fields null",
+            new ApplicationRecordDataType(
+                NodeId.NULL_VALUE, null, ApplicationType.Client, null, null, null, null)),
+        Arguments.of(
+            "all fields populated",
+            new ApplicationRecordDataType(
+                new NodeId(2, "app-1"),
+                "urn:eclipse:milo:test",
+                ApplicationType.ClientAndServer,
+                new LocalizedText[] {
+                  LocalizedText.english("Test"), new LocalizedText("de", "Test")
+                },
+                "urn:eclipse:milo:product",
+                new String[] {
+                  "opc.tcp://localhost:4840/test", "opc.tcp://localhost:4840/discovery"
+                },
+                new String[] {"NA", "DA"})));
+  }
+
+  // Part 12 §6.5.5 defines ApplicationRecordDataType with GDS-namespace encoding ids, so the codec
+  // can only be found once DataTypeInitializer has resolved them through a NamespaceTable that
+  // contains the GDS URI. This proves that registration plus the generated codec round-trip a
+  // record through an ExtensionObject the way a Directory method result carries it.
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("records")
+  void binaryEncodingRoundTripsThroughExtensionObject(String name, ApplicationRecordDataType record)
+      throws Exception {
+
+    EncodingContext context = gdsEncodingContext();
+
+    ExtensionObject encoded = ExtensionObject.encode(context, record);
+    Object decoded = encoded.decode(context);
+
+    assertEquals(
+        GdsNodeIds.ApplicationRecordDataType_Encoding_DefaultBinary.toNodeIdOrThrow(
+            context.getNamespaceTable()),
+        encoded.getEncodingOrTypeId(),
+        "encoded with the GDS-namespace binary encoding id");
+    assertEquals(record, decoded);
+  }
+
+  private static EncodingContext gdsEncodingContext() {
+    var namespaceTable = new NamespaceTable();
+    namespaceTable.add("urn:some:other:namespace");
+    namespaceTable.add(GDS_URI);
+    assertEquals(ushort(2), namespaceTable.getIndex(GDS_URI), "GDS is not at index 1");
+
+    DataTypeManager dataTypeManager = DefaultDataTypeManager.createAndInitialize(namespaceTable);
+    DataTypeInitializer.initialize(namespaceTable, dataTypeManager);
+
+    return new EncodingContext() {
+      @Override
+      public DataTypeManager getDataTypeManager() {
+        return dataTypeManager;
+      }
+
+      @Override
+      public EncodingManager getEncodingManager() {
+        return OpcUaEncodingManager.getInstance();
+      }
+
+      @Override
+      public EncodingLimits getEncodingLimits() {
+        return EncodingLimits.DEFAULT;
+      }
+
+      @Override
+      public NamespaceTable getNamespaceTable() {
+        return namespaceTable;
+      }
+
+      @Override
+      public ServerTable getServerTable() {
+        return new ServerTable();
+      }
+    };
+  }
+}

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/security/TrustListManagerLastUpdateTimeTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/security/TrustListManagerLastUpdateTimeTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.core.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.cert.X509CRL;
+import java.security.cert.X509Certificate;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.util.CertificateUtil;
+import org.eclipse.milo.opcua.stack.core.util.CrlTestUtil;
+import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateBuilder;
+import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateGenerator;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * {@link TrustListManager#getLastUpdateTime()} is what a GDS Pull client compares against the
+ * server's {@code TrustListType.LastUpdateTime} (Part 12 §7.6) and what a Push server exposes as
+ * that property (Part 12 §7.8.2.1). Both roles need it to move on every change to the list, not
+ * only at initialization.
+ */
+public class TrustListManagerLastUpdateTimeTest {
+
+  private static final X509Certificate CERTIFICATE;
+  private static final X509CRL CRL;
+
+  static {
+    try {
+      KeyPair keyPair = SelfSignedCertificateGenerator.generateRsaKeyPair(2048);
+      CERTIFICATE =
+          new SelfSignedCertificateBuilder(keyPair)
+              .setApplicationUri("urn:eclipse:milo:test")
+              .build();
+      CRL = CrlTestUtil.generateCrl(CERTIFICATE, keyPair.getPrivate());
+    } catch (Exception e) {
+      throw new ExceptionInInitializerError(e);
+    }
+  }
+
+  static Stream<Arguments> mutations() {
+    return Stream.of(
+        mutation("setTrustedCertificates", m -> m.setTrustedCertificates(List.of(CERTIFICATE))),
+        mutation("setIssuerCertificates", m -> m.setIssuerCertificates(List.of(CERTIFICATE))),
+        mutation("setTrustedCrls", m -> m.setTrustedCrls(List.of(CRL))),
+        mutation("setIssuerCrls", m -> m.setIssuerCrls(List.of(CRL))),
+        mutation("addTrustedCertificate", m -> m.addTrustedCertificate(CERTIFICATE)),
+        mutation("addIssuerCertificate", m -> m.addIssuerCertificate(CERTIFICATE)),
+        mutation(
+            "removeTrustedCertificate",
+            m -> {
+              m.addTrustedCertificate(CERTIFICATE);
+              m.removeTrustedCertificate(thumbprint());
+            }),
+        mutation(
+            "removeIssuerCertificate",
+            m -> {
+              m.addIssuerCertificate(CERTIFICATE);
+              m.removeIssuerCertificate(thumbprint());
+            }));
+  }
+
+  private static Arguments mutation(String name, Consumer<TrustListManager> mutation) {
+    return Arguments.of(name, mutation);
+  }
+
+  private static ByteString thumbprint() {
+    try {
+      return CertificateUtil.thumbprint(CERTIFICATE);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Wait until the clock has moved past {@code time}, so a following mutation cannot land on the
+   * same {@link DateTime#now()} tick and a strict "after" comparison is meaningful.
+   */
+  private static void awaitClockTickAfter(DateTime time) {
+    while (DateTime.now().getUtcTime() <= time.getUtcTime()) {
+      Thread.onSpinWait();
+    }
+  }
+
+  abstract static class Contract {
+
+    TrustListManager manager;
+
+    abstract TrustListManager createManager() throws Exception;
+
+    @BeforeEach
+    void setUp() throws Exception {
+      manager = createManager();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+      manager.close();
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource(
+        "org.eclipse.milo.opcua.stack.core.security.TrustListManagerLastUpdateTimeTest#mutations")
+    void mutationAdvancesLastUpdateTime(String name, Consumer<TrustListManager> mutation) {
+      DateTime before = manager.getLastUpdateTime();
+      awaitClockTickAfter(before);
+
+      mutation.accept(manager);
+
+      DateTime after = manager.getLastUpdateTime();
+      assertTrue(
+          after.getUtcTime() > before.getUtcTime(),
+          name + " must advance lastUpdateTime: before=" + before + ", after=" + after);
+    }
+
+    // Removing a certificate that is not in the list changes nothing, so the timestamp must not
+    // claim an update happened.
+    @Test
+    void removeOfUnknownThumbprintDoesNotAdvanceLastUpdateTime() {
+      DateTime before = manager.getLastUpdateTime();
+      awaitClockTickAfter(before);
+
+      boolean removed = manager.removeTrustedCertificate(ByteString.of(new byte[] {1, 2, 3}));
+
+      assertFalse(removed);
+      assertEquals(before, manager.getLastUpdateTime());
+    }
+  }
+
+  @Nested
+  class Memory extends Contract {
+    @Override
+    TrustListManager createManager() {
+      return new MemoryTrustListManager();
+    }
+  }
+
+  @Nested
+  class FileBased extends Contract {
+    @TempDir Path tempDir;
+
+    @Override
+    TrustListManager createManager() throws Exception {
+      return FileBasedTrustListManager.createAndInitialize(
+          Files.createTempDirectory(tempDir, "pki"));
+    }
+  }
+}

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/util/CertificateUtilTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/util/CertificateUtilTest.java
@@ -13,9 +13,12 @@ package org.eclipse.milo.opcua.stack.core.util;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.google.common.primitives.Bytes;
 import java.security.KeyPair;
+import java.security.cert.X509CRL;
 import java.security.cert.X509Certificate;
 import java.util.List;
 import org.bouncycastle.asn1.pkcs.Attribute;
@@ -27,6 +30,8 @@ import org.bouncycastle.asn1.x509.Extensions;
 import org.bouncycastle.asn1.x509.KeyPurposeId;
 import org.bouncycastle.asn1.x509.KeyUsage;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
 import org.junit.jupiter.api.Test;
 
 public class CertificateUtilTest {
@@ -143,5 +148,46 @@ public class CertificateUtilTest {
     BasicConstraints basicConstraints =
         BasicConstraints.getInstance(basicConstraintsExt.getParsedValue());
     assertFalse(basicConstraints.isCA(), "basicConstraints should have cA=false");
+  }
+
+  // A GDS TrustList delivers CRLs as bare DER ByteStrings (Part 12 §7.8.2.8); the decoded CRL
+  // must carry the revocation entries of the original so validation can act on them.
+  @Test
+  public void decodeCrlRoundTripsDerEncodedCrl() throws Exception {
+    X509CRL crl = CrlTestUtil.generateCrl(certificate, keyPair.getPrivate(), certificate);
+
+    X509CRL decoded = CertificateUtil.decodeCrl(crl.getEncoded());
+
+    assertEquals(crl, decoded);
+    assertTrue(decoded.isRevoked(certificate), "revocation entry survives decode");
+  }
+
+  @Test
+  public void decodeCrlsDecodesConcatenatedDerCrls() throws Exception {
+    X509CRL crl1 = CrlTestUtil.generateCrl(certificate, keyPair.getPrivate());
+    X509CRL crl2 = CrlTestUtil.generateCrl(certificate, keyPair.getPrivate(), certificate);
+    byte[] concatenated = Bytes.concat(crl1.getEncoded(), crl2.getEncoded());
+
+    List<X509CRL> decoded = CertificateUtil.decodeCrls(concatenated);
+
+    assertEquals(List.of(crl1, crl2), decoded);
+  }
+
+  // Trust list application must fail loudly on a corrupt CRL rather than silently dropping it,
+  // otherwise a revoked certificate could stay trusted.
+  @Test
+  public void decodeCrlRejectsMalformedBytesWithBadDecodingError() {
+    byte[] garbage = {0x30, 0x03, 0x02, 0x01};
+
+    UaException e = assertThrows(UaException.class, () -> CertificateUtil.decodeCrl(garbage));
+
+    assertEquals(StatusCodes.Bad_DecodingError, e.getStatusCode().value());
+  }
+
+  @Test
+  public void decodeCrlRejectsEmptyInput() {
+    UaException e = assertThrows(UaException.class, () -> CertificateUtil.decodeCrl(new byte[0]));
+
+    assertEquals(StatusCodes.Bad_DecodingError, e.getStatusCode().value());
   }
 }

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/util/CrlTestUtil.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/util/CrlTestUtil.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.core.util;
+
+import java.security.PrivateKey;
+import java.security.cert.X509CRL;
+import java.security.cert.X509Certificate;
+import java.util.Date;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.CRLReason;
+import org.bouncycastle.cert.X509CRLHolder;
+import org.bouncycastle.cert.X509v2CRLBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509CRLConverter;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+
+/** Builds X.509 CRLs for tests that need real, decodable CRL bytes. */
+public final class CrlTestUtil {
+
+  private CrlTestUtil() {}
+
+  /**
+   * Generate a CRL issued by {@code issuer} that revokes {@code revoked}.
+   *
+   * @param issuer the issuing certificate.
+   * @param issuerKey the private key matching {@code issuer}.
+   * @param revoked the certificates to list as revoked; may be empty.
+   * @return a signed {@link X509CRL}.
+   * @throws Exception if building or signing the CRL fails.
+   */
+  public static X509CRL generateCrl(
+      X509Certificate issuer, PrivateKey issuerKey, X509Certificate... revoked) throws Exception {
+
+    var builder =
+        new X509v2CRLBuilder(
+            X500Name.getInstance(issuer.getSubjectX500Principal().getEncoded()), new Date());
+
+    builder.setNextUpdate(new Date(System.currentTimeMillis() + 60_000));
+
+    for (X509Certificate certificate : revoked) {
+      builder.addCRLEntry(
+          certificate.getSerialNumber(),
+          new Date(System.currentTimeMillis() - 60_000),
+          CRLReason.privilegeWithdrawn);
+    }
+
+    X509CRLHolder holder =
+        builder.build(new JcaContentSignerBuilder("SHA256WithRSAEncryption").build(issuerKey));
+
+    return new JcaX509CRLConverter().getCRL(holder);
+  }
+}

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/util/validation/CertificateValidationUtilTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/util/validation/CertificateValidationUtilTest.java
@@ -42,15 +42,11 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 import org.bouncycastle.asn1.x500.X500Name;
-import org.bouncycastle.asn1.x509.CRLReason;
 import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.asn1.x509.KeyUsage;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.bouncycastle.cert.CertIOException;
-import org.bouncycastle.cert.X509CRLHolder;
-import org.bouncycastle.cert.X509v2CRLBuilder;
 import org.bouncycastle.cert.X509v3CertificateBuilder;
-import org.bouncycastle.cert.jcajce.JcaX509CRLConverter;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.operator.ContentSigner;
@@ -59,6 +55,7 @@ import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.util.CrlTestUtil;
 import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateBuilder;
 import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateGenerator;
 import org.eclipse.milo.opcua.stack.core.util.validation.TestCertificateGenerator.TestCertificates;
@@ -285,8 +282,9 @@ public class CertificateValidationUtilTest {
               () -> {
                 Set<X509CRL> x509CRLS =
                     Set.of(
-                        generateCrl(caRoot, testCertificates.getPrivateKey(ALIAS_CA_ROOT)),
-                        generateCrl(
+                        CrlTestUtil.generateCrl(
+                            caRoot, testCertificates.getPrivateKey(ALIAS_CA_ROOT)),
+                        CrlTestUtil.generateCrl(
                             caIntermediate,
                             testCertificates.getPrivateKey(ALIAS_CA_INTERMEDIATE),
                             leafIntermediateSigned));
@@ -325,9 +323,9 @@ public class CertificateValidationUtilTest {
               () -> {
                 Set<X509CRL> x509CRLS =
                     Set.of(
-                        generateCrl(
+                        CrlTestUtil.generateCrl(
                             caRoot, testCertificates.getPrivateKey(ALIAS_CA_ROOT), caIntermediate),
-                        generateCrl(
+                        CrlTestUtil.generateCrl(
                             caIntermediate, testCertificates.getPrivateKey(ALIAS_CA_INTERMEDIATE)));
 
                 PKIXCertPathBuilderResult pathBuilderResult =
@@ -421,7 +419,7 @@ public class CertificateValidationUtilTest {
               () -> {
                 Set<X509CRL> x509CRLS =
                     Set.of(
-                        generateCrl(
+                        CrlTestUtil.generateCrl(
                             caRoot, testCertificates.getPrivateKey(ALIAS_CA_ROOT), caIntermediate));
 
                 PKIXCertPathBuilderResult pathBuilderResult =
@@ -494,35 +492,6 @@ public class CertificateValidationUtilTest {
     checkHostnameOrIpAddress(createSelfSignedCertificate("DIGITALPETRI.COM"), hostname);
     checkHostnameOrIpAddress(createSelfSignedCertificate("DIGITALPETRI.com"), hostname);
     checkHostnameOrIpAddress(createSelfSignedCertificate("DigitalPetri.com"), hostname);
-  }
-
-  private X509CRL generateCrl(
-      X509Certificate ca, PrivateKey caPrivateKey, X509Certificate... revoked) throws Exception {
-    X509v2CRLBuilder builder =
-        new X509v2CRLBuilder(
-            X500Name.getInstance(ca.getSubjectX500Principal().getEncoded()), new Date());
-
-    builder.setNextUpdate(new Date(System.currentTimeMillis() + 60_000));
-
-    for (X509Certificate certificate : revoked) {
-      builder.addCRLEntry(
-          certificate.getSerialNumber(),
-          new Date(System.currentTimeMillis() - 60_000),
-          CRLReason.privilegeWithdrawn);
-    }
-
-    JcaContentSignerBuilder contentSignerBuilder =
-        new JcaContentSignerBuilder("SHA256WithRSAEncryption");
-
-    contentSignerBuilder.setProvider("BC");
-
-    X509CRLHolder crlHolder = builder.build(contentSignerBuilder.build(caPrivateKey));
-
-    JcaX509CRLConverter converter = new JcaX509CRLConverter();
-
-    converter.setProvider("BC");
-
-    return converter.getCRL(crlHolder);
   }
 
   private static X509Certificate createSelfSignedCertificate(String dnsName) throws Exception {


### PR DESCRIPTION
Milo has no support for the OPC UA Global Discovery Server (OPC 10000-12). An application that wants a GDS to issue its certificate and manage its trust list has to hand-roll the GDS namespace, the `Directory` method calls, and the FileType read loop. This PR adds the GDS information model to the core modules and a new `milo-sdk-client-gds` module that lets a client register itself, request and renew certificates through the Pull Model (Part 12 §7.6), and read and apply GDS trust lists.

The model is generated from GDS NodeSet2 1.05.07 and checked in, the same way the namespace 0 model is handled. `GdsNodeIds` and `ApplicationRecordDataType` land in `stack-core`, the client and server ObjectType node classes and initializers in `sdk-client` and `sdk-server`, and the legacy type dictionary entry in `dtd-core` (deprecated with the rest of that module). Nothing runs during namespace 0 startup: the GDS namespace index differs per server, so the initializers take a `NamespaceTable` and are invoked explicitly once a client has read the server's namespace array.

The client layer is deliberately thin. `GdsClient` wraps a connected `OpcUaClient`, resolves the namespace index, registers the codec and object types, and exposes every `DirectoryType` and `CertificateDirectoryType` method with a typed signature in blocking and async forms. Each wrapper issues a single `Call` with the NodeIds fixed by the NodeSet, validates output arguments by type and count, and throws Bad operation statuses as `UaException` so callers can branch on the codes Part 12 defines (`Bad_NothingToDo` for a pending request, and so on). `TrustListReader` reads a TrustList via the FileType `Open`/`Read`/`Close` methods and decodes the bare `TrustListDataType` body. `TrustListApplier` replaces each specified list in a `TrustListManager` in full, decoding everything first so a malformed entry rejects the update without partial application. There is no Pull engine: scheduling, persistence of the `ApplicationId` and pending `RequestId`s, retry policy, and what to do with an issued certificate depend on the application, so the application drives the sequence. `docs/features/gds-client.md` describes the design, the usage pattern, and the regeneration procedure.

Two changes in `stack-core` support this. `CertificateUtil` gains `decodeCrl` and `decodeCrls`, which fail with `Bad_DecodingError` on a corrupt CRL instead of silently dropping it; `FileBasedTrustListManager` now uses the same helper for CRL files. `FileBasedTrustListManager` also updates `lastUpdateTime` on every change to a list rather than only at initialization, since a Pull client compares that value against the server's `TrustListType.LastUpdateTime` and a Push server exposes it as that property.

`GdsPullExample` runs the sequence once against a GDS named by system properties, with defaults matching the UA-.NETStandard reference GDS. The example has not yet been run against a real GDS; that manual check is outstanding.

Verification: `mise exec -- mvn -q spotless:check` and `mise exec -- mvn -q clean install -DskipTests` pass on the branch. The new and touched tests pass in `stack-core` (`CertificateUtilTest`, `CertificateValidationUtilTest`, `TrustListManagerLastUpdateTimeTest`, `ApplicationRecordDataTypeTest`), in `sdk-client-gds`, and in `integration-tests` (`GdsClientTest`, `GdsClientWithoutGdsNamespaceTest`, `TrustListReaderTest`, `GdsServerModelTest`), which run against an in-process fake GDS namespace. The full test suite was not run.

Known limitations, also recorded in the feature doc: `GetCertificates`, `CheckRevocationStatus`, and `RevokeCertificate` exist as `Directory` methods only from NodeSet 1.05.07, so older GDS deployments fail those wrappers; `StartNewKeyPairRequest` is a thin wrapper with no PFX/PEM private key helper; `TrustListApplier.apply` issues four separate `set*` calls, so a concurrent validation can briefly see a mix of old and new lists; and KeyCredential management, AuthorizationServices, and the GDS audit event types are covered only by their generated model classes.
