### PR TITLE
Improve GDS interoperability and reusable testing

### DIFF
--- a/docs/features/gds-client.md
+++ b/docs/features/gds-client.md
@@ -52,6 +52,14 @@ pending `RequestId`s, retry policy, and what to do with an issued certificate de
 application's configuration and lifecycle, so there is no Pull engine; the application drives the
 sequence.
 
+The publishable `milo-sdk-client-gds-testing` module provides `FakeGdsNamespace` in
+`org.eclipse.milo.opcua.sdk.client.gds.testing`. It hosts an in-memory GDS on a Milo server for
+application-side Pull workflow tests. Tests can control registration and CertificateDirectory
+access, pre-register applications, change the advertised application certificate types, delay or
+reject requests, and inspect method counters and TrustList file calls. The artifact is listed in
+`milo-bom` and is separate from `milo-sdk-client-gds` to avoid adding server dependencies to the
+runtime client module.
+
 * * *
 
 ## How it works

--- a/docs/features/gds-client.md
+++ b/docs/features/gds-client.md
@@ -41,7 +41,8 @@ listed in `milo-bom`). It depends only on `milo-sdk-client` and shares the packa
 
 - `GdsClient` wraps a connected `OpcUaClient` and exposes every `DirectoryType` and
   `CertificateDirectoryType` method with a typed signature, plus reads of a CertificateGroup's
-  `CertificateTypes` and a TrustList's `LastUpdateTime` and `UpdateFrequency`.
+  `CertificateTypes` and a TrustList's `LastUpdateTime` and `UpdateFrequency`. It also resolves a
+  desired certificate type to the value accepted by a group's certificate request methods.
 - `TrustListReader` reads a `TrustListType` object with the FileType `Open`, `Read`, and `Close`
   methods and decodes the body into a `TrustListDataType`.
 - `TrustListApplier` installs a `TrustListDataType` into a `TrustListManager` and builds one back
@@ -95,9 +96,9 @@ each wrapper issues exactly one `Call` request with the known ids: `FindApplicat
 No browse or argument read precedes a call. The generated node classes remain available for
 callers who want to navigate the `Applications` and `CertificateGroups` folders.
 
-Results are not interpreted. A Bad operation-level status becomes a `UaMethodException` (a
-`UaException`) carrying the server's `StatusCode`, so a caller branches on the codes Part 12
-defines: `Bad_NothingToDo` from `FinishRequest` means the request is still pending,
+Method wrapper results are not interpreted. A Bad operation-level status becomes a
+`UaMethodException` (a `UaException`) carrying the server's `StatusCode`, so a caller branches on
+the codes Part 12 defines: `Bad_NothingToDo` from `FinishRequest` means the request is still pending,
 `Bad_RequestNotAllowed` means it was rejected, `Bad_UserAccessDenied` means the session lacks the
 role, and `Bad_CertificateUriInvalid` means the CSR's ApplicationUri does not match the record.
 Output arguments are validated by type and count; a server that returns something other than the
@@ -110,6 +111,17 @@ or an empty ByteString for the `PrivateKey` output, and `FinishRequestResult.pri
 both cases; `issuerCertificates()` is an empty array when the chain is not returned.
 `TrustListInfo.updateFrequency()` is null when the GDS does not expose the optional
 `UpdateFrequency` property.
+
+`resolveCertificateTypeId(groupId, desiredTypeId)` interprets `CertificateTypes` locally. It
+returns the desired id for an exact advertised match. It returns null, selecting the group's
+default, only when every advertised non-null type is an abstract ancestor of the desired type in
+the standard CertificateType hierarchy. It fails with `Bad_NotSupported` when the advertised
+types are incompatible, including a list that mixes an abstract ancestor with an incompatible
+abstract type or a concrete type other than the desired one, because the group default could then
+be a different profile. In particular, `RsaMinApplicationCertificateType` and
+`RsaSha256ApplicationCertificateType` are sibling types, so neither can stand in for the other.
+Types outside namespace 0 are matched exactly only; their subtype relationships are not
+evaluated.
 
 ### TrustList files
 
@@ -158,16 +170,25 @@ NodeId applicationId =
                 null))
         : found[0].getApplicationId();
 
