### PR TITLE
Correct certificate identity resolution

### DIFF
--- a/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/GdsPullExample.java
+++ b/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/GdsPullExample.java
@@ -76,7 +76,7 @@ public class GdsPullExample implements ClientExample {
     client.connect();
 
     GdsClient gds = GdsClient.create(client);
-    String applicationUri = client.getConfig().getApplicationUri();
+    String applicationUri = client.getConfig().getApplicationUri().orElseThrow();
 
     // Part 12 §6.4: look for an existing registration before creating one.
     ApplicationRecordDataType[] found = gds.findApplications(applicationUri);
@@ -171,7 +171,7 @@ public class GdsPullExample implements ClientExample {
   private static ApplicationRecordDataType clientRecord(OpcUaClient client) {
     return new ApplicationRecordDataType(
         NodeId.NULL_VALUE,
-        client.getConfig().getApplicationUri(),
+        client.getConfig().getApplicationUri().orElseThrow(),
         ApplicationType.Client,
         new LocalizedText[] {client.getConfig().getApplicationName()},
         client.getConfig().getProductUri(),

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/OpcUaClientConfigTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/OpcUaClientConfigTest.java
@@ -13,7 +13,6 @@ package org.eclipse.milo.opcua.sdk.client;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -121,7 +120,7 @@ public class OpcUaClientConfigTest {
     assertSame(original.getCertificateIdentitySelector(), copy.getCertificateIdentitySelector());
     assertEquals(original.getCertificateGroupId(), copy.getCertificateGroupId());
     assertEquals(original.getCertificateTypeId(), copy.getCertificateTypeId());
-    assertEquals(original.isApplicationUriConfigured(), copy.isApplicationUriConfigured());
+    assertEquals(original.getApplicationUri(), copy.getApplicationUri());
     assertTrue(copy.getCertificateIdentity(SecurityPolicy.None.getProfile()).isEmpty());
   }
 
@@ -144,9 +143,8 @@ public class OpcUaClientConfigTest {
     OpcUaClientConfig derivedCopy = OpcUaClientConfig.copy(derived).build();
     OpcUaClientConfig explicitCopy = OpcUaClientConfig.copy(explicit).build();
 
-    assertFalse(derivedCopy.isApplicationUriConfigured());
-    assertTrue(explicitCopy.isApplicationUriConfigured());
-    assertEquals("urn:eclipse:milo:test:explicit", explicitCopy.getApplicationUri());
+    assertTrue(derivedCopy.getApplicationUri().isEmpty());
+    assertEquals(Optional.of("urn:eclipse:milo:test:explicit"), explicitCopy.getApplicationUri());
   }
 
   @Test
@@ -345,7 +343,7 @@ public class OpcUaClientConfigTest {
 
     OpcUaClient client = client(config);
 
-    assertEquals("urn:eclipse:milo:test:explicit", client.resolveApplicationUri(Optional.empty()));
+    assertEquals("urn:eclipse:milo:test:explicit", client.resolveApplicationUri(null));
   }
 
   // The certificate presented for the endpoint defines the application instance, so its URI must
@@ -366,7 +364,7 @@ public class OpcUaClientConfigTest {
 
     assertEquals(
         "urn:eclipse:milo:test:managed",
-        client.resolveApplicationUri(client.getCertificateIdentity(profile())));
+        client.resolveApplicationUri(client.getCertificateIdentity(profile()).orElse(null)));
   }
 
   // An explicit certificate outside the manager makes selection empty. Its SAN URI must still be
@@ -385,7 +383,7 @@ public class OpcUaClientConfigTest {
 
     assertEquals(
         "urn:eclipse:milo:test:fixed",
-        client.resolveApplicationUri(client.getCertificateIdentity(profile())));
+        client.resolveApplicationUri(client.getCertificateIdentity(profile()).orElse(null)));
   }
 
   // The placeholder remains a last resort for certificate-less clients and certificates without a
@@ -397,8 +395,7 @@ public class OpcUaClientConfigTest {
     OpcUaClient client = client(config);
 
     assertEquals(
-        "urn:eclipse:milo:client:applicationUriNotConfigured",
-        client.resolveApplicationUri(Optional.empty()));
+        "urn:eclipse:milo:client:applicationUriNotConfigured", client.resolveApplicationUri(null));
   }
 
   // A None endpoint presents no identity, but the client is still the same application. When every
@@ -416,7 +413,7 @@ public class OpcUaClientConfigTest {
 
     OpcUaClient client = client(config);
 
-    assertEquals("urn:eclipse:milo:test:managed", client.resolveApplicationUri(Optional.empty()));
+    assertEquals("urn:eclipse:milo:test:managed", client.resolveApplicationUri(null));
   }
 
   // Manager identities with differing URIs cannot define the application, so the placeholder
@@ -434,8 +431,7 @@ public class OpcUaClientConfigTest {
     OpcUaClient client = client(config);
 
     assertEquals(
-        "urn:eclipse:milo:client:applicationUriNotConfigured",
-        client.resolveApplicationUri(Optional.empty()));
+        "urn:eclipse:milo:client:applicationUriNotConfigured", client.resolveApplicationUri(null));
   }
 
   // URI inference is best-effort. A None connection must retain the placeholder when a custom
@@ -454,8 +450,7 @@ public class OpcUaClientConfigTest {
     OpcUaClient client = client(config);
 
     assertEquals(
-        "urn:eclipse:milo:client:applicationUriNotConfigured",
-        client.resolveApplicationUri(Optional.empty()));
+        "urn:eclipse:milo:client:applicationUriNotConfigured", client.resolveApplicationUri(null));
   }
 
   // A configured certificate is still presented on a None connection. If it has no SAN URI, a URI
@@ -480,8 +475,7 @@ public class OpcUaClientConfigTest {
     OpcUaClient client = client(config);
 
     assertEquals(
-        "urn:eclipse:milo:client:applicationUriNotConfigured",
-        client.resolveApplicationUri(Optional.empty()));
+        "urn:eclipse:milo:client:applicationUriNotConfigured", client.resolveApplicationUri(null));
   }
 
   // A selected identity without a SAN URI cannot define the ApplicationUri. The fixed certificate
@@ -506,8 +500,7 @@ public class OpcUaClientConfigTest {
 
     OpcUaClient client = client(config);
 
-    assertEquals(
-        "urn:eclipse:milo:test:fixed", client.resolveApplicationUri(Optional.of(identity)));
+    assertEquals("urn:eclipse:milo:test:fixed", client.resolveApplicationUri(identity));
   }
 
   // SecureChannel setup selects first. Session creation must derive the URI from that cached
@@ -532,7 +525,7 @@ public class OpcUaClientConfigTest {
     assertSame(identityA, client.getCertificateIdentity(profile).orElseThrow());
     assertEquals(
         "urn:eclipse:milo:test:a",
-        client.resolveApplicationUri(client.getCertificateIdentity(profile)));
+        client.resolveApplicationUri(client.getCertificateIdentity(profile).orElse(null)));
     assertEquals(1, selections.get());
   }
 

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/OpcUaClientConfigTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/OpcUaClientConfigTest.java
@@ -401,6 +401,89 @@ public class OpcUaClientConfigTest {
         client.resolveApplicationUri(Optional.empty()));
   }
 
+  // A None endpoint presents no identity, but the client is still the same application. When every
+  // manager identity carries the same URI, that URI must be advertised instead of the placeholder,
+  // so servers see one ApplicationUri across secure and None connections.
+  @Test
+  public void managerApplicationUriIsUsedWhenNoIdentityIsPresented() throws Exception {
+    CertificateIdentity identityA = identity("urn:eclipse:milo:test:managed", "groupA");
+    CertificateIdentity identityB = identity("urn:eclipse:milo:test:managed", "groupB");
+    OpcUaClientConfig config =
+        OpcUaClientConfig.builder()
+            .setEndpoint(endpoint)
+            .setCertificateManager(multiIdentityManager(List.of(identityA, identityB)))
+            .build();
+
+    OpcUaClient client = client(config);
+
+    assertEquals("urn:eclipse:milo:test:managed", client.resolveApplicationUri(Optional.empty()));
+  }
+
+  // Manager identities with differing URIs cannot define the application, so the placeholder
+  // remains when no identity is presented.
+  @Test
+  public void differingManagerApplicationUrisFallBackToPlaceholder() throws Exception {
+    CertificateIdentity identityA = identity("urn:eclipse:milo:test:a", "groupA");
+    CertificateIdentity identityB = identity("urn:eclipse:milo:test:b", "groupB");
+    OpcUaClientConfig config =
+        OpcUaClientConfig.builder()
+            .setEndpoint(endpoint)
+            .setCertificateManager(multiIdentityManager(List.of(identityA, identityB)))
+            .build();
+
+    OpcUaClient client = client(config);
+
+    assertEquals(
+        "urn:eclipse:milo:client:applicationUriNotConfigured",
+        client.resolveApplicationUri(Optional.empty()));
+  }
+
+  // URI inference is best-effort. A None connection must retain the placeholder when a custom
+  // manager cannot enumerate identities, instead of failing session creation.
+  @Test
+  public void managerFailureFallsBackToPlaceholder() {
+    CertificateManager certificateManager = mock(CertificateManager.class);
+    when(certificateManager.getCertificateIdentities())
+        .thenThrow(new IllegalStateException("identity store unavailable"));
+    OpcUaClientConfig config =
+        OpcUaClientConfig.builder()
+            .setEndpoint(endpoint)
+            .setCertificateManager(certificateManager)
+            .build();
+
+    OpcUaClient client = client(config);
+
+    assertEquals(
+        "urn:eclipse:milo:client:applicationUriNotConfigured",
+        client.resolveApplicationUri(Optional.empty()));
+  }
+
+  // A configured certificate is still presented on a None connection. If it has no SAN URI, a URI
+  // from an unrelated managed identity must not be advertised as though it described that
+  // certificate.
+  @Test
+  public void managerApplicationUriDoesNotReplaceMissingFixedCertificateUri() throws Exception {
+    KeyPair keyPair = SelfSignedCertificateGenerator.generateRsaKeyPair(2048);
+    X509Certificate certificateWithoutSanUri =
+        new SelfSignedCertificateBuilder(keyPair)
+            .setApplicationUri(null)
+            .addDnsName("localhost")
+            .build();
+    CertificateIdentity managed = identity("urn:eclipse:milo:test:managed", "group");
+    OpcUaClientConfig config =
+        OpcUaClientConfig.builder()
+            .setEndpoint(endpoint)
+            .setCertificateManager(multiIdentityManager(List.of(managed)))
+            .setCertificate(certificateWithoutSanUri)
+            .build();
+
+    OpcUaClient client = client(config);
+
+    assertEquals(
+        "urn:eclipse:milo:client:applicationUriNotConfigured",
+        client.resolveApplicationUri(Optional.empty()));
+  }
+
   // A selected identity without a SAN URI cannot define the ApplicationUri. The fixed certificate
   // remains the next compatibility source before the placeholder.
   @Test

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/OpcUaClientConfigTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/OpcUaClientConfigTest.java
@@ -13,6 +13,7 @@ package org.eclipse.milo.opcua.sdk.client;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -24,6 +25,8 @@ import java.security.cert.X509Certificate;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.eclipse.milo.opcua.sdk.client.identity.AnonymousProvider;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
@@ -37,16 +40,26 @@ import org.eclipse.milo.opcua.stack.core.security.DefaultCertificateManager;
 import org.eclipse.milo.opcua.stack.core.security.MemoryCertificateQuarantine;
 import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
 import org.eclipse.milo.opcua.stack.core.security.SecurityPolicyProfile;
