### PR TITLE
Make trust list replacement atomic

### DIFF
--- a/docs/features/gds-client.md
+++ b/docs/features/gds-client.md
@@ -118,14 +118,14 @@ capped so a chunk fits inside the client's `EncodingLimits.getMaxMessageSize()`.
 overload exists for unusual servers.
 
 `TrustListApplier.apply` reads `SpecifiedLists` as `TrustListMasks` bits and replaces each
-specified list in the `TrustListManager` in full. Unspecified lists are copied from one current
-snapshot. Replacement rather than merging list entries is what the Pull Model calls for: each
-specified list is the complete authoritative list, and merging its entries could never remove a
-certificate the GDS dropped. All entries are decoded before the current snapshot is read, then the
-specified and retained lists are committed as one replacement. A malformed certificate or CRL
-therefore rejects the update without changing the manager, and a concurrent validator sees either
-the old snapshot or the new one when the manager provides atomic snapshot operations, as Milo's
-built-in managers do.
+specified list in the `TrustListManager` in full. Replacement rather than merging list entries is
+what the Pull Model calls for: each specified list is the complete authoritative list, and merging
+its entries could never remove a certificate the GDS dropped. All entries are decoded first, so a
+malformed certificate or CRL rejects the update without touching the manager. The decoded lists are
+then merged into the manager's current snapshot inside `TrustListManager.update`, which Milo's
+built-in managers run under their own synchronization. Unspecified lists therefore keep whatever
+value they hold at commit time, a concurrent change to one of them is not lost, and a validator
+reading `getSnapshot()` sees either the old lists or the new ones, never a mix.
 
 * * *
 

--- a/docs/features/gds-client.md
+++ b/docs/features/gds-client.md
@@ -118,12 +118,14 @@ capped so a chunk fits inside the client's `EncodingLimits.getMaxMessageSize()`.
 overload exists for unusual servers.
 
 `TrustListApplier.apply` reads `SpecifiedLists` as `TrustListMasks` bits and replaces each
-specified list in the `TrustListManager` in full (`setIssuerCertificates`,
-`setTrustedCertificates`, `setIssuerCrls`, `setTrustedCrls`, in that order). Unspecified lists are
-untouched. Replacement rather than merging is what the Pull Model calls for: each specified list
-is the complete authoritative list, and a merge could never remove a certificate the GDS dropped.
-All entries are decoded before the first replacement, so a malformed certificate or CRL rejects the
-update and leaves the manager as it was.
+specified list in the `TrustListManager` in full. Unspecified lists are copied from one current
+snapshot. Replacement rather than merging list entries is what the Pull Model calls for: each
+specified list is the complete authoritative list, and merging its entries could never remove a
+certificate the GDS dropped. All entries are decoded before the current snapshot is read, then the
+specified and retained lists are committed as one replacement. A malformed certificate or CRL
+therefore rejects the update without changing the manager, and a concurrent validator sees either
+the old snapshot or the new one when the manager provides atomic snapshot operations, as Milo's
+built-in managers do.
 
 * * *
 
@@ -239,8 +241,5 @@ server hosting the GDS namespace invokes them itself after adding the URI to its
   `Bad_MethodInvalid` or `Bad_NodeIdUnknown`.
 - `StartNewKeyPairRequest` is a thin wrapper. No helper decodes the returned PFX or PEM private
   key; prefer `StartSigningRequest` with a locally generated key pair.
-- `TrustListApplier.apply` issues four separate `set*` calls. `FileBasedTrustListManager` takes a
-  write lock per call, so a validation running concurrently can briefly see a mix of old and new
-  lists. Decoding first and applying issuer lists first bound the window.
 - KeyCredential management (Part 12 §8), AuthorizationServices (§9), and the GDS audit event types
   are covered only by their generated model classes.

--- a/opc-ua-sdk/sdk-client-gds/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/TrustListApplier.java
+++ b/opc-ua-sdk/sdk-client-gds/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/TrustListApplier.java
@@ -20,7 +20,9 @@ import java.util.List;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.security.TrustListManager;
+import org.eclipse.milo.opcua.stack.core.security.TrustListSnapshot;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.TrustListMasks;
 import org.eclipse.milo.opcua.stack.core.types.structured.TrustListDataType;
 import org.eclipse.milo.opcua.stack.core.util.CertificateUtil;