+NodeId desiredTypeId = NodeIds.RsaSha256ApplicationCertificateType;
 for (NodeId groupId : gds.getCertificateGroups(applicationId)) {
-  for (NodeId typeId : gds.readCertificateTypes(groupId)) {
-    if (gds.getCertificateStatus(applicationId, groupId, typeId)) {
-      ByteString csr = ByteString.of(CertificateUtil.generateCsr(keyPair, ...).getEncoded());
-      NodeId requestId = gds.startSigningRequest(applicationId, groupId, typeId, csr);
-      // Later, and again on Bad_NothingToDo:
-      FinishRequestResult issued = gds.finishRequest(applicationId, requestId);
-      X509Certificate certificate = CertificateUtil.decodeCertificate(issued.certificate().bytesOrEmpty());
-      GdsClient.verifyIssuedCertificate(certificate, keyPair.getPublic(), applicationUri);
-    }
+  // Groups such as DefaultUserTokenGroup do not issue application certificates and fail with
+  // Bad_NotSupported; skip signing for them but still pull their TrustList.
+  NodeId requestTypeId = null;
+  boolean issuesDesiredType = true;
+  try {
+    requestTypeId = gds.resolveCertificateTypeId(groupId, desiredTypeId);
+  } catch (UaException e) {
+    if (e.getStatusCode().value() != StatusCodes.Bad_NotSupported) throw e;
+    issuesDesiredType = false;
+  }
+  if (issuesDesiredType && gds.getCertificateStatus(applicationId, groupId, requestTypeId)) {
+    ByteString csr = ByteString.of(CertificateUtil.generateCsr(keyPair, ...).getEncoded());
+    NodeId requestId = gds.startSigningRequest(applicationId, groupId, requestTypeId, csr);
+    // Later, and again on Bad_NothingToDo:
+    FinishRequestResult issued = gds.finishRequest(applicationId, requestId);
+    X509Certificate certificate = CertificateUtil.decodeCertificate(issued.certificate().bytesOrEmpty());
+    GdsClient.verifyIssuedCertificate(certificate, keyPair.getPublic(), applicationUri);
   }
 
   NodeId trustListId = gds.getTrustList(applicationId, groupId);
@@ -188,9 +209,19 @@ key and ApplicationUri before it is installed. A certificate for the wrong key c
 the channel and one with the wrong ApplicationUri is rejected by every peer, and neither problem is
 otherwise visible until a connection fails.
 
-A null CertificateTypeId means "the group's default". Some GDS implementations advertise abstract
-types in a CertificateGroup's `CertificateTypes` and reject them when passed back, so null is the
-portable choice when the list holds no concrete type the caller recognizes.
+Use the group ids returned by `getCertificateGroups`. The OPC Foundation reference GDS identifies
+its default application group in the GDS namespace as
+`GdsNodeIds.Directory_CertificateGroups_DefaultApplicationGroup` (`ns=<gds>;i=615`). It is not the
+namespace-zero ServerConfiguration group at `ns=0;i=14156`. If a known default id is needed before
+registration, resolve the `GdsNodeIds` `ExpandedNodeId` through the connected server's
+`NamespaceTable` instead of hard-coding a namespace index.
+
+A null CertificateTypeId means "the group's default". The OPC Foundation reference GDS advertises
+the abstract `ApplicationCertificateType` as its only default-group type but rejects that abstract
+id when it is passed back to certificate methods. For a desired concrete type such as
+`RsaSha256ApplicationCertificateType`, `resolveCertificateTypeId` recognizes the advertised
+ancestor and returns null. Pass that nullable result to `GetCertificateStatus`,
+`StartSigningRequest`, or `StartNewKeyPairRequest`; null is the portable group-default request.
 
 `GdsPullExample` in `milo-examples/client-examples` runs the sequence once against a GDS named by
 the `gds.endpoint`, `gds.username`, and `gds.password` system properties, printing the issued

--- a/milo-bom/pom.xml
+++ b/milo-bom/pom.xml
@@ -58,6 +58,11 @@
       </dependency>
       <dependency>
         <groupId>org.eclipse.milo</groupId>
+        <artifactId>milo-sdk-client-gds-testing</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.milo</groupId>
         <artifactId>milo-sdk-core</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/GdsPullExample.java
+++ b/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/GdsPullExample.java
@@ -12,7 +12,6 @@ package org.eclipse.milo.examples.client;
 
 import java.security.KeyPair;
 import java.security.cert.X509Certificate;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
@@ -90,18 +89,14 @@ public class GdsPullExample implements ClientExample {
     }
 
     NodeId groupId = gds.getCertificateGroups(applicationId)[0];
-    NodeId[] certificateTypes = gds.readCertificateTypes(groupId);
-    // Ask for RsaSha256 when the group advertises it, otherwise let the GDS pick the group's
-    // default: the list may hold only the abstract ApplicationCertificateType, which the
-    // reference GDS advertises but rejects as a CertificateTypeId.
+    // Null means "the group's default", which resolve selects when the GDS advertises only the
+    // abstract ApplicationCertificateType.
     NodeId certificateTypeId =
-        Arrays.asList(certificateTypes).contains(NodeIds.RsaSha256ApplicationCertificateType)
-            ? NodeIds.RsaSha256ApplicationCertificateType
-            : null;
+        gds.resolveCertificateTypeId(groupId, NodeIds.RsaSha256ApplicationCertificateType);
     logger.info(
-        "Group {} issues {}; update required: {}",
+        "Group {} resolved request type {}; update required: {}",
         groupId,
-        Arrays.toString(certificateTypes),
+        certificateTypeId,
         gds.getCertificateStatus(applicationId, groupId, certificateTypeId));
 
     // A throwaway key pair; a real application would use the key pair of the certificate it is

--- a/opc-ua-sdk/integration-tests/pom.xml
+++ b/opc-ua-sdk/integration-tests/pom.xml
@@ -43,6 +43,12 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.milo</groupId>
+      <artifactId>milo-sdk-client-gds-testing</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.milo</groupId>
       <artifactId>milo-dtd-reader</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/AbstractGdsClientTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/AbstractGdsClientTest.java
@@ -12,6 +12,7 @@ package org.eclipse.milo.opcua.sdk.client.gds;
 
 import java.security.KeyPair;
 import java.util.List;
+import org.eclipse.milo.opcua.sdk.client.gds.testing.FakeGdsNamespace;
 import org.eclipse.milo.opcua.sdk.test.AbstractClientServerTest;
 import org.eclipse.milo.opcua.sdk.test.TestServer;
 import org.eclipse.milo.opcua.stack.core.UaException;

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/GdsClientTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/GdsClientTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.security.KeyPair;
 import java.security.cert.X509Certificate;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
 import org.eclipse.milo.opcua.sdk.client.gds.GdsClient.CertificatesResult;
@@ -301,6 +302,142 @@ public class GdsClientTest extends AbstractGdsClientTest {
           gdsClient.readCertificateTypes(gds.defaultApplicationGroupId()));
     }
 
+    // An exact match must win even if an abstract ancestor appears earlier in the advertised list;
+    // passing null would discard the caller's explicit choice on GDSes that accept the concrete id.
+    @Test
+    void resolveCertificateTypeIdReturnsExactMatchBeforeConsideringAncestors() throws Exception {
+      gds.setApplicationCertificateTypes(
+          NodeIds.ApplicationCertificateType, NodeIds.RsaSha256ApplicationCertificateType);
+
+      NodeId resolved =
+          gdsClient.resolveCertificateTypeId(
+              gds.defaultApplicationGroupId(), NodeIds.RsaSha256ApplicationCertificateType);
+
+      assertEquals(NodeIds.RsaSha256ApplicationCertificateType, resolved);
+    }
+
+    // The reference GDS advertises only the abstract ApplicationCertificateType and expects null
+    // in request methods so it can select the compatible concrete group default.
+    @Test
+    void resolveCertificateTypeIdAsyncReturnsNullForAdvertisedAncestor() throws Exception {
+      gds.setApplicationCertificateTypes(NodeIds.ApplicationCertificateType);
+
+      NodeId resolved =
+          gdsClient
+              .resolveCertificateTypeIdAsync(
+                  gds.defaultApplicationGroupId(), NodeIds.RsaSha256ApplicationCertificateType)
+              .get(2, TimeUnit.SECONDS);
+
+      assertNull(resolved);
+    }
+
+    // Null is only a safe request when the group advertises no concrete type. With a concrete
+    // sibling in the list, the group default may be that sibling's profile, so the caller must be
+    // told the desired type is unavailable instead of getting the wrong certificate later.
+    @Test
+    void resolveCertificateTypeIdRejectsAncestorMixedWithConcreteSibling() {
+      gds.setApplicationCertificateTypes(
+          NodeIds.ApplicationCertificateType, NodeIds.EccNistP256ApplicationCertificateType);
+
+      UaException e =
+          assertThrows(
+              UaException.class,
+              () ->
+                  gdsClient.resolveCertificateTypeId(
+                      gds.defaultApplicationGroupId(),
+                      NodeIds.RsaSha256ApplicationCertificateType));
+
+      assertEquals(StatusCodes.Bad_NotSupported, e.getStatusCode().value());
+    }
+
+    // An abstract type from a different branch makes the group default ambiguous even when another
+    // advertised abstract type is an ancestor of the desired type.
+    @Test
+    void resolveCertificateTypeIdRejectsAncestorMixedWithIncompatibleAbstractType() {
+      gds.setApplicationCertificateTypes(
+          NodeIds.ApplicationCertificateType, NodeIds.EccApplicationCertificateType);
+
+      UaException e =
+          assertThrows(
+              UaException.class,
+              () ->
+                  gdsClient.resolveCertificateTypeId(
+                      gds.defaultApplicationGroupId(),
+                      NodeIds.RsaSha256ApplicationCertificateType));
+
+      assertEquals(StatusCodes.Bad_NotSupported, e.getStatusCode().value());
+    }
+
+    // Part 12 §7.8.3.3 requires DefaultUserTokenGroup to leave CertificateTypes empty because it
+    // carries a TrustList for user credentials rather than certificates assigned to applications.
+    @Test
+    void resolveCertificateTypeIdRejectsGroupWithNoCertificateTypes() {
+      UaException e =
+          assertThrows(
+              UaException.class,
+              () ->
+                  gdsClient.resolveCertificateTypeId(
+                      gds.defaultUserTokenGroupId(), NodeIds.RsaSha256ApplicationCertificateType));
+
+      assertEquals(StatusCodes.Bad_NotSupported, e.getStatusCode().value());
+    }
+
+    @Test
+    void resolveCertificateTypeIdReturnsNullForIntermediateEccAncestor() throws Exception {
+      gds.setApplicationCertificateTypes(NodeIds.EccApplicationCertificateType);
+
+      NodeId resolved =
+          gdsClient.resolveCertificateTypeId(
+              gds.defaultApplicationGroupId(), NodeIds.EccNistP256ApplicationCertificateType);
+
+      assertNull(resolved);
+    }
+
+    // Part 12 §7.8.4 defines the RSA minimum and RSA SHA-256 types as siblings. Treating one as an
+    // ancestor of the other can silently request a certificate with the wrong security profile.
+    @Test
+    void resolveCertificateTypeIdRejectsSiblingRsaTypesInBothDirections() throws Exception {
+      gds.setApplicationCertificateTypes(NodeIds.RsaMinApplicationCertificateType);
+
+      UaException blocking =
+          assertThrows(
+              UaException.class,
+              () ->
+                  gdsClient.resolveCertificateTypeId(
+                      gds.defaultApplicationGroupId(),
+                      NodeIds.RsaSha256ApplicationCertificateType));
+
+      gds.setApplicationCertificateTypes(NodeIds.RsaSha256ApplicationCertificateType);
+
+      ExecutionException async =
+          assertThrows(
+              ExecutionException.class,
+              () ->
+                  gdsClient
+                      .resolveCertificateTypeIdAsync(
+                          gds.defaultApplicationGroupId(), NodeIds.RsaMinApplicationCertificateType)
+                      .get(2, TimeUnit.SECONDS));
+
+      assertEquals(StatusCodes.Bad_NotSupported, blocking.getStatusCode().value());
+      UaException asyncCause = assertInstanceOf(UaException.class, async.getCause());
+      assertEquals(StatusCodes.Bad_NotSupported, asyncCause.getStatusCode().value());
+    }
+
+    @Test
+    void resolveCertificateTypeIdRejectsIncompatibleCertificateFamily() {
+      gds.setApplicationCertificateTypes(NodeIds.EccApplicationCertificateType);
+
+      UaException e =
+          assertThrows(
+              UaException.class,
+              () ->
+                  gdsClient.resolveCertificateTypeId(
+                      gds.defaultApplicationGroupId(),
+                      NodeIds.RsaSha256ApplicationCertificateType));
+
+      assertEquals(StatusCodes.Bad_NotSupported, e.getStatusCode().value());
+    }
+
     @Test
     void getCertificateStatusReportsWhetherAnUpdateIsRequired() throws Exception {
       NodeId applicationId = registerTestApplication();
@@ -514,6 +651,7 @@ public class GdsClientTest extends AbstractGdsClientTest {
     // the issued certificate installed in the client's trust list manager.
     @Test
     void fullPullSequenceEndsWithTheGdsCaInTheTrustListManager() throws Exception {
+      gds.setApplicationCertificateTypes(NodeIds.ApplicationCertificateType);
       gds.getApplicationGroupTrustList()
           .setTrustList(
               new TrustListDataType(
@@ -532,12 +670,14 @@ public class GdsClientTest extends AbstractGdsClientTest {
               : found[0].getApplicationId();
 
       NodeId groupId = gdsClient.getCertificateGroups(applicationId)[0];
-      NodeId typeId = gdsClient.readCertificateTypes(groupId)[0];
-      assertTrue(gdsClient.getCertificateStatus(applicationId, groupId, typeId));
+      NodeId requestTypeId =
+          gdsClient.resolveCertificateTypeId(groupId, NodeIds.RsaSha256ApplicationCertificateType);
+      assertNull(requestTypeId, "an abstract advertisement selects the group default");
+      assertTrue(gdsClient.getCertificateStatus(applicationId, groupId, requestTypeId));
 
       NodeId requestId =
           gdsClient.startSigningRequest(
-              applicationId, groupId, typeId, csr(keyPair, APPLICATION_URI));
+              applicationId, groupId, requestTypeId, csr(keyPair, APPLICATION_URI));
       FinishRequestResult issued = gdsClient.finishRequest(applicationId, requestId);
       X509Certificate certificate =
           CertificateUtil.decodeCertificate(issued.certificate().bytesOrEmpty());
@@ -548,6 +688,7 @@ public class GdsClientTest extends AbstractGdsClientTest {
       TrustListApplier.apply(trustList, trustListManager);
 
       assertEquals(List.of(gds.getCaCertificate()), trustListManager.getTrustedCertificates());
+      assertNull(gds.getLastCertificateTypeId(), "the request used the portable group default");
       assertEquals(
           certificate.getIssuerX500Principal(), gds.getCaCertificate().getSubjectX500Principal());
     }

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/GdsClientTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/GdsClientTest.java
@@ -23,6 +23,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.security.KeyPair;
 import java.security.cert.X509Certificate;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
 import org.eclipse.milo.opcua.sdk.client.gds.GdsClient.CertificatesResult;
 import org.eclipse.milo.opcua.sdk.client.gds.GdsClient.FinishRequestResult;
 import org.eclipse.milo.opcua.sdk.client.gds.GdsClient.QueryApplicationsResult;
@@ -30,8 +32,11 @@ import org.eclipse.milo.opcua.sdk.client.gds.GdsClient.QueryServersResult;
 import org.eclipse.milo.opcua.sdk.client.gds.GdsClient.RevocationStatus;
 import org.eclipse.milo.opcua.sdk.client.gds.GdsClient.TrustListInfo;
 import org.eclipse.milo.opcua.sdk.client.gds.model.objects.CertificateDirectoryTypeNode;
+import org.eclipse.milo.opcua.sdk.client.gds.testing.FakeGdsNamespace.MethodAccess;
+import org.eclipse.milo.opcua.sdk.client.identity.UsernameProvider;
 import org.eclipse.milo.opcua.sdk.client.methods.UaMethodException;
 import org.eclipse.milo.opcua.sdk.client.nodes.UaObjectNode;
+import org.eclipse.milo.opcua.sdk.test.TestClient;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
@@ -103,12 +108,98 @@ public class GdsClientTest extends AbstractGdsClientTest {
 
     @Test
     void registerApplicationWithoutAdminRoleFailsWithBadUserAccessDenied() {
-      gds.setRegistrationAllowed(false);
+      gds.setRegisterApplicationAccess(MethodAccess.NOBODY);
 
       UaException e = assertThrows(UaException.class, GdsClientTest.this::registerTestApplication);
 
       assertEquals(StatusCodes.Bad_UserAccessDenied, e.getStatusCode().value());
       assertInstanceOf(UaMethodException.class, e, "carries the method result");
+      assertEquals(1, gds.getRegisterApplicationCallCount());
+    }
+
+    // Part 12 §6.4 allows an administrator to register an application before its first GDS
+    // connection, so a Pull engine must be able to exercise its find-without-register path.
+    @Test
+    void preRegisteredApplicationIsFoundWithoutCallingRegisterApplication() throws Exception {
+      NodeId applicationId = gds.preRegister(APPLICATION_URI);
+
+      ApplicationRecordDataType[] found = gdsClient.findApplications(APPLICATION_URI);
+
+      assertEquals(1, found.length);
+      assertEquals(applicationId, found[0].getApplicationId());
+      assertEquals(0, gds.getRegisterApplicationCallCount());
+    }
+
+    // Part 12 §6.4 supports credentialed onboarding separately from certificate management. The
+    // fixture defines credentialed narrowly as a session activated with a UserName token.
+    @Test
+    void credentialedRegisterAccessRejectsAnonymousAndAllowsUsernameSessions() throws Exception {
+      gds.setRegisterApplicationAccess(MethodAccess.CREDENTIALED);
+
+      UaException anonymousRegister =
+          assertThrows(UaException.class, GdsClientTest.this::registerTestApplication);
+      assertEquals(StatusCodes.Bad_UserAccessDenied, anonymousRegister.getStatusCode().value());
+
+      OpcUaClient credentialedClient = connectCredentialedClient();
+      try {
+        GdsClient credentialedGds = GdsClient.create(credentialedClient);
+        NodeId applicationId = credentialedGds.registerApplication(clientRecord());
+
+        assertEquals(
+            applicationId, gdsClient.findApplications(APPLICATION_URI)[0].getApplicationId());
+        assertEquals(
+            2, gds.getRegisterApplicationCallCount(), "denied and allowed calls are both recorded");
+      } finally {
+        credentialedClient.disconnectAsync().get(2, TimeUnit.SECONDS);
+      }
+    }
+
+    // Registration access and CertificateDirectory access are separate knobs so a test can model a
+    // GDS that lets anyone register but requires credentials (or nobody) for certificate methods.
+    @Test
+    void certificateDirectoryAccessIsIndependentOfRegisterApplicationAccess() throws Exception {
+      gds.setRegisterApplicationAccess(MethodAccess.CREDENTIALED);
+
+      OpcUaClient credentialedClient = connectCredentialedClient();
+      try {
+        GdsClient credentialedGds = GdsClient.create(credentialedClient);
+        NodeId applicationId = credentialedGds.registerApplication(clientRecord());
+
+        assertArrayEquals(
+            defaultCertificateGroups(),
+            gdsClient.getCertificateGroups(applicationId),
+            "registration access does not restrict CertificateDirectory methods");
+
+        gds.setCertificateDirectoryAccess(MethodAccess.CREDENTIALED);
+
+        UaException anonymousDirectory =
+            assertThrows(UaException.class, () -> gdsClient.getCertificateGroups(applicationId));
+        assertEquals(StatusCodes.Bad_UserAccessDenied, anonymousDirectory.getStatusCode().value());
+        assertArrayEquals(
+            defaultCertificateGroups(), credentialedGds.getCertificateGroups(applicationId));
+
+        gds.setCertificateDirectoryAccess(MethodAccess.NOBODY);
+
+        UaException deniedDirectory =
+            assertThrows(
+                UaException.class, () -> credentialedGds.getCertificateGroups(applicationId));
+        assertEquals(StatusCodes.Bad_UserAccessDenied, deniedDirectory.getStatusCode().value());
+      } finally {
+        credentialedClient.disconnectAsync().get(2, TimeUnit.SECONDS);
+      }
+    }
+
+    private OpcUaClient connectCredentialedClient() throws Exception {
+      OpcUaClient credentialedClient =
+          TestClient.create(
+              server,
+              config -> config.setIdentityProvider(new UsernameProvider("user1", "password")));
+      credentialedClient.connect();
+      return credentialedClient;
+    }
+
+    private NodeId[] defaultCertificateGroups() {
+      return new NodeId[] {gds.defaultApplicationGroupId(), gds.defaultUserTokenGroupId()};
     }
 
     @Test
@@ -189,9 +280,7 @@ public class GdsClientTest extends AbstractGdsClientTest {
             NodeIds.EccNistP256ApplicationCertificateType
           },
           gdsClient.readCertificateTypes(groups[0]));
-      assertArrayEquals(
-          new NodeId[] {NodeIds.RsaSha256ApplicationCertificateType},
-          gdsClient.readCertificateTypes(groups[1]));
+      assertArrayEquals(new NodeId[0], gdsClient.readCertificateTypes(groups[1]));
     }
 
     @Test
@@ -201,6 +290,15 @@ public class GdsClientTest extends AbstractGdsClientTest {
               UaException.class, () -> gdsClient.readCertificateTypes(gdsClient.getDirectoryId()));
 
       assertEquals(StatusCodes.Bad_NotFound, e.getStatusCode().value());
+    }
+
+    @Test
+    void configuredCertificateTypesAreAdvertisedAfterNamespaceStartup() throws Exception {
+      gds.setApplicationCertificateTypes(NodeIds.ApplicationCertificateType);
+
+      assertArrayEquals(
+          new NodeId[] {NodeIds.ApplicationCertificateType},
+          gdsClient.readCertificateTypes(gds.defaultApplicationGroupId()));
     }
 
     @Test
@@ -298,6 +396,10 @@ public class GdsClientTest extends AbstractGdsClientTest {
 
       assertEquals(StatusCodes.Bad_NothingToDo, first.getStatusCode().value());
       assertEquals(StatusCodes.Bad_NothingToDo, second.getStatusCode().value());
+      assertEquals(1, gds.getRegisterApplicationCallCount());
+      assertEquals(1, gds.getStartSigningRequestCallCount());
+      assertEquals(3, gds.getFinishRequestCallCount());
+      assertEquals(NodeIds.RsaSha256ApplicationCertificateType, gds.getLastCertificateTypeId());
 
       X509Certificate certificate =
           CertificateUtil.decodeCertificate(issued.certificate().bytesOrEmpty());
@@ -317,6 +419,8 @@ public class GdsClientTest extends AbstractGdsClientTest {
       KeyPair keyPair = SelfSignedCertificateGenerator.generateRsaKeyPair(2048);
       NodeId requestId =
           gdsClient.startSigningRequest(applicationId, null, null, csr(keyPair, APPLICATION_URI));
+
+      assertNull(gds.getLastCertificateTypeId(), "the null group default is recorded as null");
 
       UaException e =
           assertThrows(UaException.class, () -> gdsClient.finishRequest(applicationId, requestId));

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/TrustListReaderTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/TrustListReaderTest.java
@@ -18,7 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
-import org.eclipse.milo.opcua.sdk.client.gds.FakeGdsNamespace.TrustListFile;
+import org.eclipse.milo.opcua.sdk.client.gds.testing.FakeGdsNamespace.TrustListFile;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;

--- a/opc-ua-sdk/pom.xml
+++ b/opc-ua-sdk/pom.xml
@@ -34,6 +34,7 @@
     <module>sdk-client-gds</module>
     <module>sdk-core</module>
     <module>sdk-server</module>
+    <module>sdk-client-gds-testing</module>
     <module>integration-tests</module>
   </modules>
 

--- a/opc-ua-sdk/sdk-client-gds-testing/pom.xml
+++ b/opc-ua-sdk/sdk-client-gds-testing/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2026 the Eclipse Milo Authors
+  ~
+  ~ This program and the accompanying materials are made
+  ~ available under the terms of the Eclipse Public License 2.0
+  ~ which is available at https://www.eclipse.org/legal/epl-2.0/
+  ~
+  ~ SPDX-License-Identifier: EPL-2.0
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.eclipse.milo</groupId>
+    <artifactId>milo-opc-ua-sdk</artifactId>
+    <version>1.2.0-SNAPSHOT</version>
+  </parent>
+
+  <name>Milo :: SDK Client GDS Testing</name>
+
+  <artifactId>milo-sdk-client-gds-testing</artifactId>
+
+  <properties>
+    <javaModuleName>org.eclipse.milo.opcua.sdk.client.gds.testing</javaModuleName>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.milo</groupId>
+      <artifactId>milo-sdk-client-gds</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.milo</groupId>
+      <artifactId>milo-sdk-server</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/opc-ua-sdk/sdk-client-gds-testing/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/testing/FakeGdsNamespace.java
+++ b/opc-ua-sdk/sdk-client-gds-testing/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/testing/FakeGdsNamespace.java
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-package org.eclipse.milo.opcua.sdk.client.gds;
+package org.eclipse.milo.opcua.sdk.client.gds.testing;
 
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
 
@@ -39,6 +39,7 @@ import org.bouncycastle.cert.X509v3CertificateBuilder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
+import org.eclipse.milo.opcua.sdk.client.gds.GdsClient;
 import org.eclipse.milo.opcua.sdk.core.AccessLevel;
 import org.eclipse.milo.opcua.sdk.core.Reference;
 import org.eclipse.milo.opcua.sdk.core.ValueRanks;
@@ -47,6 +48,7 @@ import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
 import org.eclipse.milo.opcua.sdk.server.items.DataItem;
 import org.eclipse.milo.opcua.sdk.server.items.MonitoredItem;
 import org.eclipse.milo.opcua.sdk.server.methods.AbstractMethodInvocationHandler;
+import org.eclipse.milo.opcua.sdk.server.methods.AbstractMethodInvocationHandler.InvocationContext;
 import org.eclipse.milo.opcua.sdk.server.model.objects.DataTypeEncodingTypeNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaDataTypeNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaMethodNode;
@@ -74,7 +76,9 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.ApplicationType;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.OpenFileMode;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.UserTokenType;
 import org.eclipse.milo.opcua.stack.core.types.structured.ApplicationDescription;
 import org.eclipse.milo.opcua.stack.core.types.structured.Argument;
 import org.eclipse.milo.opcua.stack.core.types.structured.ServerOnNetwork;
@@ -85,17 +89,33 @@ import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateGenerator;
 import org.jspecify.annotations.Nullable;
 
 /**
- * An in-memory GDS hosted on the test server: the GDS namespace, the {@code
- * ApplicationRecordDataType}, the {@code Directory} object with every DirectoryType and
- * CertificateDirectoryType method, two certificate groups, and their TrustList files.
+ * An in-memory GDS test fixture: the GDS namespace, the {@code ApplicationRecordDataType}, the
+ * {@code Directory} object with every DirectoryType and CertificateDirectoryType method, two
+ * certificate groups, and their TrustList files.
  *
  * <p>Behaviour is deliberately simple and controllable from tests: registrations are kept in a map,
  * signing requests are issued by a throwaway CA after a configurable number of {@code
  * Bad_NothingToDo} polls, and each TrustList records the FileType calls made against it.
+ *
+ * <p>Construct the fixture with the server under test, call {@link #startup()} before starting the
+ * server, and call {@link #shutdown()} during teardown. Call {@link #reset()} between tests that
+ * share an instance.
  */
 public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
 
   public static final String NAMESPACE_URI = GdsClient.NAMESPACE_URI;
+
+  /** Access requirements for controlled GDS methods. */
+  public enum MethodAccess {
+    /** Allow calls from any activated session. */
+    ANYONE,
+
+    /** Allow calls only from a session activated with a UserName identity token. */
+    CREDENTIALED,
+
+    /** Deny every call with {@code Bad_UserAccessDenied}. */
+    NOBODY
+  }
 
   /** Recorded FileType calls and served body of one TrustList object. */
   public static final class TrustListFile {
@@ -153,11 +173,17 @@ public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
   private final Map<NodeId, List<X509Certificate>> issued = new ConcurrentHashMap<>();
   private final Set<ByteString> revoked = ConcurrentHashMap.newKeySet();
   private final AtomicInteger nextId = new AtomicInteger(1);
+  private final AtomicInteger registerApplicationCallCount = new AtomicInteger();
+  private final AtomicInteger startSigningRequestCallCount = new AtomicInteger();
+  private final AtomicInteger finishRequestCallCount = new AtomicInteger();
 
   private final TrustListFile applicationGroupTrustList = new TrustListFile();
   private final TrustListFile userTokenGroupTrustList = new TrustListFile();
 
-  private volatile boolean registrationAllowed = true;
+  private volatile MethodAccess registerApplicationAccess = MethodAccess.ANYONE;
+  private volatile MethodAccess certificateDirectoryAccess = MethodAccess.ANYONE;
+  private volatile NodeId[] applicationGroupCertificateTypes = defaultCertificateTypes();
+  private volatile @Nullable NodeId lastCertificateTypeId;
   private volatile int pollsBeforeIssued = 0;
   private volatile boolean rejectRequests = false;
   private volatile boolean updateRequired = true;
@@ -173,6 +199,12 @@ public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
             .build();
 
     getLifecycleManager().addStartupTask(this::addNodes);
+  }
+
+  private static NodeId[] defaultCertificateTypes() {
+    return new NodeId[] {
+      NodeIds.RsaSha256ApplicationCertificateType, NodeIds.EccNistP256ApplicationCertificateType
+    };
   }
 
   // The GDS tests never subscribe to anything in this namespace.
@@ -203,8 +235,72 @@ public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
     return userTokenGroupTrustList;
   }
 
-  public void setRegistrationAllowed(boolean registrationAllowed) {
-    this.registrationAllowed = registrationAllowed;
+  /** Set the access required to call {@code RegisterApplication}. */
+  public void setRegisterApplicationAccess(MethodAccess access) {
+    this.registerApplicationAccess = Objects.requireNonNull(access);
+  }
+
+  /** Set the access required to call the CertificateDirectoryType methods. */
+  public void setCertificateDirectoryAccess(MethodAccess access) {
+    this.certificateDirectoryAccess = Objects.requireNonNull(access);
+  }
+
+  /** Configure the CertificateTypes advertised by the DefaultApplicationGroup. */
+  public void setApplicationCertificateTypes(NodeId... certificateTypes) {
+    this.applicationGroupCertificateTypes = Objects.requireNonNull(certificateTypes).clone();
+  }
+
+  /**
+   * Number of calls made to {@code RegisterApplication} since the last {@link #reset()}, including
+   * calls that were denied or rejected.
+   */
+  public int getRegisterApplicationCallCount() {
+    return registerApplicationCallCount.get();
+  }
+
+  /**
+   * Number of calls made to {@code StartSigningRequest} since the last {@link #reset()}, including
+   * calls that were denied or rejected.
+   */
+  public int getStartSigningRequestCallCount() {
+    return startSigningRequestCallCount.get();
+  }
+
+  /**
+   * Number of calls made to {@code FinishRequest} since the last {@link #reset()}, including calls
+   * that were denied or rejected.
+   */
+  public int getFinishRequestCallCount() {
+    return finishRequestCallCount.get();
+  }
+
+  /**
+   * Get the CertificateTypeId the client sent in the most recent {@code StartSigningRequest},
+   * including calls that were denied or rejected.
+   *
+   * @return the CertificateTypeId from the last {@code StartSigningRequest}, or {@code null} if it
+   *     was null or no request has been made since the last {@link #reset()}.
+   */
+  public @Nullable NodeId getLastCertificateTypeId() {
+    return lastCertificateTypeId;
+  }
+
+  /** Pre-register an application as if it had been added by a GDS administrator. */
+  public NodeId preRegister(String applicationUri) {
+    NodeId applicationId = newNodeId("Applications/" + nextId.getAndIncrement());
+
+    applications.put(
+        applicationId,
+        new ApplicationRecordDataType(
+            applicationId,
+            applicationUri,
+            ApplicationType.Client,
+            new LocalizedText[0],
+            null,
+            null,
+            null));
+
+    return applicationId;
   }
 
   /**
@@ -228,7 +324,13 @@ public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
     requests.clear();
     issued.clear();
     revoked.clear();
-    registrationAllowed = true;
+    registerApplicationAccess = MethodAccess.ANYONE;
+    certificateDirectoryAccess = MethodAccess.ANYONE;
+    applicationGroupCertificateTypes = defaultCertificateTypes();
+    registerApplicationCallCount.set(0);
+    startSigningRequestCallCount.set(0);
+    finishRequestCallCount.set(0);
+    lastCertificateTypeId = null;
     pollsBeforeIssued = 0;
     rejectRequests = false;
     updateRequired = true;
@@ -268,10 +370,7 @@ public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
           GdsNodeIds.Directory_CertificateGroups_DefaultApplicationGroup,
           "DefaultApplicationGroup",
           GdsNodeIds.Directory_CertificateGroups_DefaultApplicationGroup_CertificateTypes,
-          new NodeId[] {
-            NodeIds.RsaSha256ApplicationCertificateType,
-            NodeIds.EccNistP256ApplicationCertificateType
-          },
+          () -> applicationGroupCertificateTypes.clone(),
           GdsNodeIds.Directory_CertificateGroups_DefaultApplicationGroup_TrustList,
           applicationGroupTrustList,
           true);
@@ -281,7 +380,7 @@ public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
           GdsNodeIds.Directory_CertificateGroups_DefaultUserTokenGroup,
           "DefaultUserTokenGroup",
           GdsNodeIds.Directory_CertificateGroups_DefaultUserTokenGroup_CertificateTypes,
-          new NodeId[] {NodeIds.RsaSha256ApplicationCertificateType},
+          () -> new NodeId[0],
           GdsNodeIds.Directory_CertificateGroups_DefaultUserTokenGroup_TrustList,
           userTokenGroupTrustList,
           false);
@@ -409,7 +508,7 @@ public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
       ExpandedNodeId groupId,
       String name,
       ExpandedNodeId certificateTypesId,
-      NodeId[] certificateTypes,
+      Supplier<NodeId[]> certificateTypes,
       ExpandedNodeId trustListId,
       TrustListFile file,
       boolean optionalProperties) {
@@ -428,8 +527,8 @@ public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
         "CertificateTypes",
         NodeIds.NodeId,
         ValueRanks.OneDimension,
-        new Variant(certificateTypes),
-        null);
+        Variant.NULL_VALUE,
+        () -> new Variant(certificateTypes.get()));
 
     UaObjectNode trustList =
         addObject(
@@ -515,7 +614,7 @@ public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
         new QualifiedName(0, "Open"),
         new Argument[] {argument("Mode", NodeIds.Byte, ValueRanks.Scalar)},
         new Argument[] {argument("FileHandle", NodeIds.UInt32, ValueRanks.Scalar)},
-        inputs -> {
+        (context, inputs) -> {
           file.calls.add("Open");
 
           UByte mode = (UByte) inputs[0].value();
@@ -538,7 +637,7 @@ public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
           argument("Length", NodeIds.Int32, ValueRanks.Scalar)
         },
         new Argument[] {argument("Data", NodeIds.ByteString, ValueRanks.Scalar)},
-        inputs -> {
+        (context, inputs) -> {
           UInteger handle = (UInteger) inputs[0].value();
           int length = Objects.requireNonNull((Integer) inputs[1].value());
 
@@ -568,7 +667,7 @@ public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
         new QualifiedName(0, "Close"),
         new Argument[] {argument("FileHandle", NodeIds.UInt32, ValueRanks.Scalar)},
         new Argument[0],
-        inputs -> {
+        (context, inputs) -> {
           file.calls.add("Close");
 
           UInteger handle = (UInteger) inputs[0].value();
@@ -589,7 +688,7 @@ public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
         newQualifiedName("FindApplications"),
         new Argument[] {argument("ApplicationUri", NodeIds.String, ValueRanks.Scalar)},
         new Argument[] {argument("Applications", applicationRecordId, ValueRanks.OneDimension)},
-        inputs -> {
+        (context, inputs) -> {
           String applicationUri = (String) inputs[0].value();
 
           ApplicationRecordDataType[] matches =
@@ -606,10 +705,9 @@ public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
         newQualifiedName("RegisterApplication"),
         new Argument[] {argument("Application", applicationRecordId, ValueRanks.Scalar)},
         new Argument[] {argument("ApplicationId", NodeIds.NodeId, ValueRanks.Scalar)},
-        inputs -> {
-          if (!registrationAllowed) {
-            throw new UaException(StatusCodes.Bad_UserAccessDenied);
-          }
+        (context, inputs) -> {
+          registerApplicationCallCount.incrementAndGet();
+          requireAccess(context, registerApplicationAccess);
 
           ApplicationRecordDataType record = applicationArgument(inputs[0]);
           NodeId applicationId = newNodeId("Applications/" + nextId.getAndIncrement());
@@ -625,7 +723,7 @@ public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
         newQualifiedName("UpdateApplication"),
         new Argument[] {argument("Application", applicationRecordId, ValueRanks.Scalar)},
         new Argument[0],
-        inputs -> {
+        (context, inputs) -> {
           ApplicationRecordDataType record = applicationArgument(inputs[0]);
 
           requireApplication(record.getApplicationId());
@@ -640,7 +738,7 @@ public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
         newQualifiedName("UnregisterApplication"),
         new Argument[] {argument("ApplicationId", NodeIds.NodeId, ValueRanks.Scalar)},
         new Argument[0],
-        inputs -> {
+        (context, inputs) -> {
           NodeId applicationId = (NodeId) inputs[0].value();
 
           requireApplication(applicationId);
@@ -655,7 +753,7 @@ public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
         newQualifiedName("GetApplication"),
         new Argument[] {argument("ApplicationId", NodeIds.NodeId, ValueRanks.Scalar)},
         new Argument[] {argument("Application", applicationRecordId, ValueRanks.Scalar)},
-        inputs -> {
+        (context, inputs) -> {
           NodeId applicationId = (NodeId) inputs[0].value();
 
           return new Variant[] {new Variant(requireApplication(applicationId))};
@@ -679,7 +777,7 @@ public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
           argument("NextRecordId", NodeIds.UInt32, ValueRanks.Scalar),
           argument("Applications", NodeIds.ApplicationDescription, ValueRanks.OneDimension)
         },
-        inputs -> {
+        (context, inputs) -> {
           ApplicationDescription[] descriptions =
               applications.values().stream()
                   .map(FakeGdsNamespace::toDescription)
@@ -708,7 +806,7 @@ public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
           argument("LastCounterResetTime", NodeIds.UtcTime, ValueRanks.Scalar),
           argument("Servers", NodeIds.ServerOnNetwork, ValueRanks.OneDimension)
         },
-        inputs -> {
+        (context, inputs) -> {
           ServerOnNetwork[] servers =
               applications.values().stream()
                   .map(
@@ -738,7 +836,11 @@ public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
           argument("CertificateRequest", NodeIds.ByteString, ValueRanks.Scalar)
         },
         new Argument[] {argument("RequestId", NodeIds.NodeId, ValueRanks.Scalar)},
-        inputs -> {
+        (context, inputs) -> {
+          startSigningRequestCallCount.incrementAndGet();
+          lastCertificateTypeId = nonNullNodeId((NodeId) inputs[2].value());
+          requireAccess(context, certificateDirectoryAccess);
+
           NodeId applicationId = (NodeId) inputs[0].value();
           ByteString certificateRequest = (ByteString) inputs[3].value();
 
@@ -770,7 +872,9 @@ public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
           argument("PrivateKeyPassword", NodeIds.String, ValueRanks.Scalar)
         },
         new Argument[] {argument("RequestId", NodeIds.NodeId, ValueRanks.Scalar)},
-        inputs -> {
+        (context, inputs) -> {
+          requireAccess(context, certificateDirectoryAccess);
+
           NodeId applicationId = (NodeId) inputs[0].value();
 
           requireApplication(applicationId);
@@ -794,7 +898,10 @@ public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
           argument("PrivateKey", NodeIds.ByteString, ValueRanks.Scalar),
           argument("IssuerCertificates", NodeIds.ByteString, ValueRanks.OneDimension)
         },
-        inputs -> {
+        (context, inputs) -> {
+          finishRequestCallCount.incrementAndGet();
+          requireAccess(context, certificateDirectoryAccess);
+
           NodeId applicationId = (NodeId) inputs[0].value();
           NodeId requestId = (NodeId) inputs[1].value();
 
@@ -855,7 +962,9 @@ public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
         newQualifiedName("GetCertificateGroups"),
         new Argument[] {argument("ApplicationId", NodeIds.NodeId, ValueRanks.Scalar)},
         new Argument[] {argument("CertificateGroupIds", NodeIds.NodeId, ValueRanks.OneDimension)},
-        inputs -> {
+        (context, inputs) -> {
+          requireAccess(context, certificateDirectoryAccess);
+
           requireApplication((NodeId) inputs[0].value());
 
           return new Variant[] {
@@ -879,7 +988,9 @@ public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
           argument("CertificateTypeIds", NodeIds.NodeId, ValueRanks.OneDimension),
           argument("Certificates", NodeIds.ByteString, ValueRanks.OneDimension)
         },
-        inputs -> {
+        (context, inputs) -> {
+          requireAccess(context, certificateDirectoryAccess);
+
           NodeId applicationId = (NodeId) inputs[0].value();
           requireApplication(applicationId);
 
@@ -908,7 +1019,9 @@ public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
           argument("CertificateGroupId", NodeIds.NodeId, ValueRanks.Scalar)
         },
         new Argument[] {argument("TrustListId", NodeIds.NodeId, ValueRanks.Scalar)},
-        inputs -> {
+        (context, inputs) -> {
+          requireAccess(context, certificateDirectoryAccess);
+
           requireApplication((NodeId) inputs[0].value());
 
           NodeId groupId = (NodeId) inputs[1].value();
@@ -942,7 +1055,9 @@ public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
           argument("CertificateTypeId", NodeIds.NodeId, ValueRanks.Scalar)
         },
         new Argument[] {argument("UpdateRequired", NodeIds.Boolean, ValueRanks.Scalar)},
-        inputs -> {
+        (context, inputs) -> {
+          requireAccess(context, certificateDirectoryAccess);
+
           requireApplication((NodeId) inputs[0].value());
 
           return new Variant[] {Variant.ofBoolean(updateRequired)};
@@ -957,7 +1072,9 @@ public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
           argument("Certificate", NodeIds.ByteString, ValueRanks.Scalar)
         },
         new Argument[0],
-        inputs -> {
+        (context, inputs) -> {
+          requireAccess(context, certificateDirectoryAccess);
+
           requireApplication((NodeId) inputs[0].value());
 
           revoked.add((ByteString) inputs[1].value());
@@ -974,7 +1091,9 @@ public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
           argument("CertificateStatus", NodeIds.StatusCode, ValueRanks.Scalar),
           argument("ValidityTime", NodeIds.UtcTime, ValueRanks.Scalar)
         },
-        inputs -> {
+        (context, inputs) -> {
+          requireAccess(context, certificateDirectoryAccess);
+
           ByteString certificate = (ByteString) inputs[0].value();
 
           StatusCode status =
@@ -991,7 +1110,7 @@ public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
 
   @FunctionalInterface
   private interface MethodBody {
-    Variant[] invoke(Variant[] inputs) throws UaException;
+    Variant[] invoke(InvocationContext context, Variant[] inputs) throws UaException;
   }
 
   private void addMethod(
@@ -1033,7 +1152,7 @@ public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
           @Override
           protected Variant[] invoke(InvocationContext invocationContext, Variant[] inputValues)
               throws UaException {
-            return body.invoke(inputValues);
+            return body.invoke(invocationContext, inputValues);
           }
         });
 
@@ -1042,6 +1161,29 @@ public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
 
   private static Argument argument(String name, NodeId dataTypeId, int valueRank) {
     return new Argument(name, dataTypeId, valueRank, null, LocalizedText.NULL_VALUE);
+  }
+
+  private static void requireAccess(InvocationContext context, MethodAccess access)
+      throws UaException {
+
+    boolean allowed =
+        switch (access) {
+          case ANYONE -> true;
+          case CREDENTIALED ->
+              context
+                  .getSession()
+                  .map(session -> session.getTokenType() == UserTokenType.UserName)
+                  .orElse(false);
+          case NOBODY -> false;
+        };
+
+    if (!allowed) {
+      throw new UaException(StatusCodes.Bad_UserAccessDenied);
+    }
+  }
+
+  private static @Nullable NodeId nonNullNodeId(@Nullable NodeId nodeId) {
+    return nodeId == null || nodeId.isNull() ? null : nodeId;
   }
 
   private ApplicationRecordDataType requireApplication(@Nullable NodeId applicationId)

--- a/opc-ua-sdk/sdk-client-gds-testing/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/testing/package-info.java
+++ b/opc-ua-sdk/sdk-client-gds-testing/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/testing/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/**
+ * Reusable server-side fixtures for testing applications built on the Milo GDS client.
+ *
+ * <p>{@link org.eclipse.milo.opcua.sdk.client.gds.testing.FakeGdsNamespace} hosts an in-memory GDS
+ * namespace on an {@link org.eclipse.milo.opcua.sdk.server.OpcUaServer}. Tests can control access,
+ * registration, certificate issuance, and TrustList responses, then inspect recorded calls. The
+ * fixture must be started before the server and shut down during test teardown.
+ */
+@NullMarked
+package org.eclipse.milo.opcua.sdk.client.gds.testing;
+
+import org.jspecify.annotations.NullMarked;

--- a/opc-ua-sdk/sdk-client-gds/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/GdsClient.java
+++ b/opc-ua-sdk/sdk-client-gds/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/GdsClient.java
@@ -16,11 +16,14 @@ import static java.util.concurrent.CompletableFuture.failedFuture;
 import java.security.PublicKey;
 import java.security.cert.X509Certificate;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
 import org.eclipse.milo.opcua.sdk.client.methods.UaMethodException;
 import org.eclipse.milo.opcua.stack.core.NamespaceTable;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.gds.DataTypeInitializer;
@@ -56,6 +59,10 @@ import org.jspecify.annotations.Nullable;
  * #finishRequest} means "poll again later" and {@link StatusCodes#Bad_RequestNotAllowed} means the
  * request was rejected.
  *
+ * <p>{@link #resolveCertificateTypeId(NodeId, NodeId)} is the exception to this pass-through rule:
+ * it interprets a group's advertised CertificateTypes locally and reports {@link
+ * StatusCodes#Bad_NotSupported} when none is compatible with the desired type.
+ *
  * <p>The Pull Model sequence (Part 12 §7.6) is:
  *
  * <pre>{@code
@@ -65,13 +72,22 @@ import org.jspecify.annotations.Nullable;
  * NodeId applicationId =
  *     found.length == 0 ? gds.registerApplication(record) : found[0].getApplicationId();
  *
+ * NodeId desiredTypeId = NodeIds.RsaSha256ApplicationCertificateType;
  * for (NodeId groupId : gds.getCertificateGroups(applicationId)) {
- *   for (NodeId typeId : gds.readCertificateTypes(groupId)) {
- *     if (gds.getCertificateStatus(applicationId, groupId, typeId)) {
- *       NodeId requestId = gds.startSigningRequest(applicationId, groupId, typeId, csr);
- *       // later, repeat until it no longer fails with Bad_NothingToDo:
- *       FinishRequestResult issued = gds.finishRequest(applicationId, requestId);
- *     }
+ *   // Groups such as DefaultUserTokenGroup do not issue application certificates and fail
+ *   // with Bad_NotSupported; skip signing for them but still pull their TrustList.
+ *   NodeId requestTypeId = null;
+ *   boolean issuesDesiredType = true;
+ *   try {
+ *     requestTypeId = gds.resolveCertificateTypeId(groupId, desiredTypeId);
+ *   } catch (UaException e) {
+ *     if (e.getStatusCode().value() != StatusCodes.Bad_NotSupported) throw e;
+ *     issuesDesiredType = false;
+ *   }
+ *   if (issuesDesiredType && gds.getCertificateStatus(applicationId, groupId, requestTypeId)) {
+ *     NodeId requestId = gds.startSigningRequest(applicationId, groupId, requestTypeId, csr);
+ *     // later, repeat until it no longer fails with Bad_NothingToDo:
+ *     FinishRequestResult issued = gds.finishRequest(applicationId, requestId);
  *   }
  *   NodeId trustListId = gds.getTrustList(applicationId, groupId);
  *   TrustListDataType trustList = TrustListReader.read(client, trustListId);
@@ -87,6 +103,44 @@ public final class GdsClient {
 
   /** The URI of the GDS namespace, {@code http://opcfoundation.org/UA/GDS/}. */
   public static final String NAMESPACE_URI = "http://opcfoundation.org/UA/GDS/";
+
+  private static final Map<NodeId, NodeId> CERTIFICATE_TYPE_SUPERTYPES =
+      Map.ofEntries(
+          Map.entry(NodeIds.ApplicationCertificateType, NodeIds.CertificateType),
+          Map.entry(NodeIds.HttpsCertificateType, NodeIds.CertificateType),
+          Map.entry(NodeIds.UserCertificateType, NodeIds.CertificateType),
+          Map.entry(NodeIds.TlsCertificateType, NodeIds.CertificateType),
+          Map.entry(NodeIds.TlsServerCertificateType, NodeIds.TlsCertificateType),
+          Map.entry(NodeIds.TlsClientCertificateType, NodeIds.TlsCertificateType),
+          Map.entry(NodeIds.RsaMinApplicationCertificateType, NodeIds.ApplicationCertificateType),
+          Map.entry(
+              NodeIds.RsaSha256ApplicationCertificateType, NodeIds.ApplicationCertificateType),
+          Map.entry(NodeIds.EccApplicationCertificateType, NodeIds.ApplicationCertificateType),
+          Map.entry(
+              NodeIds.EccNistP256ApplicationCertificateType, NodeIds.EccApplicationCertificateType),
+          Map.entry(
+              NodeIds.EccNistP384ApplicationCertificateType, NodeIds.EccApplicationCertificateType),
+          Map.entry(
+              NodeIds.EccBrainpoolP256r1ApplicationCertificateType,
+              NodeIds.EccApplicationCertificateType),
+          Map.entry(
+              NodeIds.EccBrainpoolP384r1ApplicationCertificateType,
+              NodeIds.EccApplicationCertificateType),
+          Map.entry(
+              NodeIds.EccCurve25519ApplicationCertificateType,
+              NodeIds.EccApplicationCertificateType),
+          Map.entry(
+              NodeIds.EccCurve448ApplicationCertificateType,
+              NodeIds.EccApplicationCertificateType));
+
+  /** Abstract CertificateTypes in the standard hierarchy. */
+  private static final Set<NodeId> ABSTRACT_CERTIFICATE_TYPES =
+      Set.of(
+          NodeIds.CertificateType,
+          NodeIds.ApplicationCertificateType,
+          NodeIds.UserCertificateType,
+          NodeIds.TlsCertificateType,
+          NodeIds.EccApplicationCertificateType);
 
   private final OpcUaClient client;
   private final NodeId directoryId;
@@ -437,7 +491,9 @@ public final class GdsClient {
    * @param applicationId the ApplicationId returned by registration.
    * @param certificateGroupId the CertificateGroup the certificate belongs to, or null for the
    *     default group.
-   * @param certificateTypeId the CertificateType to issue, or null for the group's default.
+   * @param certificateTypeId the CertificateType to issue, or null for the group's default; use
+   *     {@link #resolveCertificateTypeId(NodeId, NodeId)} to select this value from an advertised
+   *     group.
    * @param certificateRequest the DER-encoded PKCS#10 request.
    * @return the RequestId to pass to {@link #finishRequest(NodeId, NodeId)}.
    * @throws UaException if the call fails.
@@ -489,7 +545,9 @@ public final class GdsClient {
    * @param applicationId the ApplicationId returned by registration.
    * @param certificateGroupId the CertificateGroup the certificate belongs to, or null for the
    *     default group.
-   * @param certificateTypeId the CertificateType to issue, or null for the group's default.
+   * @param certificateTypeId the CertificateType to issue, or null for the group's default; use
+   *     {@link #resolveCertificateTypeId(NodeId, NodeId)} to select this value from an advertised
+   *     group.
    * @param subjectName the subject name to put in the certificate, or null to let the GDS choose.
    * @param domainNames the domain names to put in the certificate, or null to let the GDS choose.
    * @param privateKeyFormat {@code "PFX"} or {@code "PEM"}, or null for the GDS default.
@@ -698,7 +756,8 @@ public final class GdsClient {
    *
    * @param applicationId the ApplicationId returned by registration.
    * @param certificateGroupId the CertificateGroup, or null for the default group.
-   * @param certificateTypeId the CertificateType, or null for the group's default.
+   * @param certificateTypeId the CertificateType, or null for the group's default; use {@link
+   *     #resolveCertificateTypeId(NodeId, NodeId)} to select this value from an advertised group.
    * @return {@code true} if a new certificate should be requested.
    * @throws UaException if the call fails.
    */
@@ -799,6 +858,10 @@ public final class GdsClient {
   /**
    * Read the {@code CertificateTypes} property of a CertificateGroup on the GDS.
    *
+   * <p>The returned ids may identify abstract types such as {@link
+   * NodeIds#ApplicationCertificateType}. Use {@link #resolveCertificateTypeId(NodeId, NodeId)} when
+   * selecting the value to pass to a certificate request method.
+   *
    * @param certificateGroupId a group id returned by {@link #getCertificateGroups(NodeId)}.
    * @return the CertificateType ids the group issues, e.g. {@code
    *     RsaSha256ApplicationCertificateType}.
@@ -823,6 +886,59 @@ public final class GdsClient {
                         "CertificateTypes", certificateGroupId, values.get(0), NodeId[].class);
 
                 return completedFuture(certificateTypes != null ? certificateTypes : new NodeId[0]);
+              } catch (UaException e) {
+                return failedFuture(e);
+              }
+            });
+  }
+
+  /**
+   * Resolve the CertificateTypeId to request for a desired certificate type.
+   *
+   * <p>An exact advertised match returns {@code desiredTypeId}. If the group advertises only
+   * abstract types and every advertised non-null type is an ancestor of the desired type, this
+   * returns {@code null} so the request selects the group's default. Any other advertised list,
+   * including one that holds an incompatible abstract type or a concrete sibling of the desired
+   * type, fails with {@link StatusCodes#Bad_NotSupported}.
+   *
+   * <p>The standard CertificateType hierarchy is evaluated locally without browsing the server.
+   * CertificateTypes outside namespace 0 are matched exactly only; their subtype relationships are
+   * not evaluated. Passing an abstract type as {@code desiredTypeId} returns it unchanged on an
+   * exact match, which a GDS may reject.
+   *
+   * @param certificateGroupId a group id returned by {@link #getCertificateGroups(NodeId)}.
+   * @param desiredTypeId the concrete CertificateType the application needs.
+   * @return the desired type for an exact match, or {@code null} to request a compatible group
+   *     default.
+   * @throws UaException if the property cannot be read or the group cannot issue the desired type.
+   */
+  public @Nullable NodeId resolveCertificateTypeId(NodeId certificateGroupId, NodeId desiredTypeId)
+      throws UaException {
+
+    return ClientCalls.await(resolveCertificateTypeIdAsync(certificateGroupId, desiredTypeId));
+  }
+
+  /**
+   * Asynchronous form of {@link #resolveCertificateTypeId(NodeId, NodeId)}.
+   *
+   * @param certificateGroupId a group id returned by {@link #getCertificateGroups(NodeId)}.
+   * @param desiredTypeId the concrete CertificateType the application needs.
+   * @return a future completing with the desired type for an exact match, or {@code null} to
+   *     request a compatible group default. The future completes exceptionally with {@link
+   *     UaException} carrying {@link StatusCodes#Bad_NotSupported} when the advertised types are
+   *     incompatible.
+   */
+  public CompletableFuture<@Nullable NodeId> resolveCertificateTypeIdAsync(
+      NodeId certificateGroupId, NodeId desiredTypeId) {
+
+    return readCertificateTypesAsync(certificateGroupId)
+        .thenCompose(
+            advertisedTypeIds -> {
+              try {
+                @Nullable NodeId requestTypeId =
+                    selectCertificateTypeId(certificateGroupId, desiredTypeId, advertisedTypeIds);
+
+                return completedFuture(requestTypeId);
               } catch (UaException e) {
                 return failedFuture(e);
               }
@@ -966,6 +1082,57 @@ public final class GdsClient {
 
   private static NodeId orNull(@Nullable NodeId nodeId) {
     return nodeId != null ? nodeId : NodeId.NULL_VALUE;
+  }
+
+  private static @Nullable NodeId selectCertificateTypeId(
+      NodeId certificateGroupId, NodeId desiredTypeId, NodeId[] advertisedTypeIds)
+      throws UaException {
+
+    for (NodeId advertisedTypeId : advertisedTypeIds) {
+      if (desiredTypeId.equals(advertisedTypeId)) {
+        return desiredTypeId;
+      }
+    }
+
+    // Null selects the group's default, which is only predictable when every advertised non-null
+    // type is an abstract ancestor; any other type could identify a different profile.
+    boolean ancestorAdvertised = false;
+
+    for (NodeId advertisedTypeId : advertisedTypeIds) {
+      if (advertisedTypeId == null || advertisedTypeId.isNull()) {
+        continue;
+      }
+      if (!ABSTRACT_CERTIFICATE_TYPES.contains(advertisedTypeId)
+          || !isStrictCertificateSubtypeOf(desiredTypeId, advertisedTypeId)) {
+        ancestorAdvertised = false;
+        break;
+      }
+      ancestorAdvertised = true;
+    }
+
+    if (ancestorAdvertised) {
+      return null;
+    }
+
+    throw new UaException(
+        StatusCodes.Bad_NotSupported,
+        String.format(
+            "CertificateGroup %s cannot issue desired CertificateType %s",
+            certificateGroupId, desiredTypeId));
+  }
+
+  private static boolean isStrictCertificateSubtypeOf(NodeId typeId, NodeId potentialSupertypeId) {
+    NodeId supertypeId = CERTIFICATE_TYPE_SUPERTYPES.get(typeId);
+
+    while (supertypeId != null) {
+      if (supertypeId.equals(potentialSupertypeId)) {
+        return true;
+      }
+
+      supertypeId = CERTIFICATE_TYPE_SUPERTYPES.get(supertypeId);
+    }
+
+    return false;
   }
 
   /**

--- a/opc-ua-sdk/sdk-client-gds/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/package-info.java
+++ b/opc-ua-sdk/sdk-client-gds/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/package-info.java
@@ -39,11 +39,13 @@
  * <h2>Data flow</h2>
  *
  * <p>The Pull Model (Part 12 §7.6) runs against the {@code Directory} object: find or register the
- * application record, list the certificate groups the GDS manages for it, and for each group and
- * certificate type ask whether an update is required, submit a signing request, and poll {@code
- * FinishRequest} until it stops failing with {@code Bad_NothingToDo}. The group's TrustList is read
- * whenever its {@code LastUpdateTime} moves past the time the application last applied it, and is
- * applied to the {@code TrustListManager} of the matching local certificate group.
+ * application record, list the certificate groups the GDS manages for it, resolve the
+ * CertificateTypeId to request for each desired certificate type with {@link
+ * org.eclipse.milo.opcua.sdk.client.gds.GdsClient#resolveCertificateTypeId}, ask whether an update
+ * is required, submit a signing request, and poll {@code FinishRequest} until it stops failing with
+ * {@code Bad_NothingToDo}. The group's TrustList is read whenever its {@code LastUpdateTime} moves
+ * past the time the application last applied it, and is applied to the {@code TrustListManager} of
+ * the matching local certificate group.
  *
  * <h2>Boundaries</h2>
  *
@@ -54,8 +56,9 @@
  * ApplicationId} and pending {@code RequestId}s across restarts, verifies issued certificates
  * against its own key pairs, and decides which {@code TrustListManager} receives a pulled list.
  * Method results are returned as the GDS reports them; a Bad status is thrown as a {@link
- * org.eclipse.milo.opcua.stack.core.UaException} carrying the original code and is never
- * interpreted or retried here.
+ * org.eclipse.milo.opcua.stack.core.UaException} carrying the original code and is never retried
+ * here. Certificate type resolution is local and reports {@code Bad_NotSupported} when the
+ * advertised types are incompatible with the desired type.
  *
  * <p>Nothing in this package runs during namespace 0 startup. The GDS namespace index is only known
  * once a client has read a server's namespace array, so the model registrations happen in {@code


### PR DESCRIPTION
This improves interoperability with GDS implementations that advertise abstract certificate types and makes the in-process GDS fixture reusable by downstream Pull workflow tests.

The new published `milo-sdk-client-gds-testing` artifact hosts `FakeGdsNamespace` in a non-split `.testing` package. It adds independent registration and certificate-directory access controls, configurable advertised certificate types, administrator pre-registration, request counters, and last-certificate-type recording. Milo's integration tests now consume this artifact directly.

`GdsClient` now provides blocking and asynchronous certificate-type resolution. Exact advertised matches retain the desired concrete ID, a true advertised ancestor selects the group default with `null`, and incompatible types fail with `Bad_NotSupported`. The hierarchy preserves `RsaMinApplicationCertificateType` and `RsaSha256ApplicationCertificateType` as siblings. The feature guide and pull example cover the reference GDS's abstract advertisement, namespace-specific group IDs, and portable null request.

Verification:

- `mise exec -- mvn -q -pl opc-ua-sdk/integration-tests -am test -Dtest=GdsClientTest`
- `mise exec -- mvn -q -pl opc-ua-sdk/sdk-client-gds test`
- `mise exec -- mvn -q spotless:apply`
- `mise exec -- mvn -q clean compile`
- `mise exec -- mvn -q clean verify`

Closes #1856
Closes #1852
Closes #1850