+import org.eclipse.milo.opcua.stack.core.types.UaRequestMessageType;
+import org.eclipse.milo.opcua.stack.core.types.UaResponseMessageType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.ApplicationType;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.MessageSecurityMode;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.UserTokenType;
+import org.eclipse.milo.opcua.stack.core.types.structured.ApplicationDescription;
+import org.eclipse.milo.opcua.stack.core.types.structured.CreateSessionRequest;
 import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
 import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
 import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateBuilder;
 import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateGenerator;
+import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.transport.client.ClientApplicationContext;
 import org.eclipse.milo.opcua.stack.transport.client.OpcClientTransport;
 import org.eclipse.milo.opcua.stack.transport.client.OpcClientTransportConfig;
+import org.eclipse.milo.opcua.stack.transport.client.tcp.OpcTcpClientTransportConfig;
 import org.junit.jupiter.api.Test;
 
 public class OpcUaClientConfigTest {
@@ -108,7 +121,32 @@ public class OpcUaClientConfigTest {
     assertSame(original.getCertificateIdentitySelector(), copy.getCertificateIdentitySelector());
     assertEquals(original.getCertificateGroupId(), copy.getCertificateGroupId());
     assertEquals(original.getCertificateTypeId(), copy.getCertificateTypeId());
+    assertEquals(original.isApplicationUriConfigured(), copy.isApplicationUriConfigured());
     assertTrue(copy.getCertificateIdentity(SecurityPolicy.None.getProfile()).isEmpty());
+  }
+
+  // Copying an unset URI must preserve certificate-based derivation, while an explicitly set URI
+  // must remain authoritative in the copied config.
+  @Test
+  public void copyPreservesApplicationUriExplicitness() {
+    OpcUaClientConfig derived =
+        OpcUaClientConfig.builder()
+            .setEndpoint(endpoint)
+            .setDiscoveryEndpoints(List.of(endpoint))
+            .build();
+    OpcUaClientConfig explicit =
+        OpcUaClientConfig.builder()
+            .setEndpoint(endpoint)
+            .setDiscoveryEndpoints(List.of(endpoint))
+            .setApplicationUri("urn:eclipse:milo:test:explicit")
+            .build();
+
+    OpcUaClientConfig derivedCopy = OpcUaClientConfig.copy(derived).build();
+    OpcUaClientConfig explicitCopy = OpcUaClientConfig.copy(explicit).build();
+
+    assertFalse(derivedCopy.isApplicationUriConfigured());
+    assertTrue(explicitCopy.isApplicationUriConfigured());
+    assertEquals("urn:eclipse:milo:test:explicit", explicitCopy.getApplicationUri());
   }
 
   @Test
@@ -293,6 +331,156 @@ public class OpcUaClientConfigTest {
     assertEquals(certificateB, client.getCertificateIdentity(profile).orElseThrow().certificate());
   }
 
+  // setApplicationUri() is an explicit application identity choice and must override certificate
+  // SAN URIs, including the URI on the manager-selected identity.
+  @Test
+  public void explicitApplicationUriTakesPrecedence() throws Exception {
+    CertificateIdentity identity = identity("urn:eclipse:milo:test:managed", "group");
+    OpcUaClientConfig config =
+        OpcUaClientConfig.builder()
+            .setEndpoint(endpoint)
+            .setCertificateManager(multiIdentityManager(List.of(identity)))
+            .setApplicationUri("urn:eclipse:milo:test:explicit")
+            .build();
+
+    OpcUaClient client = client(config);
+
+    assertEquals("urn:eclipse:milo:test:explicit", client.resolveApplicationUri(Optional.empty()));
+  }
+
+  // The certificate presented for the endpoint defines the application instance, so its URI must
+  // win over a legacy fixed certificate that is only retained as a compatibility fallback.
+  @Test
+  public void selectedIdentityApplicationUriTakesPrecedenceOverFixedCertificate() throws Exception {
+    CertificateIdentity identity = identity("urn:eclipse:milo:test:managed", "group");
+    X509Certificate fixedCertificate = certificate("urn:eclipse:milo:test:fixed");
+    OpcUaClientConfig config =
+        OpcUaClientConfig.builder()
+            .setEndpoint(endpoint)
+            .setCertificateManager(multiIdentityManager(List.of(identity)))
+            .setCertificateIdentitySelector(context -> Optional.of(identity))
+            .setCertificate(fixedCertificate)
+            .build();
+
+    OpcUaClient client = client(config);
+
+    assertEquals(
+        "urn:eclipse:milo:test:managed",
+        client.resolveApplicationUri(client.getCertificateIdentity(profile())));
+  }
+
+  // An explicit certificate outside the manager makes selection empty. Its SAN URI must still be
+  // used with the fixed key material selected by the compatibility fallback.
+  @Test
+  public void fixedCertificateApplicationUriIsCompatibilityFallback() throws Exception {
+    X509Certificate fixedCertificate = certificate("urn:eclipse:milo:test:fixed");
+    OpcUaClientConfig config =
+        OpcUaClientConfig.builder()
+            .setEndpoint(endpoint)
+            .setCertificateManager(multiIdentityManager(List.of()))
+            .setCertificate(fixedCertificate)
+            .build();
+
+    OpcUaClient client = client(config);
+
+    assertEquals(
+        "urn:eclipse:milo:test:fixed",
+        client.resolveApplicationUri(client.getCertificateIdentity(profile())));
+  }
+
+  // The placeholder remains a last resort for certificate-less clients and certificates without a
+  // SAN URI.
+  @Test
+  public void applicationUriPlaceholderIsUsedLast() throws Exception {
+    OpcUaClientConfig config = OpcUaClientConfig.builder().setEndpoint(endpoint).build();
+
+    OpcUaClient client = client(config);
+
+    assertEquals(
+        "urn:eclipse:milo:client:applicationUriNotConfigured",
+        client.resolveApplicationUri(Optional.empty()));
+  }
+
+  // A selected identity without a SAN URI cannot define the ApplicationUri. The fixed certificate
+  // remains the next compatibility source before the placeholder.
+  @Test
+  public void fixedCertificateApplicationUriFollowsSelectedIdentityWithoutSanUri()
+      throws Exception {
+    KeyPair keyPair = SelfSignedCertificateGenerator.generateRsaKeyPair(2048);
+    X509Certificate certificateWithoutSanUri =
+        new SelfSignedCertificateBuilder(keyPair)
+            .setApplicationUri(null)
+            .addDnsName("localhost")
+            .build();
+    CertificateIdentity identity = identity(keyPair, certificateWithoutSanUri, "group");
+    X509Certificate fixedCertificate = certificate("urn:eclipse:milo:test:fixed");
+    OpcUaClientConfig config =
+        OpcUaClientConfig.builder()
+            .setEndpoint(endpoint)
+            .setCertificateManager(multiIdentityManager(List.of(identity)))
+            .setCertificate(fixedCertificate)
+            .build();
+
+    OpcUaClient client = client(config);
+
+    assertEquals(
+        "urn:eclipse:milo:test:fixed", client.resolveApplicationUri(Optional.of(identity)));
+  }
+
+  // SecureChannel setup selects first. Session creation must derive the URI from that cached
+  // identity even when other manager identities carry a different ApplicationUri.
+  @Test
+  public void applicationUriUsesCachedSelectedIdentityWhenManagerUrisDiffer() throws Exception {
+    CertificateIdentity identityA = identity("urn:eclipse:milo:test:a", "groupA");
+    CertificateIdentity identityB = identity("urn:eclipse:milo:test:b", "groupB");
+    AtomicInteger selections = new AtomicInteger();
+    CertificateIdentitySelector selector =
+        context -> Optional.of(selections.getAndIncrement() == 0 ? identityA : identityB);
+    OpcUaClientConfig config =
+        OpcUaClientConfig.builder()
+            .setEndpoint(endpoint)
+            .setCertificateManager(multiIdentityManager(List.of(identityA, identityB)))
+            .setCertificateIdentitySelector(selector)
+            .build();
+
+    OpcUaClient client = client(config);
+    SecurityPolicyProfile profile = SecurityPolicy.Basic256Sha256.getProfile();
+
+    assertSame(identityA, client.getCertificateIdentity(profile).orElseThrow());
+    assertEquals(
+        "urn:eclipse:milo:test:a",
+        client.resolveApplicationUri(client.getCertificateIdentity(profile)));
+    assertEquals(1, selections.get());
+  }
+
+  // CreateSession must send the URI from the same effective identity whose certificate it places in
+  // the request, otherwise servers reject ActivateSession with Bad_CertificateUriInvalid.
+  @Test
+  public void createSessionUsesSelectedIdentityApplicationUri() throws Exception {
+    CertificateIdentity identity = identity("urn:eclipse:milo:test:managed", "group");
+    OpcUaClientConfig config =
+        OpcUaClientConfig.builder()
+            .setEndpoint(secureEndpoint(identity.certificate()))
+            .setCertificateManager(multiIdentityManager(List.of(identity)))
+            .build();
+    CapturingClientTransport transport = new CapturingClientTransport();
+    OpcUaClient client = new OpcUaClient(config, transport);
+    CompletableFuture<OpcUaClient> connectFuture = client.connectAsync();
+
+    try {
+      CreateSessionRequest request = transport.createSessionRequest.get(5, TimeUnit.SECONDS);
+
+      assertEquals(
+          "urn:eclipse:milo:test:managed", request.getClientDescription().getApplicationUri());
+      assertArrayEquals(
+          identity.certificate().getEncoded(), request.getClientCertificate().bytes());
+    } finally {
+      transport.releasePending();
+      client.disconnectAsync().get(5, TimeUnit.SECONDS);
+      connectFuture.cancel(true);
+    }
+  }
+
   private static CertificateManager multiIdentityManager(List<CertificateIdentity> identities) {
     return new CertificateManager() {
       @Override
@@ -347,11 +535,103 @@ public class OpcUaClientConfigTest {
         new X509Certificate[] {certificate});
   }
 
+  private static CertificateIdentity identity(String applicationUri, String group)
+      throws Exception {
+    KeyPair keyPair = SelfSignedCertificateGenerator.generateRsaKeyPair(2048);
+    return identity(keyPair, certificate(keyPair, applicationUri), group);
+  }
+
   private static X509Certificate rsaCertificate(KeyPair keyPair) throws Exception {
+    return certificate(keyPair, "urn:eclipse:milo:test:certificate-identity-cache");
+  }
+
+  private static X509Certificate certificate(String applicationUri) throws Exception {
+    return certificate(SelfSignedCertificateGenerator.generateRsaKeyPair(2048), applicationUri);
+  }
+
+  private static X509Certificate certificate(KeyPair keyPair, String applicationUri)
+      throws Exception {
     return new SelfSignedCertificateBuilder(keyPair)
         .setCommonName("certificate-identity-cache-test")
-        .setApplicationUri("urn:eclipse:milo:test:certificate-identity-cache")
+        .setApplicationUri(applicationUri)
         .addDnsName("localhost")
         .build();
+  }
+
+  private static OpcUaClient client(OpcUaClientConfig config) {
+    OpcClientTransportConfig transportConfig = mock(OpcClientTransportConfig.class);
+    when(transportConfig.getExecutor()).thenReturn(Stack.sharedExecutor());
+    OpcClientTransport transport = mock(OpcClientTransport.class);
+    when(transport.getConfig()).thenReturn(transportConfig);
+
+    return new OpcUaClient(config, transport);
+  }
+
+  private static SecurityPolicyProfile profile() {
+    return SecurityPolicy.Basic256Sha256.getProfile();
+  }
+
+  private static EndpointDescription secureEndpoint(X509Certificate serverCertificate)
+      throws Exception {
+    ApplicationDescription server =
+        new ApplicationDescription(
+            "urn:eclipse:milo:test:server",
+            "urn:eclipse:milo:test:product",
+            LocalizedText.english("test server"),
+            ApplicationType.Server,
+            null,
+            null,
+            null);
+
+    return new EndpointDescription(
+        "opc.tcp://localhost:62541",
+        server,
+        ByteString.of(serverCertificate.getEncoded()),
+        MessageSecurityMode.SignAndEncrypt,
+        SecurityPolicy.Basic256Sha256.getUri(),
+        new UserTokenPolicy[] {
+          new UserTokenPolicy("anonymous", UserTokenType.Anonymous, null, null, null)
+        },
+        Stack.TCP_UASC_UABINARY_TRANSPORT_URI,
+        null);
+  }
+
+  private static final class CapturingClientTransport implements OpcClientTransport {
+    private final OpcClientTransportConfig config =
+        OpcTcpClientTransportConfig.newBuilder().build();
+    private final CompletableFuture<CreateSessionRequest> createSessionRequest =
+        new CompletableFuture<>();
+    private final CompletableFuture<UaResponseMessageType> pendingResponse =
+        new CompletableFuture<>();
+
+    @Override
+    public OpcClientTransportConfig getConfig() {
+      return config;
+    }
+
+    @Override
+    public CompletableFuture<Unit> connect(ClientApplicationContext applicationContext) {
+      return CompletableFuture.completedFuture(Unit.VALUE);
+    }
+
+    @Override
+    public CompletableFuture<Unit> disconnect() {
+      return CompletableFuture.completedFuture(Unit.VALUE);
+    }
+
+    @Override
+    public CompletableFuture<UaResponseMessageType> sendRequestMessage(
+        UaRequestMessageType requestMessage) {
+
+      if (requestMessage instanceof CreateSessionRequest request) {
+        createSessionRequest.complete(request);
+      }
+
+      return pendingResponse;
+    }
+
+    void releasePending() {
+      pendingResponse.completeExceptionally(new RuntimeException("test cleanup"));
+    }
   }
 }

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/CloseSessionWrongChannelTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/CloseSessionWrongChannelTest.java
@@ -95,7 +95,7 @@ public class CloseSessionWrongChannelTest {
 
     ApplicationDescription clientDescription =
         new ApplicationDescription(
-            client.getConfig().getApplicationUri(),
+            client.resolveApplicationUri(null),
             client.getConfig().getProductUri(),
             client.getConfig().getApplicationName(),
             ApplicationType.Client,

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/SessionEvictionTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/SessionEvictionTest.java
@@ -215,7 +215,7 @@ public class SessionEvictionTest {
 
     ApplicationDescription clientDescription =
         new ApplicationDescription(
-            client.getConfig().getApplicationUri(),
+            client.resolveApplicationUri(null),
             client.getConfig().getProductUri(),
             client.getConfig().getApplicationName(),
             ApplicationType.Client,

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClient.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClient.java
@@ -162,6 +162,7 @@ import org.eclipse.milo.opcua.stack.core.types.structured.ViewDescription;
 import org.eclipse.milo.opcua.stack.core.types.structured.WriteRequest;
 import org.eclipse.milo.opcua.stack.core.types.structured.WriteResponse;
 import org.eclipse.milo.opcua.stack.core.types.structured.WriteValue;
+import org.eclipse.milo.opcua.stack.core.util.CertificateUtil;
 import org.eclipse.milo.opcua.stack.core.util.ExecutionQueue;
 import org.eclipse.milo.opcua.stack.core.util.Lists;
 import org.eclipse.milo.opcua.stack.core.util.LongSequence;
@@ -514,6 +515,7 @@ public class OpcUaClient {
   private final Object certificateIdentityLock = new Object();
   private final Map<SecurityPolicyProfile, Optional<CertificateIdentity>>
       selectedCertificateIdentities = new HashMap<>();
+  private boolean managerIdentityApplicationUrisChecked;
 
   public OpcUaClient(OpcUaClientConfig config, OpcClientTransport transport) {
     this.config = config;
@@ -846,6 +848,66 @@ public class OpcUaClient {
   }
 
   /**
+   * Resolve the client application URI from the effective certificate identity.
+   *
+   * <p>An explicitly configured URI takes precedence. Otherwise the URI is read from {@code
+   * certificateIdentity}, then the fixed compatibility certificate. The configured placeholder is
+   * returned only when neither certificate contains a SAN URI.
+   *
+   * @param certificateIdentity the identity selected for the connection, or empty when no managed
+   *     identity is presented.
+   * @return the effective client application URI.
+   */
+  public String resolveApplicationUri(Optional<CertificateIdentity> certificateIdentity) {
+    if (config.isApplicationUriConfigured()) {
+      return config.getApplicationUri();
+    }
+
+    if (certificateIdentity.isPresent()) {
+      warnIfManagerIdentityApplicationUrisDiffer();
+
+      Optional<String> applicationUri =
+          CertificateUtil.getSanUri(certificateIdentity.get().certificate());
+      if (applicationUri.isPresent()) {
+        return applicationUri.get();
+      }
+    }
+
+    return config
+        .getCertificate()
+        .flatMap(CertificateUtil::getSanUri)
+        .orElse(config.getApplicationUri());
+  }
+
+  private void warnIfManagerIdentityApplicationUrisDiffer() {
+    synchronized (certificateIdentityLock) {
+      if (managerIdentityApplicationUrisChecked) {
+        return;
+      }
+      managerIdentityApplicationUrisChecked = true;
+    }
+
+    try {
+      List<String> applicationUris =
+          config.getCertificateManager().stream()
+              .flatMap(manager -> manager.getCertificateIdentities().stream())
+              .map(CertificateIdentity::certificate)
+              .map(CertificateUtil::getSanUri)
+              .flatMap(Optional::stream)
+              .distinct()
+              .sorted()
+              .toList();
+
+      if (applicationUris.size() > 1) {
+        logger.warn(
+            "CertificateManager identities have differing ApplicationUris: {}", applicationUris);
+      }
+    } catch (RuntimeException e) {
+      logger.warn("Could not compare CertificateManager identity ApplicationUris", e);
+    }
+  }
+
+  /**
    * Clear the cached certificate identities so that the next {@link
    * #getCertificateIdentity(SecurityPolicyProfile)} re-evaluates the configured selector, picking
    * up any rotation in the underlying {@code CertificateManager}.
@@ -853,6 +915,7 @@ public class OpcUaClient {
   private void clearCertificateIdentities() {
     synchronized (certificateIdentityLock) {
       selectedCertificateIdentities.clear();
+      managerIdentityApplicationUrisChecked = false;
     }
   }
 

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClient.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClient.java
@@ -515,7 +515,7 @@ public class OpcUaClient {
   private final Object certificateIdentityLock = new Object();
   private final Map<SecurityPolicyProfile, Optional<CertificateIdentity>>
       selectedCertificateIdentities = new HashMap<>();
-  private boolean managerIdentityApplicationUrisChecked;
+  private @Nullable List<String> managerApplicationUris;
 
   public OpcUaClient(OpcUaClientConfig config, OpcClientTransport transport) {
     this.config = config;
@@ -841,6 +841,10 @@ public class OpcUaClient {
       }
 
       Optional<CertificateIdentity> selected = config.getCertificateIdentity(securityPolicyProfile);
+      if (selectedCertificateIdentities.isEmpty()) {
+        // First selection for this connection: surface inconsistent manager identities once.
+        getManagerApplicationUris();
+      }
       selectedCertificateIdentities.put(securityPolicyProfile, selected);
 
       return selected;
@@ -851,8 +855,10 @@ public class OpcUaClient {
    * Resolve the client application URI from the effective certificate identity.
    *
    * <p>An explicitly configured URI takes precedence. Otherwise the URI is read from {@code
-   * certificateIdentity}, then the fixed compatibility certificate. The configured placeholder is
-   * returned only when neither certificate contains a SAN URI.
+   * certificateIdentity}, then the fixed compatibility certificate. When no certificate is
+   * presented, the URI shared by every {@link CertificateManager} identity is used so a {@link
+   * SecurityPolicy#None} connection still advertises the same URI as secure connections. The
+   * configured placeholder is returned only when none of these yields a SAN URI.
    *
    * @param certificateIdentity the identity selected for the connection, or empty when no managed
    *     identity is presented.
@@ -863,47 +869,58 @@ public class OpcUaClient {
       return config.getApplicationUri();
     }
 
-    if (certificateIdentity.isPresent()) {
-      warnIfManagerIdentityApplicationUrisDiffer();
+    Optional<X509Certificate> fixedCertificate = config.getCertificate();
+    Optional<String> certificateApplicationUri =
+        certificateIdentity
+            .map(CertificateIdentity::certificate)
+            .flatMap(CertificateUtil::getSanUri)
+            .or(() -> fixedCertificate.flatMap(CertificateUtil::getSanUri));
 
-      Optional<String> applicationUri =
-          CertificateUtil.getSanUri(certificateIdentity.get().certificate());
-      if (applicationUri.isPresent()) {
-        return applicationUri.get();
-      }
+    if (certificateApplicationUri.isPresent()) {
+      return certificateApplicationUri.get();
     }
 
-    return config
-        .getCertificate()
-        .flatMap(CertificateUtil::getSanUri)
-        .orElse(config.getApplicationUri());
+    return certificateIdentity.isEmpty() && fixedCertificate.isEmpty()
+        ? getManagerApplicationUri().orElse(config.getApplicationUri())
+        : config.getApplicationUri();
   }
 
-  private void warnIfManagerIdentityApplicationUrisDiffer() {
+  private Optional<String> getManagerApplicationUri() {
+    List<String> applicationUris = getManagerApplicationUris();
+
+    return applicationUris.size() == 1 ? Optional.of(applicationUris.get(0)) : Optional.empty();
+  }
+
+  /**
+   * Get the distinct SAN URIs of the {@link CertificateManager} identities, computed once per
+   * connection and logged at WARN when they differ.
+   */
+  private List<String> getManagerApplicationUris() {
     synchronized (certificateIdentityLock) {
-      if (managerIdentityApplicationUrisChecked) {
-        return;
-      }
-      managerIdentityApplicationUrisChecked = true;
-    }
+      if (managerApplicationUris == null) {
+        try {
+          managerApplicationUris =
+              config.getCertificateManager().stream()
+                  .flatMap(manager -> manager.getCertificateIdentities().stream())
+                  .map(CertificateIdentity::certificate)
+                  .map(CertificateUtil::getSanUri)
+                  .flatMap(Optional::stream)
+                  .distinct()
+                  .sorted()
+                  .toList();
 
-    try {
-      List<String> applicationUris =
-          config.getCertificateManager().stream()
-              .flatMap(manager -> manager.getCertificateIdentities().stream())
-              .map(CertificateIdentity::certificate)
-              .map(CertificateUtil::getSanUri)
-              .flatMap(Optional::stream)
-              .distinct()
-              .sorted()
-              .toList();
-
-      if (applicationUris.size() > 1) {
-        logger.warn(
-            "CertificateManager identities have differing ApplicationUris: {}", applicationUris);
+          if (managerApplicationUris.size() > 1) {
+            logger.warn(
+                "CertificateManager identities have differing ApplicationUris: {}",
+                managerApplicationUris);
+          }
+        } catch (RuntimeException e) {
+          logger.warn("Could not inspect CertificateManager identity ApplicationUris", e);
+          managerApplicationUris = List.of();
+        }
       }
-    } catch (RuntimeException e) {
-      logger.warn("Could not compare CertificateManager identity ApplicationUris", e);
+
+      return managerApplicationUris;
     }
   }
 
@@ -915,7 +932,7 @@ public class OpcUaClient {
   private void clearCertificateIdentities() {
     synchronized (certificateIdentityLock) {
       selectedCertificateIdentities.clear();
-      managerIdentityApplicationUrisChecked = false;
+      managerApplicationUris = null;
     }
   }
 

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClient.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClient.java
@@ -62,6 +62,7 @@ import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingManager;
 import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
 import org.eclipse.milo.opcua.stack.core.encoding.EncodingManager;
 import org.eclipse.milo.opcua.stack.core.security.CertificateIdentity;
+import org.eclipse.milo.opcua.stack.core.security.CertificateManager;
 import org.eclipse.milo.opcua.stack.core.security.CertificateValidator;
 import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
 import org.eclipse.milo.opcua.stack.core.security.SecurityPolicyProfile;
@@ -182,6 +183,13 @@ import org.slf4j.LoggerFactory;
 public class OpcUaClient {
 
   public static final String SDK_VERSION = ManifestUtil.read("X-SDK-Version").orElse("dev");
+
+  /**
+   * Placeholder application URI advertised when no URI was configured and none could be derived
+   * from a certificate; see {@link #resolveApplicationUri(CertificateIdentity)}.
+   */
+  public static final String APPLICATION_URI_NOT_CONFIGURED =
+      "urn:eclipse:milo:client:applicationUriNotConfigured";
 
   // Package-private and non-final so tests can shorten the bound. See disconnectAsync().
   static long disconnectCloseSessionTimeoutMillis = 5_000L;
@@ -857,32 +865,41 @@ public class OpcUaClient {
    * <p>An explicitly configured URI takes precedence. Otherwise the URI is read from {@code
    * certificateIdentity}, then the fixed compatibility certificate. When no certificate is
    * presented, the URI shared by every {@link CertificateManager} identity is used so a {@link
-   * SecurityPolicy#None} connection still advertises the same URI as secure connections. The
-   * configured placeholder is returned only when none of these yields a SAN URI.
+   * SecurityPolicy#None} connection still advertises the same URI as secure connections. The {@link
+   * #APPLICATION_URI_NOT_CONFIGURED} placeholder is returned only when none of these yields a SAN
+   * URI.
    *
-   * @param certificateIdentity the identity selected for the connection, or empty when no managed
-   *     identity is presented.
+   * @param certificateIdentity the identity selected for the connection, or {@code null} when no
+   *     managed identity is presented.
    * @return the effective client application URI.
    */
-  public String resolveApplicationUri(Optional<CertificateIdentity> certificateIdentity) {
-    if (config.isApplicationUriConfigured()) {
-      return config.getApplicationUri();
+  public String resolveApplicationUri(@Nullable CertificateIdentity certificateIdentity) {
+    Optional<String> configuredUri = config.getApplicationUri();
+    if (configuredUri.isPresent()) {
+      return configuredUri.get();
     }
 
     Optional<X509Certificate> fixedCertificate = config.getCertificate();
-    Optional<String> certificateApplicationUri =
-        certificateIdentity
-            .map(CertificateIdentity::certificate)
-            .flatMap(CertificateUtil::getSanUri)
-            .or(() -> fixedCertificate.flatMap(CertificateUtil::getSanUri));
 
-    if (certificateApplicationUri.isPresent()) {
-      return certificateApplicationUri.get();
+    if (certificateIdentity != null) {
+      Optional<String> uri = CertificateUtil.getSanUri(certificateIdentity.certificate());
+      if (uri.isPresent()) {
+        return uri.get();
+      }
     }
 
-    return certificateIdentity.isEmpty() && fixedCertificate.isEmpty()
-        ? getManagerApplicationUri().orElse(config.getApplicationUri())
-        : config.getApplicationUri();
+    if (fixedCertificate.isPresent()) {
+      Optional<String> uri = CertificateUtil.getSanUri(fixedCertificate.get());
+      if (uri.isPresent()) {
+        return uri.get();
+      }
+    }
+
+    if (certificateIdentity == null && fixedCertificate.isEmpty()) {
+      return getManagerApplicationUri().orElse(APPLICATION_URI_NOT_CONFIGURED);
+    }
+
+    return APPLICATION_URI_NOT_CONFIGURED;
   }
 
   private Optional<String> getManagerApplicationUri() {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClientConfig.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClientConfig.java
@@ -165,6 +165,21 @@ public interface OpcUaClientConfig {
   String getApplicationUri();
 
   /**
+   * Whether {@link #getApplicationUri()} was explicitly configured.
+   *
+   * <p>The default preserves the behavior of custom config implementations, whose returned URI is
+   * treated as explicit. Configs built by {@link OpcUaClientConfigBuilder} return {@code false}
+   * when {@link OpcUaClientConfigBuilder#setApplicationUri(String)} was not called, allowing the
+   * client to derive the URI from its effective certificate identity.
+   *
+   * @return {@code true} when the configured application URI takes precedence over certificate
+   *     identity resolution.
+   */
+  default boolean isApplicationUriConfigured() {
+    return true;
+  }
+
+  /**
    * @return the URI for the client's application product.
    */
   String getProductUri();
@@ -274,7 +289,9 @@ public interface OpcUaClientConfig {
     builder.setCertificateGroupId(config.getCertificateGroupId().orElse(null));
     builder.setCertificateTypeId(config.getCertificateTypeId().orElse(null));
     builder.setApplicationName(config.getApplicationName());
-    builder.setApplicationUri(config.getApplicationUri());
+    if (config.isApplicationUriConfigured()) {
+      builder.setApplicationUri(config.getApplicationUri());
+    }
     builder.setProductUri(config.getProductUri());
     builder.setSessionName(config.getSessionName());
     builder.setSessionTimeout(config.getSessionTimeout());

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClientConfig.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClientConfig.java
@@ -159,25 +159,15 @@ public interface OpcUaClientConfig {
   LocalizedText getApplicationName();
 
   /**
-   * @return a URI for the client's application instance. This should be the same as the URI in the
-   *     client certificate, if present.
-   */
-  String getApplicationUri();
-
-  /**
-   * Whether {@link #getApplicationUri()} was explicitly configured.
+   * The explicitly configured client application URI.
    *
-   * <p>The default preserves the behavior of custom config implementations, whose returned URI is
-   * treated as explicit. Configs built by {@link OpcUaClientConfigBuilder} return {@code false}
-   * when {@link OpcUaClientConfigBuilder#setApplicationUri(String)} was not called, allowing the
-   * client to derive the URI from its effective certificate identity.
+   * <p>When empty, the client derives the URI from its effective certificate identity; see {@link
+   * OpcUaClient#resolveApplicationUri(CertificateIdentity)}.
    *
-   * @return {@code true} when the configured application URI takes precedence over certificate
-   *     identity resolution.
+   * @return the explicitly configured client application URI, or empty when it should be derived
+   *     from the effective certificate identity.
    */
-  default boolean isApplicationUriConfigured() {
-    return true;
-  }
+  Optional<String> getApplicationUri();
 
   /**
    * @return the URI for the client's application product.
@@ -289,9 +279,7 @@ public interface OpcUaClientConfig {
     builder.setCertificateGroupId(config.getCertificateGroupId().orElse(null));
     builder.setCertificateTypeId(config.getCertificateTypeId().orElse(null));
     builder.setApplicationName(config.getApplicationName());
-    if (config.isApplicationUriConfigured()) {
-      builder.setApplicationUri(config.getApplicationUri());
-    }
+    config.getApplicationUri().ifPresent(builder::setApplicationUri);
     builder.setProductUri(config.getProductUri());
     builder.setSessionName(config.getSessionName());
     builder.setSessionTimeout(config.getSessionTimeout());

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClientConfigBuilder.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClientConfigBuilder.java
@@ -49,6 +49,7 @@ public class OpcUaClientConfigBuilder {
   private LocalizedText applicationName =
       LocalizedText.english("Eclipse Milo application name not configured");
   private String applicationUri = "urn:eclipse:milo:client:applicationUriNotConfigured";
+  private boolean applicationUriConfigured;
   private String productUri = "https://github.com/eclipse-milo/milo";
 
   private Supplier<String> sessionName;
@@ -75,8 +76,18 @@ public class OpcUaClientConfigBuilder {
     return this;
   }
 
+  /**
+   * Set the client application URI explicitly.
+   *
+   * <p>An explicitly configured URI takes precedence over the URI in the effective client
+   * certificate identity.
+   *
+   * @param applicationUri the client application URI.
+   * @return this builder.
+   */
   public OpcUaClientConfigBuilder setApplicationUri(String applicationUri) {
     this.applicationUri = applicationUri;
+    applicationUriConfigured = true;
     return this;
   }
 
@@ -253,6 +264,7 @@ public class OpcUaClientConfigBuilder {
         certificateValidator,
         applicationName,
         applicationUri,
+        applicationUriConfigured,
         productUri,
         sessionName,
         sessionLocaleIds,
@@ -283,6 +295,7 @@ public class OpcUaClientConfigBuilder {
     private final CertificateValidator certificateValidator;
     private final LocalizedText applicationName;
     private final String applicationUri;
+    private final boolean applicationUriConfigured;
     private final String productUri;
     private final Supplier<String> sessionName;
     private final String[] sessionLocaleIds;
@@ -312,6 +325,7 @@ public class OpcUaClientConfigBuilder {
         CertificateValidator certificateValidator,
         LocalizedText applicationName,
         String applicationUri,
+        boolean applicationUriConfigured,
         String productUri,
         Supplier<String> sessionName,
         String[] sessionLocaleIds,
@@ -339,6 +353,7 @@ public class OpcUaClientConfigBuilder {
       this.certificateValidator = certificateValidator;
       this.applicationName = applicationName;
       this.applicationUri = applicationUri;
+      this.applicationUriConfigured = applicationUriConfigured;
       this.productUri = productUri;
       this.sessionName = sessionName;
       this.sessionLocaleIds = sessionLocaleIds;
@@ -413,6 +428,11 @@ public class OpcUaClientConfigBuilder {
     @Override
     public String getApplicationUri() {
       return applicationUri;
+    }
+
+    @Override
+    public boolean isApplicationUriConfigured() {
+      return applicationUriConfigured;
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClientConfigBuilder.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClientConfigBuilder.java
@@ -48,8 +48,7 @@ public class OpcUaClientConfigBuilder {
 
   private LocalizedText applicationName =
       LocalizedText.english("Eclipse Milo application name not configured");
-  private String applicationUri = "urn:eclipse:milo:client:applicationUriNotConfigured";
-  private boolean applicationUriConfigured;
+  private @Nullable String applicationUri;
   private String productUri = "https://github.com/eclipse-milo/milo";
 
   private Supplier<String> sessionName;
@@ -87,7 +86,6 @@ public class OpcUaClientConfigBuilder {
    */
   public OpcUaClientConfigBuilder setApplicationUri(String applicationUri) {
     this.applicationUri = applicationUri;
-    applicationUriConfigured = true;
     return this;
   }
 
@@ -264,7 +262,6 @@ public class OpcUaClientConfigBuilder {
         certificateValidator,
         applicationName,
         applicationUri,
-        applicationUriConfigured,
         productUri,
         sessionName,
         sessionLocaleIds,
@@ -294,8 +291,7 @@ public class OpcUaClientConfigBuilder {
     private final @Nullable NodeId certificateTypeId;
     private final CertificateValidator certificateValidator;
     private final LocalizedText applicationName;
-    private final String applicationUri;
-    private final boolean applicationUriConfigured;
+    private final @Nullable String applicationUri;
     private final String productUri;
     private final Supplier<String> sessionName;
     private final String[] sessionLocaleIds;
@@ -324,8 +320,7 @@ public class OpcUaClientConfigBuilder {
         @Nullable NodeId certificateTypeId,
         CertificateValidator certificateValidator,
         LocalizedText applicationName,
-        String applicationUri,
-        boolean applicationUriConfigured,
+        @Nullable String applicationUri,
         String productUri,
         Supplier<String> sessionName,
         String[] sessionLocaleIds,
@@ -353,7 +348,6 @@ public class OpcUaClientConfigBuilder {
       this.certificateValidator = certificateValidator;
       this.applicationName = applicationName;
       this.applicationUri = applicationUri;
-      this.applicationUriConfigured = applicationUriConfigured;
       this.productUri = productUri;
       this.sessionName = sessionName;
       this.sessionLocaleIds = sessionLocaleIds;
@@ -426,13 +420,8 @@ public class OpcUaClientConfigBuilder {
     }
 
     @Override
-    public String getApplicationUri() {
-      return applicationUri;
-    }
-
-    @Override
-    public boolean isApplicationUriConfigured() {
-      return applicationUriConfigured;
+    public Optional<String> getApplicationUri() {
+      return Optional.ofNullable(applicationUri);
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmFactory.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmFactory.java
@@ -1342,7 +1342,7 @@ public class SessionFsmFactory {
 
       ApplicationDescription clientDescription =
           new ApplicationDescription(
-              client.resolveApplicationUri(certificateIdentity),
+              client.resolveApplicationUri(certificateIdentity.orElse(null)),
               client.getConfig().getProductUri(),
               client.getConfig().getApplicationName(),
               ApplicationType.Client,

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmFactory.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmFactory.java
@@ -1342,7 +1342,7 @@ public class SessionFsmFactory {
 
       ApplicationDescription clientDescription =
           new ApplicationDescription(
-              client.getConfig().getApplicationUri(),
+              client.resolveApplicationUri(certificateIdentity),
               client.getConfig().getProductUri(),
               client.getConfig().getApplicationName(),
               ApplicationType.Client,

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/EndpointCertificateConfig.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/EndpointCertificateConfig.java
@@ -26,7 +26,8 @@ import org.jspecify.annotations.Nullable;
  * <p>Use this with {@link EndpointConfig.Builder#setEndpointCertificateConfig} when an endpoint
  * should select its advertised certificate from the server {@link CertificateManager}. Endpoints
  * that use {@link EndpointConfig.Builder#setCertificate(X509Certificate)} continue to advertise
- * that fixed certificate directly.
+ * that fixed certificate directly. Secure endpoints without either configuration select from the
+ * DefaultApplicationGroup.
  */
 @NullMarked
 public final class EndpointCertificateConfig {

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/EndpointConfig.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/EndpointConfig.java
@@ -245,10 +245,12 @@ public class EndpointConfig {
      * Set the certificate selection request for this endpoint.
      *
      * <p>Leave this unset when the endpoint should advertise the fixed certificate configured with
-     * {@link #setCertificate(X509Certificate)} or {@link #setCertificate(Supplier)}.
+     * {@link #setCertificate(X509Certificate)} or {@link #setCertificate(Supplier)}. A secure
+     * endpoint without a fixed certificate or selection request uses the server certificate
+     * manager's DefaultApplicationGroup.
      *
      * @param endpointCertificateConfig the certificate selection request, or {@code null} to use
-     *     the configured certificate supplier.
+     *     the configured certificate supplier or the implicit DefaultApplicationGroup.
      * @return this builder.
      */
     public Builder setEndpointCertificateConfig(
@@ -306,9 +308,6 @@ public class EndpointConfig {
         if (securityMode != MessageSecurityMode.Sign
             && securityMode != MessageSecurityMode.SignAndEncrypt) {
           throw new IllegalArgumentException("securityMode: " + securityMode);
-        }
-        if (certificateSupplier.get() == null && endpointCertificateConfig == null) {
-          throw new IllegalStateException("security requires certificate or certificate config");
         }
       }
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServer.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServer.java
@@ -1269,14 +1269,17 @@ public class OpcUaServer extends AbstractServiceHandler {
     try {
       CertificateIdentity certificateIdentity = null;
       X509Certificate certificate = endpoint.getCertificate();
+      // A fixed certificate without a selection request is advertised verbatim; everything else
+      // selects a managed identity.
+      boolean managed = endpoint.getEndpointCertificateConfig().isPresent() || certificate == null;
 
       if (endpoint.getSecurityPolicy() != SecurityPolicy.None) {
         securityProviderResolver.resolve(profile);
 
-        if (endpoint.getEndpointCertificateConfig().isPresent() || certificate == null) {
+        if (managed) {
           certificateIdentity = resolveCertificateIdentity(endpoint, profile, certificate);
           certificate = certificateIdentity.certificate();
-        } else if (certificate != null && profile.secureChannelEnhancements()) {
+        } else if (profile.secureChannelEnhancements()) {
           // The legacy fixed-certificate API (setCertificate) advertises the certificate verbatim,
           // bypassing the CertificateIdentitySelector compatibility checks. Enhanced policies (e.g.
           // ECC) require a matching certificate family, so an RSA fixed certificate paired with an
@@ -1284,18 +1287,12 @@ public class OpcUaServer extends AbstractServiceHandler {
           // rather than advertise an unusable endpoint.
           CertificateCompatibility.checkCompatible(profile, certificate);
         }
-      } else {
-        Optional<SecurityPolicyProfile> tokenProfile =
-            getEncryptedUserTokenSecurityPolicyProfile(endpoint);
+      } else if (managed) {
+        certificateIdentity =
+            resolveUserTokenCertificateIdentity(endpoint, certificate).orElse(null);
 
-        if (tokenProfile.isPresent()) {
-          securityProviderResolver.resolve(tokenProfile.get());
-
-          if (endpoint.getEndpointCertificateConfig().isPresent() || certificate == null) {
-            certificateIdentity =
-                resolveCertificateIdentity(endpoint, tokenProfile.get(), certificate);
-            certificate = certificateIdentity.certificate();
-          }
+        if (certificateIdentity != null) {
+          certificate = certificateIdentity.certificate();
         }
       }
 
@@ -1345,15 +1342,12 @@ public class OpcUaServer extends AbstractServiceHandler {
       throw new EndpointResolutionException("no CertificateManager configured");
     }
 
-    EndpointCertificateConfig certificateConfig =
-        endpoint.getEndpointCertificateConfig().orElse(null);
-
-    NodeId certificateGroupId =
-        certificateConfig != null
-            ? certificateConfig.getCertificateGroupId()
-            : NodeIds.ServerConfiguration_CertificateGroups_DefaultApplicationGroup;
+    NodeId certificateGroupId = effectiveCertificateGroupId(endpoint);
     NodeId certificateTypeId =
-        certificateConfig != null ? certificateConfig.getCertificateTypeId().orElse(null) : null;
+        endpoint
+            .getEndpointCertificateConfig()
+            .flatMap(EndpointCertificateConfig::getCertificateTypeId)
+            .orElse(null);
 
     CertificateIdentitySelectionContext context =
         CertificateIdentitySelectionContext.forEndpointAdvertisement(
@@ -1374,35 +1368,92 @@ public class OpcUaServer extends AbstractServiceHandler {
     return selectedIdentity;
   }
 
-  private Optional<SecurityPolicyProfile> getEncryptedUserTokenSecurityPolicyProfile(
-      EndpointConfig endpoint) throws UaException {
+  /**
+   * Select the certificate a {@link SecurityPolicy#None} endpoint advertises so clients can encrypt
+   * legacy UserName and IssuedToken secrets.
+   *
+   * <p>Returns empty when no token policy needs one. An implicit DefaultApplicationGroup request
+   * that cannot be satisfied also returns empty, after a WARN, so the endpoint stays advertised
+   * without a certificate and anonymous access keeps working. An explicit {@link
+   * EndpointCertificateConfig} that cannot be satisfied still omits the endpoint.
+   */
+  private Optional<CertificateIdentity> resolveUserTokenCertificateIdentity(
+      EndpointConfig endpoint, @Nullable X509Certificate certificate)
+      throws UaException, EndpointResolutionException {
+
+    List<SecurityPolicyProfile> tokenProfiles =
+        getEncryptedUserTokenSecurityPolicyProfiles(endpoint);
+
+    if (tokenProfiles.isEmpty()) {
+      return Optional.empty();
+    }
+
+    String failureReason = "no compatible certificate identity found";
+
+    for (SecurityPolicyProfile tokenProfile : tokenProfiles) {
+      try {
+        securityProviderResolver.resolve(tokenProfile);
+
+        return Optional.of(resolveCertificateIdentity(endpoint, tokenProfile, certificate));
+      } catch (UaException | EndpointResolutionException e) {
+        failureReason = Objects.toString(e.getMessage(), e.getClass().getSimpleName());
+      }
+    }
+
+    if (endpoint.getEndpointCertificateConfig().isPresent()) {
+      throw new EndpointResolutionException(failureReason);
+    }
+
+    logger.warn(
+        "Advertising endpoint without a certificate; encrypted user tokens will be rejected:"
+            + " endpointUrl={}, reason={}",
+        endpoint.getEndpointUrl(),
+        failureReason);
+
+    return Optional.empty();
+  }
+
+  private static List<SecurityPolicyProfile> getEncryptedUserTokenSecurityPolicyProfiles(
+      EndpointConfig endpoint) {
+
+    List<SecurityPolicyProfile> profiles = new ArrayList<>();
 
     for (UserTokenPolicy tokenPolicy : endpoint.getTokenPolicies()) {
       UserTokenType tokenType = tokenPolicy.getTokenType();
 
       if (tokenType == UserTokenType.UserName || tokenType == UserTokenType.IssuedToken) {
-        SecurityPolicy securityPolicy =
-            SecurityPolicy.fromUri(endpoint.getEffectiveTokenSecurityPolicyUri(tokenPolicy));
+        SecurityPolicy securityPolicy;
+        try {
+          securityPolicy =
+              SecurityPolicy.fromUri(endpoint.getEffectiveTokenSecurityPolicyUri(tokenPolicy));
+        } catch (UaException e) {
+          // An unknown token security policy cannot use this server's certificate, so it does not
+          // decide whether the endpoint advertises one.
+          continue;
+        }
 
         SecurityPolicyProfile profile = SecurityPolicyProfiles.get(securityPolicy);
 
-        if (securityPolicy != SecurityPolicy.None && !profile.usesEnhancedUserTokenSecret()) {
-          return Optional.of(profile);
+        if (securityPolicy != SecurityPolicy.None
+            && !profile.usesEnhancedUserTokenSecret()
+            && !profiles.contains(profile)) {
+          profiles.add(profile);
         }
       }
     }
 
-    return Optional.empty();
+    return profiles;
+  }
+
+  private static NodeId effectiveCertificateGroupId(EndpointConfig endpoint) {
+    return endpoint
+        .getEndpointCertificateConfig()
+        .map(EndpointCertificateConfig::getCertificateGroupId)
+        .orElse(NodeIds.ServerConfiguration_CertificateGroups_DefaultApplicationGroup);
   }
 
   private void logOmittedEndpoint(EndpointConfig endpoint, String reason) {
-    String certificateGroup =
-        endpoint
-            .getEndpointCertificateConfig()
-            .map(config -> config.getCertificateGroupId().toParseableString())
-            .orElse(
-                NodeIds.ServerConfiguration_CertificateGroups_DefaultApplicationGroup
-                    .toParseableString());
+    String certificateGroup = effectiveCertificateGroupId(endpoint).toParseableString();
     String certificateType =
         endpoint
             .getEndpointCertificateConfig()

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServer.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServer.java
@@ -107,8 +107,10 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.ApplicationType;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.MessageSecurityMode;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.UserTokenType;
 import org.eclipse.milo.opcua.stack.core.types.structured.ApplicationDescription;
 import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
+import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
 import org.eclipse.milo.opcua.stack.core.util.CertificateUtil;
 import org.eclipse.milo.opcua.stack.core.util.EndpointUtil;
 import org.eclipse.milo.opcua.stack.core.util.FutureUtils;
@@ -1271,7 +1273,7 @@ public class OpcUaServer extends AbstractServiceHandler {
       if (endpoint.getSecurityPolicy() != SecurityPolicy.None) {
         securityProviderResolver.resolve(profile);
 
-        if (endpoint.getEndpointCertificateConfig().isPresent()) {
+        if (endpoint.getEndpointCertificateConfig().isPresent() || certificate == null) {
           certificateIdentity = resolveCertificateIdentity(endpoint, profile, certificate);
           certificate = certificateIdentity.certificate();
         } else if (certificate != null && profile.secureChannelEnhancements()) {
@@ -1281,6 +1283,19 @@ public class OpcUaServer extends AbstractServiceHandler {
           // ECC policy can never complete a handshake. Omit such endpoints from advertisement
           // rather than advertise an unusable endpoint.
           CertificateCompatibility.checkCompatible(profile, certificate);
+        }
+      } else {
+        Optional<SecurityPolicyProfile> tokenProfile =
+            getEncryptedUserTokenSecurityPolicyProfile(endpoint);
+
+        if (tokenProfile.isPresent()) {
+          securityProviderResolver.resolve(tokenProfile.get());
+
+          if (endpoint.getEndpointCertificateConfig().isPresent() || certificate == null) {
+            certificateIdentity =
+                resolveCertificateIdentity(endpoint, tokenProfile.get(), certificate);
+            certificate = certificateIdentity.certificate();
+          }
         }
       }
 
@@ -1334,7 +1349,9 @@ public class OpcUaServer extends AbstractServiceHandler {
         endpoint.getEndpointCertificateConfig().orElse(null);
 
     NodeId certificateGroupId =
-        certificateConfig != null ? certificateConfig.getCertificateGroupId() : null;
+        certificateConfig != null
+            ? certificateConfig.getCertificateGroupId()
+            : NodeIds.ServerConfiguration_CertificateGroups_DefaultApplicationGroup;
     NodeId certificateTypeId =
         certificateConfig != null ? certificateConfig.getCertificateTypeId().orElse(null) : null;
 
@@ -1357,12 +1374,35 @@ public class OpcUaServer extends AbstractServiceHandler {
     return selectedIdentity;
   }
 
+  private Optional<SecurityPolicyProfile> getEncryptedUserTokenSecurityPolicyProfile(
+      EndpointConfig endpoint) throws UaException {
+
+    for (UserTokenPolicy tokenPolicy : endpoint.getTokenPolicies()) {
+      UserTokenType tokenType = tokenPolicy.getTokenType();
+
+      if (tokenType == UserTokenType.UserName || tokenType == UserTokenType.IssuedToken) {
+        SecurityPolicy securityPolicy =
+            SecurityPolicy.fromUri(endpoint.getEffectiveTokenSecurityPolicyUri(tokenPolicy));
+
+        SecurityPolicyProfile profile = SecurityPolicyProfiles.get(securityPolicy);
+
+        if (securityPolicy != SecurityPolicy.None && !profile.usesEnhancedUserTokenSecret()) {
+          return Optional.of(profile);
+        }
+      }
+    }
+
+    return Optional.empty();
+  }
+
   private void logOmittedEndpoint(EndpointConfig endpoint, String reason) {
     String certificateGroup =
         endpoint
             .getEndpointCertificateConfig()
             .map(config -> config.getCertificateGroupId().toParseableString())
-            .orElse("<any>");
+            .orElse(
+                NodeIds.ServerConfiguration_CertificateGroups_DefaultApplicationGroup
+                    .toParseableString());
     String certificateType =
         endpoint
             .getEndpointCertificateConfig()

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/package-info.java
@@ -20,13 +20,17 @@
  *
  * <p>Endpoint advertisement starts from the {@link
  * org.eclipse.milo.opcua.sdk.server.EndpointConfig} instances in {@link
- * org.eclipse.milo.opcua.sdk.server.OpcUaServerConfig}. A secure endpoint may either advertise a
- * fixed certificate supplied directly on the endpoint config, or it may use {@link
+ * org.eclipse.milo.opcua.sdk.server.OpcUaServerConfig}. A secure endpoint may advertise a fixed
+ * certificate supplied directly on the endpoint config, use {@link
  * org.eclipse.milo.opcua.sdk.server.EndpointCertificateConfig} to select a compatible local
  * identity from the configured {@link
- * org.eclipse.milo.opcua.stack.core.security.CertificateManager}. Endpoints whose security policy
- * or certificate request cannot be served by the current runtime are omitted from discovery
- * advertisements.
+ * org.eclipse.milo.opcua.stack.core.security.CertificateManager}, or, with neither configured,
+ * select from the manager's DefaultApplicationGroup. A SecurityPolicy.None endpoint whose UserName
+ * or IssuedToken policies encrypt secrets with a legacy RSA policy selects a certificate the same
+ * way, against the token policies' profiles. An implicit selection failure keeps the None endpoint
+ * advertised without a certificate, while an unsatisfied explicit certificate request omits it.
+ * Other endpoints whose security policy or certificate request cannot be served by the current
+ * runtime are omitted from discovery advertisements.
  *
  * <h2>Lifecycle extensions</h2>
  *

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/EndpointConfigTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/EndpointConfigTest.java
@@ -300,6 +300,38 @@ public class EndpointConfigTest {
         description.getServerCertificate().bytesOrEmpty());
   }
 
+  // One advertised certificate only needs to support a usable token policy. Selection must keep
+  // trying when the available identity is incompatible with an earlier legacy policy.
+  @Test
+  public void noneEndpointTriesEachLegacyTokenPolicyWhenSelectingCertificate() throws Exception {
+    CertificateMaterial rsaMin =
+        rsaCertificate(NodeIds.RsaMinApplicationCertificateType, "rsa-min");
+    CertificateManager certificateManager =
+        manager(
+            group(NodeIds.ServerConfiguration_CertificateGroups_DefaultApplicationGroup, rsaMin));
+    UserTokenPolicy rsaSha256Policy =
+        new UserTokenPolicy(
+            "rsa-sha256",
+            UserTokenType.UserName,
+            null,
+            null,
+            SecurityPolicy.Basic256Sha256.getUri());
+    UserTokenPolicy rsaMinPolicy =
+        new UserTokenPolicy(
+            "rsa-min", UserTokenType.UserName, null, null, SecurityPolicy.Basic128Rsa15.getUri());
+    EndpointConfig endpoint =
+        EndpointConfig.newBuilder().addTokenPolicies(rsaSha256Policy, rsaMinPolicy).build();
+
+    EndpointDescription description =
+        server(Set.of(endpoint), certificateManager)
+            .getApplicationContext()
+            .getEndpointDescriptions()
+            .get(0);
+
+    assertArrayEquals(
+        rsaMin.certificate().getEncoded(), description.getServerCertificate().bytesOrEmpty());
+  }
+
   // Anonymous access over a None endpoint needs no certificate and must remain certificate-free
   // even when the server has a managed application identity.
   @Test
@@ -317,6 +349,50 @@ public class EndpointConfigTest {
             .get(0);
 
     assertTrue(description.getServerCertificate().isNullOrEmpty());
+  }
+
+  // Before implicit selection existed, a None endpoint with an encrypted user token policy was
+  // advertised without a certificate. A server with no usable managed identity must keep that
+  // behavior so anonymous access still works, instead of losing the endpoint entirely.
+  @Test
+  public void encryptedUserTokenOnNoneEndpointWithoutIdentityStaysAdvertised() throws Exception {
+    UserTokenPolicy tokenPolicy =
+        new UserTokenPolicy(
+            "encrypted",
+            UserTokenType.UserName,
+            null,
+            null,
+            SecurityPolicy.Basic256Sha256.getUri());
+    EndpointConfig endpoint =
+        EndpointConfig.newBuilder()
+            .addTokenPolicy(EndpointConfig.Builder.USER_TOKEN_POLICY_ANONYMOUS)
+            .addTokenPolicy(tokenPolicy)
+            .build();
+
+    List<EndpointDescription> descriptions =
+        server(Set.of(endpoint), manager()).getApplicationContext().getEndpointDescriptions();
+
+    assertEquals(1, descriptions.size());
+    assertTrue(descriptions.get(0).getServerCertificate().isNullOrEmpty());
+  }
+
+  // A token policy with an unrecognized security policy URI cannot drive certificate selection.
+  // It must not cause the endpoint, and its other token policies, to be omitted.
+  @Test
+  public void unknownTokenSecurityPolicyDoesNotOmitNoneEndpoint() throws Exception {
+    UserTokenPolicy tokenPolicy =
+        new UserTokenPolicy(
+            "custom", UserTokenType.UserName, null, null, "http://example.com/UA/SecurityPolicy#X");
+    EndpointConfig endpoint =
+        EndpointConfig.newBuilder()
+            .addTokenPolicy(EndpointConfig.Builder.USER_TOKEN_POLICY_ANONYMOUS)
+            .addTokenPolicy(tokenPolicy)
+            .build();
+
+    List<EndpointDescription> descriptions =
+        server(Set.of(endpoint), manager()).getApplicationContext().getEndpointDescriptions();
+
+    assertEquals(1, descriptions.size());
   }
 
   // A fixed certificate remains authoritative on a None endpoint that encrypts user tokens, which

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/EndpointConfigTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/EndpointConfigTest.java
@@ -58,10 +58,12 @@ import org.eclipse.milo.opcua.stack.core.types.structured.GetEndpointsRequest;
 import org.eclipse.milo.opcua.stack.core.types.structured.GetEndpointsResponse;
 import org.eclipse.milo.opcua.stack.core.types.structured.RequestHeader;
 import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
+import org.eclipse.milo.opcua.stack.core.util.CertificateUtil;
 import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateBuilder;
 import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateGenerator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
 public class EndpointConfigTest {
@@ -96,12 +98,11 @@ public class EndpointConfigTest {
                 .build());
   }
 
+  // Secure endpoints may defer certificate selection to the server's DefaultApplicationGroup.
   @Test
-  public void missingCertificateThrows() {
-    assertThrows(
-        IllegalStateException.class,
+  public void secureEndpointWithoutCertificateConfigurationIsAccepted() {
+    assertDoesNotThrow(
         () ->
-            // missing certificate
             EndpointConfig.newBuilder()
                 .setSecurityPolicy(SecurityPolicy.Basic128Rsa15)
                 .setSecurityMode(MessageSecurityMode.SignAndEncrypt)
@@ -200,6 +201,182 @@ public class EndpointConfigTest {
 
     assertArrayEquals(
         certificate.certificate().getEncoded(), description.getServerCertificate().bytesOrEmpty());
+  }
+
+  // An implicit managed certificate request is constrained to the DefaultApplicationGroup instead
+  // of selecting a compatible identity from an unrelated group.
+  @Test
+  public void secureEndpointDefaultsToManagedDefaultApplicationGroup() throws Exception {
+    CertificateMaterial other = rsaCertificate("other");
+    CertificateMaterial defaultApplication = rsaCertificate("default-application");
+    CertificateManager certificateManager =
+        manager(
+            group(new NodeId(2, "other-group"), other),
+            group(
+                NodeIds.ServerConfiguration_CertificateGroups_DefaultApplicationGroup,
+                defaultApplication));
+
+    EndpointConfig endpoint =
+        EndpointConfig.newBuilder()
+            .setSecurityPolicy(SecurityPolicy.Basic256Sha256)
+            .setSecurityMode(MessageSecurityMode.SignAndEncrypt)
+            .build();
+
+    EndpointDescription description =
+        server(Set.of(endpoint), certificateManager)
+            .getApplicationContext()
+            .getEndpointDescriptions()
+            .get(0);
+
+    assertArrayEquals(
+        defaultApplication.certificate().getEncoded(),
+        description.getServerCertificate().bytesOrEmpty());
+  }
+
+  // Part 4 §5.7.3.1 encrypts username and issued-token secrets using the certificate advertised by
+  // a None endpoint. Selection must use the effective token policy profile, not
+  // SecurityPolicy.None.
+  @ParameterizedTest
+  @EnumSource(
+      value = UserTokenType.class,
+      names = {"UserName", "IssuedToken"})
+  public void encryptedUserTokenOnNoneEndpointUsesManagedCertificate(UserTokenType tokenType)
+      throws Exception {
+    CertificateMaterial rsaMin =
+        rsaCertificate(NodeIds.RsaMinApplicationCertificateType, "rsa-min");
+    CertificateMaterial rsaSha256 = rsaCertificate("rsa-sha256");
+    CertificateManager certificateManager =
+        manager(
+            group(
+                NodeIds.ServerConfiguration_CertificateGroups_DefaultApplicationGroup,
+                rsaMin,
+                rsaSha256));
+    UserTokenPolicy tokenPolicy =
+        new UserTokenPolicy(
+            "encrypted", tokenType, null, null, SecurityPolicy.Basic256Sha256.getUri());
+    EndpointConfig endpoint = EndpointConfig.newBuilder().addTokenPolicy(tokenPolicy).build();
+
+    EndpointDescription description =
+        server(Set.of(endpoint), certificateManager)
+            .getApplicationContext()
+            .getEndpointDescriptions()
+            .get(0);
+
+    assertArrayEquals(
+        rsaSha256.certificate().getEncoded(), description.getServerCertificate().bytesOrEmpty());
+  }
+
+  // Enhanced token secrets cannot run on a None channel. They must not prevent a later usable RSA
+  // token policy from selecting the certificate that clients need for legacy secret encryption.
+  @Test
+  public void noneEndpointSkipsEnhancedTokenPolicyWhenSelectingCertificate() throws Exception {
+    CertificateMaterial rsaCertificate = rsaCertificate("rsa");
+    CertificateManager certificateManager =
+        manager(
+            group(
+                NodeIds.ServerConfiguration_CertificateGroups_DefaultApplicationGroup,
+                rsaCertificate));
+    UserTokenPolicy enhancedPolicy =
+        new UserTokenPolicy(
+            "enhanced",
+            UserTokenType.UserName,
+            null,
+            null,
+            SecurityPolicy.ECC_nistP256_AesGcm.getUri());
+    UserTokenPolicy rsaPolicy =
+        new UserTokenPolicy(
+            "rsa", UserTokenType.UserName, null, null, SecurityPolicy.Basic256Sha256.getUri());
+    EndpointConfig endpoint =
+        EndpointConfig.newBuilder().addTokenPolicies(enhancedPolicy, rsaPolicy).build();
+
+    EndpointDescription description =
+        server(Set.of(endpoint), certificateManager)
+            .getApplicationContext()
+            .getEndpointDescriptions()
+            .get(0);
+
+    assertArrayEquals(
+        rsaCertificate.certificate().getEncoded(),
+        description.getServerCertificate().bytesOrEmpty());
+  }
+
+  // Anonymous access over a None endpoint needs no certificate and must remain certificate-free
+  // even when the server has a managed application identity.
+  @Test
+  public void anonymousNoneEndpointRemainsCertificateFree() throws Exception {
+    CertificateMaterial managed = rsaCertificate("managed");
+    CertificateManager certificateManager =
+        manager(
+            group(NodeIds.ServerConfiguration_CertificateGroups_DefaultApplicationGroup, managed));
+    EndpointConfig endpoint = EndpointConfig.newBuilder().build();
+
+    EndpointDescription description =
+        server(Set.of(endpoint), certificateManager)
+            .getApplicationContext()
+            .getEndpointDescriptions()
+            .get(0);
+
+    assertTrue(description.getServerCertificate().isNullOrEmpty());
+  }
+
+  // A fixed certificate remains authoritative on a None endpoint that encrypts user tokens, which
+  // preserves the legacy configuration path when a manager contains a different identity.
+  @Test
+  public void encryptedUserTokenOnNoneEndpointPreservesFixedCertificate() throws Exception {
+    CertificateMaterial fixed = rsaCertificate("fixed");
+    CertificateMaterial managed = rsaCertificate("managed");
+    CertificateManager certificateManager =
+        manager(
+            group(NodeIds.ServerConfiguration_CertificateGroups_DefaultApplicationGroup, fixed),
+            group(new NodeId(2, "other-group"), managed));
+    UserTokenPolicy tokenPolicy =
+        new UserTokenPolicy(
+            "username", UserTokenType.UserName, null, null, SecurityPolicy.Basic256Sha256.getUri());
+    EndpointConfig endpoint =
+        EndpointConfig.newBuilder()
+            .setCertificate(fixed.certificate())
+            .addTokenPolicy(tokenPolicy)
+            .build();
+
+    EndpointDescription description =
+        server(Set.of(endpoint), certificateManager)
+            .getApplicationContext()
+            .getEndpointDescriptions()
+            .get(0);
+
+    assertArrayEquals(
+        fixed.certificate().getEncoded(), description.getServerCertificate().bytesOrEmpty());
+    assertTrue(
+        certificateManager.getKeyPair(CertificateUtil.thumbprint(fixed.certificate())).isPresent());
+  }
+
+  // An explicit selection request constrains a fixed certificate on a None endpoint just as it
+  // does on a secure endpoint. The server must omit the endpoint instead of silently replacing the
+  // pinned certificate with another group's identity.
+  @Test
+  public void certificateConfigConstrainsFixedCertificateOnNoneEndpoint() throws Exception {
+    CertificateMaterial fixed = rsaCertificate("fixed");
+    CertificateMaterial managed = rsaCertificate("managed");
+    CertificateManager certificateManager =
+        manager(
+            group(new NodeId(2, "fixed-group"), fixed),
+            group(NodeIds.ServerConfiguration_CertificateGroups_DefaultApplicationGroup, managed));
+    UserTokenPolicy tokenPolicy =
+        new UserTokenPolicy(
+            "username", UserTokenType.UserName, null, null, SecurityPolicy.Basic256Sha256.getUri());
+    EndpointConfig endpoint =
+        EndpointConfig.newBuilder()
+            .setCertificate(fixed.certificate())
+            .setEndpointCertificateConfig(EndpointCertificateConfig.newBuilder().build())
+            .addTokenPolicy(tokenPolicy)
+            .build();
+
+    List<EndpointDescription> descriptions =
+        server(Set.of(endpoint), certificateManager)
+            .getApplicationContext()
+            .getEndpointDescriptions();
+
+    assertTrue(descriptions.isEmpty());
   }
 
   // Legacy fixed-certificate endpoints remain authoritative even when other managed identities
@@ -694,6 +871,12 @@ public class EndpointConfigTest {
 
   private static CertificateMaterial rsaCertificate(String commonName) throws Exception {
 
+    return rsaCertificate(NodeIds.RsaSha256ApplicationCertificateType, commonName);
+  }
+
+  private static CertificateMaterial rsaCertificate(NodeId certificateTypeId, String commonName)
+      throws Exception {
+
     KeyPair keyPair = SelfSignedCertificateGenerator.generateRsaKeyPair(2048);
     X509Certificate certificate =
         new SelfSignedCertificateBuilder(keyPair)
@@ -702,8 +885,7 @@ public class EndpointConfigTest {
             .setApplicationUri("urn:test:" + commonName)
             .build();
 
-    return new CertificateMaterial(
-        NodeIds.RsaSha256ApplicationCertificateType, keyPair, new X509Certificate[] {certificate});
+    return new CertificateMaterial(certificateTypeId, keyPair, new X509Certificate[] {certificate});
   }
 
   private static CertificateMaterial nistP256Certificate() throws Exception {

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/CertificateIdentitySelectionContext.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/CertificateIdentitySelectionContext.java
@@ -30,8 +30,9 @@ import org.jspecify.annotations.Nullable;
  *     be used.
  * @param certificateTypeId the preferred certificate type, or {@code null} if the policy should
  *     decide.
- * @param explicitCertificate an explicitly configured certificate to prefer when it is present in
- *     the manager, or {@code null}.
+ * @param explicitCertificate an explicitly configured certificate that pins selection to its
+ *     compatible manager identity, or {@code null}. Selectors return empty when the pinned
+ *     certificate is not available so callers can use fixed-certificate compatibility paths.
  */
 @NullMarked
 public record CertificateIdentitySelectionContext(

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/DefaultCertificateIdentitySelector.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/DefaultCertificateIdentitySelector.java
@@ -109,25 +109,19 @@ public final class DefaultCertificateIdentitySelector implements CertificateIden
 
   private static Optional<CertificateIdentity> selectExplicitIdentity(
       CertificateIdentitySelectionContext context,
-      @Nullable ByteString explicitThumbprint,
+      ByteString explicitThumbprint,
       List<CertificateIdentity> candidates)
       throws UaException {
 
-    if (explicitThumbprint == null) {
-      return Optional.empty();
-    }
-
-    CertificateIdentity selected = null;
-    Comparator<CertificateIdentity> order = selectionOrder(context);
+    List<CertificateIdentity> pinned = new ArrayList<>();
 
     for (CertificateIdentity candidate : candidates) {
-      if (explicitThumbprint.equals(candidate.thumbprint())
-          && (selected == null || order.compare(candidate, selected) < 0)) {
-        selected = candidate;
+      if (explicitThumbprint.equals(candidate.thumbprint())) {
+        pinned.add(candidate);
       }
     }
 
-    return Optional.ofNullable(selected);
+    return pinned.stream().min(selectionOrder(context));
   }
 
   private static @Nullable ByteString explicitThumbprint(

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/DefaultCertificateIdentitySelector.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/DefaultCertificateIdentitySelector.java
@@ -33,9 +33,12 @@ import org.slf4j.LoggerFactory;
  * identities that are locally compatible with the security policy profile (see {@link
  * CertificateCompatibility#checkLocalCompatible(SecurityPolicyProfile, CertificateIdentity)}, which
  * enforces functional requirements but does not reject legacy RSA identities for omitting the
- * strict KeyUsage bit set). Among the remaining candidates it prefers an explicitly configured
- * certificate when it is present in the manager, an exact certificate type request, the type
- * preferred by the security policy profile, and finally stable certificate group/type ordering.
+ * strict KeyUsage bit set). An explicitly configured certificate pins selection to the matching
+ * manager identity. If the manager does not contain that certificate, or the identity is not
+ * compatible with the requested profile, the selector returns empty so the caller can use its
+ * fixed-certificate fallback. Without an explicit certificate, the selector prefers an exact
+ * certificate type request, the type preferred by the security policy profile, and finally stable
+ * certificate group/type ordering.
  *
  * <p>An explicitly configured certificate that is excluded for incompatibility is logged at {@code
  * WARN} with the reason, so it is never silently lost. A routine non-match among the other
@@ -97,15 +100,8 @@ public final class DefaultCertificateIdentitySelector implements CertificateIden
       }
     }
 
-    if (candidates.isEmpty()) {
-      return Optional.empty();
-    }
-
-    Optional<CertificateIdentity> explicitIdentity =
-        selectExplicitIdentity(context, explicitThumbprint, candidates);
-
-    if (explicitIdentity.isPresent()) {
-      return explicitIdentity;
+    if (explicitThumbprint != null) {
+      return selectExplicitIdentity(context, explicitThumbprint, candidates);
     }
 
     return candidates.stream().min(selectionOrder(context));

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/security/DefaultCertificateIdentitySelectorTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/security/DefaultCertificateIdentitySelectorTest.java
@@ -79,7 +79,60 @@ class DefaultCertificateIdentitySelectorTest {
     assertEquals(identity, selected.get());
   }
 
+  // An explicit certificate pins the configured identity. If it is external to the manager, the
+  // caller must receive Optional.empty so it can use the matching fixed key pair and chain.
+  @Test
+  void returnsEmptyWhenExplicitCertificateIsNotManaged() throws Exception {
+    CertificateIdentity managedIdentity =
+        rsaIdentity(KeyUsage.digitalSignature | KeyUsage.keyEncipherment);
+    CertificateIdentity explicitIdentity =
+        rsaIdentity(KeyUsage.digitalSignature | KeyUsage.keyEncipherment);
+
+    CertificateIdentitySelectionContext context =
+        CertificateIdentitySelectionContext.forClientConnectionSetup(
+            certificateManager(List.of(managedIdentity)),
+            SecurityPolicy.Basic256Sha256.getProfile(),
+            null,
+            null,
+            explicitIdentity.certificate());
+
+    Optional<CertificateIdentity> selected =
+        DefaultCertificateIdentitySelector.create().select(context);
+
+    assertTrue(selected.isEmpty());
+  }
+
+  // A manager entry for the explicit certificate must not allow selection to fall through to a
+  // different identity when the pinned identity is incompatible with the security policy.
+  @Test
+  void returnsEmptyWhenExplicitCertificateIsIncompatible() throws Exception {
+    CertificateIdentity compatibleIdentity =
+        rsaIdentity(KeyUsage.digitalSignature | KeyUsage.keyEncipherment);
+    CertificateIdentity explicitIdentity =
+        rsaIdentity(
+            NodeIds.RsaMinApplicationCertificateType,
+            KeyUsage.digitalSignature | KeyUsage.keyEncipherment);
+
+    CertificateIdentitySelectionContext context =
+        CertificateIdentitySelectionContext.forClientConnectionSetup(
+            certificateManager(List.of(compatibleIdentity, explicitIdentity)),
+            SecurityPolicy.Basic256Sha256.getProfile(),
+            null,
+            null,
+            explicitIdentity.certificate());
+
+    Optional<CertificateIdentity> selected =
+        DefaultCertificateIdentitySelector.create().select(context);
+
+    assertTrue(selected.isEmpty());
+  }
+
   private static CertificateIdentity rsaIdentity(int keyUsage) throws Exception {
+    return rsaIdentity(NodeIds.RsaSha256ApplicationCertificateType, keyUsage);
+  }
+
+  private static CertificateIdentity rsaIdentity(NodeId certificateTypeId, int keyUsage)
+      throws Exception {
     KeyPair keyPair = SelfSignedCertificateGenerator.generateRsaKeyPair(2048);
     X509Certificate certificate =
         new SelfSignedCertificateBuilder(keyPair, new KeyUsageCertificateGenerator(keyUsage))
@@ -89,16 +142,20 @@ class DefaultCertificateIdentitySelectorTest {
 
     return new CertificateIdentity(
         NodeIds.ServerConfiguration_CertificateGroups_DefaultApplicationGroup,
-        NodeIds.RsaSha256ApplicationCertificateType,
+        certificateTypeId,
         keyPair,
         new X509Certificate[] {certificate});
   }
 
   private static CertificateManager singleIdentityManager(CertificateIdentity identity) {
+    return certificateManager(List.of(identity));
+  }
+
+  private static CertificateManager certificateManager(List<CertificateIdentity> identities) {
     return new CertificateManager() {
       @Override
       public List<CertificateIdentity> getCertificateIdentities() {
-        return List.of(identity);
+        return identities;
       }
 
       @Override


### PR DESCRIPTION
This corrects certificate identity resolution so explicit certificate choices remain authoritative and manager-backed identities stay consistent across client connection setup, session creation, and server endpoint advertisement.

The default identity selector now treats an explicit certificate as a pin. If the certificate is absent from the manager or incompatible with the requested security profile, selection returns empty so the existing fixed-certificate path can use the matching key material instead of silently presenting another identity.

When the client ApplicationUri is not explicitly configured, CreateSession now derives it from the cached certificate identity selected for the connection. It falls back to the fixed certificate SAN URI and then the existing placeholder. The client preserves explicit `setApplicationUri` precedence and warns when manager-backed identities contain different ApplicationUris.

Server endpoint resolution now uses the DefaultApplicationGroup for secure endpoints without explicit certificate configuration. SecurityPolicy.None endpoints with username or issued-token policies that use legacy encryption select a managed certificate against the effective user-token security profile. Fixed-certificate configurations remain compatible, and anonymous None endpoints remain certificate-free.

Verification:

- `mise exec -- mvn -q -pl opc-ua-stack/stack-core test -Dtest=DefaultCertificateIdentitySelectorTest`
- `mise exec -- mvn -q -pl opc-ua-sdk/integration-tests -am test -Dtest=OpcUaClientConfigTest -Dsurefire.failIfNoSpecifiedTests=false`
- `mise exec -- mvn -q -pl opc-ua-sdk/sdk-server -am verify -Dtest=EndpointConfigTest -Dsurefire.failIfNoSpecifiedTests=false`
- `mise exec -- mvn -q spotless:apply`
- `mise exec -- mvn -q clean compile`
- `mise exec -- mvn -q clean verify`

Closes #1854
Closes #1847
Closes #1848
Closes #1849