@@ -44,9 +46,8 @@ public final class TrustListApplier {
    * the certificates and CRLs it carries.
    *
    * <p>All entries are decoded before anything is replaced, so a malformed entry rejects the whole
-   * update and the manager is unchanged. Lists are replaced in the order issuer certificates,
-   * trusted certificates, issuer CRLs, trusted CRLs. The replacements are separate operations on
-   * the manager, so a validation running concurrently may briefly see a mix of old and new lists.
+   * update and the manager is unchanged. Specified lists are merged with one current snapshot and
+   * the resulting snapshot is committed in one replacement.
    *
    * @param trustList the list to apply.
    * @param manager the {@link TrustListManager} to update.
@@ -75,18 +76,22 @@ public final class TrustListApplier {
             ? decodeCrls("TrustedCrls", trustList.getTrustedCrls())
             : null;
 
-    if (issuerCertificates != null) {
-      manager.setIssuerCertificates(issuerCertificates);
+    if (issuerCertificates == null
+        && trustedCertificates == null
+        && issuerCrls == null
+        && trustedCrls == null) {
+      return;
     }
-    if (trustedCertificates != null) {
-      manager.setTrustedCertificates(trustedCertificates);
-    }
-    if (issuerCrls != null) {
-      manager.setIssuerCrls(issuerCrls);
-    }
-    if (trustedCrls != null) {
-      manager.setTrustedCrls(trustedCrls);
-    }
+
+    TrustListSnapshot current = manager.getSnapshot();
+
+    manager.replaceAll(
+        new TrustListSnapshot(
+            issuerCertificates != null ? issuerCertificates : current.issuerCertificates(),
+            issuerCrls != null ? issuerCrls : current.issuerCrls(),
+            trustedCertificates != null ? trustedCertificates : current.trustedCertificates(),
+            trustedCrls != null ? trustedCrls : current.trustedCrls(),
+            DateTime.now()));
   }
 
   /**
@@ -102,16 +107,18 @@ public final class TrustListApplier {
   public static TrustListDataType toTrustListDataType(TrustListManager manager, int masks)
       throws UaException {
 
+    TrustListSnapshot snapshot = manager.getSnapshot();
+
     return new TrustListDataType(
         uint(masks),
         isSet(masks, TrustListMasks.TrustedCertificates)
-            ? encodeCertificates(manager.getTrustedCertificates())
+            ? encodeCertificates(snapshot.trustedCertificates())
             : null,
-        isSet(masks, TrustListMasks.TrustedCrls) ? encodeCrls(manager.getTrustedCrls()) : null,
+        isSet(masks, TrustListMasks.TrustedCrls) ? encodeCrls(snapshot.trustedCrls()) : null,
         isSet(masks, TrustListMasks.IssuerCertificates)
-            ? encodeCertificates(manager.getIssuerCertificates())
+            ? encodeCertificates(snapshot.issuerCertificates())
             : null,
-        isSet(masks, TrustListMasks.IssuerCrls) ? encodeCrls(manager.getIssuerCrls()) : null);
+        isSet(masks, TrustListMasks.IssuerCrls) ? encodeCrls(snapshot.issuerCrls()) : null);
   }
 
   private static boolean isSet(int masks, TrustListMasks mask) {

--- a/opc-ua-sdk/sdk-client-gds/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/TrustListApplier.java
+++ b/opc-ua-sdk/sdk-client-gds/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/TrustListApplier.java
@@ -22,7 +22,6 @@ import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.security.TrustListManager;
 import org.eclipse.milo.opcua.stack.core.security.TrustListSnapshot;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
-import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.TrustListMasks;
 import org.eclipse.milo.opcua.stack.core.types.structured.TrustListDataType;
 import org.eclipse.milo.opcua.stack.core.util.CertificateUtil;
@@ -46,8 +45,10 @@ public final class TrustListApplier {
    * the certificates and CRLs it carries.
    *
    * <p>All entries are decoded before anything is replaced, so a malformed entry rejects the whole
-   * update and the manager is unchanged. Specified lists are merged with one current snapshot and
-   * the resulting snapshot is committed in one replacement.
+   * update and the manager is unchanged. The specified lists are then merged into the manager's
+   * current snapshot through {@link TrustListManager#update}, so unspecified lists keep whatever
+   * value they hold at commit time and the replacement is published as one snapshot. If no list is
+   * specified nothing is committed.
    *
    * @param trustList the list to apply.
    * @param manager the {@link TrustListManager} to update.
@@ -83,15 +84,25 @@ public final class TrustListApplier {
       return;
     }
 
-    TrustListSnapshot current = manager.getSnapshot();
+    manager.update(
+        current -> {
+          TrustListSnapshot updated = current;
 
-    manager.replaceAll(
-        new TrustListSnapshot(
-            issuerCertificates != null ? issuerCertificates : current.issuerCertificates(),
-            issuerCrls != null ? issuerCrls : current.issuerCrls(),
-            trustedCertificates != null ? trustedCertificates : current.trustedCertificates(),
-            trustedCrls != null ? trustedCrls : current.trustedCrls(),
-            DateTime.now()));
+          if (issuerCertificates != null) {
+            updated = updated.withIssuerCertificates(issuerCertificates);
+          }
+          if (trustedCertificates != null) {
+            updated = updated.withTrustedCertificates(trustedCertificates);
+          }
+          if (issuerCrls != null) {
+            updated = updated.withIssuerCrls(issuerCrls);
+          }
+          if (trustedCrls != null) {
+            updated = updated.withTrustedCrls(trustedCrls);
+          }
+
+          return updated;
+        });
   }
 
   /**

--- a/opc-ua-sdk/sdk-client-gds/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/package-info.java
+++ b/opc-ua-sdk/sdk-client-gds/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/package-info.java
@@ -34,7 +34,8 @@
  * org.eclipse.milo.opcua.stack.core.types.structured.TrustListDataType}. {@link
  * org.eclipse.milo.opcua.sdk.client.gds.TrustListApplier} installs that structure into a {@link
  * org.eclipse.milo.opcua.stack.core.security.TrustListManager}, replacing each list the structure
- * marks as specified, and can build the structure back from a manager.
+ * marks as specified in one snapshot replacement, and can build the structure back from one manager
+ * snapshot.
  *
  * <h2>Data flow</h2>
  *

--- a/opc-ua-sdk/sdk-client-gds/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/package-info.java
+++ b/opc-ua-sdk/sdk-client-gds/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/package-info.java
@@ -34,8 +34,8 @@
  * org.eclipse.milo.opcua.stack.core.types.structured.TrustListDataType}. {@link
  * org.eclipse.milo.opcua.sdk.client.gds.TrustListApplier} installs that structure into a {@link
  * org.eclipse.milo.opcua.stack.core.security.TrustListManager}, replacing each list the structure
- * marks as specified in one snapshot replacement, and can build the structure back from one manager
- * snapshot.
+ * marks as specified through one {@code TrustListManager.update} call, and can build the structure
+ * back from one manager snapshot.
  *
  * <h2>Data flow</h2>
  *

--- a/opc-ua-sdk/sdk-client-gds/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/TrustListApplierTest.java
+++ b/opc-ua-sdk/sdk-client-gds/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/TrustListApplierTest.java
@@ -20,10 +20,12 @@ import java.security.cert.X509CRL;
 import java.security.cert.X509Certificate;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.security.MemoryTrustListManager;
 import org.eclipse.milo.opcua.stack.core.security.TrustListManager;
+import org.eclipse.milo.opcua.stack.core.security.TrustListSnapshot;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.TrustListMasks;
 import org.eclipse.milo.opcua.stack.core.types.structured.TrustListDataType;
@@ -45,11 +47,11 @@ public class TrustListApplierTest {
   private static final X509CRL NEW_TRUSTED_CRL = TestPki.crl();
   private static final X509CRL NEW_ISSUER_CRL = TestPki.crl();
 
-  private MemoryTrustListManager manager;
+  private RecordingMemoryTrustListManager manager;
 
   @BeforeEach
   void populateManagerWithOldLists() {
-    manager = new MemoryTrustListManager();
+    manager = new RecordingMemoryTrustListManager();
     manager.setTrustedCertificates(List.of(OLD_TRUSTED));
     manager.setIssuerCertificates(List.of(OLD_ISSUER));
     manager.setTrustedCrls(List.of(OLD_TRUSTED_CRL));
@@ -89,6 +91,8 @@ public class TrustListApplierTest {
           List.of(trustedCrls ? NEW_TRUSTED_CRL : OLD_TRUSTED_CRL), manager.getTrustedCrls());
       assertEquals(List.of(issuerCerts ? NEW_ISSUER : OLD_ISSUER), manager.getIssuerCertificates());
       assertEquals(List.of(issuerCrls ? NEW_ISSUER_CRL : OLD_ISSUER_CRL), manager.getIssuerCrls());
+      assertEquals(1, manager.snapshotReads.get());
+      assertEquals(1, manager.replacements.get());
     }
 
     @Test
@@ -99,6 +103,25 @@ public class TrustListApplierTest {
       assertEquals(List.of(NEW_TRUSTED_CRL), manager.getTrustedCrls());
       assertEquals(List.of(NEW_ISSUER), manager.getIssuerCertificates());
       assertEquals(List.of(NEW_ISSUER_CRL), manager.getIssuerCrls());
+      assertEquals(1, manager.snapshotReads.get());
+      assertEquals(1, manager.replacements.get());
+    }
+
+    // A partial update spanning multiple fields must retain both unspecified fields from the same
+    // old snapshot and publish all changes through one replacement.
+    @Test
+    void applyWithMultiplePartialMasksCommitsOneMergedSnapshot() throws Exception {
+      int masks =
+          TrustListMasks.TrustedCertificates.getValue() | TrustListMasks.IssuerCrls.getValue();
+
+      TrustListApplier.apply(newTrustList(masks), manager);
+
+      assertEquals(List.of(NEW_TRUSTED), manager.getTrustedCertificates());
+      assertEquals(List.of(OLD_TRUSTED_CRL), manager.getTrustedCrls());
+      assertEquals(List.of(OLD_ISSUER), manager.getIssuerCertificates());
+      assertEquals(List.of(NEW_ISSUER_CRL), manager.getIssuerCrls());
+      assertEquals(1, manager.snapshotReads.get());
+      assertEquals(1, manager.replacements.get());
     }
 
     // The GDS delivers the complete authoritative list; a certificate it dropped must disappear
@@ -117,6 +140,15 @@ public class TrustListApplierTest {
 
       assertEquals(List.of(), manager.getTrustedCertificates());
       assertEquals(List.of(OLD_ISSUER), manager.getIssuerCertificates(), "unspecified, untouched");
+      assertEquals(1, manager.replacements.get());
+    }
+
+    @Test
+    void applyWithNoSpecifiedListsDoesNotPublishAnUpdate() throws Exception {
+      TrustListApplier.apply(newTrustList(TrustListMasks.None.getValue()), manager);
+
+      assertEquals(0, manager.snapshotReads.get());
+      assertEquals(0, manager.replacements.get());
     }
 
     // A half-applied update would leave the manager trusting a new certificate set without the
@@ -138,6 +170,8 @@ public class TrustListApplierTest {
       assertEquals(List.of(OLD_TRUSTED), manager.getTrustedCertificates());
       assertEquals(List.of(OLD_ISSUER), manager.getIssuerCertificates());
       assertEquals(List.of(OLD_ISSUER_CRL), manager.getIssuerCrls());
+      assertEquals(0, manager.snapshotReads.get());
+      assertEquals(0, manager.replacements.get());
     }
 
     @Test
@@ -155,6 +189,8 @@ public class TrustListApplierTest {
 
       assertEquals(StatusCodes.Bad_CertificateInvalid, e.getStatusCode().value());
       assertEquals(List.of(OLD_TRUSTED_CRL), manager.getTrustedCrls());
+      assertEquals(0, manager.snapshotReads.get());
+      assertEquals(0, manager.replacements.get());
     }
   }
 
@@ -177,6 +213,7 @@ public class TrustListApplierTest {
           Set.copyOf(manager.getIssuerCertificates()), Set.copyOf(copy.getIssuerCertificates()));
       assertEquals(Set.copyOf(manager.getTrustedCrls()), Set.copyOf(copy.getTrustedCrls()));
       assertEquals(Set.copyOf(manager.getIssuerCrls()), Set.copyOf(copy.getIssuerCrls()));
+      assertEquals(1, manager.snapshotReads.get());
     }
 
     @Test
@@ -193,6 +230,25 @@ public class TrustListApplierTest {
       assertEquals(1, trustList.getIssuerCrls().length);
       assertNull(trustList.getTrustedCrls());
       assertNull(trustList.getIssuerCertificates());
+      assertEquals(1, manager.snapshotReads.get());
+    }
+  }
+
+  private static final class RecordingMemoryTrustListManager extends MemoryTrustListManager {
+
+    private final AtomicInteger snapshotReads = new AtomicInteger();
+    private final AtomicInteger replacements = new AtomicInteger();
+
+    @Override
+    public TrustListSnapshot getSnapshot() {
+      snapshotReads.incrementAndGet();
+      return super.getSnapshot();
+    }
+
+    @Override
+    public void replaceAll(TrustListSnapshot snapshot) {
+      replacements.incrementAndGet();
+      super.replaceAll(snapshot);
     }
   }
 }

--- a/opc-ua-sdk/sdk-client-gds/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/TrustListApplierTest.java
+++ b/opc-ua-sdk/sdk-client-gds/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/TrustListApplierTest.java
@@ -14,6 +14,7 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.security.cert.X509CRL;
@@ -21,6 +22,7 @@ import java.security.cert.X509Certificate;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.UnaryOperator;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.security.MemoryTrustListManager;
@@ -56,6 +58,10 @@ public class TrustListApplierTest {
     manager.setIssuerCertificates(List.of(OLD_ISSUER));
     manager.setTrustedCrls(List.of(OLD_TRUSTED_CRL));
     manager.setIssuerCrls(List.of(OLD_ISSUER_CRL));
+
+    // The setters above commit through update(); only calls made by the test count.
+    manager.updates.set(0);
+    manager.snapshotReads.set(0);
   }
 
   /** A trust list carrying the "new" material in every field, specified by {@code masks}. */
@@ -91,8 +97,7 @@ public class TrustListApplierTest {
           List.of(trustedCrls ? NEW_TRUSTED_CRL : OLD_TRUSTED_CRL), manager.getTrustedCrls());
       assertEquals(List.of(issuerCerts ? NEW_ISSUER : OLD_ISSUER), manager.getIssuerCertificates());
       assertEquals(List.of(issuerCrls ? NEW_ISSUER_CRL : OLD_ISSUER_CRL), manager.getIssuerCrls());
-      assertEquals(1, manager.snapshotReads.get());
-      assertEquals(1, manager.replacements.get());
+      assertEquals(1, manager.updates.get());
     }
 
     @Test
@@ -103,12 +108,11 @@ public class TrustListApplierTest {
       assertEquals(List.of(NEW_TRUSTED_CRL), manager.getTrustedCrls());
       assertEquals(List.of(NEW_ISSUER), manager.getIssuerCertificates());
       assertEquals(List.of(NEW_ISSUER_CRL), manager.getIssuerCrls());
-      assertEquals(1, manager.snapshotReads.get());
-      assertEquals(1, manager.replacements.get());
+      assertEquals(1, manager.updates.get());
     }
 
-    // A partial update spanning multiple fields must retain both unspecified fields from the same
-    // old snapshot and publish all changes through one replacement.
+    // A partial update spanning multiple fields must retain the unspecified fields and publish all
+    // changes through one update.
     @Test
     void applyWithMultiplePartialMasksCommitsOneMergedSnapshot() throws Exception {
       int masks =
@@ -120,8 +124,7 @@ public class TrustListApplierTest {
       assertEquals(List.of(OLD_TRUSTED_CRL), manager.getTrustedCrls());
       assertEquals(List.of(OLD_ISSUER), manager.getIssuerCertificates());
       assertEquals(List.of(NEW_ISSUER_CRL), manager.getIssuerCrls());
-      assertEquals(1, manager.snapshotReads.get());
-      assertEquals(1, manager.replacements.get());
+      assertEquals(1, manager.updates.get());
     }
 
     // The GDS delivers the complete authoritative list; a certificate it dropped must disappear
@@ -140,15 +143,18 @@ public class TrustListApplierTest {
 
       assertEquals(List.of(), manager.getTrustedCertificates());
       assertEquals(List.of(OLD_ISSUER), manager.getIssuerCertificates(), "unspecified, untouched");
-      assertEquals(1, manager.replacements.get());
+      assertEquals(1, manager.updates.get());
     }
 
+    // An update that changes nothing must not publish a new snapshot or move lastUpdateTime.
     @Test
     void applyWithNoSpecifiedListsDoesNotPublishAnUpdate() throws Exception {
+      TrustListSnapshot before = manager.getSnapshot();
+
       TrustListApplier.apply(newTrustList(TrustListMasks.None.getValue()), manager);
 
-      assertEquals(0, manager.snapshotReads.get());
-      assertEquals(0, manager.replacements.get());
+      assertSame(before, manager.getSnapshot());
+      assertEquals(0, manager.updates.get());
     }
 
     // A half-applied update would leave the manager trusting a new certificate set without the
@@ -170,8 +176,7 @@ public class TrustListApplierTest {
       assertEquals(List.of(OLD_TRUSTED), manager.getTrustedCertificates());
       assertEquals(List.of(OLD_ISSUER), manager.getIssuerCertificates());
       assertEquals(List.of(OLD_ISSUER_CRL), manager.getIssuerCrls());
-      assertEquals(0, manager.snapshotReads.get());
-      assertEquals(0, manager.replacements.get());
+      assertEquals(0, manager.updates.get());
     }
 
     @Test
@@ -189,8 +194,7 @@ public class TrustListApplierTest {
 
       assertEquals(StatusCodes.Bad_CertificateInvalid, e.getStatusCode().value());
       assertEquals(List.of(OLD_TRUSTED_CRL), manager.getTrustedCrls());
-      assertEquals(0, manager.snapshotReads.get());
-      assertEquals(0, manager.replacements.get());
+      assertEquals(0, manager.updates.get());
     }
   }
 
@@ -237,7 +241,7 @@ public class TrustListApplierTest {
   private static final class RecordingMemoryTrustListManager extends MemoryTrustListManager {
 
     private final AtomicInteger snapshotReads = new AtomicInteger();
-    private final AtomicInteger replacements = new AtomicInteger();
+    private final AtomicInteger updates = new AtomicInteger();
 
     @Override
     public TrustListSnapshot getSnapshot() {
@@ -246,9 +250,9 @@ public class TrustListApplierTest {
     }
 
     @Override
-    public void replaceAll(TrustListSnapshot snapshot) {
-      replacements.incrementAndGet();
-      super.replaceAll(snapshot);
+    public TrustListSnapshot update(UnaryOperator<TrustListSnapshot> update) {
+      updates.incrementAndGet();
+      return super.update(update);
     }
   }
 }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/DefaultClientCertificateValidator.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/DefaultClientCertificateValidator.java
@@ -79,14 +79,15 @@ public class DefaultClientCertificateValidator implements CertificateValidator {
       @Nullable SecurityPolicyProfile securityPolicyProfile)
       throws UaException {
 
+    TrustListSnapshot trustListSnapshot = trustListManager.getSnapshot();
     PKIXCertPathBuilderResult certPathResult;
 
     try {
       certPathResult =
           CertificateValidationUtil.buildTrustedCertPath(
               certificateChain,
-              trustListManager.getTrustedCertificates(),
-              trustListManager.getIssuerCertificates());
+              trustListSnapshot.trustedCertificates(),
+              trustListSnapshot.issuerCertificates());
     } catch (UaException e) {
       certificateChain.forEach(certificateQuarantine::addRejectedCertificate);
 
@@ -97,8 +98,8 @@ public class DefaultClientCertificateValidator implements CertificateValidator {
 
     try {
       List<X509CRL> crls = new ArrayList<>();
-      crls.addAll(trustListManager.getTrustedCrls());
-      crls.addAll(trustListManager.getIssuerCrls());
+      crls.addAll(trustListSnapshot.trustedCrls());
+      crls.addAll(trustListSnapshot.issuerCrls());
 
       CertificateValidationUtil.validateTrustedCertPath(
           certPathResult.getCertPath(),

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/DefaultServerCertificateValidator.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/DefaultServerCertificateValidator.java
@@ -84,14 +84,15 @@ public class DefaultServerCertificateValidator implements CertificateValidator {
       @Nullable SecurityPolicyProfile securityPolicyProfile)
       throws UaException {
 
+    TrustListSnapshot trustListSnapshot = trustListManager.getSnapshot();
     PKIXCertPathBuilderResult certPathResult;
 
     try {
       certPathResult =
           buildTrustedCertPath(
               certificateChain,
-              trustListManager.getTrustedCertificates(),
-              trustListManager.getIssuerCertificates());
+              trustListSnapshot.trustedCertificates(),
+              trustListSnapshot.issuerCertificates());
     } catch (UaException e) {
       certificateChain.forEach(certificateQuarantine::addRejectedCertificate);
 
@@ -112,8 +113,8 @@ public class DefaultServerCertificateValidator implements CertificateValidator {
 
     try {
       List<X509CRL> crls = new ArrayList<>();
-      crls.addAll(trustListManager.getTrustedCrls());
-      crls.addAll(trustListManager.getIssuerCrls());
+      crls.addAll(trustListSnapshot.trustedCrls());
+      crls.addAll(trustListSnapshot.issuerCrls());
 
       validateTrustedCertPath(
           certPathResult.getCertPath(),

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/FileBasedTrustListManager.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/FileBasedTrustListManager.java
@@ -35,8 +35,9 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.UnaryOperator;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
@@ -50,22 +51,18 @@ import org.slf4j.LoggerFactory;
  *
  * <p>{@link #initialize()} starts a background thread that watches the configured directories for
  * changes. Each OPC UA application should create one shared instance and call {@link #close()} when
- * the application shuts down.
+ * the application shuts down. Directory reloads and API updates publish all four lists as one
+ * immutable snapshot.
  */
 public class FileBasedTrustListManager implements TrustListManager, Closeable {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(FileBasedTrustListManager.class);
 
-  private final ReadWriteLock readWriteLock = new ReentrantReadWriteLock();
+  private final Lock mutationLock = new ReentrantLock();
 
-  private final AtomicReference<DateTime> lastUpdateTime =
-      new AtomicReference<>(DateTime.MIN_VALUE);
-
-  private final Set<X509Certificate> issuerCertificates = new HashSet<>();
-  private final Set<X509CRL> issuerCrls = new HashSet<>();
-
-  private final Set<X509Certificate> trustedCertificates = new HashSet<>();
-  private final Set<X509CRL> trustedCrls = new HashSet<>();
+  private final AtomicReference<TrustListSnapshot> snapshot =
+      new AtomicReference<>(
+          new TrustListSnapshot(List.of(), List.of(), List.of(), List.of(), DateTime.MIN_VALUE));
 
   private Thread watchThread;
   private WatchService watchService;
@@ -107,38 +104,35 @@ public class FileBasedTrustListManager implements TrustListManager, Closeable {
             StandardWatchEventKinds.ENTRY_CREATE,
             StandardWatchEventKinds.ENTRY_DELETE,
             StandardWatchEventKinds.ENTRY_MODIFY),
-        this::synchronizeIssuerCerts);
+        this::synchronizeAll);
     watchKeys.put(
         issuerCrlDir.register(
             watchService,
             StandardWatchEventKinds.ENTRY_CREATE,
             StandardWatchEventKinds.ENTRY_DELETE,
             StandardWatchEventKinds.ENTRY_MODIFY),
-        this::synchronizeIssuerCrl);
+        this::synchronizeAll);
     watchKeys.put(
         trustedCertsDir.register(
             watchService,
             StandardWatchEventKinds.ENTRY_CREATE,
             StandardWatchEventKinds.ENTRY_DELETE,
             StandardWatchEventKinds.ENTRY_MODIFY),
-        this::synchronizeTrustedCerts);
+        this::synchronizeAll);
     watchKeys.put(
         trustedCrlDir.register(
             watchService,
             StandardWatchEventKinds.ENTRY_CREATE,
             StandardWatchEventKinds.ENTRY_DELETE,
             StandardWatchEventKinds.ENTRY_MODIFY),
-        this::synchronizeTrustedCrl);
+        this::synchronizeAll);
+
+    synchronizeAll();
 
     watchThread = new Thread(new WatchKeyRunner(watchService, watchKeys));
     watchThread.setName("milo-trust-list-watcher");
     watchThread.setDaemon(true);
     watchThread.start();
-
-    synchronizeIssuerCerts();
-    synchronizeIssuerCrl();
-    synchronizeTrustedCerts();
-    synchronizeTrustedCrl();
   }
 
   @Override
@@ -155,202 +149,181 @@ public class FileBasedTrustListManager implements TrustListManager, Closeable {
       }
     }
 
-    readWriteLock.writeLock().lock();
+    mutationLock.lock();
     try {
-      issuerCertificates.clear();
-      issuerCrls.clear();
-      trustedCertificates.clear();
-      trustedCrls.clear();
+      TrustListSnapshot current = snapshot.get();
+      snapshot.set(
+          new TrustListSnapshot(
+              List.of(), List.of(), List.of(), List.of(), current.lastUpdateTime()));
     } finally {
-      readWriteLock.writeLock().unlock();
+      mutationLock.unlock();
+    }
+  }
+
+  @Override
+  public TrustListSnapshot getSnapshot() {
+    return snapshot.get();
+  }
+
+  @Override
+  public void replaceAll(TrustListSnapshot snapshot) {
+    mutationLock.lock();
+    try {
+      replaceAllLocked(snapshot);
+    } finally {
+      mutationLock.unlock();
     }
   }
 
   @Override
   public List<X509CRL> getIssuerCrls() {
-    readWriteLock.readLock().lock();
-    try {
-      return List.copyOf(issuerCrls);
-    } finally {
-      readWriteLock.readLock().unlock();
-    }
+    return snapshot.get().issuerCrls();
   }
 
   @Override
   public List<X509CRL> getTrustedCrls() {
-    readWriteLock.readLock().lock();
-    try {
-      return List.copyOf(trustedCrls);
-    } finally {
-      readWriteLock.readLock().unlock();
-    }
+    return snapshot.get().trustedCrls();
   }
 
   @Override
   public List<X509Certificate> getIssuerCertificates() {
-    readWriteLock.readLock().lock();
-    try {
-      return List.copyOf(issuerCertificates);
-    } finally {
-      readWriteLock.readLock().unlock();
-    }
+    return snapshot.get().issuerCertificates();
   }
 
   @Override
   public List<X509Certificate> getTrustedCertificates() {
-    readWriteLock.readLock().lock();
-    try {
-      return List.copyOf(trustedCertificates);
-    } finally {
-      readWriteLock.readLock().unlock();
-    }
+    return snapshot.get().trustedCertificates();
   }
 
   @Override
   public void setIssuerCrls(List<X509CRL> issuerCrls) {
-    readWriteLock.writeLock().lock();
-    try {
-      Set<X509CRL> oldSet = Set.copyOf(this.issuerCrls);
-
-      this.issuerCrls.clear();
-      this.issuerCrls.addAll(issuerCrls);
-
-      Set<X509CRL> toWrite = Sets.difference(this.issuerCrls, oldSet);
-      Set<X509CRL> toDelete = Sets.difference(oldSet, this.issuerCrls);
-
-      toWrite.forEach(crl -> writeCrlToDir(crl, issuerCrlDir));
-      toDelete.forEach(crl -> deleteCrlFromDir(crl, issuerCrlDir));
-
-      touchLastUpdateTime();
-    } finally {
-      readWriteLock.writeLock().unlock();
-    }
+    updateSnapshot(
+        current ->
+            new TrustListSnapshot(
+                current.issuerCertificates(),
+                issuerCrls,
+                current.trustedCertificates(),
+                current.trustedCrls(),
+                DateTime.now()));
   }
 
   @Override
   public void setTrustedCrls(List<X509CRL> trustedCrls) {
-    readWriteLock.writeLock().lock();
-    try {
-      Set<X509CRL> oldSet = Set.copyOf(this.trustedCrls);
-
-      this.trustedCrls.clear();
-      this.trustedCrls.addAll(trustedCrls);
-
-      Set<X509CRL> toWrite = Sets.difference(this.trustedCrls, oldSet);
-      Set<X509CRL> toDelete = Sets.difference(oldSet, this.trustedCrls);
-
-      toWrite.forEach(crl -> writeCrlToDir(crl, trustedCrlDir));
-      toDelete.forEach(crl -> deleteCrlFromDir(crl, trustedCrlDir));
-
-      touchLastUpdateTime();
-    } finally {
-      readWriteLock.writeLock().unlock();
-    }
+    updateSnapshot(
+        current ->
+            new TrustListSnapshot(
+                current.issuerCertificates(),
+                current.issuerCrls(),
+                current.trustedCertificates(),
+                trustedCrls,
+                DateTime.now()));
   }
 
   @Override
   public void setIssuerCertificates(List<X509Certificate> issuerCertificates) {
-    readWriteLock.writeLock().lock();
-    try {
-      Set<X509Certificate> oldSet = Set.copyOf(this.issuerCertificates);
-
-      this.issuerCertificates.clear();
-      this.issuerCertificates.addAll(issuerCertificates);
-
-      Set<X509Certificate> toWrite = Sets.difference(this.issuerCertificates, oldSet);
-      Set<X509Certificate> toDelete = Sets.difference(oldSet, this.issuerCertificates);
-
-      toWrite.forEach(cert -> writeCertificateToDir(cert, issuerCertsDir));
-      toDelete.forEach(cert -> deleteCertificateFromDir(cert, issuerCertsDir));
-
-      touchLastUpdateTime();
-    } finally {
-      readWriteLock.writeLock().unlock();
-    }
+    updateSnapshot(
+        current ->
+            new TrustListSnapshot(
+                issuerCertificates,
+                current.issuerCrls(),
+                current.trustedCertificates(),
+                current.trustedCrls(),
+                DateTime.now()));
   }
 
   @Override
   public void setTrustedCertificates(List<X509Certificate> trustedCertificates) {
-    readWriteLock.writeLock().lock();
-    try {
-      Set<X509Certificate> oldSet = Set.copyOf(this.trustedCertificates);
-
-      this.trustedCertificates.clear();
-      this.trustedCertificates.addAll(trustedCertificates);
-
-      Set<X509Certificate> toWrite = Sets.difference(this.trustedCertificates, oldSet);
-      Set<X509Certificate> toDelete = Sets.difference(oldSet, this.trustedCertificates);
-
-      toWrite.forEach(cert -> writeCertificateToDir(cert, trustedCertsDir));
-      toDelete.forEach(cert -> deleteCertificateFromDir(cert, trustedCertsDir));
-
-      touchLastUpdateTime();
-    } finally {
-      readWriteLock.writeLock().unlock();
-    }
+    updateSnapshot(
+        current ->
+            new TrustListSnapshot(
+                current.issuerCertificates(),
+                current.issuerCrls(),
+                trustedCertificates,
+                current.trustedCrls(),
+                DateTime.now()));
   }
 
   @Override
   public void addIssuerCertificate(X509Certificate certificate) {
-    readWriteLock.writeLock().lock();
-    try {
-      issuerCertificates.add(certificate);
+    updateSnapshot(
+        current -> {
+          var issuerCertificates = new HashSet<>(current.issuerCertificates());
+          issuerCertificates.add(certificate);
 
-      writeCertificateToDir(certificate, issuerCertsDir);
-
-      touchLastUpdateTime();
-    } finally {
-      readWriteLock.writeLock().unlock();
-    }
+          return new TrustListSnapshot(
+              List.copyOf(issuerCertificates),
+              current.issuerCrls(),
+              current.trustedCertificates(),
+              current.trustedCrls(),
+              DateTime.now());
+        });
   }
 
   @Override
   public void addTrustedCertificate(X509Certificate certificate) {
-    readWriteLock.writeLock().lock();
-    try {
-      trustedCertificates.add(certificate);
+    updateSnapshot(
+        current -> {
+          var trustedCertificates = new HashSet<>(current.trustedCertificates());
+          trustedCertificates.add(certificate);
 
-      writeCertificateToDir(certificate, trustedCertsDir);
-
-      touchLastUpdateTime();
-    } finally {
-      readWriteLock.writeLock().unlock();
-    }
+          return new TrustListSnapshot(
+              current.issuerCertificates(),
+              current.issuerCrls(),
+              List.copyOf(trustedCertificates),
+              current.trustedCrls(),
+              DateTime.now());
+        });
   }
 
   @Override
   public boolean removeIssuerCertificate(ByteString thumbprint) {
-    readWriteLock.writeLock().lock();
+    mutationLock.lock();
     try {
       deleteCertificateFromDir(thumbprint, issuerCertsDir);
 
+      TrustListSnapshot current = snapshot.get();
+      var issuerCertificates = new HashSet<>(current.issuerCertificates());
       boolean removed = remove(thumbprint, issuerCertificates);
 
       if (removed) {
-        touchLastUpdateTime();
+        snapshot.set(
+            new TrustListSnapshot(
+                List.copyOf(issuerCertificates),
+                current.issuerCrls(),
+                current.trustedCertificates(),
+                current.trustedCrls(),
+                DateTime.now()));
       }
 
       return removed;
     } finally {
-      readWriteLock.writeLock().unlock();
+      mutationLock.unlock();
     }
   }
 
   @Override
   public boolean removeTrustedCertificate(ByteString thumbprint) {
-    readWriteLock.writeLock().lock();
+    mutationLock.lock();
     try {
       deleteCertificateFromDir(thumbprint, trustedCertsDir);
 
+      TrustListSnapshot current = snapshot.get();
+      var trustedCertificates = new HashSet<>(current.trustedCertificates());
       boolean removed = remove(thumbprint, trustedCertificates);
 
       if (removed) {
-        touchLastUpdateTime();
+        snapshot.set(
+            new TrustListSnapshot(
+                current.issuerCertificates(),
+                current.issuerCrls(),
+                List.copyOf(trustedCertificates),
+                current.trustedCrls(),
+                DateTime.now()));
       }
 
       return removed;
     } finally {
-      readWriteLock.writeLock().unlock();
+      mutationLock.unlock();
     }
   }
 
@@ -367,87 +340,101 @@ public class FileBasedTrustListManager implements TrustListManager, Closeable {
 
   @Override
   public DateTime getLastUpdateTime() {
-    return lastUpdateTime.get();
+    return snapshot.get().lastUpdateTime();
   }
 
-  private void touchLastUpdateTime() {
-    lastUpdateTime.set(DateTime.now());
-  }
-
-  private void synchronizeIssuerCerts() {
-    LOGGER.debug("Synchronizing issuer certs...");
-
-    readWriteLock.writeLock().lock();
+  private void updateSnapshot(UnaryOperator<TrustListSnapshot> update) {
+    mutationLock.lock();
     try {
-      issuerCertificates.clear();
-
-      try (var files = Files.list(issuerCertsDir)) {
-        files.flatMap(c -> decodeCertificateFile(c).stream()).forEach(issuerCertificates::add);
-      }
-
-      touchLastUpdateTime();
-    } catch (IOException e) {
-      LOGGER.warn("Error synchronizing issuer certs", e);
+      replaceAllLocked(update.apply(snapshot.get()));
     } finally {
-      readWriteLock.writeLock().unlock();
+      mutationLock.unlock();
     }
   }
 
-  private void synchronizeIssuerCrl() {
-    LOGGER.debug("Synchronizing issuer CRLs...");
+  private void replaceAllLocked(TrustListSnapshot replacement) {
+    TrustListSnapshot current = snapshot.get();
+    TrustListSnapshot normalized = normalize(replacement);
 
-    readWriteLock.writeLock().lock();
+    updateCertificateFiles(
+        current.issuerCertificates(), normalized.issuerCertificates(), issuerCertsDir);
+    updateCrlFiles(current.issuerCrls(), normalized.issuerCrls(), issuerCrlDir);
+    updateCertificateFiles(
+        current.trustedCertificates(), normalized.trustedCertificates(), trustedCertsDir);
+    updateCrlFiles(current.trustedCrls(), normalized.trustedCrls(), trustedCrlDir);
+
+    snapshot.set(normalized);
+  }
+
+  private static TrustListSnapshot normalize(TrustListSnapshot snapshot) {
+    return new TrustListSnapshot(
+        List.copyOf(new HashSet<>(snapshot.issuerCertificates())),
+        List.copyOf(new HashSet<>(snapshot.issuerCrls())),
+        List.copyOf(new HashSet<>(snapshot.trustedCertificates())),
+        List.copyOf(new HashSet<>(snapshot.trustedCrls())),
+        snapshot.lastUpdateTime());
+  }
+
+  private static void updateCertificateFiles(
+      List<X509Certificate> current, List<X509Certificate> replacement, Path directory) {
+
+    Set<X509Certificate> currentSet = Set.copyOf(current);
+    Set<X509Certificate> replacementSet = Set.copyOf(replacement);
+
+    Sets.difference(replacementSet, currentSet)
+        .forEach(certificate -> writeCertificateToDir(certificate, directory));
+    Sets.difference(currentSet, replacementSet)
+        .forEach(certificate -> deleteCertificateFromDir(certificate, directory));
+  }
+
+  private static void updateCrlFiles(
+      List<X509CRL> current, List<X509CRL> replacement, Path directory) {
+
+    Set<X509CRL> currentSet = Set.copyOf(current);
+    Set<X509CRL> replacementSet = Set.copyOf(replacement);
+
+    Sets.difference(replacementSet, currentSet).forEach(crl -> writeCrlToDir(crl, directory));
+    Sets.difference(currentSet, replacementSet).forEach(crl -> deleteCrlFromDir(crl, directory));
+  }
+
+  private void synchronizeAll() {
+    LOGGER.debug("Synchronizing trust lists...");
+
+    mutationLock.lock();
     try {
-      issuerCrls.clear();
+      List<X509Certificate> issuerCertificates = readCertificates(issuerCertsDir);
+      List<X509CRL> issuerCrls = readCrls(issuerCrlDir);
+      List<X509Certificate> trustedCertificates = readCertificates(trustedCertsDir);
+      List<X509CRL> trustedCrls = readCrls(trustedCrlDir);
 
-      try (var files = Files.list(issuerCrlDir)) {
-        files.flatMap(c -> decodeCrlFile(c).stream()).forEach(issuerCrls::addAll);
-      }
-
-      touchLastUpdateTime();
+      snapshot.set(
+          new TrustListSnapshot(
+              issuerCertificates, issuerCrls, trustedCertificates, trustedCrls, DateTime.now()));
     } catch (IOException e) {
-      LOGGER.warn("Error synchronizing issuer CRLs", e);
+      LOGGER.warn("Error synchronizing trust lists", e);
     } finally {
-      readWriteLock.writeLock().unlock();
+      mutationLock.unlock();
     }
   }
 
-  private void synchronizeTrustedCerts() {
-    LOGGER.debug("Synchronizing trusted certs...");
+  private static List<X509Certificate> readCertificates(Path directory) throws IOException {
+    var certificates = new HashSet<X509Certificate>();
 
-    readWriteLock.writeLock().lock();
-    try {
-      trustedCertificates.clear();
-
-      try (var files = Files.list(trustedCertsDir)) {
-        files.flatMap(c -> decodeCertificateFile(c).stream()).forEach(trustedCertificates::add);
-      }
-
-      touchLastUpdateTime();
-    } catch (IOException e) {
-      LOGGER.warn("Error synchronizing trusted certs", e);
-    } finally {
-      readWriteLock.writeLock().unlock();
+    try (var files = Files.list(directory)) {
+      files.flatMap(path -> decodeCertificateFile(path).stream()).forEach(certificates::add);
     }
+
+    return List.copyOf(certificates);
   }
 
-  private void synchronizeTrustedCrl() {
-    LOGGER.debug("Synchronizing trusted CRLs...");
+  private static List<X509CRL> readCrls(Path directory) throws IOException {
+    var crls = new HashSet<X509CRL>();
 
-    readWriteLock.writeLock().lock();
-    try {
-      trustedCrls.clear();
-
-      try (var files = Files.list(trustedCrlDir)) {
-        files.flatMap(c -> decodeCrlFile(c).stream()).forEach(trustedCrls::addAll);
-      }
-
-      touchLastUpdateTime();
-    } catch (IOException e) {
-      LOGGER.warn("Error synchronizing trusted CRLs", e);
-    } finally {
-      readWriteLock.writeLock().unlock();
+    try (var files = Files.list(directory)) {
+      files.flatMap(path -> decodeCrlFile(path).stream()).forEach(crls::addAll);
     }
+
+    return List.copyOf(crls);
   }
 
   private static Optional<X509Certificate> decodeCertificateFile(Path path) {

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/FileBasedTrustListManager.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/FileBasedTrustListManager.java
@@ -28,16 +28,19 @@ import java.nio.file.WatchKey;
 import java.nio.file.WatchService;
 import java.security.cert.X509CRL;
 import java.security.cert.X509Certificate;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
 import java.util.function.UnaryOperator;
+import java.util.stream.Stream;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
@@ -51,8 +54,11 @@ import org.slf4j.LoggerFactory;
  *
  * <p>{@link #initialize()} starts a background thread that watches the configured directories for
  * changes. Each OPC UA application should create one shared instance and call {@link #close()} when
- * the application shuts down. Directory reloads and API updates publish all four lists as one
- * immutable snapshot.
+ * the application shuts down.
+ *
+ * <p>Every change is published as one immutable {@link TrustListSnapshot}. API updates write the
+ * affected files and publish all four lists together; a directory reload triggered by the watcher
+ * replaces only the list for that directory.
  */
 public class FileBasedTrustListManager implements TrustListManager, Closeable {
 
@@ -61,8 +67,7 @@ public class FileBasedTrustListManager implements TrustListManager, Closeable {
   private final Lock mutationLock = new ReentrantLock();
 
   private final AtomicReference<TrustListSnapshot> snapshot =
-      new AtomicReference<>(
-          new TrustListSnapshot(List.of(), List.of(), List.of(), List.of(), DateTime.MIN_VALUE));
+      new AtomicReference<>(TrustListSnapshot.empty());
 
   private Thread watchThread;
   private WatchService watchService;
@@ -97,42 +102,28 @@ public class FileBasedTrustListManager implements TrustListManager, Closeable {
     watchService = FileSystems.getDefault().newWatchService();
 
     Map<WatchKey, Runnable> watchKeys = new ConcurrentHashMap<>();
+    watchKeys.put(register(issuerCertsDir), this::synchronizeIssuerCertificates);
+    watchKeys.put(register(issuerCrlDir), this::synchronizeIssuerCrls);
+    watchKeys.put(register(trustedCertsDir), this::synchronizeTrustedCertificates);
+    watchKeys.put(register(trustedCrlDir), this::synchronizeTrustedCrls);
 
-    watchKeys.put(
-        issuerCertsDir.register(
-            watchService,
-            StandardWatchEventKinds.ENTRY_CREATE,
-            StandardWatchEventKinds.ENTRY_DELETE,
-            StandardWatchEventKinds.ENTRY_MODIFY),
-        this::synchronizeAll);
-    watchKeys.put(
-        issuerCrlDir.register(
-            watchService,
-            StandardWatchEventKinds.ENTRY_CREATE,
-            StandardWatchEventKinds.ENTRY_DELETE,
-            StandardWatchEventKinds.ENTRY_MODIFY),
-        this::synchronizeAll);
-    watchKeys.put(
-        trustedCertsDir.register(
-            watchService,
-            StandardWatchEventKinds.ENTRY_CREATE,
-            StandardWatchEventKinds.ENTRY_DELETE,
-            StandardWatchEventKinds.ENTRY_MODIFY),
-        this::synchronizeAll);
-    watchKeys.put(
-        trustedCrlDir.register(
-            watchService,
-            StandardWatchEventKinds.ENTRY_CREATE,
-            StandardWatchEventKinds.ENTRY_DELETE,
-            StandardWatchEventKinds.ENTRY_MODIFY),
-        this::synchronizeAll);
-
-    synchronizeAll();
+    synchronizeIssuerCertificates();
+    synchronizeIssuerCrls();
+    synchronizeTrustedCertificates();
+    synchronizeTrustedCrls();
 
     watchThread = new Thread(new WatchKeyRunner(watchService, watchKeys));
     watchThread.setName("milo-trust-list-watcher");
     watchThread.setDaemon(true);
     watchThread.start();
+  }
+
+  private WatchKey register(Path directory) throws IOException {
+    return directory.register(
+        watchService,
+        StandardWatchEventKinds.ENTRY_CREATE,
+        StandardWatchEventKinds.ENTRY_DELETE,
+        StandardWatchEventKinds.ENTRY_MODIFY);
   }
 
   @Override
@@ -151,10 +142,7 @@ public class FileBasedTrustListManager implements TrustListManager, Closeable {
 
     mutationLock.lock();
     try {
-      TrustListSnapshot current = snapshot.get();
-      snapshot.set(
-          new TrustListSnapshot(
-              List.of(), List.of(), List.of(), List.of(), current.lastUpdateTime()));
+      snapshot.set(TrustListSnapshot.empty().withLastUpdateTime(snapshot.get().lastUpdateTime()));
     } finally {
       mutationLock.unlock();
     }
@@ -165,11 +153,53 @@ public class FileBasedTrustListManager implements TrustListManager, Closeable {
     return snapshot.get();
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Files for added and removed entries are written before the snapshot is published. A write or
+   * delete that fails is logged; the published snapshot still reflects the requested state, and a
+   * later directory reload reconciles it with the directory contents.
+   */
   @Override
-  public void replaceAll(TrustListSnapshot snapshot) {
+  public TrustListSnapshot update(UnaryOperator<TrustListSnapshot> update) {
     mutationLock.lock();
     try {
-      replaceAllLocked(snapshot);
+      TrustListSnapshot current = snapshot.get();
+      TrustListSnapshot updated = Objects.requireNonNull(update.apply(current));
+
+      if (updated == current) {
+        return current;
+      }
+
+      updateFiles(
+          current.issuerCertificates(),
+          updated.issuerCertificates(),
+          issuerCertsDir,
+          FileBasedTrustListManager::writeCertificateToDir,
+          FileBasedTrustListManager::deleteCertificateFromDir);
+      updateFiles(
+          current.issuerCrls(),
+          updated.issuerCrls(),
+          issuerCrlDir,
+          FileBasedTrustListManager::writeCrlToDir,
+          FileBasedTrustListManager::deleteCrlFromDir);
+      updateFiles(
+          current.trustedCertificates(),
+          updated.trustedCertificates(),
+          trustedCertsDir,
+          FileBasedTrustListManager::writeCertificateToDir,
+          FileBasedTrustListManager::deleteCertificateFromDir);
+      updateFiles(
+          current.trustedCrls(),
+          updated.trustedCrls(),
+          trustedCrlDir,
+          FileBasedTrustListManager::writeCrlToDir,
+          FileBasedTrustListManager::deleteCrlFromDir);
+
+      TrustListSnapshot committed = updated.withLastUpdateTime(DateTime.now());
+      snapshot.set(committed);
+
+      return committed;
     } finally {
       mutationLock.unlock();
     }
@@ -197,145 +227,56 @@ public class FileBasedTrustListManager implements TrustListManager, Closeable {
 
   @Override
   public void setIssuerCrls(List<X509CRL> issuerCrls) {
-    updateSnapshot(
-        current ->
-            new TrustListSnapshot(
-                current.issuerCertificates(),
-                issuerCrls,
-                current.trustedCertificates(),
-                current.trustedCrls(),
-                DateTime.now()));
+    update(current -> current.withIssuerCrls(issuerCrls));
   }
 
   @Override
   public void setTrustedCrls(List<X509CRL> trustedCrls) {
-    updateSnapshot(
-        current ->
-            new TrustListSnapshot(
-                current.issuerCertificates(),
-                current.issuerCrls(),
-                current.trustedCertificates(),
-                trustedCrls,
-                DateTime.now()));
+    update(current -> current.withTrustedCrls(trustedCrls));
   }
 
   @Override
   public void setIssuerCertificates(List<X509Certificate> issuerCertificates) {
-    updateSnapshot(
-        current ->
-            new TrustListSnapshot(
-                issuerCertificates,
-                current.issuerCrls(),
-                current.trustedCertificates(),
-                current.trustedCrls(),
-                DateTime.now()));
+    update(current -> current.withIssuerCertificates(issuerCertificates));
   }
 
   @Override
   public void setTrustedCertificates(List<X509Certificate> trustedCertificates) {
-    updateSnapshot(
-        current ->
-            new TrustListSnapshot(
-                current.issuerCertificates(),
-                current.issuerCrls(),
-                trustedCertificates,
-                current.trustedCrls(),
-                DateTime.now()));
+    update(current -> current.withTrustedCertificates(trustedCertificates));
   }
 
   @Override
   public void addIssuerCertificate(X509Certificate certificate) {
-    updateSnapshot(
-        current -> {
-          var issuerCertificates = new HashSet<>(current.issuerCertificates());
-          issuerCertificates.add(certificate);
-
-          return new TrustListSnapshot(
-              List.copyOf(issuerCertificates),
-              current.issuerCrls(),
-              current.trustedCertificates(),
-              current.trustedCrls(),
-              DateTime.now());
-        });
+    update(
+        current ->
+            current.withIssuerCertificates(
+                TrustListEdits.append(current.issuerCertificates(), certificate)));
   }
 
   @Override
   public void addTrustedCertificate(X509Certificate certificate) {
-    updateSnapshot(
-        current -> {
-          var trustedCertificates = new HashSet<>(current.trustedCertificates());
-          trustedCertificates.add(certificate);
-
-          return new TrustListSnapshot(
-              current.issuerCertificates(),
-              current.issuerCrls(),
-              List.copyOf(trustedCertificates),
-              current.trustedCrls(),
-              DateTime.now());
-        });
+    update(
+        current ->
+            current.withTrustedCertificates(
+                TrustListEdits.append(current.trustedCertificates(), certificate)));
   }
 
   @Override
   public boolean removeIssuerCertificate(ByteString thumbprint) {
-    mutationLock.lock();
-    try {
-      deleteCertificateFromDir(thumbprint, issuerCertsDir);
-
-      TrustListSnapshot current = snapshot.get();
-      var issuerCertificates = new HashSet<>(current.issuerCertificates());
-      boolean removed = remove(thumbprint, issuerCertificates);
-
-      if (removed) {
-        snapshot.set(
-            new TrustListSnapshot(
-                List.copyOf(issuerCertificates),
-                current.issuerCrls(),
-                current.trustedCertificates(),
-                current.trustedCrls(),
-                DateTime.now()));
-      }
-
-      return removed;
-    } finally {
-      mutationLock.unlock();
-    }
+    return TrustListEdits.remove(
+        this,
+        thumbprint,
+        TrustListSnapshot::issuerCertificates,
+        TrustListSnapshot::withIssuerCertificates);
   }
 
   @Override
   public boolean removeTrustedCertificate(ByteString thumbprint) {
-    mutationLock.lock();
-    try {
-      deleteCertificateFromDir(thumbprint, trustedCertsDir);
-
-      TrustListSnapshot current = snapshot.get();
-      var trustedCertificates = new HashSet<>(current.trustedCertificates());
-      boolean removed = remove(thumbprint, trustedCertificates);
-
-      if (removed) {
-        snapshot.set(
-            new TrustListSnapshot(
-                current.issuerCertificates(),
-                current.issuerCrls(),
-                List.copyOf(trustedCertificates),
-                current.trustedCrls(),
-                DateTime.now()));
-      }
-
-      return removed;
-    } finally {
-      mutationLock.unlock();
-    }
-  }
-
-  private static boolean remove(ByteString thumbprint, Set<X509Certificate> certificates) {
-    return certificates.removeIf(
-        certificate -> {
-          try {
-            return CertificateUtil.thumbprint(certificate).equals(thumbprint);
-          } catch (UaException ignored) {
-            return false;
-          }
-        });
+    return TrustListEdits.remove(
+        this,
+        thumbprint,
+        TrustListSnapshot::trustedCertificates,
+        TrustListSnapshot::withTrustedCertificates);
   }
 
   @Override
@@ -343,98 +284,81 @@ public class FileBasedTrustListManager implements TrustListManager, Closeable {
     return snapshot.get().lastUpdateTime();
   }
 
-  private void updateSnapshot(UnaryOperator<TrustListSnapshot> update) {
-    mutationLock.lock();
-    try {
-      replaceAllLocked(update.apply(snapshot.get()));
-    } finally {
-      mutationLock.unlock();
+  /** Write files for entries added to {@code replacement} and delete files for entries removed. */
+  private static <T> void updateFiles(
+      List<T> current,
+      List<T> replacement,
+      Path directory,
+      BiConsumer<T, Path> write,
+      BiConsumer<T, Path> delete) {
+
+    if (current.equals(replacement)) {
+      return;
     }
+
+    Set<T> currentSet = Set.copyOf(current);
+    Set<T> replacementSet = Set.copyOf(replacement);
+
+    Sets.difference(replacementSet, currentSet).forEach(entry -> write.accept(entry, directory));
+    Sets.difference(currentSet, replacementSet).forEach(entry -> delete.accept(entry, directory));
   }
 
-  private void replaceAllLocked(TrustListSnapshot replacement) {
-    TrustListSnapshot current = snapshot.get();
-    TrustListSnapshot normalized = normalize(replacement);
-
-    updateCertificateFiles(
-        current.issuerCertificates(), normalized.issuerCertificates(), issuerCertsDir);
-    updateCrlFiles(current.issuerCrls(), normalized.issuerCrls(), issuerCrlDir);
-    updateCertificateFiles(
-        current.trustedCertificates(), normalized.trustedCertificates(), trustedCertsDir);
-    updateCrlFiles(current.trustedCrls(), normalized.trustedCrls(), trustedCrlDir);
-
-    snapshot.set(normalized);
+  private void synchronizeIssuerCertificates() {
+    synchronize(
+        "issuer certificates",
+        current -> current.withIssuerCertificates(readCertificates(issuerCertsDir)));
   }
 
-  private static TrustListSnapshot normalize(TrustListSnapshot snapshot) {
-    return new TrustListSnapshot(
-        List.copyOf(new HashSet<>(snapshot.issuerCertificates())),
-        List.copyOf(new HashSet<>(snapshot.issuerCrls())),
-        List.copyOf(new HashSet<>(snapshot.trustedCertificates())),
-        List.copyOf(new HashSet<>(snapshot.trustedCrls())),
-        snapshot.lastUpdateTime());
+  private void synchronizeIssuerCrls() {
+    synchronize("issuer CRLs", current -> current.withIssuerCrls(readCrls(issuerCrlDir)));
   }
 
-  private static void updateCertificateFiles(
-      List<X509Certificate> current, List<X509Certificate> replacement, Path directory) {
-
-    Set<X509Certificate> currentSet = Set.copyOf(current);
-    Set<X509Certificate> replacementSet = Set.copyOf(replacement);
-
-    Sets.difference(replacementSet, currentSet)
-        .forEach(certificate -> writeCertificateToDir(certificate, directory));
-    Sets.difference(currentSet, replacementSet)
-        .forEach(certificate -> deleteCertificateFromDir(certificate, directory));
+  private void synchronizeTrustedCertificates() {
+    synchronize(
+        "trusted certificates",
+        current -> current.withTrustedCertificates(readCertificates(trustedCertsDir)));
   }
 
-  private static void updateCrlFiles(
-      List<X509CRL> current, List<X509CRL> replacement, Path directory) {
-
-    Set<X509CRL> currentSet = Set.copyOf(current);
-    Set<X509CRL> replacementSet = Set.copyOf(replacement);
-
-    Sets.difference(replacementSet, currentSet).forEach(crl -> writeCrlToDir(crl, directory));
-    Sets.difference(currentSet, replacementSet).forEach(crl -> deleteCrlFromDir(crl, directory));
+  private void synchronizeTrustedCrls() {
+    synchronize("trusted CRLs", current -> current.withTrustedCrls(readCrls(trustedCrlDir)));
   }
 
-  private void synchronizeAll() {
-    LOGGER.debug("Synchronizing trust lists...");
+  /**
+   * Reload one directory and publish the current snapshot with that directory's list replaced. If
+   * the directory cannot be listed the previous snapshot is kept.
+   */
+  private void synchronize(String name, Reload reload) {
+    LOGGER.debug("Synchronizing {}...", name);
 
     mutationLock.lock();
     try {
-      List<X509Certificate> issuerCertificates = readCertificates(issuerCertsDir);
-      List<X509CRL> issuerCrls = readCrls(issuerCrlDir);
-      List<X509Certificate> trustedCertificates = readCertificates(trustedCertsDir);
-      List<X509CRL> trustedCrls = readCrls(trustedCrlDir);
-
-      snapshot.set(
-          new TrustListSnapshot(
-              issuerCertificates, issuerCrls, trustedCertificates, trustedCrls, DateTime.now()));
+      snapshot.set(reload.apply(snapshot.get()).withLastUpdateTime(DateTime.now()));
     } catch (IOException e) {
-      LOGGER.warn("Error synchronizing trust lists", e);
+      LOGGER.warn("Error synchronizing {}", name, e);
     } finally {
       mutationLock.unlock();
     }
+  }
+
+  @FunctionalInterface
+  private interface Reload {
+    TrustListSnapshot apply(TrustListSnapshot current) throws IOException;
   }
 
   private static List<X509Certificate> readCertificates(Path directory) throws IOException {
-    var certificates = new HashSet<X509Certificate>();
-
-    try (var files = Files.list(directory)) {
-      files.flatMap(path -> decodeCertificateFile(path).stream()).forEach(certificates::add);
-    }
-
-    return List.copyOf(certificates);
+    return readAll(directory, path -> decodeCertificateFile(path).stream());
   }
 
   private static List<X509CRL> readCrls(Path directory) throws IOException {
-    var crls = new HashSet<X509CRL>();
+    return readAll(directory, path -> decodeCrlFile(path).stream().flatMap(List::stream));
+  }
+
+  private static <T> List<T> readAll(Path directory, Function<Path, Stream<T>> decode)
+      throws IOException {
 
     try (var files = Files.list(directory)) {
-      files.flatMap(path -> decodeCrlFile(path).stream()).forEach(crls::addAll);
+      return files.flatMap(decode).toList();
     }
-
-    return List.copyOf(crls);
   }
 
   private static Optional<X509Certificate> decodeCertificateFile(Path path) {
@@ -478,16 +402,8 @@ public class FileBasedTrustListManager implements TrustListManager, Closeable {
 
   private static void deleteCertificateFromDir(X509Certificate certificate, Path path) {
     try {
-      deleteCertificateFromDir(ByteString.of(sha1(certificate.getEncoded())), path);
-    } catch (Exception e) {
-      LOGGER.error("Error deleting certificate", e);
-    }
-  }
-
-  private static void deleteCertificateFromDir(ByteString thumbprint, Path path) {
-    try {
-      String filename = String.format("%s.der", ByteBufUtil.hexDump(thumbprint.bytesOrEmpty()));
-      File file = path.resolve(filename).toFile();
+      String thumbprint = ByteBufUtil.hexDump(sha1(certificate.getEncoded()));
+      File file = path.resolve(String.format("%s.der", thumbprint)).toFile();
 
       if (file.exists()) {
         Files.delete(file.toPath());
@@ -518,16 +434,8 @@ public class FileBasedTrustListManager implements TrustListManager, Closeable {
 
   private static void deleteCrlFromDir(X509CRL crl, Path path) {
     try {
-      deleteCrlFromDir(ByteString.of(sha1(crl.getEncoded())), path);
-    } catch (Exception e) {
-      LOGGER.error("Error deleting CRL", e);
-    }
-  }
-
-  private static void deleteCrlFromDir(ByteString thumbprint, Path path) {
-    try {
-      String filename = String.format("%s.crl", ByteBufUtil.hexDump(thumbprint.bytesOrEmpty()));
-      File file = path.resolve(filename).toFile();
+      String thumbprint = ByteBufUtil.hexDump(sha1(crl.getEncoded()));
+      File file = path.resolve(String.format("%s.crl", thumbprint)).toFile();
 
       if (file.exists()) {
         Files.delete(file.toPath());

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/MemoryTrustListManager.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/MemoryTrustListManager.java
@@ -12,22 +12,18 @@ package org.eclipse.milo.opcua.stack.core.security;
 
 import java.security.cert.X509CRL;
 import java.security.cert.X509Certificate;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.UnaryOperator;
-import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
-import org.eclipse.milo.opcua.stack.core.util.CertificateUtil;
 
 /** An in-memory {@link TrustListManager} that publishes each update as one immutable snapshot. */
 public class MemoryTrustListManager implements TrustListManager {
 
   private final AtomicReference<TrustListSnapshot> snapshot =
-      new AtomicReference<>(
-          new TrustListSnapshot(List.of(), List.of(), List.of(), List.of(), DateTime.MIN_VALUE));
+      new AtomicReference<>(TrustListSnapshot.empty());
 
   @Override
   public TrustListSnapshot getSnapshot() {
@@ -35,8 +31,13 @@ public class MemoryTrustListManager implements TrustListManager {
   }
 
   @Override
-  public void replaceAll(TrustListSnapshot snapshot) {
-    this.snapshot.set(Objects.requireNonNull(snapshot));
+  public TrustListSnapshot update(UnaryOperator<TrustListSnapshot> update) {
+    return snapshot.updateAndGet(
+        current -> {
+          TrustListSnapshot updated = Objects.requireNonNull(update.apply(current));
+
+          return updated == current ? current : updated.withLastUpdateTime(DateTime.now());
+        });
   }
 
   @Override
@@ -61,140 +62,60 @@ public class MemoryTrustListManager implements TrustListManager {
 
   @Override
   public void setIssuerCrls(List<X509CRL> issuerCrls) {
-    updateSnapshot(
-        current ->
-            new TrustListSnapshot(
-                current.issuerCertificates(),
-                issuerCrls,
-                current.trustedCertificates(),
-                current.trustedCrls(),
-                DateTime.now()));
+    update(current -> current.withIssuerCrls(issuerCrls));
   }
 
   @Override
   public void setTrustedCrls(List<X509CRL> trustedCrls) {
-    updateSnapshot(
-        current ->
-            new TrustListSnapshot(
-                current.issuerCertificates(),
-                current.issuerCrls(),
-                current.trustedCertificates(),
-                trustedCrls,
-                DateTime.now()));
+    update(current -> current.withTrustedCrls(trustedCrls));
   }
 
   @Override
   public void setIssuerCertificates(List<X509Certificate> issuerCertificates) {
-    updateSnapshot(
-        current ->
-            new TrustListSnapshot(
-                issuerCertificates,
-                current.issuerCrls(),
-                current.trustedCertificates(),
-                current.trustedCrls(),
-                DateTime.now()));
+    update(current -> current.withIssuerCertificates(issuerCertificates));
   }
 
   @Override
   public void setTrustedCertificates(List<X509Certificate> trustedCertificates) {
-    updateSnapshot(
-        current ->
-            new TrustListSnapshot(
-                current.issuerCertificates(),
-                current.issuerCrls(),
-                trustedCertificates,
-                current.trustedCrls(),
-                DateTime.now()));
+    update(current -> current.withTrustedCertificates(trustedCertificates));
   }
 
   @Override
   public void addIssuerCertificate(X509Certificate certificate) {
-    updateSnapshot(
-        current -> {
-          var issuerCertificates = new ArrayList<>(current.issuerCertificates());
-          issuerCertificates.add(certificate);
-
-          return new TrustListSnapshot(
-              issuerCertificates,
-              current.issuerCrls(),
-              current.trustedCertificates(),
-              current.trustedCrls(),
-              DateTime.now());
-        });
+    update(
+        current ->
+            current.withIssuerCertificates(
+                TrustListEdits.append(current.issuerCertificates(), certificate)));
   }
 
   @Override
   public void addTrustedCertificate(X509Certificate certificate) {
-    updateSnapshot(
-        current -> {
-          var trustedCertificates = new ArrayList<>(current.trustedCertificates());
-          trustedCertificates.add(certificate);
-
-          return new TrustListSnapshot(
-              current.issuerCertificates(),
-              current.issuerCrls(),
-              trustedCertificates,
-              current.trustedCrls(),
-              DateTime.now());
-        });
+    update(
+        current ->
+            current.withTrustedCertificates(
+                TrustListEdits.append(current.trustedCertificates(), certificate)));
   }
 
   @Override
   public boolean removeIssuerCertificate(ByteString thumbprint) {
-    return removeCertificate(thumbprint, true);
+    return TrustListEdits.remove(
+        this,
+        thumbprint,
+        TrustListSnapshot::issuerCertificates,
+        TrustListSnapshot::withIssuerCertificates);
   }
 
   @Override
   public boolean removeTrustedCertificate(ByteString thumbprint) {
-    return removeCertificate(thumbprint, false);
+    return TrustListEdits.remove(
+        this,
+        thumbprint,
+        TrustListSnapshot::trustedCertificates,
+        TrustListSnapshot::withTrustedCertificates);
   }
 
   @Override
   public DateTime getLastUpdateTime() {
     return snapshot.get().lastUpdateTime();
-  }
-
-  private boolean removeCertificate(ByteString thumbprint, boolean issuer) {
-    while (true) {
-      TrustListSnapshot current = snapshot.get();
-      List<X509Certificate> certificates =
-          issuer ? current.issuerCertificates() : current.trustedCertificates();
-      var updatedCertificates = new ArrayList<>(certificates);
-
-      if (!updatedCertificates.removeIf(c -> thumbprintMatches(c, thumbprint))) {
-        return false;
-      }
-
-      TrustListSnapshot updated =
-          issuer
-              ? new TrustListSnapshot(
-                  updatedCertificates,
-                  current.issuerCrls(),
-                  current.trustedCertificates(),
-                  current.trustedCrls(),
-                  DateTime.now())
-              : new TrustListSnapshot(
-                  current.issuerCertificates(),
-                  current.issuerCrls(),
-                  updatedCertificates,
-                  current.trustedCrls(),
-                  DateTime.now());
-
-      if (snapshot.compareAndSet(current, updated)) {
-        return true;
-      }
-    }
-  }
-
-  private void updateSnapshot(UnaryOperator<TrustListSnapshot> update) {
-    snapshot.updateAndGet(update);
-  }
-
-  private static boolean thumbprintMatches(X509Certificate certificate, ByteString thumbprint) {
-    try {
-      return CertificateUtil.thumbprint(certificate).equals(thumbprint);
-    } catch (UaException e) {
-      return false;
-    }
   }
 }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/MemoryTrustListManager.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/MemoryTrustListManager.java
@@ -13,134 +13,181 @@ package org.eclipse.milo.opcua.stack.core.security;
 import java.security.cert.X509CRL;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.UnaryOperator;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
 import org.eclipse.milo.opcua.stack.core.util.CertificateUtil;
 
+/** An in-memory {@link TrustListManager} that publishes each update as one immutable snapshot. */
 public class MemoryTrustListManager implements TrustListManager {
 
-  private final AtomicReference<DateTime> lastUpdateTime =
-      new AtomicReference<>(DateTime.MIN_VALUE);
+  private final AtomicReference<TrustListSnapshot> snapshot =
+      new AtomicReference<>(
+          new TrustListSnapshot(List.of(), List.of(), List.of(), List.of(), DateTime.MIN_VALUE));
 
-  private final List<X509Certificate> issuerCertificates =
-      Collections.synchronizedList(new ArrayList<>());
-  private final List<X509Certificate> trustedCertificates =
-      Collections.synchronizedList(new ArrayList<>());
+  @Override
+  public TrustListSnapshot getSnapshot() {
+    return snapshot.get();
+  }
 
-  private final List<X509CRL> issuerCrls = Collections.synchronizedList(new ArrayList<>());
-  private final List<X509CRL> trustedCrls = Collections.synchronizedList(new ArrayList<>());
+  @Override
+  public void replaceAll(TrustListSnapshot snapshot) {
+    this.snapshot.set(Objects.requireNonNull(snapshot));
+  }
 
   @Override
   public List<X509CRL> getIssuerCrls() {
-    synchronized (issuerCrls) {
-      return List.copyOf(issuerCrls);
-    }
+    return snapshot.get().issuerCrls();
   }
 
   @Override
   public List<X509CRL> getTrustedCrls() {
-    synchronized (trustedCrls) {
-      return List.copyOf(trustedCrls);
-    }
+    return snapshot.get().trustedCrls();
   }
 
   @Override
   public List<X509Certificate> getIssuerCertificates() {
-    synchronized (issuerCertificates) {
-      return List.copyOf(issuerCertificates);
-    }
+    return snapshot.get().issuerCertificates();
   }
 
   @Override
   public List<X509Certificate> getTrustedCertificates() {
-    synchronized (trustedCertificates) {
-      return List.copyOf(trustedCertificates);
-    }
+    return snapshot.get().trustedCertificates();
   }
 
   @Override
   public void setIssuerCrls(List<X509CRL> issuerCrls) {
-    synchronized (this.issuerCrls) {
-      this.issuerCrls.clear();
-      this.issuerCrls.addAll(issuerCrls);
-
-      lastUpdateTime.set(DateTime.now());
-    }
+    updateSnapshot(
+        current ->
+            new TrustListSnapshot(
+                current.issuerCertificates(),
+                issuerCrls,
+                current.trustedCertificates(),
+                current.trustedCrls(),
+                DateTime.now()));
   }
 
   @Override
   public void setTrustedCrls(List<X509CRL> trustedCrls) {
-    synchronized (this.trustedCrls) {
-      this.trustedCrls.clear();
-      this.trustedCrls.addAll(trustedCrls);
-
-      lastUpdateTime.set(DateTime.now());
-    }
+    updateSnapshot(
+        current ->
+            new TrustListSnapshot(
+                current.issuerCertificates(),
+                current.issuerCrls(),
+                current.trustedCertificates(),
+                trustedCrls,
+                DateTime.now()));
   }
 
   @Override
   public void setIssuerCertificates(List<X509Certificate> issuerCertificates) {
-    synchronized (this.issuerCertificates) {
-      this.issuerCertificates.clear();
-      this.issuerCertificates.addAll(issuerCertificates);
-
-      lastUpdateTime.set(DateTime.now());
-    }
+    updateSnapshot(
+        current ->
+            new TrustListSnapshot(
+                issuerCertificates,
+                current.issuerCrls(),
+                current.trustedCertificates(),
+                current.trustedCrls(),
+                DateTime.now()));
   }
 
   @Override
   public void setTrustedCertificates(List<X509Certificate> trustedCertificates) {
-    synchronized (this.trustedCertificates) {
-      this.trustedCertificates.clear();
-      this.trustedCertificates.addAll(trustedCertificates);
-
-      lastUpdateTime.set(DateTime.now());
-    }
+    updateSnapshot(
+        current ->
+            new TrustListSnapshot(
+                current.issuerCertificates(),
+                current.issuerCrls(),
+                trustedCertificates,
+                current.trustedCrls(),
+                DateTime.now()));
   }
 
   @Override
   public void addIssuerCertificate(X509Certificate certificate) {
-    issuerCertificates.add(certificate);
+    updateSnapshot(
+        current -> {
+          var issuerCertificates = new ArrayList<>(current.issuerCertificates());
+          issuerCertificates.add(certificate);
 
-    lastUpdateTime.set(DateTime.now());
+          return new TrustListSnapshot(
+              issuerCertificates,
+              current.issuerCrls(),
+              current.trustedCertificates(),
+              current.trustedCrls(),
+              DateTime.now());
+        });
   }
 
   @Override
   public void addTrustedCertificate(X509Certificate certificate) {
-    trustedCertificates.add(certificate);
+    updateSnapshot(
+        current -> {
+          var trustedCertificates = new ArrayList<>(current.trustedCertificates());
+          trustedCertificates.add(certificate);
 
-    lastUpdateTime.set(DateTime.now());
+          return new TrustListSnapshot(
+              current.issuerCertificates(),
+              current.issuerCrls(),
+              trustedCertificates,
+              current.trustedCrls(),
+              DateTime.now());
+        });
   }
 
   @Override
   public boolean removeIssuerCertificate(ByteString thumbprint) {
-    boolean removed = issuerCertificates.removeIf(c -> thumbprintMatches(c, thumbprint));
-
-    if (removed) {
-      lastUpdateTime.set(DateTime.now());
-    }
-
-    return removed;
+    return removeCertificate(thumbprint, true);
   }
 
   @Override
   public boolean removeTrustedCertificate(ByteString thumbprint) {
-    boolean removed = trustedCertificates.removeIf(c -> thumbprintMatches(c, thumbprint));
-
-    if (removed) {
-      lastUpdateTime.set(DateTime.now());
-    }
-
-    return removed;
+    return removeCertificate(thumbprint, false);
   }
 
   @Override
   public DateTime getLastUpdateTime() {
-    return lastUpdateTime.get();
+    return snapshot.get().lastUpdateTime();
+  }
+
+  private boolean removeCertificate(ByteString thumbprint, boolean issuer) {
+    while (true) {
+      TrustListSnapshot current = snapshot.get();
+      List<X509Certificate> certificates =
+          issuer ? current.issuerCertificates() : current.trustedCertificates();
+      var updatedCertificates = new ArrayList<>(certificates);
+
+      if (!updatedCertificates.removeIf(c -> thumbprintMatches(c, thumbprint))) {
+        return false;
+      }
+
+      TrustListSnapshot updated =
+          issuer
+              ? new TrustListSnapshot(
+                  updatedCertificates,
+                  current.issuerCrls(),
+                  current.trustedCertificates(),
+                  current.trustedCrls(),
+                  DateTime.now())
+              : new TrustListSnapshot(
+                  current.issuerCertificates(),
+                  current.issuerCrls(),
+                  updatedCertificates,
+                  current.trustedCrls(),
+                  DateTime.now());
+
+      if (snapshot.compareAndSet(current, updated)) {
+        return true;
+      }
+    }
+  }
+
+  private void updateSnapshot(UnaryOperator<TrustListSnapshot> update) {
+    snapshot.updateAndGet(update);
   }
 
   private static boolean thumbprintMatches(X509Certificate certificate, ByteString thumbprint) {

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/TrustListEdits.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/TrustListEdits.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.core.security;
+
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.util.CertificateUtil;
+
+/** Snapshot edits shared by the built-in {@link TrustListManager} implementations. */
+final class TrustListEdits {
+
+  private TrustListEdits() {}
+
+  static List<X509Certificate> append(
+      List<X509Certificate> certificates, X509Certificate certificate) {
+
+    return Stream.concat(certificates.stream(), Stream.of(certificate)).toList();
+  }
+
+  /**
+   * Remove the certificate identified by {@code thumbprint} from one of {@code manager}'s
+   * certificate lists via {@link TrustListManager#update}.
+   *
+   * @param manager the manager to update.
+   * @param thumbprint the thumbprint to remove.
+   * @param list reads the target list from a snapshot.
+   * @param with derives a snapshot with the target list replaced.
+   * @return {@code true} if a certificate with a matching thumbprint was removed.
+   */
+  static boolean remove(
+      TrustListManager manager,
+      ByteString thumbprint,
+      Function<TrustListSnapshot, List<X509Certificate>> list,
+      BiFunction<TrustListSnapshot, List<X509Certificate>, TrustListSnapshot> with) {
+
+    // The operator may run more than once if the manager retries; the last run is the one that
+    // commits, so the flag it leaves behind is the right one.
+    var removed = new AtomicBoolean();
+
+    manager.update(
+        current -> {
+          var certificates = new ArrayList<>(list.apply(current));
+          removed.set(certificates.removeIf(c -> thumbprintMatches(c, thumbprint)));
+
+          return removed.get() ? with.apply(current, certificates) : current;
+        });
+
+    return removed.get();
+  }
+
+  private static boolean thumbprintMatches(X509Certificate certificate, ByteString thumbprint) {
+    try {
+      return CertificateUtil.thumbprint(certificate).equals(thumbprint);
+    } catch (UaException e) {
+      return false;
+    }
+  }
+}

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/TrustListManager.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/TrustListManager.java
@@ -22,6 +22,9 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
  * <p>Each OPC UA application should create one shared {@link TrustListManager}. Components that
  * receive the manager, such as a certificate validator, borrow it and do not close it.
  *
+ * <p>Use {@link #getSnapshot()} when one operation needs multiple lists from the same manager
+ * state.
+ *
  * <p>The application must call {@link #close()} when it shuts down. Implementations that do not
  * hold resources may use the default no-op implementation.
  */
@@ -36,6 +39,59 @@ public interface TrustListManager extends AutoCloseable {
    */
   @Override
   default void close() throws Exception {}
+
+  /**
+   * Get an immutable snapshot of all trust lists and their last update time.
+   *
+   * <p>Built-in implementations return a snapshot captured atomically. The default reads the
+   * individual properties in sequence and therefore cannot guarantee a coherent view during a
+   * concurrent update.
+   *
+   * @return the current trust-list snapshot.
+   */
+  default TrustListSnapshot getSnapshot() {
+    return new TrustListSnapshot(
+        getIssuerCertificates(),
+        getIssuerCrls(),
+        getTrustedCertificates(),
+        getTrustedCrls(),
+        getLastUpdateTime());
+  }
+
+  /**
+   * Replace all trust-list state with {@code snapshot}.
+   *
+   * <p>Built-in implementations publish the replacement atomically. The default invokes the four
+   * individual setters in sequence, so other implementations must override this method to provide
+   * the same atomicity. Implementations using the default retain control of their last update time.
+   *
+   * @param snapshot the replacement trust-list state.
+   */
+  default void replaceAll(TrustListSnapshot snapshot) {
+    setIssuerCertificates(snapshot.issuerCertificates());
+    setIssuerCrls(snapshot.issuerCrls());
+    setTrustedCertificates(snapshot.trustedCertificates());
+    setTrustedCrls(snapshot.trustedCrls());
+  }
+
+  /**
+   * Replace all four trust lists and set their last update time to the current time.
+   *
+   * @param issuerCertificates the new issuer certificates.
+   * @param issuerCrls the new issuer certificate revocation lists.
+   * @param trustedCertificates the new trusted certificates.
+   * @param trustedCrls the new trusted certificate revocation lists.
+   */
+  default void replaceAll(
+      List<X509Certificate> issuerCertificates,
+      List<X509CRL> issuerCrls,
+      List<X509Certificate> trustedCertificates,
+      List<X509CRL> trustedCrls) {
+
+    replaceAll(
+        new TrustListSnapshot(
+            issuerCertificates, issuerCrls, trustedCertificates, trustedCrls, DateTime.now()));
+  }
 
   /**
    * Get the list of Issuer CRLs.

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/TrustListManager.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/TrustListManager.java
@@ -13,6 +13,8 @@ package org.eclipse.milo.opcua.stack.core.security;
 import java.security.cert.X509CRL;
 import java.security.cert.X509Certificate;
 import java.util.List;
+import java.util.Objects;
+import java.util.function.UnaryOperator;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
 
@@ -23,6 +25,7 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
  * receive the manager, such as a certificate validator, borrow it and do not close it.
  *
  * <p>Use {@link #getSnapshot()} when one operation needs multiple lists from the same manager
+ * state, and {@link #update(UnaryOperator)} when one operation must read and then change that
  * state.
  *
  * <p>The application must call {@link #close()} when it shuts down. Implementations that do not
@@ -59,38 +62,49 @@ public interface TrustListManager extends AutoCloseable {
   }
 
   /**
-   * Replace all trust-list state with {@code snapshot}.
+   * Apply {@code update} to the current snapshot and commit the result as one replacement.
    *
-   * <p>Built-in implementations publish the replacement atomically. The default invokes the four
-   * individual setters in sequence, so other implementations must override this method to provide
-   * the same atomicity. Implementations using the default retain control of their last update time.
+   * <p>{@code update} receives the current snapshot and returns the snapshot to commit. Returning
+   * the same instance it received commits nothing. The manager sets the committed snapshot's last
+   * update time to the commit time; the time carried by the returned snapshot is ignored.
+   *
+   * <p>Built-in implementations apply {@code update} under their own synchronization, so a
+   * read-modify-write expressed through this method cannot lose a concurrent change. {@code update}
+   * may be invoked more than once if the manager retries, so it should be free of side effects. The
+   * default reads {@link #getSnapshot()} and calls the four individual setters in sequence; other
+   * implementations must override this method to provide the same atomicity.
+   *
+   * @param update the transformation to apply.
+   * @return the committed snapshot, or the current snapshot if nothing was committed.
+   */
+  default TrustListSnapshot update(UnaryOperator<TrustListSnapshot> update) {
+    TrustListSnapshot current = getSnapshot();
+    TrustListSnapshot updated = Objects.requireNonNull(update.apply(current));
+
+    if (updated == current) {
+      return current;
+    }
+
+    setIssuerCertificates(updated.issuerCertificates());
+    setIssuerCrls(updated.issuerCrls());
+    setTrustedCertificates(updated.trustedCertificates());
+    setTrustedCrls(updated.trustedCrls());
+
+    return getSnapshot();
+  }
+
+  /**
+   * Replace all four trust lists with those in {@code snapshot} as one replacement.
+   *
+   * <p>Equivalent to {@code update(current -> snapshot)}; see {@link #update(UnaryOperator)} for
+   * the atomicity and last update time contract.
    *
    * @param snapshot the replacement trust-list state.
    */
   default void replaceAll(TrustListSnapshot snapshot) {
-    setIssuerCertificates(snapshot.issuerCertificates());
-    setIssuerCrls(snapshot.issuerCrls());
-    setTrustedCertificates(snapshot.trustedCertificates());
-    setTrustedCrls(snapshot.trustedCrls());
-  }
+    Objects.requireNonNull(snapshot);
 
-  /**
-   * Replace all four trust lists and set their last update time to the current time.
-   *
-   * @param issuerCertificates the new issuer certificates.
-   * @param issuerCrls the new issuer certificate revocation lists.
-   * @param trustedCertificates the new trusted certificates.
-   * @param trustedCrls the new trusted certificate revocation lists.
-   */
-  default void replaceAll(
-      List<X509Certificate> issuerCertificates,
-      List<X509CRL> issuerCrls,
-      List<X509Certificate> trustedCertificates,
-      List<X509CRL> trustedCrls) {
-
-    replaceAll(
-        new TrustListSnapshot(
-            issuerCertificates, issuerCrls, trustedCertificates, trustedCrls, DateTime.now()));
+    update(current -> snapshot);
   }
 
   /**

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/TrustListSnapshot.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/TrustListSnapshot.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.core.security;
+
+import java.security.cert.X509CRL;
+import java.security.cert.X509Certificate;
+import java.util.List;
+import java.util.Objects;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+
+/**
+ * An immutable view of all certificate trust lists and the time they were last updated.
+ *
+ * <p>Use a snapshot when an operation must read more than one list consistently. The contained
+ * lists are immutable copies of the lists supplied at construction time.
+ *
+ * @param issuerCertificates the issuer certificates.
+ * @param issuerCrls the issuer certificate revocation lists.
+ * @param trustedCertificates the trusted certificates.
+ * @param trustedCrls the trusted certificate revocation lists.
+ * @param lastUpdateTime the time the trust lists were last updated.
+ */
+public record TrustListSnapshot(
+    List<X509Certificate> issuerCertificates,
+    List<X509CRL> issuerCrls,
+    List<X509Certificate> trustedCertificates,
+    List<X509CRL> trustedCrls,
+    DateTime lastUpdateTime) {
+
+  public TrustListSnapshot {
+    issuerCertificates = List.copyOf(issuerCertificates);
+    issuerCrls = List.copyOf(issuerCrls);
+    trustedCertificates = List.copyOf(trustedCertificates);
+    trustedCrls = List.copyOf(trustedCrls);
+    lastUpdateTime = Objects.requireNonNull(lastUpdateTime);
+  }
+}

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/TrustListSnapshot.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/TrustListSnapshot.java
@@ -12,6 +12,7 @@ package org.eclipse.milo.opcua.stack.core.security;
 
 import java.security.cert.X509CRL;
 import java.security.cert.X509Certificate;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
@@ -19,8 +20,12 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
 /**
  * An immutable view of all certificate trust lists and the time they were last updated.
  *
- * <p>Use a snapshot when an operation must read more than one list consistently. The contained
- * lists are immutable copies of the lists supplied at construction time.
+ * <p>Use a snapshot when an operation must read more than one list consistently. Each list is an
+ * immutable copy of the list supplied at construction time, with duplicate entries removed while
+ * preserving the first occurrence.
+ *
+ * <p>The {@code with*} methods derive a new snapshot with one list replaced. They keep {@code
+ * lastUpdateTime} unchanged; a {@link TrustListManager} stamps the time when it commits.
  *
  * @param issuerCertificates the issuer certificates.
  * @param issuerCrls the issuer certificate revocation lists.
@@ -36,10 +41,67 @@ public record TrustListSnapshot(
     DateTime lastUpdateTime) {
 
   public TrustListSnapshot {
-    issuerCertificates = List.copyOf(issuerCertificates);
-    issuerCrls = List.copyOf(issuerCrls);
-    trustedCertificates = List.copyOf(trustedCertificates);
-    trustedCrls = List.copyOf(trustedCrls);
+    issuerCertificates = distinct(issuerCertificates);
+    issuerCrls = distinct(issuerCrls);
+    trustedCertificates = distinct(trustedCertificates);
+    trustedCrls = distinct(trustedCrls);
     lastUpdateTime = Objects.requireNonNull(lastUpdateTime);
+  }
+
+  /**
+   * @return a snapshot with all lists empty and {@code lastUpdateTime} set to {@link
+   *     DateTime#MIN_VALUE}.
+   */
+  public static TrustListSnapshot empty() {
+    return new TrustListSnapshot(List.of(), List.of(), List.of(), List.of(), DateTime.MIN_VALUE);
+  }
+
+  /**
+   * @param issuerCertificates the replacement issuer certificates.
+   * @return a copy of this snapshot with {@code issuerCertificates} replaced.
+   */
+  public TrustListSnapshot withIssuerCertificates(List<X509Certificate> issuerCertificates) {
+    return new TrustListSnapshot(
+        issuerCertificates, issuerCrls, trustedCertificates, trustedCrls, lastUpdateTime);
+  }
+
+  /**
+   * @param issuerCrls the replacement issuer CRLs.
+   * @return a copy of this snapshot with {@code issuerCrls} replaced.
+   */
+  public TrustListSnapshot withIssuerCrls(List<X509CRL> issuerCrls) {
+    return new TrustListSnapshot(
+        issuerCertificates, issuerCrls, trustedCertificates, trustedCrls, lastUpdateTime);
+  }
+
+  /**
+   * @param trustedCertificates the replacement trusted certificates.
+   * @return a copy of this snapshot with {@code trustedCertificates} replaced.
+   */
+  public TrustListSnapshot withTrustedCertificates(List<X509Certificate> trustedCertificates) {
+    return new TrustListSnapshot(
+        issuerCertificates, issuerCrls, trustedCertificates, trustedCrls, lastUpdateTime);
+  }
+
+  /**
+   * @param trustedCrls the replacement trusted CRLs.
+   * @return a copy of this snapshot with {@code trustedCrls} replaced.
+   */
+  public TrustListSnapshot withTrustedCrls(List<X509CRL> trustedCrls) {
+    return new TrustListSnapshot(
+        issuerCertificates, issuerCrls, trustedCertificates, trustedCrls, lastUpdateTime);
+  }
+
+  /**
+   * @param lastUpdateTime the replacement last update time.
+   * @return a copy of this snapshot with {@code lastUpdateTime} replaced.
+   */
+  public TrustListSnapshot withLastUpdateTime(DateTime lastUpdateTime) {
+    return new TrustListSnapshot(
+        issuerCertificates, issuerCrls, trustedCertificates, trustedCrls, lastUpdateTime);
+  }
+
+  private static <T> List<T> distinct(List<T> list) {
+    return List.copyOf(new LinkedHashSet<>(list));
   }
 }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/package-info.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/package-info.java
@@ -71,9 +71,10 @@
  * and trust material. Certificate validators enforce trust-list and certificate-chain decisions at
  * connection boundaries; callers should keep certificate lookup, trust configuration, and policy
  * selection coordinated through these APIs. Operations that consume multiple trust lists should
- * capture one {@link org.eclipse.milo.opcua.stack.core.security.TrustListSnapshot}. Built-in trust
- * list managers capture that snapshot atomically; custom managers should override the snapshot
- * operations when they need the same guarantee. {@link
+ * capture one {@link org.eclipse.milo.opcua.stack.core.security.TrustListSnapshot}, and operations
+ * that read and then change trust lists should do so through {@code TrustListManager.update}.
+ * Built-in trust list managers capture snapshots and apply updates atomically; custom managers
+ * should override those two methods when they need the same guarantee. {@link
  * org.eclipse.milo.opcua.stack.core.security.CertificateIdentity} represents a concrete local
  * identity selected from those sources for endpoint advertisement or SecureChannel setup. {@link
  * org.eclipse.milo.opcua.stack.core.security.CertificateCompatibility} contains the

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/package-info.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/package-info.java
@@ -70,7 +70,10 @@
  * <p>Certificate managers and certificate groups remain the source of local certificate identity
  * and trust material. Certificate validators enforce trust-list and certificate-chain decisions at
  * connection boundaries; callers should keep certificate lookup, trust configuration, and policy
- * selection coordinated through these APIs. {@link
+ * selection coordinated through these APIs. Operations that consume multiple trust lists should
+ * capture one {@link org.eclipse.milo.opcua.stack.core.security.TrustListSnapshot}. Built-in trust
+ * list managers capture that snapshot atomically; custom managers should override the snapshot
+ * operations when they need the same guarantee. {@link
  * org.eclipse.milo.opcua.stack.core.security.CertificateIdentity} represents a concrete local
  * identity selected from those sources for endpoint advertisement or SecureChannel setup. {@link
  * org.eclipse.milo.opcua.stack.core.security.CertificateCompatibility} contains the

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/security/DefaultCertificateValidatorTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/security/DefaultCertificateValidatorTest.java
@@ -11,18 +11,22 @@
 package org.eclipse.milo.opcua.stack.core.security;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
+import java.security.cert.X509CRL;
 import java.security.cert.X509Certificate;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.asn1.x509.KeyUsage;
 import org.bouncycastle.cert.CertIOException;
 import org.bouncycastle.cert.X509v3CertificateBuilder;
 import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
 import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateBuilder;
 import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateGenerator;
 import org.eclipse.milo.opcua.stack.core.util.validation.CaSignedCertificateBuilder;
@@ -242,6 +246,36 @@ class DefaultCertificateValidatorTest {
                 List.of(certificate), null, null, SecurityPolicy.Basic256Sha256.getProfile()));
   }
 
+  // Certificate path construction and revocation checks must use the same trust-list generation.
+  @Test
+  void defaultClientValidatorReadsOneTrustListSnapshot() {
+    X509Certificate certificate = createRsaCertificate();
+    var trustListManager = new SnapshotOnlyTrustListManager(certificate);
+    var validator =
+        new DefaultClientCertificateValidator(
+            trustListManager,
+            ValidationCheck.NO_OPTIONAL_CHECKS,
+            new MemoryCertificateQuarantine());
+
+    assertDoesNotThrow(() -> validator.validateCertificateChain(List.of(certificate), null, null));
+    assertEquals(1, trustListManager.snapshotReads.get());
+  }
+
+  // Servers have the same two-phase path and revocation validation boundary as clients.
+  @Test
+  void defaultServerValidatorReadsOneTrustListSnapshot() {
+    X509Certificate certificate = createRsaCertificate();
+    var trustListManager = new SnapshotOnlyTrustListManager(certificate);
+    var validator =
+        new DefaultServerCertificateValidator(
+            trustListManager,
+            ValidationCheck.NO_OPTIONAL_CHECKS,
+            new MemoryCertificateQuarantine());
+
+    assertDoesNotThrow(() -> validator.validateCertificateChain(List.of(certificate), null, null));
+    assertEquals(1, trustListManager.snapshotReads.get());
+  }
+
   private static X509Certificate createMinimalEccCertificate() throws Exception {
     KeyPair keyPair = SelfSignedCertificateGenerator.generateNistP256KeyPair();
 
@@ -355,6 +389,43 @@ class DefaultCertificateValidatorTest {
     MemoryTrustListManager trustListManager = new MemoryTrustListManager();
     trustListManager.addTrustedCertificate(certificate);
     return trustListManager;
+  }
+
+  private static final class SnapshotOnlyTrustListManager extends MemoryTrustListManager {
+
+    private final AtomicInteger snapshotReads = new AtomicInteger();
+
+    SnapshotOnlyTrustListManager(X509Certificate trustedCertificate) {
+      replaceAll(
+          new TrustListSnapshot(
+              List.of(), List.of(), List.of(trustedCertificate), List.of(), DateTime.MIN_VALUE));
+    }
+
+    @Override
+    public TrustListSnapshot getSnapshot() {
+      snapshotReads.incrementAndGet();
+      return super.getSnapshot();
+    }
+
+    @Override
+    public List<X509CRL> getIssuerCrls() {
+      throw new AssertionError("validator must use getSnapshot()");
+    }
+
+    @Override
+    public List<X509CRL> getTrustedCrls() {
+      throw new AssertionError("validator must use getSnapshot()");
+    }
+
+    @Override
+    public List<X509Certificate> getIssuerCertificates() {
+      throw new AssertionError("validator must use getSnapshot()");
+    }
+
+    @Override
+    public List<X509Certificate> getTrustedCertificates() {
+      throw new AssertionError("validator must use getSnapshot()");
+    }
   }
 
   private record CertificateChain(X509Certificate certificate, X509Certificate issuerCertificate) {}

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/security/TrustListManagerAtomicityTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/security/TrustListManagerAtomicityTest.java
@@ -1,0 +1,349 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.core.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.cert.X509CRL;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.util.CrlTestUtil;
+import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateBuilder;
+import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class TrustListManagerAtomicityTest {
+
+  private static final Generation GENERATION_A = createGeneration("generation-a", new DateTime(1));
+  private static final Generation GENERATION_B = createGeneration("generation-b", new DateTime(2));
+
+  @TempDir Path tempDir;
+
+  // A validator must never combine certificates and CRLs from different replacement generations.
+  @Test
+  void memoryManagerPublishesOnlyCompleteSnapshotsDuringConcurrentReplacement() throws Exception {
+    try (var manager = new MemoryTrustListManager()) {
+      assertAtomicReplacement(manager, 10_001);
+    }
+  }
+
+  // File writes must finish before one complete replacement becomes visible to in-memory readers.
+  @Test
+  void fileManagerPublishesOnlyCompleteSnapshotsDuringConcurrentReplacement() throws Exception {
+    Path baseDir = Files.createTempDirectory(tempDir, "pki");
+    Path issuerCertsDir = Files.createDirectories(baseDir.resolve("issuer/certs"));
+    Path issuerCrlDir = Files.createDirectories(baseDir.resolve("issuer/crl"));
+    Path trustedCertsDir = Files.createDirectories(baseDir.resolve("trusted/certs"));
+    Path trustedCrlDir = Files.createDirectories(baseDir.resolve("trusted/crl"));
+
+    try (var manager =
+        new FileBasedTrustListManager(
+            issuerCertsDir, issuerCrlDir, trustedCertsDir, trustedCrlDir)) {
+
+      assertAtomicReplacement(manager, 25);
+    }
+  }
+
+  // Writer-generated events must reload all four directories before the watcher publishes state.
+  @Test
+  void fileWatcherPublishesACompleteReload() throws Exception {
+    try (var manager =
+        FileBasedTrustListManager.createAndInitialize(Files.createTempDirectory(tempDir, "pki"))) {
+
+      manager.replaceAll(GENERATION_A.snapshot());
+
+      TrustListSnapshot reloaded = awaitWatcherReload(manager, GENERATION_A.lastUpdateTime());
+      assertTrue(GENERATION_A.matchesLists(reloaded));
+    }
+  }
+
+  // A snapshot stays coherent even if a caller reuses and mutates its constructor inputs.
+  @Test
+  void snapshotDefensivelyCopiesItsLists() {
+    var certificates = new ArrayList<>(GENERATION_A.certificates());
+    var crls = new ArrayList<>(GENERATION_A.crls());
+    var snapshot =
+        new TrustListSnapshot(certificates, crls, certificates, crls, DateTime.MIN_VALUE);
+
+    certificates.clear();
+    crls.clear();
+
+    assertEquals(GENERATION_A.certificates(), snapshot.issuerCertificates());
+    assertEquals(GENERATION_A.crls(), snapshot.issuerCrls());
+    assertEquals(GENERATION_A.certificates(), snapshot.trustedCertificates());
+    assertEquals(GENERATION_A.crls(), snapshot.trustedCrls());
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> snapshot.trustedCertificates().add(GENERATION_B.certificate()));
+  }
+
+  @Test
+  void memoryManagerRejectsNullReplacementWithoutChangingState() {
+    var manager = new MemoryTrustListManager();
+    manager.replaceAll(GENERATION_A.snapshot());
+
+    assertThrows(NullPointerException.class, () -> manager.replaceAll((TrustListSnapshot) null));
+
+    assertEquals(GENERATION_A.snapshot(), manager.getSnapshot());
+  }
+
+  // Existing third-party implementations inherit functional defaults without implementing new
+  // methods, even though only implementations that override them can promise atomicity.
+  @Test
+  void legacyManagerUsesSnapshotDefaults() {
+    var manager = new LegacyTrustListManager();
+    TrustListSnapshot replacement = GENERATION_A.snapshot();
+
+    manager.replaceAll(replacement);
+    TrustListSnapshot captured = manager.getSnapshot();
+
+    assertTrue(GENERATION_A.matchesLists(captured));
+    assertEquals(DateTime.MIN_VALUE, captured.lastUpdateTime());
+  }
+
+  private static void assertAtomicReplacement(TrustListManager manager, int replacements)
+      throws Exception {
+
+    manager.replaceAll(GENERATION_A.snapshot());
+
+    var readerReady = new CountDownLatch(1);
+    var writerStarted = new CountDownLatch(1);
+    var readerLooping = new CountDownLatch(1);
+    var writerDone = new AtomicBoolean();
+    var sawGenerationA = new AtomicBoolean();
+    var sawGenerationB = new AtomicBoolean();
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+
+    try {
+      Future<?> writer =
+          executor.submit(
+              () -> {
+                await(readerReady);
+                writerStarted.countDown();
+                await(readerLooping);
+
+                try {
+                  for (int i = 0; i < replacements; i++) {
+                    manager.replaceAll(
+                        (i & 1) == 0 ? GENERATION_B.snapshot() : GENERATION_A.snapshot());
+                  }
+                } finally {
+                  writerDone.set(true);
+                }
+              });
+      Future<?> reader =
+          executor.submit(
+              () -> {
+                observe(manager.getSnapshot(), sawGenerationA, sawGenerationB);
+                readerReady.countDown();
+                await(writerStarted);
+                readerLooping.countDown();
+
+                do {
+                  observe(manager.getSnapshot(), sawGenerationA, sawGenerationB);
+                } while (!writerDone.get());
+
+                observe(manager.getSnapshot(), sawGenerationA, sawGenerationB);
+              });
+
+      writer.get(30, TimeUnit.SECONDS);
+      reader.get(30, TimeUnit.SECONDS);
+      assertTrue(sawGenerationA.get(), "reader did not observe generation A");
+      assertTrue(sawGenerationB.get(), "reader did not observe generation B");
+    } finally {
+      executor.shutdownNow();
+      assertTrue(executor.awaitTermination(30, TimeUnit.SECONDS));
+    }
+  }
+
+  private static void observe(
+      TrustListSnapshot snapshot, AtomicBoolean sawGenerationA, AtomicBoolean sawGenerationB) {
+
+    boolean generationA = GENERATION_A.matches(snapshot);
+    boolean generationB = GENERATION_B.matches(snapshot);
+
+    if (generationA) {
+      sawGenerationA.set(true);
+    }
+    if (generationB) {
+      sawGenerationB.set(true);
+    }
+
+    assertTrue(
+        generationA || generationB, "observed a snapshot containing mixed trust-list generations");
+  }
+
+  private static TrustListSnapshot awaitWatcherReload(
+      TrustListManager manager, DateTime replacementTime) {
+
+    long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+
+    while (System.nanoTime() < deadline) {
+      TrustListSnapshot snapshot = manager.getSnapshot();
+      if (!replacementTime.equals(snapshot.lastUpdateTime())) {
+        return snapshot;
+      }
+      Thread.onSpinWait();
+    }
+
+    throw new AssertionError("watcher did not reload the trust lists within 10 seconds");
+  }
+
+  private static void await(CountDownLatch latch) {
+    try {
+      assertTrue(latch.await(30, TimeUnit.SECONDS));
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static Generation createGeneration(String commonName, DateTime lastUpdateTime) {
+    try {
+      KeyPair keyPair = SelfSignedCertificateGenerator.generateRsaKeyPair(2048);
+      X509Certificate certificate =
+          new SelfSignedCertificateBuilder(keyPair)
+              .setCommonName(commonName)
+              .setApplicationUri("urn:eclipse:milo:test:" + commonName)
+              .build();
+      X509CRL crl = CrlTestUtil.generateCrl(certificate, keyPair.getPrivate());
+
+      return new Generation(certificate, crl, lastUpdateTime);
+    } catch (Exception e) {
+      throw new ExceptionInInitializerError(e);
+    }
+  }
+
+  private record Generation(X509Certificate certificate, X509CRL crl, DateTime lastUpdateTime) {
+
+    List<X509Certificate> certificates() {
+      return List.of(certificate);
+    }
+
+    List<X509CRL> crls() {
+      return List.of(crl);
+    }
+
+    TrustListSnapshot snapshot() {
+      return new TrustListSnapshot(certificates(), crls(), certificates(), crls(), lastUpdateTime);
+    }
+
+    boolean matches(TrustListSnapshot snapshot) {
+      return matchesLists(snapshot) && lastUpdateTime.equals(snapshot.lastUpdateTime());
+    }
+
+    boolean matchesLists(TrustListSnapshot snapshot) {
+      return certificates().equals(snapshot.issuerCertificates())
+          && crls().equals(snapshot.issuerCrls())
+          && certificates().equals(snapshot.trustedCertificates())
+          && crls().equals(snapshot.trustedCrls());
+    }
+  }
+
+  /**
+   * This fixture intentionally implements only the interface that existed before snapshot support.
+   */
+  private static final class LegacyTrustListManager implements TrustListManager {
+
+    private List<X509Certificate> issuerCertificates = List.of();
+    private List<X509CRL> issuerCrls = List.of();
+    private List<X509Certificate> trustedCertificates = List.of();
+    private List<X509CRL> trustedCrls = List.of();
+
+    @Override
+    public List<X509CRL> getIssuerCrls() {
+      return issuerCrls;
+    }
+
+    @Override
+    public List<X509CRL> getTrustedCrls() {
+      return trustedCrls;
+    }
+
+    @Override
+    public List<X509Certificate> getIssuerCertificates() {
+      return issuerCertificates;
+    }
+
+    @Override
+    public List<X509Certificate> getTrustedCertificates() {
+      return trustedCertificates;
+    }
+
+    @Override
+    public void setIssuerCrls(List<X509CRL> issuerCrls) {
+      this.issuerCrls = List.copyOf(issuerCrls);
+    }
+
+    @Override
+    public void setTrustedCrls(List<X509CRL> trustedCrls) {
+      this.trustedCrls = List.copyOf(trustedCrls);
+    }
+
+    @Override
+    public void setIssuerCertificates(List<X509Certificate> issuerCertificates) {
+      this.issuerCertificates = List.copyOf(issuerCertificates);
+    }
+
+    @Override
+    public void setTrustedCertificates(List<X509Certificate> trustedCertificates) {
+      this.trustedCertificates = List.copyOf(trustedCertificates);
+    }
+
+    @Override
+    public void addIssuerCertificate(X509Certificate certificate) {
+      issuerCertificates = append(issuerCertificates, certificate);
+    }
+
+    @Override
+    public void addTrustedCertificate(X509Certificate certificate) {
+      trustedCertificates = append(trustedCertificates, certificate);
+    }
+
+    @Override
+    public boolean removeIssuerCertificate(ByteString thumbprint) {
+      return false;
+    }
+
+    @Override
+    public boolean removeTrustedCertificate(ByteString thumbprint) {
+      return false;
+    }
+
+    @Override
+    public DateTime getLastUpdateTime() {
+      return DateTime.MIN_VALUE;
+    }
+
+    private static List<X509Certificate> append(
+        List<X509Certificate> certificates, X509Certificate certificate) {
+
+      var updated = new ArrayList<>(certificates);
+      updated.add(certificate);
+      return List.copyOf(updated);
+    }
+  }
+}

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/security/TrustListManagerAtomicityTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/security/TrustListManagerAtomicityTest.java
@@ -21,12 +21,14 @@ import java.security.cert.X509CRL;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Predicate;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
 import org.eclipse.milo.opcua.stack.core.util.CrlTestUtil;
@@ -37,8 +39,8 @@ import org.junit.jupiter.api.io.TempDir;
 
 class TrustListManagerAtomicityTest {
 
-  private static final Generation GENERATION_A = createGeneration("generation-a", new DateTime(1));
-  private static final Generation GENERATION_B = createGeneration("generation-b", new DateTime(2));
+  private static final Generation GENERATION_A = createGeneration("generation-a");
+  private static final Generation GENERATION_B = createGeneration("generation-b");
 
   @TempDir Path tempDir;
 
@@ -67,16 +69,46 @@ class TrustListManagerAtomicityTest {
     }
   }
 
-  // Writer-generated events must reload all four directories before the watcher publishes state.
+  // A certificate dropped into a directory by an operator must appear in that list without
+  // disturbing the other three, and the reload must arrive as one coherent snapshot.
   @Test
-  void fileWatcherPublishesACompleteReload() throws Exception {
+  void fileWatcherReloadsOnlyTheChangedDirectory() throws Exception {
+    Path baseDir = Files.createTempDirectory(tempDir, "pki");
+
+    try (var manager = FileBasedTrustListManager.createAndInitialize(baseDir)) {
+      manager.replaceAll(GENERATION_A.snapshot());
+
+      Files.write(
+          baseDir.resolve("trusted/certs/generation-b.der"),
+          GENERATION_B.certificate().getEncoded());
+
+      TrustListSnapshot reloaded =
+          awaitSnapshot(manager, s -> s.trustedCertificates().contains(GENERATION_B.certificate()));
+
+      assertEquals(
+          Set.of(GENERATION_A.certificate(), GENERATION_B.certificate()),
+          Set.copyOf(reloaded.trustedCertificates()));
+      assertEquals(GENERATION_A.certificates(), reloaded.issuerCertificates());
+      assertEquals(GENERATION_A.crls(), reloaded.issuerCrls());
+      assertEquals(GENERATION_A.crls(), reloaded.trustedCrls());
+    }
+  }
+
+  // Two writers changing different lists through update() must both see their change land; a
+  // read-modify-write outside the manager would let one overwrite the other.
+  @Test
+  void memoryManagerUpdatePreservesConcurrentChangesToOtherLists() throws Exception {
+    try (var manager = new MemoryTrustListManager()) {
+      assertConcurrentUpdatesAreNotLost(manager);
+    }
+  }
+
+  @Test
+  void fileManagerUpdatePreservesConcurrentChangesToOtherLists() throws Exception {
     try (var manager =
         FileBasedTrustListManager.createAndInitialize(Files.createTempDirectory(tempDir, "pki"))) {
 
-      manager.replaceAll(GENERATION_A.snapshot());
-
-      TrustListSnapshot reloaded = awaitWatcherReload(manager, GENERATION_A.lastUpdateTime());
-      assertTrue(GENERATION_A.matchesLists(reloaded));
+      assertConcurrentUpdatesAreNotLost(manager);
     }
   }
 
@@ -100,14 +132,43 @@ class TrustListManagerAtomicityTest {
         () -> snapshot.trustedCertificates().add(GENERATION_B.certificate()));
   }
 
+  // Trust lists have set semantics, so every manager must publish the same normalized contents
+  // when callers supply duplicate entries.
+  @Test
+  void snapshotRemovesDuplicateEntries() {
+    var snapshot =
+        new TrustListSnapshot(
+            List.of(GENERATION_A.certificate(), GENERATION_A.certificate()),
+            List.of(GENERATION_A.crl(), GENERATION_A.crl()),
+            List.of(GENERATION_A.certificate(), GENERATION_A.certificate()),
+            List.of(GENERATION_A.crl(), GENERATION_A.crl()),
+            DateTime.MIN_VALUE);
+
+    GENERATION_A.assertLists(snapshot);
+  }
+
   @Test
   void memoryManagerRejectsNullReplacementWithoutChangingState() {
     var manager = new MemoryTrustListManager();
     manager.replaceAll(GENERATION_A.snapshot());
+    TrustListSnapshot before = manager.getSnapshot();
 
-    assertThrows(NullPointerException.class, () -> manager.replaceAll((TrustListSnapshot) null));
+    assertThrows(NullPointerException.class, () -> manager.replaceAll(null));
+    assertThrows(NullPointerException.class, () -> manager.update(current -> null));
 
-    assertEquals(GENERATION_A.snapshot(), manager.getSnapshot());
+    assertEquals(before, manager.getSnapshot());
+  }
+
+  // The committed snapshot carries the commit time, not whatever time the caller supplied.
+  @Test
+  void managersStampLastUpdateTimeOnCommit() throws Exception {
+    try (var manager = new MemoryTrustListManager()) {
+      DateTime before = DateTime.now();
+
+      manager.replaceAll(GENERATION_A.snapshot());
+
+      assertTrue(manager.getLastUpdateTime().getUtcTime() >= before.getUtcTime());
+    }
   }
 
   // Existing third-party implementations inherit functional defaults without implementing new
@@ -120,7 +181,7 @@ class TrustListManagerAtomicityTest {
     manager.replaceAll(replacement);
     TrustListSnapshot captured = manager.getSnapshot();
 
-    assertTrue(GENERATION_A.matchesLists(captured));
+    GENERATION_A.assertLists(captured);
     assertEquals(DateTime.MIN_VALUE, captured.lastUpdateTime());
   }
 
@@ -179,6 +240,62 @@ class TrustListManagerAtomicityTest {
     }
   }
 
+  private static void assertConcurrentUpdatesAreNotLost(TrustListManager manager) throws Exception {
+
+    manager.replaceAll(GENERATION_A.snapshot());
+
+    var bothInside = new CountDownLatch(2);
+    ExecutorService executor = Executors.newFixedThreadPool(2);
+
+    try {
+      // Each operator parks until both threads have read a snapshot, so at least one of them
+      // must observe the other's commit (or be retried) for its own change to survive.
+      Future<?> issuerWriter =
+          executor.submit(
+              () ->
+                  manager.update(
+                      current -> {
+                        bothInside.countDown();
+                        awaitOrTimeout(bothInside);
+                        return current.withIssuerCertificates(GENERATION_B.certificates());
+                      }));
+      Future<?> trustedWriter =
+          executor.submit(
+              () ->
+                  manager.update(
+                      current -> {
+                        bothInside.countDown();
+                        awaitOrTimeout(bothInside);
+                        return current.withTrustedCrls(GENERATION_B.crls());
+                      }));
+
+      issuerWriter.get(30, TimeUnit.SECONDS);
+      trustedWriter.get(30, TimeUnit.SECONDS);
+    } finally {
+      executor.shutdownNow();
+      assertTrue(executor.awaitTermination(30, TimeUnit.SECONDS));
+    }
+
+    TrustListSnapshot result = manager.getSnapshot();
+    assertEquals(GENERATION_B.certificates(), result.issuerCertificates());
+    assertEquals(GENERATION_B.crls(), result.trustedCrls());
+    assertEquals(GENERATION_A.crls(), result.issuerCrls());
+    assertEquals(GENERATION_A.certificates(), result.trustedCertificates());
+  }
+
+  /**
+   * Like {@link #await(CountDownLatch)} but bounded to a short wait, because a lock-based manager
+   * runs the two operators one after the other and the second never sees the first inside.
+   */
+  private static void awaitOrTimeout(CountDownLatch latch) {
+    try {
+      latch.await(1, TimeUnit.SECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(e);
+    }
+  }
+
   private static void observe(
       TrustListSnapshot snapshot, AtomicBoolean sawGenerationA, AtomicBoolean sawGenerationB) {
 
@@ -196,20 +313,24 @@ class TrustListManagerAtomicityTest {
         generationA || generationB, "observed a snapshot containing mixed trust-list generations");
   }
 
-  private static TrustListSnapshot awaitWatcherReload(
-      TrustListManager manager, DateTime replacementTime) {
+  /**
+   * Poll until the manager publishes a snapshot matching {@code condition}. The bound is generous
+   * because the JDK's polling {@link java.nio.file.WatchService} on macOS scans every 10 seconds.
+   */
+  private static TrustListSnapshot awaitSnapshot(
+      TrustListManager manager, Predicate<TrustListSnapshot> condition) {
 
-    long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+    long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(30);
 
     while (System.nanoTime() < deadline) {
       TrustListSnapshot snapshot = manager.getSnapshot();
-      if (!replacementTime.equals(snapshot.lastUpdateTime())) {
+      if (condition.test(snapshot)) {
         return snapshot;
       }
       Thread.onSpinWait();
     }
 
-    throw new AssertionError("watcher did not reload the trust lists within 10 seconds");
+    throw new AssertionError("watcher did not reload the trust lists within 30 seconds");
   }
 
   private static void await(CountDownLatch latch) {
@@ -221,7 +342,7 @@ class TrustListManagerAtomicityTest {
     }
   }
 
-  private static Generation createGeneration(String commonName, DateTime lastUpdateTime) {
+  private static Generation createGeneration(String commonName) {
     try {
       KeyPair keyPair = SelfSignedCertificateGenerator.generateRsaKeyPair(2048);
       X509Certificate certificate =
@@ -231,13 +352,13 @@ class TrustListManagerAtomicityTest {
               .build();
       X509CRL crl = CrlTestUtil.generateCrl(certificate, keyPair.getPrivate());
 
-      return new Generation(certificate, crl, lastUpdateTime);
+      return new Generation(certificate, crl);
     } catch (Exception e) {
       throw new ExceptionInInitializerError(e);
     }
   }
 
-  private record Generation(X509Certificate certificate, X509CRL crl, DateTime lastUpdateTime) {
+  private record Generation(X509Certificate certificate, X509CRL crl) {
 
     List<X509Certificate> certificates() {
       return List.of(certificate);
@@ -248,18 +369,22 @@ class TrustListManagerAtomicityTest {
     }
 
     TrustListSnapshot snapshot() {
-      return new TrustListSnapshot(certificates(), crls(), certificates(), crls(), lastUpdateTime);
+      return new TrustListSnapshot(
+          certificates(), crls(), certificates(), crls(), DateTime.MIN_VALUE);
     }
 
     boolean matches(TrustListSnapshot snapshot) {
-      return matchesLists(snapshot) && lastUpdateTime.equals(snapshot.lastUpdateTime());
-    }
-
-    boolean matchesLists(TrustListSnapshot snapshot) {
       return certificates().equals(snapshot.issuerCertificates())
           && crls().equals(snapshot.issuerCrls())
           && certificates().equals(snapshot.trustedCertificates())
           && crls().equals(snapshot.trustedCrls());
+    }
+
+    void assertLists(TrustListSnapshot snapshot) {
+      assertEquals(certificates(), snapshot.issuerCertificates());
+      assertEquals(crls(), snapshot.issuerCrls());
+      assertEquals(certificates(), snapshot.trustedCertificates());
+      assertEquals(crls(), snapshot.trustedCrls());
     }
   }
 

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/security/TrustListManagerLastUpdateTimeTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/security/TrustListManagerLastUpdateTimeTest.java
@@ -67,6 +67,11 @@ public class TrustListManagerLastUpdateTimeTest {
         mutation("setIssuerCertificates", m -> m.setIssuerCertificates(List.of(CERTIFICATE))),
         mutation("setTrustedCrls", m -> m.setTrustedCrls(List.of(CRL))),
         mutation("setIssuerCrls", m -> m.setIssuerCrls(List.of(CRL))),
+        mutation(
+            "replaceAll",
+            m ->
+                m.replaceAll(
+                    List.of(CERTIFICATE), List.of(CRL), List.of(CERTIFICATE), List.of(CRL))),
         mutation("addTrustedCertificate", m -> m.addTrustedCertificate(CERTIFICATE)),
         mutation("addIssuerCertificate", m -> m.addIssuerCertificate(CERTIFICATE)),
         mutation(

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/security/TrustListManagerLastUpdateTimeTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/security/TrustListManagerLastUpdateTimeTest.java
@@ -67,11 +67,19 @@ public class TrustListManagerLastUpdateTimeTest {
         mutation("setIssuerCertificates", m -> m.setIssuerCertificates(List.of(CERTIFICATE))),
         mutation("setTrustedCrls", m -> m.setTrustedCrls(List.of(CRL))),
         mutation("setIssuerCrls", m -> m.setIssuerCrls(List.of(CRL))),
+        // The manager owns lastUpdateTime, so the time carried by a replacement snapshot must
+        // be ignored rather than installed.
         mutation(
             "replaceAll",
             m ->
                 m.replaceAll(
-                    List.of(CERTIFICATE), List.of(CRL), List.of(CERTIFICATE), List.of(CRL))),
+                    new TrustListSnapshot(
+                        List.of(CERTIFICATE),
+                        List.of(CRL),
+                        List.of(CERTIFICATE),
+                        List.of(CRL),
+                        DateTime.MIN_VALUE))),
+        mutation("update", m -> m.update(current -> current.withTrustedCrls(List.of(CRL)))),
         mutation("addTrustedCertificate", m -> m.addTrustedCertificate(CERTIFICATE)),
         mutation("addIssuerCertificate", m -> m.addIssuerCertificate(CERTIFICATE)),
         mutation(
@@ -151,6 +159,18 @@ public class TrustListManagerLastUpdateTimeTest {
       boolean removed = manager.removeTrustedCertificate(ByteString.of(new byte[] {1, 2, 3}));
 
       assertFalse(removed);
+      assertEquals(before, manager.getLastUpdateTime());
+    }
+
+    // An update operator that returns the snapshot it was given commits nothing.
+    @Test
+    void identityUpdateDoesNotAdvanceLastUpdateTime() {
+      DateTime before = manager.getLastUpdateTime();
+      awaitClockTickAfter(before);
+
+      TrustListSnapshot committed = manager.update(current -> current);
+
+      assertEquals(before, committed.lastUpdateTime());
       assertEquals(before, manager.getLastUpdateTime());
     }
   }


### PR DESCRIPTION
Trust-list updates could expose validators to certificates and CRLs from different generations because each list was read and replaced independently. This change adds an immutable `TrustListSnapshot` containing all four lists and `lastUpdateTime`, then makes the memory and file-backed managers publish those snapshots atomically. Existing third-party `TrustListManager` implementations remain source-compatible through default snapshot and replacement methods.

Client and server validators now capture one snapshot for path construction and revocation checks. `TrustListApplier` decodes every requested field, merges partial masks with one current snapshot, and commits the result through one replacement. The file-backed manager stages disk writes and complete watcher reloads before publishing in-memory state.

Verification performed:

- `mise exec -- mvn -q spotless:apply`
- `mise exec -- mvn -q clean compile`
- Targeted `TrustListManagerAtomicityTest`, `TrustListManagerLastUpdateTimeTest`, and `DefaultCertificateValidatorTest` in `stack-core`
- Targeted `TrustListApplierTest` in `sdk-client-gds`
- Complete test suites for `stack-core` and `sdk-client-gds`

Closes #1853
