### PR TITLE
Support application-owned certificate groups and persistent storage

### DIFF
--- a/milo-examples/server-examples/src/main/java/org/eclipse/milo/examples/server/ExampleServer.java
+++ b/milo-examples/server-examples/src/main/java/org/eclipse/milo/examples/server/ExampleServer.java
@@ -181,8 +181,10 @@ public class ExampleServer {
         new DefaultServerCertificateValidator(trustListManager, certificateQuarantine);
 
     var defaultGroup =
-        DefaultApplicationGroup.createAndInitialize(
+        new DefaultApplicationGroup(
             trustListManager, certificateStore, certificateFactory, certificateValidator);
+
+    defaultGroup.createMissingCertificates();
 
     var certificateManager = new DefaultCertificateManager(certificateQuarantine, defaultGroup);
 

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/test/TestServer.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/test/TestServer.java
@@ -188,8 +188,10 @@ public final class TestServer {
         new DefaultServerCertificateValidator(trustListManager, certificateQuarantine);
 
     var defaultGroup =
-        DefaultApplicationGroup.createAndInitialize(
+        new DefaultApplicationGroup(
             trustListManager, certificateStore, certificateFactory, certificateValidator);
+
+    defaultGroup.createMissingCertificates();
 
     var certificateManager = new DefaultCertificateManager(certificateQuarantine, defaultGroup);
 

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/AbstractCertificateFactory.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/AbstractCertificateFactory.java
@@ -45,10 +45,10 @@ import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateGenerator;
  * {@link StatusCodes#Bad_NotSupported} so a factory does not silently claim support for identities
  * it cannot issue.
  *
- * <p>When {@link DefaultApplicationGroup#initialize()} finds that its {@link CertificateStore} is
- * missing an entry for a configured certificate type, it calls {@link #createKeyPair(NodeId)}
- * followed by {@link #createCertificateChain(NodeId, KeyPair)} for that same type. If a store is
- * pre-populated for a type, the factory is not used for that entry.
+ * <p>When {@link DefaultApplicationGroup#createMissingCertificates()} finds that its {@link
+ * CertificateStore} is missing an entry for a configured certificate type, it calls {@link
+ * #createKeyPair(NodeId)} followed by {@link #createCertificateChain(NodeId, KeyPair)} for that
+ * same type. If a store is pre-populated for a type, the factory is not used for that entry.
  *
  * <p>Example:
  *
@@ -80,8 +80,8 @@ import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateGenerator;
  *       }
  *     };
  *
- * DefaultApplicationGroup group =
- *     DefaultApplicationGroup.createAndInitialize(
+ * var group =
+ *     new DefaultApplicationGroup(
  *         trustListManager,
  *         certificateStore,
  *         certificateFactory,
@@ -89,6 +89,8 @@ import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateGenerator;
  *         List.of(
  *             NodeIds.RsaSha256ApplicationCertificateType,
  *             NodeIds.EccNistP256ApplicationCertificateType));
+ *
+ * group.createMissingCertificates();
  * }</pre>
  */
 public abstract class AbstractCertificateFactory implements CertificateFactory {

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/DefaultApplicationGroup.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/DefaultApplicationGroup.java
@@ -14,6 +14,7 @@ import java.security.KeyPair;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
@@ -28,7 +29,11 @@ import org.slf4j.LoggerFactory;
  *
  * <p>By default, this group supports the {@link NodeIds#RsaSha256ApplicationCertificateType}
  * CertificateType, which can be used with 2048- and 4096-bit RSA keys. Callers can configure
- * additional certificate type IDs when a server manages multiple application identities.
+ * additional certificate type IDs and an application-defined group ID.
+ *
+ * <p>Construction does not initialize the group. Call {@link #initialize()} to create material for
+ * missing certificate types, or leave the group uninitialized when an external authority supplies
+ * its certificates.
  */
 public class DefaultApplicationGroup implements CertificateGroup {
 
@@ -36,6 +41,7 @@ public class DefaultApplicationGroup implements CertificateGroup {
 
   private final AtomicBoolean initialized = new AtomicBoolean(false);
 
+  private final NodeId certificateGroupId;
   private final CertificateValidator certificateValidator;
 
   private final TrustListManager trustListManager;
@@ -58,11 +64,11 @@ public class DefaultApplicationGroup implements CertificateGroup {
       CertificateValidator certificateValidator) {
 
     this(
+        NodeIds.ServerConfiguration_CertificateGroups_DefaultApplicationGroup,
         trustListManager,
         certificateStore,
         certificateFactory,
-        certificateValidator,
-        List.of(NodeIds.RsaSha256ApplicationCertificateType));
+        certificateValidator);
   }
 
   /**
@@ -82,6 +88,60 @@ public class DefaultApplicationGroup implements CertificateGroup {
       CertificateValidator certificateValidator,
       List<NodeId> supportedCertificateTypeIds) {
 
+    this(
+        NodeIds.ServerConfiguration_CertificateGroups_DefaultApplicationGroup,
+        trustListManager,
+        certificateStore,
+        certificateFactory,
+        certificateValidator,
+        supportedCertificateTypeIds);
+  }
+
+  /**
+   * Create an application-defined group for RSA SHA-256 application certificates.
+   *
+   * @param certificateGroupId the {@link NodeId} identifying this group.
+   * @param trustListManager the {@link TrustListManager} for this group.
+   * @param certificateStore the {@link CertificateStore} for local certificate material.
+   * @param certificateFactory the {@link CertificateFactory} for missing certificates.
+   * @param certificateValidator the {@link CertificateValidator} for remote certificates.
+   */
+  public DefaultApplicationGroup(
+      NodeId certificateGroupId,
+      TrustListManager trustListManager,
+      CertificateStore certificateStore,
+      CertificateFactory certificateFactory,
+      CertificateValidator certificateValidator) {
+
+    this(
+        certificateGroupId,
+        trustListManager,
+        certificateStore,
+        certificateFactory,
+        certificateValidator,
+        List.of(NodeIds.RsaSha256ApplicationCertificateType));
+  }
+
+  /**
+   * Create an application-defined group for the configured certificate type IDs.
+   *
+   * @param certificateGroupId the {@link NodeId} identifying this group.
+   * @param trustListManager the {@link TrustListManager} for this group.
+   * @param certificateStore the {@link CertificateStore} for local certificate material.
+   * @param certificateFactory the {@link CertificateFactory} for missing certificates.
+   * @param certificateValidator the {@link CertificateValidator} for remote certificates.
+   * @param supportedCertificateTypeIds the certificate type IDs this group supports.
+   * @throws IllegalArgumentException if {@code supportedCertificateTypeIds} is empty.
+   */
+  public DefaultApplicationGroup(
+      NodeId certificateGroupId,
+      TrustListManager trustListManager,
+      CertificateStore certificateStore,
+      CertificateFactory certificateFactory,
+      CertificateValidator certificateValidator,
+      List<NodeId> supportedCertificateTypeIds) {
+
+    this.certificateGroupId = Objects.requireNonNull(certificateGroupId, "certificateGroupId");
     this.trustListManager = trustListManager;
     this.certificateStore = certificateStore;
     this.certificateFactory = certificateFactory;
@@ -118,7 +178,7 @@ public class DefaultApplicationGroup implements CertificateGroup {
 
   @Override
   public NodeId getCertificateGroupId() {
-    return NodeIds.ServerConfiguration_CertificateGroups_DefaultApplicationGroup;
+    return certificateGroupId;
   }
 
   @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/DefaultApplicationGroup.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/DefaultApplicationGroup.java
@@ -16,7 +16,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicBoolean;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
@@ -25,21 +24,43 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Default OPC UA application certificate group backed by a {@link CertificateStore}.
+ * OPC UA application certificate group backed by a {@link CertificateStore}.
+ *
+ * <p>The group reads and writes its {@link CertificateStore} directly and has no lifecycle of its
+ * own: it is usable as soon as it is constructed, and it exposes whatever certificate material the
+ * store holds for its supported certificate types.
+ *
+ * <p>When the store is missing material for a supported certificate type, {@link
+ * #createMissingCertificates()} uses the {@link CertificateFactory} to generate it. This is a
+ * convenience for applications that want Milo to bootstrap a self-signed identity. Applications
+ * whose certificates are provisioned externally, for example by a GDS or deployment tooling, never
+ * need to call it.
  *
  * <p>By default, this group supports the {@link NodeIds#RsaSha256ApplicationCertificateType}
  * CertificateType, which can be used with 2048- and 4096-bit RSA keys. Callers can configure
  * additional certificate type IDs and an application-defined group ID.
  *
- * <p>Construction does not initialize the group. Call {@link #initialize()} to create material for
- * missing certificate types, or leave the group uninitialized when an external authority supplies
- * its certificates.
+ * <p>Example, bootstrapping a self-signed identity when the store is empty:
+ *
+ * <pre>{@code
+ * var group =
+ *     new DefaultApplicationGroup(
+ *         trustListManager, certificateStore, certificateFactory, certificateValidator);
+ *
+ * group.createMissingCertificates();
+ * }</pre>
+ *
+ * <p>Example, using material an external authority has already placed in the store:
+ *
+ * <pre>{@code
+ * var group =
+ *     new DefaultApplicationGroup(
+ *         trustListManager, certificateStore, certificateFactory, certificateValidator);
+ * }</pre>
  */
 public class DefaultApplicationGroup implements CertificateGroup {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultApplicationGroup.class);
-
-  private final AtomicBoolean initialized = new AtomicBoolean(false);
 
   private final NodeId certificateGroupId;
   private final CertificateValidator certificateValidator;
@@ -153,15 +174,23 @@ public class DefaultApplicationGroup implements CertificateGroup {
     }
   }
 
-  public synchronized void initialize() throws Exception {
-    if (initialized.get()) {
-      return;
-    }
+  /**
+   * Create certificate material for every supported certificate type the {@link CertificateStore}
+   * is missing.
+   *
+   * <p>For each missing type, the {@link CertificateFactory} creates a key pair and certificate
+   * chain, which are then stored. Types that already have an entry are left untouched. The call is
+   * idempotent and may be repeated, for example after a failure or after an entry has been removed
+   * from the store.
+   *
+   * @return the certificate type IDs for which material was created, in supported-type order; empty
+   *     if the store already held every supported type.
+   * @throws Exception if the store or the factory fails for any certificate type. Material created
+   *     for earlier types before the failure remains in the store.
+   */
+  public synchronized List<NodeId> createMissingCertificates() throws Exception {
+    var created = new ArrayList<NodeId>();
 
-    // Only latch the initialized flag after every configured certificate type has been
-    // successfully created/stored. If a later type fails (e.g. a factory throwing
-    // Bad_NotSupported for an ECC hook), the flag stays false so initialize() can be retried
-    // rather than leaving the group permanently half-initialized.
     for (NodeId certificateTypeId : getSupportedCertificateTypeIds()) {
       if (!certificateStore.contains(certificateTypeId)) {
         KeyPair keyPair = certificateFactory.createKeyPair(certificateTypeId);
@@ -170,10 +199,24 @@ public class DefaultApplicationGroup implements CertificateGroup {
 
         certificateStore.set(
             certificateTypeId, new CertificateStore.Entry(keyPair.getPrivate(), certificateChain));
+
+        created.add(certificateTypeId);
       }
     }
 
-    initialized.set(true);
+    return List.copyOf(created);
+  }
+
+  /**
+   * Create certificate material for every supported certificate type the store is missing.
+   *
+   * @throws Exception if the store or the factory fails for any certificate type.
+   * @deprecated use {@link #createMissingCertificates()}. The group has no initialization step;
+   *     this method only creates missing certificate material.
+   */
+  @Deprecated
+  public void initialize() throws Exception {
+    createMissingCertificates();
   }
 
   @Override
@@ -275,15 +318,20 @@ public class DefaultApplicationGroup implements CertificateGroup {
   }
 
   /**
-   * Create and initialize a {@link DefaultApplicationGroup}.
+   * Create a default application group and create any certificate material the store is missing.
    *
    * @param trustListManager the {@link TrustListManager} to use.
    * @param certificateStore the {@link CertificateStore} to use.
    * @param certificateFactory the {@link CertificateFactory} to use.
    * @param certificateValidator the {@link CertificateValidator} to use.
-   * @return an initialized {@link DefaultApplicationGroup} instance.
-   * @throws Exception if an error occurs while initializing the {@link DefaultApplicationGroup}.
+   * @return a {@link DefaultApplicationGroup} whose store holds material for every supported
+   *     certificate type.
+   * @throws Exception if creating or storing missing certificate material fails.
+   * @deprecated construct the group directly, then call {@link #createMissingCertificates()} if
+   *     Milo should generate material the store is missing. Omit that call when certificates are
+   *     provisioned externally.
    */
+  @Deprecated
   public static DefaultApplicationGroup createAndInitialize(
       TrustListManager trustListManager,
       CertificateStore certificateStore,
@@ -300,16 +348,21 @@ public class DefaultApplicationGroup implements CertificateGroup {
   }
 
   /**
-   * Create and initialize a {@link DefaultApplicationGroup}.
+   * Create a default application group and create any certificate material the store is missing.
    *
    * @param trustListManager the {@link TrustListManager} to use.
    * @param certificateStore the {@link CertificateStore} to use.
    * @param certificateFactory the {@link CertificateFactory} to use.
    * @param certificateValidator the {@link CertificateValidator} to use.
    * @param supportedCertificateTypeIds the certificate type IDs this group supports.
-   * @return an initialized {@link DefaultApplicationGroup} instance.
-   * @throws Exception if an error occurs while initializing the {@link DefaultApplicationGroup}.
+   * @return a {@link DefaultApplicationGroup} whose store holds material for every supported
+   *     certificate type.
+   * @throws Exception if creating or storing missing certificate material fails.
+   * @deprecated construct the group directly, then call {@link #createMissingCertificates()} if
+   *     Milo should generate material the store is missing. Omit that call when certificates are
+   *     provisioned externally.
    */
+  @Deprecated
   public static DefaultApplicationGroup createAndInitialize(
       TrustListManager trustListManager,
       CertificateStore certificateStore,
@@ -318,7 +371,7 @@ public class DefaultApplicationGroup implements CertificateGroup {
       List<NodeId> supportedCertificateTypeIds)
       throws Exception {
 
-    var defaultApplicationGroup =
+    var group =
         new DefaultApplicationGroup(
             trustListManager,
             certificateStore,
@@ -326,8 +379,8 @@ public class DefaultApplicationGroup implements CertificateGroup {
             certificateValidator,
             supportedCertificateTypeIds);
 
-    defaultApplicationGroup.initialize();
+    group.createMissingCertificates();
 
-    return defaultApplicationGroup;
+    return group;
   }
 }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/DefaultCertificateManager.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/DefaultCertificateManager.java
@@ -23,6 +23,14 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.util.CertificateUtil;
 
+/**
+ * A thread-safe, mutable registry of application-owned {@link CertificateGroup}s.
+ *
+ * <p>Adding a group atomically replaces any group with the same ID. Removing or replacing a group
+ * does not initialize or close it; the application remains responsible for the lifecycle of every
+ * group and its resources. Registry changes do not wait for aggregate lookups already in progress,
+ * and each lookup remains bound to the group instance it observed.
+ */
 public class DefaultCertificateManager implements CertificateManager {
 
   private final Map<NodeId, CertificateGroup> certificateGroups = new ConcurrentHashMap<>();
@@ -42,32 +50,53 @@ public class DefaultCertificateManager implements CertificateManager {
       CertificateQuarantine certificateQuarantine, Collection<CertificateGroup> groups) {
     this.certificateQuarantine = certificateQuarantine;
 
-    groups.forEach(g -> certificateGroups.put(g.getCertificateGroupId(), g));
+    groups.forEach(this::addCertificateGroup);
+  }
+
+  /**
+   * Add a {@link CertificateGroup} to this manager.
+   *
+   * <p>If a group with the same ID is already registered, it is atomically replaced and returned
+   * without being closed.
+   *
+   * @param group the application-owned group to add.
+   * @return the replaced group, or empty if the ID was not registered.
+   */
+  public Optional<CertificateGroup> addCertificateGroup(CertificateGroup group) {
+    return Optional.ofNullable(certificateGroups.put(group.getCertificateGroupId(), group));
+  }
+
+  /**
+   * Remove a {@link CertificateGroup} from this manager.
+   *
+   * <p>The removed group is returned without being closed.
+   *
+   * @param certificateGroupId the ID of the group to remove.
+   * @return the removed group, or empty if the ID was not registered.
+   */
+  public Optional<CertificateGroup> removeCertificateGroup(NodeId certificateGroupId) {
+    return Optional.ofNullable(certificateGroups.remove(certificateGroupId));
   }
 
   @Override
   public Optional<KeyPair> getKeyPair(ByteString thumbprint) {
     return firstMatchingEntry(thumbprint)
-        .flatMap(
-            entry -> {
-              Optional<CertificateGroup> group = getCertificateGroup(entry.certificateGroupId);
-              return group.flatMap(g -> g.getKeyPair(entry.certificateTypeId));
-            });
+        .flatMap(match -> match.group.getKeyPair(match.entry.certificateTypeId));
   }
 
   @Override
   public Optional<X509Certificate> getCertificate(ByteString thumbprint) {
-    return firstMatchingEntry(thumbprint).map(e -> e.certificateChain[0]);
+    return firstMatchingEntry(thumbprint).map(match -> match.entry.certificateChain[0]);
   }
 
   @Override
   public Optional<X509Certificate[]> getCertificateChain(ByteString thumbprint) {
-    return firstMatchingEntry(thumbprint).map(e -> e.certificateChain);
+    return firstMatchingEntry(thumbprint).map(match -> match.entry.certificateChain);
   }
 
   @Override
   public Optional<CertificateGroup> getCertificateGroup(ByteString thumbprint) {
-    return firstMatchingEntry(thumbprint).flatMap(r -> getCertificateGroup(r.certificateGroupId));
+    return firstMatchingEntry(thumbprint).map(MatchedEntry::group);
   }
 
   @Override
@@ -85,17 +114,22 @@ public class DefaultCertificateManager implements CertificateManager {
     return certificateQuarantine;
   }
 
-  private Optional<Entry> firstMatchingEntry(ByteString thumbprint) {
+  private Optional<MatchedEntry> firstMatchingEntry(ByteString thumbprint) {
     return certificateGroups.values().stream()
-        .flatMap(group -> group.getCertificateEntries().stream())
+        .flatMap(
+            group ->
+                group.getCertificateEntries().stream().map(entry -> new MatchedEntry(group, entry)))
         .filter(
-            entry -> {
+            match -> {
               try {
-                return CertificateUtil.thumbprint(entry.certificateChain[0]).equals(thumbprint);
+                return CertificateUtil.thumbprint(match.entry.certificateChain[0])
+                    .equals(thumbprint);
               } catch (UaException e) {
                 return false;
               }
             })
         .findFirst();
   }
+
+  private record MatchedEntry(CertificateGroup group, Entry entry) {}
 }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/KeyStoreCertificateStore.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/KeyStoreCertificateStore.java
@@ -31,9 +31,12 @@ import java.security.PrivateKey;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
@@ -44,15 +47,36 @@ import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * A PKCS#12-backed {@link CertificateStore}.
+ *
+ * <p>After {@link #initialize()} returns, operations on one instance are serialized. Before each
+ * {@link #set(NodeId, Entry)} or {@link #remove(NodeId)}, the store re-reads the on-disk KeyStore,
+ * so entries written by another owner before that read begins are preserved. Writes by other store
+ * instances or processes are not coordinated; overlapping read-modify-replace operations are
+ * last-replacement-wins.
+ */
 public class KeyStoreCertificateStore implements CertificateStore, Closeable {
 
-  protected static final String RSA_SHA256_ALIAS = "server-rsa-sha256";
-  protected static final String ECC_NIST_P256_ALIAS = "server-ecc-nistp256";
-  protected static final String ECC_NIST_P384_ALIAS = "server-ecc-nistp384";
-  protected static final String ECC_BRAINPOOL_P256R1_ALIAS = "server-ecc-brainpoolp256r1";
-  protected static final String ECC_BRAINPOOL_P384R1_ALIAS = "server-ecc-brainpoolp384r1";
-  protected static final String ECC_CURVE25519_ALIAS = "server-ecc-curve25519";
-  protected static final String ECC_CURVE448_ALIAS = "server-ecc-curve448";
+  private static final String DEFAULT_ALIAS_PREFIX = "server-";
+
+  /**
+   * Alias suffixes for the standard application certificate types, in the order they are preloaded.
+   * Custom certificate types use {@link NodeId#toParseableString()} as their alias.
+   */
+  private static final Map<NodeId, String> ALIAS_SUFFIXES;
+
+  static {
+    var suffixes = new LinkedHashMap<NodeId, String>();
+    suffixes.put(NodeIds.RsaSha256ApplicationCertificateType, "rsa-sha256");
+    suffixes.put(NodeIds.EccNistP256ApplicationCertificateType, "ecc-nistp256");
+    suffixes.put(NodeIds.EccNistP384ApplicationCertificateType, "ecc-nistp384");
+    suffixes.put(NodeIds.EccBrainpoolP256r1ApplicationCertificateType, "ecc-brainpoolp256r1");
+    suffixes.put(NodeIds.EccBrainpoolP384r1ApplicationCertificateType, "ecc-brainpoolp384r1");
+    suffixes.put(NodeIds.EccCurve25519ApplicationCertificateType, "ecc-curve25519");
+    suffixes.put(NodeIds.EccCurve448ApplicationCertificateType, "ecc-curve448");
+    ALIAS_SUFFIXES = Collections.unmodifiableMap(suffixes);
+  }
 
   private final Logger logger = LoggerFactory.getLogger(getClass());
 
@@ -76,14 +100,10 @@ public class KeyStoreCertificateStore implements CertificateStore, Closeable {
     if (initialized.compareAndSet(false, true)) {
       logger.info("Loading KeyStore at {}", settings.keyStorePath);
 
-      keyStore = KeyStore.getInstance("pkcs12");
-
       File keyStoreFile = settings.keyStorePath.toAbsolutePath().toFile();
 
       if (keyStoreFile.exists()) {
-        try (var inputStream = new FileInputStream(keyStoreFile)) {
-          keyStore.load(inputStream, settings.getKeyStorePassword.get());
-        }
+        keyStore = loadKeyStore(keyStoreFile.toPath());
 
         try {
           keyStoreLock.lock();
@@ -93,6 +113,7 @@ public class KeyStoreCertificateStore implements CertificateStore, Closeable {
           keyStoreLock.unlock();
         }
       } else {
+        keyStore = KeyStore.getInstance("pkcs12");
         keyStore.load(null, settings.getKeyStorePassword.get());
 
         storeKeyStore();
@@ -179,6 +200,8 @@ public class KeyStoreCertificateStore implements CertificateStore, Closeable {
       String alias = getAlias(certificateTypeId);
 
       if (alias != null) {
+        reloadBeforeWrite();
+
         char[] password = settings.getAliasPassword.apply(alias);
 
         KeyStore.Entry entry = keyStore.getEntry(alias, new KeyStore.PasswordProtection(password));
@@ -223,6 +246,8 @@ public class KeyStoreCertificateStore implements CertificateStore, Closeable {
         return;
       }
 
+      reloadBeforeWrite();
+
       char[] password = settings.getAliasPassword.apply(alias);
 
       KeyStore.Entry previousEntry =
@@ -253,23 +278,9 @@ public class KeyStoreCertificateStore implements CertificateStore, Closeable {
    *     {@code null} if the certificate type is not supported.
    */
   protected @Nullable String getAlias(NodeId certificateTypeId) {
-    if (certificateTypeId.equals(NodeIds.RsaSha256ApplicationCertificateType)) {
-      return RSA_SHA256_ALIAS;
-    } else if (certificateTypeId.equals(NodeIds.EccNistP256ApplicationCertificateType)) {
-      return ECC_NIST_P256_ALIAS;
-    } else if (certificateTypeId.equals(NodeIds.EccNistP384ApplicationCertificateType)) {
-      return ECC_NIST_P384_ALIAS;
-    } else if (certificateTypeId.equals(NodeIds.EccBrainpoolP256r1ApplicationCertificateType)) {
-      return ECC_BRAINPOOL_P256R1_ALIAS;
-    } else if (certificateTypeId.equals(NodeIds.EccBrainpoolP384r1ApplicationCertificateType)) {
-      return ECC_BRAINPOOL_P384R1_ALIAS;
-    } else if (certificateTypeId.equals(NodeIds.EccCurve25519ApplicationCertificateType)) {
-      return ECC_CURVE25519_ALIAS;
-    } else if (certificateTypeId.equals(NodeIds.EccCurve448ApplicationCertificateType)) {
-      return ECC_CURVE448_ALIAS;
-    } else {
-      return certificateTypeId.toParseableString();
-    }
+    String suffix = ALIAS_SUFFIXES.get(certificateTypeId);
+
+    return suffix != null ? settings.aliasPrefix + suffix : certificateTypeId.toParseableString();
   }
 
   /**
@@ -289,14 +300,7 @@ public class KeyStoreCertificateStore implements CertificateStore, Closeable {
    * @return the certificate type IDs to load eagerly.
    */
   protected List<NodeId> getPreloadedCertificateTypeIds() {
-    return List.of(
-        NodeIds.RsaSha256ApplicationCertificateType,
-        NodeIds.EccNistP256ApplicationCertificateType,
-        NodeIds.EccNistP384ApplicationCertificateType,
-        NodeIds.EccBrainpoolP256r1ApplicationCertificateType,
-        NodeIds.EccBrainpoolP384r1ApplicationCertificateType,
-        NodeIds.EccCurve25519ApplicationCertificateType,
-        NodeIds.EccCurve448ApplicationCertificateType);
+    return List.copyOf(ALIAS_SUFFIXES.keySet());
   }
 
   private Entry loadEntry(String alias, Key key) throws Exception {
@@ -316,6 +320,37 @@ public class KeyStoreCertificateStore implements CertificateStore, Closeable {
     } else {
       return null;
     }
+  }
+
+  /**
+   * Re-read the on-disk KeyStore immediately before a mutation.
+   *
+   * <p>This method must be called while {@link #keyStoreLock} is held. Replacing the in-memory
+   * KeyStore with the fresh snapshot preserves every alias already committed by another owner,
+   * including entries whose passwords are not available to this store.
+   */
+  private void reloadBeforeWrite() throws Exception {
+    Path keyStorePath = resolveKeyStorePath();
+
+    // A missing file has nothing to merge; storeKeyStore() recreates it from memory.
+    if (Files.exists(keyStorePath)) {
+      keyStore = loadKeyStore(keyStorePath);
+
+      // Cached entries may be stale relative to the fresh snapshot. get() refills the cache
+      // lazily rather than loading every alias here, so an unreadable foreign entry under one of
+      // this store's aliases cannot fail an unrelated write.
+      entries.clear();
+    }
+  }
+
+  private KeyStore loadKeyStore(Path keyStorePath) throws Exception {
+    KeyStore loaded = KeyStore.getInstance("pkcs12");
+
+    try (var inputStream = new FileInputStream(keyStorePath.toFile())) {
+      loaded.load(inputStream, settings.getKeyStorePassword.get());
+    }
+
+    return loaded;
   }
 
   /**
@@ -504,15 +539,9 @@ public class KeyStoreCertificateStore implements CertificateStore, Closeable {
    */
   void reload(Path keyStorePath) {
     try {
-      KeyStore reloaded = KeyStore.getInstance("pkcs12");
-
-      try (var inputStream = new FileInputStream(keyStorePath.toFile())) {
-        reloaded.load(inputStream, settings.getKeyStorePassword.get());
-      }
-
       keyStoreLock.lock();
       try {
-        keyStore = reloaded;
+        keyStore = loadKeyStore(keyStorePath);
 
         entries.clear();
         loadEntries();
@@ -545,6 +574,7 @@ public class KeyStoreCertificateStore implements CertificateStore, Closeable {
     public final Path keyStorePath;
     public final Supplier<char[]> getKeyStorePassword;
     public final Function<String, char[]> getAliasPassword;
+    public final String aliasPrefix;
     public final boolean watchForChanges;
 
     public Settings(
@@ -561,9 +591,54 @@ public class KeyStoreCertificateStore implements CertificateStore, Closeable {
         Function<String, char[]> getAliasPassword,
         boolean watchForChanges) {
 
+      this(
+          keyStorePath,
+          getKeyStorePassword,
+          getAliasPassword,
+          DEFAULT_ALIAS_PREFIX,
+          watchForChanges);
+    }
+
+    /**
+     * Create settings with a custom prefix for standard certificate type aliases.
+     *
+     * @param keyStorePath the path of the PKCS#12 KeyStore.
+     * @param getKeyStorePassword the supplier for the KeyStore password.
+     * @param getAliasPassword the function that supplies each entry password.
+     * @param aliasPrefix the prefix for standard application certificate aliases.
+     */
+    public Settings(
+        Path keyStorePath,
+        Supplier<char[]> getKeyStorePassword,
+        Function<String, char[]> getAliasPassword,
+        String aliasPrefix) {
+
+      this(keyStorePath, getKeyStorePassword, getAliasPassword, aliasPrefix, false);
+    }
+
+    /**
+     * Create settings with a custom alias prefix and optional external-change watching.
+     *
+     * <p>Watching makes completed external writes visible to reads. It does not serialize writes by
+     * separate store instances or processes.
+     *
+     * @param keyStorePath the path of the PKCS#12 KeyStore.
+     * @param getKeyStorePassword the supplier for the KeyStore password.
+     * @param getAliasPassword the function that supplies each entry password.
+     * @param aliasPrefix the prefix for standard application certificate aliases.
+     * @param watchForChanges whether to watch the KeyStore file for external changes.
+     */
+    public Settings(
+        Path keyStorePath,
+        Supplier<char[]> getKeyStorePassword,
+        Function<String, char[]> getAliasPassword,
+        String aliasPrefix,
+        boolean watchForChanges) {
+
       this.keyStorePath = keyStorePath;
       this.getKeyStorePassword = getKeyStorePassword;
       this.getAliasPassword = getAliasPassword;
+      this.aliasPrefix = Objects.requireNonNull(aliasPrefix, "aliasPrefix");
       this.watchForChanges = watchForChanges;
     }
   }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/package-info.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/package-info.java
@@ -83,6 +83,12 @@
  * file. Separate store instances and processes do not share a write lock, so applications must
  * coordinate writes that overlap.
  *
+ * <p>{@link org.eclipse.milo.opcua.stack.core.security.DefaultCertificateManager} provides a
+ * thread-safe mutable group registry. Applications own the groups and their backing stores and
+ * trust-list managers. Removing or replacing a group returns it to the application without closing
+ * its resources, so the application must coordinate final closure with any lookups already in
+ * progress.
+ *
  * <h2>Runtime boundaries</h2>
  *
  * <p>Endpoint advertisement and SecureChannel creation should combine certificate availability,

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/package-info.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/package-info.java
@@ -77,6 +77,12 @@
  * profile-specific certificate type, public key, and key-usage checks used before an identity is
  * advertised or selected for a secured connection.
  *
+ * <p>{@link org.eclipse.milo.opcua.stack.core.security.KeyStoreCertificateStore} persists local
+ * identities with a read-modify-replace boundary. Each mutation incorporates KeyStore entries
+ * committed before its disk read, including application-owned aliases, then atomically replaces the
+ * file. Separate store instances and processes do not share a write lock, so applications must
+ * coordinate writes that overlap.
+ *
  * <h2>Runtime boundaries</h2>
  *
  * <p>Endpoint advertisement and SecureChannel creation should combine certificate availability,

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/security/DefaultApplicationGroupTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/security/DefaultApplicationGroupTest.java
@@ -76,7 +76,7 @@ class DefaultApplicationGroupTest {
             new CertificateValidator.InsecureCertificateValidator(),
             certificateTypeIds);
 
-    group.initialize();
+    group.createMissingCertificates();
 
     assertEquals(certificateTypeIds, group.getSupportedCertificateTypeIds());
     assertEquals(5, group.getCertificateEntries().size());
@@ -162,7 +162,7 @@ class DefaultApplicationGroupTest {
                 NodeIds.RsaSha256ApplicationCertificateType,
                 NodeIds.EccNistP256ApplicationCertificateType));
 
-    group.initialize();
+    group.createMissingCertificates();
 
     // Arm the failure only after initialization has populated the store.
     store.failGet = true;
@@ -175,10 +175,11 @@ class DefaultApplicationGroupTest {
     assertFalse(group.getKeyPair(NodeIds.EccNistP256ApplicationCertificateType).isPresent());
   }
 
-  // A failure partway through initialize() must leave the group retryable rather than latched as
-  // a silent permanent no-op; otherwise a transient store/factory error would require a restart.
+  // A failure partway through createMissingCertificates() must leave the group retryable rather
+  // than latched as a silent permanent no-op; otherwise a transient store/factory error would
+  // require a restart.
   @Test
-  void initializeIsRetryableAfterFailure() throws Exception {
+  void createMissingCertificatesIsRetryableAfterFailure() throws Exception {
     var store = new FailingSetCertificateStore(NodeIds.EccNistP256ApplicationCertificateType);
     DefaultApplicationGroup group =
         new DefaultApplicationGroup(
@@ -191,14 +192,84 @@ class DefaultApplicationGroupTest {
                 NodeIds.EccNistP256ApplicationCertificateType));
 
     store.failSet = true;
-    assertThrows(RuntimeException.class, group::initialize);
+    assertThrows(RuntimeException.class, group::createMissingCertificates);
 
     // Clear the fault and retry; the second call must do the work rather than no-op.
     store.failSet = false;
-    group.initialize();
+    List<NodeId> created = group.createMissingCertificates();
 
+    assertEquals(
+        List.of(NodeIds.EccNistP256ApplicationCertificateType),
+        created,
+        "only the type that failed the first time should be created on retry");
     assertEquals(2, group.getCertificateEntries().size());
     assertTrue(group.getKeyPair(NodeIds.RsaSha256ApplicationCertificateType).isPresent());
+    assertTrue(group.getKeyPair(NodeIds.EccNistP256ApplicationCertificateType).isPresent());
+  }
+
+  // Externally provisioned material must survive createMissingCertificates(): the factory only
+  // fills gaps, so an application that mixes a GDS-issued RSA identity with a Milo-generated ECC
+  // identity keeps the GDS-issued one, and the return value tells the caller what was generated.
+  @Test
+  void createMissingCertificatesReportsOnlyTypesItCreatedAndKeepsExistingEntries()
+      throws Exception {
+    var certificateStore = new MemoryCertificateStore();
+    var certificateFactory = new CurrentEccCertificateFactory();
+    KeyPair keyPair = certificateFactory.createRsaSha256KeyPair();
+    X509Certificate[] certificateChain =
+        certificateFactory.createRsaSha256CertificateChain(keyPair);
+    certificateStore.set(
+        NodeIds.RsaSha256ApplicationCertificateType,
+        new CertificateStore.Entry(keyPair.getPrivate(), certificateChain));
+
+    DefaultApplicationGroup group =
+        new DefaultApplicationGroup(
+            new MemoryTrustListManager(),
+            certificateStore,
+            certificateFactory,
+            new CertificateValidator.InsecureCertificateValidator(),
+            List.of(
+                NodeIds.RsaSha256ApplicationCertificateType,
+                NodeIds.EccNistP256ApplicationCertificateType));
+
+    List<NodeId> created = group.createMissingCertificates();
+
+    assertEquals(List.of(NodeIds.EccNistP256ApplicationCertificateType), created);
+    assertSame(
+        certificateChain,
+        group.getCertificateChain(NodeIds.RsaSha256ApplicationCertificateType).orElseThrow(),
+        "pre-existing entry must not be replaced");
+    assertTrue(group.getKeyPair(NodeIds.EccNistP256ApplicationCertificateType).isPresent());
+
+    assertEquals(
+        List.of(),
+        group.createMissingCertificates(),
+        "nothing is missing on the second call, so nothing should be created");
+  }
+
+  // A group is a view over its store, not a lifecycle: if an entry disappears after the first
+  // call (a KeyStore reload, an application removing it), a later call must re-create it rather
+  // than treat the group as already provisioned.
+  @Test
+  void createMissingCertificatesRecreatesEntryRemovedFromStore() throws Exception {
+    var certificateStore = new MemoryCertificateStore();
+    DefaultApplicationGroup group =
+        new DefaultApplicationGroup(
+            new MemoryTrustListManager(),
+            certificateStore,
+            new CurrentEccCertificateFactory(),
+            new CertificateValidator.InsecureCertificateValidator(),
+            List.of(
+                NodeIds.RsaSha256ApplicationCertificateType,
+                NodeIds.EccNistP256ApplicationCertificateType));
+
+    group.createMissingCertificates();
+    certificateStore.remove(NodeIds.EccNistP256ApplicationCertificateType);
+    assertFalse(group.getKeyPair(NodeIds.EccNistP256ApplicationCertificateType).isPresent());
+
+    List<NodeId> created = group.createMissingCertificates();
+
+    assertEquals(List.of(NodeIds.EccNistP256ApplicationCertificateType), created);
     assertTrue(group.getKeyPair(NodeIds.EccNistP256ApplicationCertificateType).isPresent());
   }
 

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/security/DefaultApplicationGroupTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/security/DefaultApplicationGroupTest.java
@@ -12,6 +12,7 @@ package org.eclipse.milo.opcua.stack.core.security;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -29,6 +30,20 @@ import org.junit.jupiter.api.Test;
 
 @NullMarked
 class DefaultApplicationGroupTest {
+
+  @Test
+  void legacyConstructorUsesDefaultApplicationGroupId() {
+    DefaultApplicationGroup group =
+        new DefaultApplicationGroup(
+            new MemoryTrustListManager(),
+            new MemoryCertificateStore(),
+            new TestCertificateFactory(),
+            new CertificateValidator.InsecureCertificateValidator());
+
+    assertEquals(
+        NodeIds.ServerConfiguration_CertificateGroups_DefaultApplicationGroup,
+        group.getCertificateGroupId());
+  }
 
   @Test
   void defaultConstructorSupportsRsaSha256Only() {
@@ -80,6 +95,35 @@ class DefaultApplicationGroupTest {
         group.getCertificateChain(NodeIds.EccCurve25519ApplicationCertificateType).isPresent());
     assertTrue(
         group.getCertificateChain(NodeIds.EccCurve448ApplicationCertificateType).isPresent());
+  }
+
+  // Externally issued material must be usable under an application-defined group ID without
+  // initialize() generating a replacement certificate first.
+  @Test
+  void customGroupAcceptsExternallyIssuedCertificateWithoutInitialization() throws Exception {
+    var certificateGroupId = new NodeId(2, "gds-managed");
+    var certificateStore = new MemoryCertificateStore();
+    var certificateFactory = new TestCertificateFactory();
+    KeyPair keyPair = certificateFactory.createRsaSha256KeyPair();
+    X509Certificate[] certificateChain =
+        certificateFactory.createRsaSha256CertificateChain(keyPair);
+    certificateStore.set(
+        NodeIds.RsaSha256ApplicationCertificateType,
+        new CertificateStore.Entry(keyPair.getPrivate(), certificateChain));
+
+    DefaultApplicationGroup group =
+        new DefaultApplicationGroup(
+            certificateGroupId,
+            new MemoryTrustListManager(),
+            certificateStore,
+            certificateFactory,
+            new CertificateValidator.InsecureCertificateValidator(),
+            List.of(NodeIds.RsaSha256ApplicationCertificateType));
+
+    List<Entry> entries = group.getCertificateEntries();
+    assertEquals(1, entries.size());
+    assertEquals(certificateGroupId, entries.get(0).certificateGroupId);
+    assertSame(certificateChain, entries.get(0).certificateChain);
   }
 
   @Test

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/security/DefaultCertificateManagerTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/security/DefaultCertificateManagerTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.core.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.security.KeyPair;
+import java.security.cert.X509Certificate;
+import java.util.List;
+import java.util.Optional;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.security.CertificateGroup.Entry;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.util.CertificateUtil;
+import org.junit.jupiter.api.Test;
+
+class DefaultCertificateManagerTest {
+
+  @Test
+  void duplicateGroupIdAtomicallyReplacesAndReturnsPreviousGroup() {
+    var groupId = new NodeId(2, "dynamic");
+    TrackingApplicationGroup original = newGroup(groupId);
+    TrackingApplicationGroup replacement = newGroup(groupId);
+    var manager = new DefaultCertificateManager(new MemoryCertificateQuarantine());
+
+    assertTrue(manager.addCertificateGroup(original).isEmpty());
+    assertSame(original, manager.getCertificateGroup(groupId).orElseThrow());
+
+    assertSame(original, manager.addCertificateGroup(replacement).orElseThrow());
+    assertSame(replacement, manager.getCertificateGroup(groupId).orElseThrow());
+    assertFalse(original.trustListManager.closed);
+  }
+
+  @Test
+  void removeReturnsGroupWithoutClosingApplicationResources() {
+    var groupId = new NodeId(2, "dynamic");
+    TrackingApplicationGroup group = newGroup(groupId);
+    var manager = new DefaultCertificateManager(new MemoryCertificateQuarantine(), group);
+
+    assertSame(group, manager.removeCertificateGroup(groupId).orElseThrow());
+    assertTrue(manager.getCertificateGroup(groupId).isEmpty());
+    assertFalse(group.trustListManager.closed);
+    assertTrue(manager.removeCertificateGroup(groupId).isEmpty());
+  }
+
+  // A replacement can overlap a thumbprint scan. The result must stay bound to the group that
+  // supplied the matching entry, not combine that entry with the replacement group's key pair.
+  @Test
+  void thumbprintLookupStaysBoundToMatchedGroupDuringReplacement() throws Exception {
+    var groupId = new NodeId(2, "dynamic");
+    GroupFixture originalFixture = newPopulatedGroup(groupId);
+    GroupFixture replacementFixture = newPopulatedGroup(groupId);
+    var manager =
+        new DefaultCertificateManager(new MemoryCertificateQuarantine(), originalFixture.group);
+    originalFixture.group.afterEntriesRead =
+        () -> manager.addCertificateGroup(replacementFixture.group);
+    ByteString thumbprint = CertificateUtil.thumbprint(originalFixture.certificateChain[0]);
+
+    Optional<KeyPair> keyPair = manager.getKeyPair(thumbprint);
+
+    assertTrue(keyPair.isPresent());
+    assertEquals(originalFixture.keyPair.getPrivate(), keyPair.orElseThrow().getPrivate());
+    assertSame(replacementFixture.group, manager.getCertificateGroup(groupId).orElseThrow());
+  }
+
+  private static TrackingApplicationGroup newGroup(NodeId groupId) {
+    return new TrackingApplicationGroup(
+        groupId,
+        new TrackingTrustListManager(),
+        new MemoryCertificateStore(),
+        new TestCertificateFactory());
+  }
+
+  private static GroupFixture newPopulatedGroup(NodeId groupId) throws Exception {
+    var certificateFactory = new TestCertificateFactory();
+    KeyPair keyPair = certificateFactory.createRsaSha256KeyPair();
+    X509Certificate[] certificateChain =
+        certificateFactory.createRsaSha256CertificateChain(keyPair);
+    var certificateStore = new MemoryCertificateStore();
+    certificateStore.set(
+        NodeIds.RsaSha256ApplicationCertificateType,
+        new CertificateStore.Entry(keyPair.getPrivate(), certificateChain));
+    var group =
+        new TrackingApplicationGroup(
+            groupId, new TrackingTrustListManager(), certificateStore, certificateFactory);
+
+    return new GroupFixture(group, keyPair, certificateChain);
+  }
+
+  private record GroupFixture(
+      TrackingApplicationGroup group, KeyPair keyPair, X509Certificate[] certificateChain) {}
+
+  private static final class TrackingApplicationGroup extends DefaultApplicationGroup {
+
+    private final TrackingTrustListManager trustListManager;
+    private Runnable afterEntriesRead = () -> {};
+
+    private TrackingApplicationGroup(
+        NodeId certificateGroupId,
+        TrackingTrustListManager trustListManager,
+        CertificateStore certificateStore,
+        CertificateFactory certificateFactory) {
+
+      super(
+          certificateGroupId,
+          trustListManager,
+          certificateStore,
+          certificateFactory,
+          new CertificateValidator.InsecureCertificateValidator());
+
+      this.trustListManager = trustListManager;
+    }
+
+    @Override
+    public List<Entry> getCertificateEntries() {
+      List<Entry> entries = super.getCertificateEntries();
+
+      afterEntriesRead.run();
+      afterEntriesRead = () -> {};
+
+      return entries;
+    }
+  }
+
+  private static final class TrackingTrustListManager extends MemoryTrustListManager {
+
+    private boolean closed;
+
+    @Override
+    public void close() {
+      closed = true;
+    }
+  }
+}

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/security/KeyStoreCertificateStoreTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/security/KeyStoreCertificateStoreTest.java
@@ -134,6 +134,62 @@ class KeyStoreCertificateStoreTest extends CertificateStoreTest {
     assertNotNull(store.get(certificateTypeId));
   }
 
+  // Application-owned entries may be committed after this store initializes. A later certificate
+  // update must merge that completed write without needing the foreign entry's password.
+  @Test
+  void setPreservesCompletedExternalChanges() throws Exception {
+    var certificateTypeId = new NodeId(2, "managed");
+    CertificateStore.Entry externalEntry = newEntry();
+
+    writeExternalEntry("application-pending", externalEntry, "external-password".toCharArray());
+
+    certificateStore.set(certificateTypeId, newEntry());
+
+    KeyStore persisted = loadKeyStore();
+    assertTrue(persisted.isKeyEntry("managed"));
+    assertNotNull(persisted.getKey("application-pending", "external-password".toCharArray()));
+  }
+
+  // An operator may delete the KeyStore file while the store is running. A write then has nothing
+  // to merge and must recreate the file from memory rather than fail.
+  @Test
+  void setRecreatesDeletedKeyStoreFile() throws Exception {
+    Files.delete(keyStorePath);
+
+    certificateStore.set(new NodeId(2, "recreated"), newEntry());
+
+    KeyStore persisted = loadKeyStore();
+    assertTrue(persisted.isKeyEntry("test"));
+    assertTrue(persisted.isKeyEntry("recreated"));
+  }
+
+  // A removal after external file deletion must update both the recreated file and the in-memory
+  // cache, or subsequent reads keep returning the deleted certificate.
+  @Test
+  void removeRecreatesDeletedKeyStoreFileWithoutLeavingStaleCacheEntry() throws Exception {
+    Files.delete(keyStorePath);
+
+    assertNotNull(certificateStore.remove(new NodeId(2, "test")));
+
+    assertFalse(certificateStore.contains(new NodeId(2, "test")));
+    assertFalse(loadKeyStore().containsAlias("test"));
+  }
+
+  // Removal is also a whole-file rewrite, so it must preserve external entries committed before
+  // the removal begins while deleting only its own target alias.
+  @Test
+  void removePreservesCompletedExternalChanges() throws Exception {
+    CertificateStore.Entry externalEntry = newEntry();
+
+    writeExternalEntry("application-pending", externalEntry, "external-password".toCharArray());
+
+    assertNotNull(certificateStore.remove(new NodeId(2, "test")));
+
+    KeyStore persisted = loadKeyStore();
+    assertFalse(persisted.containsAlias("test"));
+    assertNotNull(persisted.getKey("application-pending", "external-password".toCharArray()));
+  }
+
   @Test
   void watchEventsResolveAgainstTheWatchedDirectory() {
     Path watchedDirectory = keyStorePath.getParent();
@@ -187,26 +243,52 @@ class KeyStoreCertificateStoreTest extends CertificateStoreTest {
                 keyStorePath, "password"::toCharArray, alias -> "password".toCharArray()))) {
 
       assertEquals(
-          KeyStoreCertificateStore.RSA_SHA256_ALIAS,
-          store.getAlias(NodeIds.RsaSha256ApplicationCertificateType));
+          "server-rsa-sha256", store.getAlias(NodeIds.RsaSha256ApplicationCertificateType));
       assertEquals(
-          KeyStoreCertificateStore.ECC_NIST_P256_ALIAS,
-          store.getAlias(NodeIds.EccNistP256ApplicationCertificateType));
+          "server-ecc-nistp256", store.getAlias(NodeIds.EccNistP256ApplicationCertificateType));
       assertEquals(
-          KeyStoreCertificateStore.ECC_NIST_P384_ALIAS,
-          store.getAlias(NodeIds.EccNistP384ApplicationCertificateType));
+          "server-ecc-nistp384", store.getAlias(NodeIds.EccNistP384ApplicationCertificateType));
       assertEquals(
-          KeyStoreCertificateStore.ECC_BRAINPOOL_P256R1_ALIAS,
+          "server-ecc-brainpoolp256r1",
           store.getAlias(NodeIds.EccBrainpoolP256r1ApplicationCertificateType));
       assertEquals(
-          KeyStoreCertificateStore.ECC_BRAINPOOL_P384R1_ALIAS,
+          "server-ecc-brainpoolp384r1",
           store.getAlias(NodeIds.EccBrainpoolP384r1ApplicationCertificateType));
       assertEquals(
-          KeyStoreCertificateStore.ECC_CURVE25519_ALIAS,
-          store.getAlias(NodeIds.EccCurve25519ApplicationCertificateType));
+          "server-ecc-curve25519", store.getAlias(NodeIds.EccCurve25519ApplicationCertificateType));
       assertEquals(
-          KeyStoreCertificateStore.ECC_CURVE448_ALIAS,
-          store.getAlias(NodeIds.EccCurve448ApplicationCertificateType));
+          "server-ecc-curve448", store.getAlias(NodeIds.EccCurve448ApplicationCertificateType));
+      assertEquals(
+          new NodeId(2, "custom").toParseableString(), store.getAlias(new NodeId(2, "custom")));
+    }
+  }
+
+  @Test
+  void configuredAliasPrefixNamesStandardCertificateTypes() throws IOException {
+    try (var store =
+        new KeyStoreCertificateStore(
+            new KeyStoreCertificateStore.Settings(
+                keyStorePath,
+                "password"::toCharArray,
+                alias -> "password".toCharArray(),
+                "client-"))) {
+
+      assertEquals(
+          "client-rsa-sha256", store.getAlias(NodeIds.RsaSha256ApplicationCertificateType));
+      assertEquals(
+          "client-ecc-nistp256", store.getAlias(NodeIds.EccNistP256ApplicationCertificateType));
+      assertEquals(
+          "client-ecc-nistp384", store.getAlias(NodeIds.EccNistP384ApplicationCertificateType));
+      assertEquals(
+          "client-ecc-brainpoolp256r1",
+          store.getAlias(NodeIds.EccBrainpoolP256r1ApplicationCertificateType));
+      assertEquals(
+          "client-ecc-brainpoolp384r1",
+          store.getAlias(NodeIds.EccBrainpoolP384r1ApplicationCertificateType));
+      assertEquals(
+          "client-ecc-curve25519", store.getAlias(NodeIds.EccCurve25519ApplicationCertificateType));
+      assertEquals(
+          "client-ecc-curve448", store.getAlias(NodeIds.EccCurve448ApplicationCertificateType));
       assertEquals(
           new NodeId(2, "custom").toParseableString(), store.getAlias(new NodeId(2, "custom")));
     }
@@ -250,10 +332,7 @@ class KeyStoreCertificateStoreTest extends CertificateStoreTest {
     KeyStore keyStore = KeyStore.getInstance("pkcs12");
     keyStore.load(null, "password".toCharArray());
     keyStore.setKeyEntry(
-        KeyStoreCertificateStore.RSA_SHA256_ALIAS,
-        keyPair.getPrivate(),
-        "password".toCharArray(),
-        certificateChain);
+        "server-rsa-sha256", keyPair.getPrivate(), "password".toCharArray(), certificateChain);
 
     try (var outputStream = Files.newOutputStream(keyStorePath)) {
       keyStore.store(outputStream, "password".toCharArray());
@@ -265,7 +344,7 @@ class KeyStoreCertificateStoreTest extends CertificateStoreTest {
                 keyStorePath,
                 "password"::toCharArray,
                 alias -> {
-                  if (!KeyStoreCertificateStore.RSA_SHA256_ALIAS.equals(alias)) {
+                  if (!"server-rsa-sha256".equals(alias)) {
                     throw new AssertionError("unexpected password request for alias: " + alias);
                   }
 
@@ -338,6 +417,27 @@ class KeyStoreCertificateStoreTest extends CertificateStoreTest {
         return certificateTypeId.getIdentifier().toString();
       }
     };
+  }
+
+  private void writeExternalEntry(String alias, CertificateStore.Entry entry, char[] aliasPassword)
+      throws Exception {
+
+    KeyStore keyStore = loadKeyStore();
+    keyStore.setKeyEntry(alias, entry.privateKey, aliasPassword, entry.certificateChain);
+
+    try (var outputStream = Files.newOutputStream(keyStorePath)) {
+      keyStore.store(outputStream, "password".toCharArray());
+    }
+  }
+
+  private KeyStore loadKeyStore() throws Exception {
+    KeyStore keyStore = KeyStore.getInstance("pkcs12");
+
+    try (var inputStream = Files.newInputStream(keyStorePath)) {
+      keyStore.load(inputStream, "password".toCharArray());
+    }
+
+    return keyStore;
   }
 
   private static CertificateStore.Entry newEntry() {

--- a/opc-ua-stack/stack-tests/src/test/java/org/eclipse/milo/opcua/stack/TestCertificateManager.java
+++ b/opc-ua-stack/stack-tests/src/test/java/org/eclipse/milo/opcua/stack/TestCertificateManager.java
@@ -43,7 +43,7 @@ public class TestCertificateManager implements CertificateManager {
     this.certificate = certificate;
 
     certificateGroup =
-        DefaultApplicationGroup.createAndInitialize(
+        new DefaultApplicationGroup(
             new MemoryTrustListManager(),
             new MemoryCertificateStore(),
             new AbstractCertificateFactory() {
@@ -58,6 +58,8 @@ public class TestCertificateManager implements CertificateManager {
               }
             },
             certificateValidator);
+
+    certificateGroup.createMissingCertificates();
   }
 
   @Override

--- a/opc-ua-stack/transport/src/test/java/org/eclipse/milo/opcua/stack/transport/client/tcp/TestCertificateManager.java
+++ b/opc-ua-stack/transport/src/test/java/org/eclipse/milo/opcua/stack/transport/client/tcp/TestCertificateManager.java
@@ -45,7 +45,7 @@ public class TestCertificateManager implements CertificateManager {
     certificateThumbprint = CertificateUtil.thumbprint(certificate);
 
     certificateGroup =
-        DefaultApplicationGroup.createAndInitialize(
+        new DefaultApplicationGroup(
             new MemoryTrustListManager(),
             new MemoryCertificateStore(),
             new AbstractCertificateFactory() {
@@ -60,6 +60,8 @@ public class TestCertificateManager implements CertificateManager {
               }
             },
             certificateValidator);
+
+    certificateGroup.createMissingCertificates();
   }
 
   @Override


### PR DESCRIPTION
This makes Milo's default certificate infrastructure usable by applications that create and remove certificate groups at runtime while sharing persistent PKCS#12 storage with application-owned entries.

`KeyStoreCertificateStore` now reloads current on-disk state before each mutation, preserving completed external changes without needing passwords for foreign aliases. If the KeyStore file has been deleted out from under the store, the next write recreates it from the in-memory snapshot. Standard certificate aliases accept a configurable prefix while existing constructors continue to produce the `server-*` aliases. The per-type `protected` alias constants were removed in favor of a single alias table; subclasses should resolve aliases through `getAlias(NodeId)`. The documented boundary remains last-replacement-wins for writes that overlap across processes or store instances.

`DefaultApplicationGroup` now accepts an application-defined group `NodeId` without changing existing constructor behavior. `DefaultCertificateManager` now supports atomic add, replacement, and removal of application-owned groups. Duplicate IDs replace and return the previous group, and removal returns the group without closing its resources. Thumbprint lookups remain bound to the group instance that supplied the matching certificate when registry changes overlap a lookup.

`DefaultApplicationGroup` no longer has an initialization lifecycle. The group is a view over its `CertificateStore` and is usable as soon as it is constructed. The self-signed bootstrap step is now `createMissingCertificates()`, which returns the certificate types it generated and can be called again later, for example after an entry has been removed from the store. `initialize()` and `createAndInitialize()` remain as deprecated delegates. Applications whose certificates are provisioned externally, such as by a GDS, never need to call it.

## Verification

- `mise exec -- mvn -q -pl opc-ua-stack/stack-core test -Dtest=KeyStoreCertificateStoreTest,DefaultApplicationGroupTest,DefaultCertificateManagerTest`
- `mise exec -- mvn -q spotless:apply`
- `mise exec -- mvn -q clean compile`
- `mise exec -- mvn -q -pl opc-ua-stack/stack-core test`

Closes #1855
Closes #1851
Closes #1846
