### PR TITLE
Recover from missing or inaccurate server operation limits

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/OperationLimitsTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/OperationLimitsTest.java
@@ -10,24 +10,51 @@
 
 package org.eclipse.milo.opcua.sdk.client;
 
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
 import org.eclipse.milo.opcua.sdk.test.AbstractClientServerTest;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.TimestampsToReturn;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 public class OperationLimitsTest extends AbstractClientServerTest {
+
+  private static final List<NodeId> OPERATION_LIMIT_NODES =
+      List.of(
+          NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerRead,
+          NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerWrite,
+          NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerMethodCall,
+          NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerBrowse,
+          NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerRegisterNodes,
+          NodeIds
+              .Server_ServerCapabilities_OperationLimits_MaxNodesPerTranslateBrowsePathsToNodeIds,
+          NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerNodeManagement,
+          NodeIds.Server_ServerCapabilities_OperationLimits_MaxMonitoredItemsPerCall,
+          NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerHistoryReadData,
+          NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerHistoryReadEvents,
+          NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerHistoryUpdateData,
+          NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerHistoryUpdateEvents);
 
   @Test
   void readOperationLimits() throws UaException {
@@ -117,5 +144,142 @@ public class OperationLimitsTest extends AbstractClientServerTest {
 
     assertTrue(operationLimits.maxNodesPerHistoryUpdateEvents().isPresent());
     assertEquals(1200, operationLimits.maxNodesPerHistoryUpdateEvents().get().intValue());
+  }
+
+  // A server may enforce a hidden Read limit of one, while every OperationLimits property remains
+  // individually readable. Discovery must preserve the declared property mapping in this case.
+  @Test
+  void bulkTooManyOperationsReadsEveryLimitIndividuallyInPropertyOrder() throws UaException {
+    OpcUaClient mockClient = mock(OpcUaClient.class);
+    List<DataValue> values = operationLimitValues();
+
+    when(mockClient.readValues(anyDouble(), any(), anyList()))
+        .thenThrow(new UaException(StatusCodes.Bad_TooManyOperations));
+    when(mockClient.readValue(anyDouble(), any(), any(NodeId.class)))
+        .thenAnswer(
+            invocation -> {
+              NodeId nodeId = invocation.getArgument(2);
+              return values.get(OPERATION_LIMIT_NODES.indexOf(nodeId));
+            });
+
+    OperationLimits operationLimits = OperationLimits.read(mockClient);
+
+    assertEquals(
+        List.of(
+            uint(1), uint(2), uint(3), uint(4), uint(5), uint(6), uint(7), uint(8), uint(9),
+            uint(10), uint(11), uint(12)),
+        presentValues(operationLimits));
+
+    ArgumentCaptor<NodeId> nodeIds = ArgumentCaptor.forClass(NodeId.class);
+    verify(mockClient, times(OPERATION_LIMIT_NODES.size()))
+        .readValue(eq(0.0), eq(TimestampsToReturn.Neither), nodeIds.capture());
+    assertEquals(OPERATION_LIMIT_NODES, nodeIds.getAllValues());
+  }
+
+  // Only Bad_TooManyOperations says that reducing the number of operations can make the same
+  // request safe to replay. Other service failures must remain visible to the caller.
+  @Test
+  void nonTooManyBulkServiceFailurePropagatesWithoutSingletonReads() throws UaException {
+    OpcUaClient mockClient = mock(OpcUaClient.class);
+    when(mockClient.readValues(anyDouble(), any(), anyList()))
+        .thenThrow(new UaException(StatusCodes.Bad_Timeout));
+
+    UaException exception = assertThrows(UaException.class, () -> OperationLimits.read(mockClient));
+
+    assertEquals(StatusCodes.Bad_Timeout, exception.getStatusCode().value());
+    verify(mockClient, never()).readValue(anyDouble(), any(), any(NodeId.class));
+  }
+
+  // A singleton service failure does not prove that an optional node is absent. Propagating it
+  // leaves the lazy cache retryable instead of caching a partial set of limits.
+  @Test
+  void singletonServiceFailureAbortsDiscovery() throws UaException {
+    OpcUaClient mockClient = mock(OpcUaClient.class);
+    when(mockClient.readValues(anyDouble(), any(), anyList()))
+        .thenThrow(new UaException(StatusCodes.Bad_TooManyOperations));
+    when(mockClient.readValue(anyDouble(), any(), any(NodeId.class)))
+        .thenReturn(operationLimitValues().get(0))
+        .thenThrow(new UaException(StatusCodes.Bad_Timeout));
+
+    UaException exception = assertThrows(UaException.class, () -> OperationLimits.read(mockClient));
+
+    assertEquals(StatusCodes.Bad_Timeout, exception.getStatusCode().value());
+    verify(mockClient, times(2)).readValue(anyDouble(), any(), any(NodeId.class));
+  }
+
+  // Optional OperationLimits nodes report absence through per-operation data, so bad and null
+  // singleton values must not turn an otherwise valid discovery into a service failure.
+  @Test
+  void badAndNullSingletonValuesRemainAbsent() throws UaException {
+    OpcUaClient mockClient = mock(OpcUaClient.class);
+    List<DataValue> values = operationLimitValues();
+
+    when(mockClient.readValues(anyDouble(), any(), anyList()))
+        .thenThrow(new UaException(StatusCodes.Bad_TooManyOperations));
+    when(mockClient.readValue(anyDouble(), any(), any(NodeId.class)))
+        .thenAnswer(
+            invocation -> {
+              NodeId nodeId = invocation.getArgument(2);
+              int index = OPERATION_LIMIT_NODES.indexOf(nodeId);
+              return switch (index) {
+                case 0 -> new DataValue(StatusCodes.Bad_NodeIdUnknown);
+                case 1 -> null;
+                default -> values.get(index);
+              };
+            });
+
+    OperationLimits operationLimits = OperationLimits.read(mockClient);
+
+    assertTrue(operationLimits.maxNodesPerRead().isEmpty());
+    assertTrue(operationLimits.maxNodesPerWrite().isEmpty());
+    assertEquals(uint(3), operationLimits.maxNodesPerMethodCall().orElseThrow());
+    verify(mockClient, times(OPERATION_LIMIT_NODES.size()))
+        .readValue(anyDouble(), any(), any(NodeId.class));
+  }
+
+  // A successful service response with the wrong number of per-operation results is malformed and
+  // must fail deterministically before any property is indexed or a fallback is attempted.
+  @Test
+  void bulkResponseWithWrongResultCountThrowsBadUnexpectedError() throws UaException {
+    OpcUaClient mockClient = mock(OpcUaClient.class);
+    when(mockClient.readValues(anyDouble(), any(), anyList()))
+        .thenReturn(operationLimitValues().subList(0, OPERATION_LIMIT_NODES.size() - 1));
+
+    UaException exception = assertThrows(UaException.class, () -> OperationLimits.read(mockClient));
+
+    assertEquals(StatusCodes.Bad_UnexpectedError, exception.getStatusCode().value());
+    verify(mockClient, never()).readValue(anyDouble(), any(), any(NodeId.class));
+  }
+
+  private static List<DataValue> operationLimitValues() {
+    return List.of(
+        new DataValue(new Variant(uint(1))),
+        new DataValue(new Variant(uint(2))),
+        new DataValue(new Variant(uint(3))),
+        new DataValue(new Variant(uint(4))),
+        new DataValue(new Variant(uint(5))),
+        new DataValue(new Variant(uint(6))),
+        new DataValue(new Variant(uint(7))),
+        new DataValue(new Variant(uint(8))),
+        new DataValue(new Variant(uint(9))),
+        new DataValue(new Variant(uint(10))),
+        new DataValue(new Variant(uint(11))),
+        new DataValue(new Variant(uint(12))));
+  }
+
+  private static List<UInteger> presentValues(OperationLimits limits) {
+    return List.of(
+        limits.maxNodesPerRead().orElseThrow(),
+        limits.maxNodesPerWrite().orElseThrow(),
+        limits.maxNodesPerMethodCall().orElseThrow(),
+        limits.maxNodesPerBrowse().orElseThrow(),
+        limits.maxNodesPerRegisterNodes().orElseThrow(),
+        limits.maxNodesPerTranslateBrowsePathsToNodeIds().orElseThrow(),
+        limits.maxNodesPerNodeManagement().orElseThrow(),
+        limits.maxMonitoredItemsPerCall().orElseThrow(),
+        limits.maxNodesPerHistoryReadData().orElseThrow(),
+        limits.maxNodesPerHistoryReadEvents().orElseThrow(),
+        limits.maxNodesPerHistoryUpdateData().orElseThrow(),
+        limits.maxNodesPerHistoryUpdateEvents().orElseThrow());
   }
 }

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/SessionInitializerOperationLimitTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/SessionInitializerOperationLimitTest.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import org.eclipse.milo.opcua.sdk.server.EndpointConfig;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableNode;
+import org.eclipse.milo.opcua.sdk.server.servicesets.AttributeServiceSet;
+import org.eclipse.milo.opcua.sdk.server.servicesets.impl.DefaultAttributeServiceSet;
+import org.eclipse.milo.opcua.sdk.test.TestClient;
+import org.eclipse.milo.opcua.sdk.test.TestServer;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.structured.HistoryReadRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.HistoryReadResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.HistoryUpdateRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.HistoryUpdateResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.ReadRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.ReadResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.ReadValueId;
+import org.eclipse.milo.opcua.stack.core.types.structured.WriteRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.WriteResponse;
+import org.eclipse.milo.opcua.stack.transport.server.ServiceRequestContext;
+import org.junit.jupiter.api.Test;
+
+class SessionInitializerOperationLimitTest {
+
+  private static final long AWAIT_TIMEOUT_SECONDS = 10;
+
+  private static final List<NodeId> TABLE_NODES =
+      List.of(NodeIds.Server_NamespaceArray, NodeIds.Server_ServerArray);
+
+  // NamespaceArray and ServerArray are independent values. A server whose hidden Read limit is
+  // one must still populate both client tables after rejecting the optimistic two-node request.
+  @Test
+  void tooManyOperationsRetriesNamespaceAndServerArraysIndividually() throws Exception {
+    try (Fixture fixture = new Fixture(StatusCodes.Bad_TooManyOperations)) {
+      assertArrayEquals(
+          fixture.server.getNamespaceTable().toArray(),
+          fixture.client.getNamespaceTable().toArray());
+      assertArrayEquals(
+          fixture.server.getServerTable().toArray(), fixture.client.getServerTable().toArray());
+
+      assertEquals(TABLE_NODES, fixture.attributeServiceSet.tableReads.get(0));
+      assertEquals(
+          1, fixture.attributeServiceSet.countReadsOf(List.of(NodeIds.Server_NamespaceArray)));
+      assertEquals(
+          1, fixture.attributeServiceSet.countReadsOf(List.of(NodeIds.Server_ServerArray)));
+      assertEquals(3, fixture.attributeServiceSet.tableReads.size());
+    }
+  }
+
+  // A failure unrelated to request cardinality gives no assurance that replaying the Read is safe.
+  // The best-effort initializer must leave it alone and let session establishment continue.
+  @Test
+  void nonTooManyOperationsFailureDoesNotRetryTableReads() throws Exception {
+    try (Fixture fixture = new Fixture(StatusCodes.Bad_Timeout)) {
+      assertEquals(List.of(TABLE_NODES), fixture.attributeServiceSet.tableReads);
+    }
+  }
+
+  // The two fallback Reads are independent. Failure to read one optional local table must not
+  // discard the other table's successful result or fail session establishment.
+  @Test
+  void oneFailedSingletonDoesNotDiscardTheOtherTable() throws Exception {
+    try (Fixture fixture =
+        new Fixture(StatusCodes.Bad_TooManyOperations, NodeIds.Server_ServerArray)) {
+
+      assertArrayEquals(
+          fixture.server.getNamespaceTable().toArray(),
+          fixture.client.getNamespaceTable().toArray());
+      assertArrayEquals(new String[0], fixture.client.getServerTable().toArray());
+      assertEquals(3, fixture.attributeServiceSet.tableReads.size());
+    }
+  }
+
+  // OperationLimits describe the active server Session. Reusing the previous Session's lazy value
+  // after a reconnect can make every SDK-owned partition use a stale limit.
+  @Test
+  void newSessionInvalidatesCachedOperationLimits() throws Exception {
+    try (Fixture fixture = new Fixture(StatusCodes.Good)) {
+      OperationLimits initialLimits = fixture.client.getOperationLimits();
+      assertEquals(uint(10_000), initialLimits.maxNodesPerRead().orElseThrow());
+
+      UaVariableNode maxNodesPerRead =
+          (UaVariableNode)
+              fixture
+                  .server
+                  .getAddressSpaceManager()
+                  .getManagedNode(NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerRead)
+                  .orElseThrow();
+      maxNodesPerRead.setValue(new DataValue(new Variant(uint(17))));
+
+      assertEquals(
+          uint(10_000),
+          fixture.client.getOperationLimits().maxNodesPerRead().orElseThrow(),
+          "precondition: the first Session's OperationLimits were not cached");
+
+      fixture.client.disconnect();
+      fixture.client.connect();
+
+      assertEquals(uint(17), fixture.client.getOperationLimits().maxNodesPerRead().orElseThrow());
+    }
+  }
+
+  private static final class Fixture implements AutoCloseable {
+
+    final OpcUaServer server;
+    final OpcUaClient client;
+    final TableReadAttributeServiceSet attributeServiceSet;
+
+    Fixture(long bootstrapFailure) throws Exception {
+      this(bootstrapFailure, NodeId.NULL_VALUE);
+    }
+
+    Fixture(long bootstrapFailure, NodeId singletonFailureNode) throws Exception {
+      server = TestServer.create().getServer();
+      attributeServiceSet =
+          new TableReadAttributeServiceSet(server, bootstrapFailure, singletonFailureNode);
+
+      for (EndpointConfig endpoint : server.getConfig().getEndpoints()) {
+        server.addServiceSet(endpoint.getPath(), attributeServiceSet);
+      }
+
+      server.startup().get(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+      client =
+          TestClient.create(
+              server, config -> config.setKeepAliveInterval(uint(TimeUnit.MINUTES.toMillis(1))));
+      client.connect();
+    }
+
+    @Override
+    public void close() throws Exception {
+      try {
+        client.disconnectAsync().get(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+      } finally {
+        server.shutdown().get(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+      }
+    }
+  }
+
+  /** Records table Reads and scripts the service result of the optimistic two-node request. */
+  private static final class TableReadAttributeServiceSet implements AttributeServiceSet {
+
+    private final AttributeServiceSet delegate;
+    private final long bootstrapFailure;
+    private final NodeId singletonFailureNode;
+
+    final List<List<NodeId>> tableReads = new CopyOnWriteArrayList<>();
+
+    TableReadAttributeServiceSet(
+        OpcUaServer server, long bootstrapFailure, NodeId singletonFailureNode) {
+      this.delegate = new DefaultAttributeServiceSet(Objects.requireNonNull(server, "server"));
+      this.bootstrapFailure = bootstrapFailure;
+      this.singletonFailureNode = singletonFailureNode;
+    }
+
+    @Override
+    public ReadResponse onRead(ServiceRequestContext context, ReadRequest request)
+        throws UaException {
+
+      List<NodeId> nodeIds = tableNodeIds(request);
+      if (!nodeIds.isEmpty()) {
+        tableReads.add(nodeIds);
+
+        if (nodeIds.equals(TABLE_NODES) && bootstrapFailure != StatusCodes.Good) {
+          throw new UaException(bootstrapFailure);
+        }
+        if (nodeIds.equals(List.of(singletonFailureNode))) {
+          throw new UaException(StatusCodes.Bad_Timeout);
+        }
+      }
+
+      return delegate.onRead(context, request);
+    }
+
+    @Override
+    public HistoryReadResponse onHistoryRead(
+        ServiceRequestContext context, HistoryReadRequest request) throws UaException {
+      return delegate.onHistoryRead(context, request);
+    }
+
+    @Override
+    public WriteResponse onWrite(ServiceRequestContext context, WriteRequest request)
+        throws UaException {
+      return delegate.onWrite(context, request);
+    }
+
+    @Override
+    public HistoryUpdateResponse onHistoryUpdate(
+        ServiceRequestContext context, HistoryUpdateRequest request) throws UaException {
+      return delegate.onHistoryUpdate(context, request);
+    }
+
+    int countReadsOf(List<NodeId> expected) {
+      return (int) tableReads.stream().filter(expected::equals).count();
+    }
+
+    private static List<NodeId> tableNodeIds(ReadRequest request) {
+      ReadValueId[] nodesToRead = request.getNodesToRead();
+      if (nodesToRead == null || nodesToRead.length == 0) {
+        return List.of();
+      }
+
+      List<NodeId> nodeIds = Arrays.stream(nodesToRead).map(ReadValueId::getNodeId).toList();
+
+      return nodeIds.stream().allMatch(TABLE_NODES::contains) ? nodeIds : List.of();
+    }
+  }
+}

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/MonitoredItemOperationLimitFallbackTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/MonitoredItemOperationLimitFallbackTest.java
@@ -1,0 +1,677 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.subscriptions;
+
+import static java.util.Objects.requireNonNull;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.server.EndpointConfig;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.sdk.test.DelegatingMonitoredItemServiceSet;
+import org.eclipse.milo.opcua.sdk.test.TestClient;
+import org.eclipse.milo.opcua.sdk.test.TestServer;
+import org.eclipse.milo.opcua.stack.core.AttributeId;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.MonitoringMode;
+import org.eclipse.milo.opcua.stack.core.types.structured.CreateMonitoredItemsRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.CreateMonitoredItemsResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.DeleteMonitoredItemsRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.DeleteMonitoredItemsResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.ModifyMonitoredItemsRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.ModifyMonitoredItemsResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.ReadValueId;
+import org.eclipse.milo.opcua.stack.core.types.structured.SetMonitoringModeRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.SetMonitoringModeResponse;
+import org.eclipse.milo.opcua.stack.transport.server.ServiceRequestContext;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies recovery when a Server enforces a lower MaxMonitoredItemsPerCall than it advertises.
+ *
+ * <p>The service set records the actual wire operations and delegates accepted singleton requests
+ * to the real Server. This lets each test verify both the retry shape and the client-side state
+ * produced by successful responses.
+ */
+public class MonitoredItemOperationLimitFallbackTest {
+
+  /**
+   * A rejected Create partition must be replayed in order, and the learned singleton limit must
+   * immediately apply to every monitored-item service owned by the Subscription.
+   */
+  @Test
+  void createFallbackPreservesOrderAndTheLearnedLimitIsShared() throws Exception {
+    try (var fixture = new Fixture()) {
+      var subscription = new OpcUaSubscription(fixture.client);
+      subscription.setMaxMonitoredItemsPerCall(uint(2));
+      subscription.create();
+
+      try {
+        addItems(subscription, 5);
+
+        List<MonitoredItemServiceOperationResult> createResults =
+            subscription.createMonitoredItems();
+
+        assertGood(createResults, 5);
+        assertEquals(
+            List.of(2, 1, 1, 1, 1, 1),
+            fixture.serviceSet.requestSizes(Operation.CREATE),
+            "the failed pair must be retried as singletons and all later work must stay singleton");
+
+        List<UInteger> createOrder =
+            fixture.serviceSet.requests(Operation.CREATE).stream()
+                .skip(1)
+                .flatMap(List::stream)
+                .toList();
+        assertEquals(
+            createOrder,
+            createResults.stream()
+                .map(result -> result.monitoredItem().getClientHandle().orElseThrow())
+                .toList(),
+            "the result list must retain the wire-operation order after the retry");
+
+        List<OpcUaMonitoredItem> items =
+            createResults.stream().map(MonitoredItemServiceOperationResult::monitoredItem).toList();
+
+        fixture.serviceSet.clearRequests();
+        for (int i = 0; i < items.size(); i++) {
+          items.get(i).setSamplingInterval(100.0 + i);
+        }
+
+        List<MonitoredItemServiceOperationResult> modifyResults =
+            subscription.modifyMonitoredItems();
+
+        assertGood(modifyResults, 5);
+        assertEquals(
+            List.of(1, 1, 1, 1, 1),
+            fixture.serviceSet.requestSizes(Operation.MODIFY),
+            "Modify must immediately reuse the limit learned by Create");
+        assertEquals(
+            fixture.serviceSet.requests(Operation.MODIFY).stream().flatMap(List::stream).toList(),
+            monitoredItemIds(modifyResults));
+
+        fixture.serviceSet.clearRequests();
+        List<MonitoredItemServiceOperationResult> modeResults =
+            subscription.setMonitoringMode(MonitoringMode.Disabled, items);
+
+        assertGood(modeResults, 5);
+        assertEquals(
+            List.of(1, 1, 1, 1, 1),
+            fixture.serviceSet.requestSizes(Operation.SET_MONITORING_MODE),
+            "SetMonitoringMode must immediately reuse the limit learned by Create");
+        assertEquals(items, resultItems(modeResults));
+
+        Map<UInteger, OpcUaMonitoredItem> itemsById = itemsByMonitoredItemId(items);
+        fixture.serviceSet.clearRequests();
+        subscription.removeMonitoredItems(items);
+
+        List<MonitoredItemServiceOperationResult> deleteResults =
+            subscription.deleteMonitoredItems();
+
+        assertGood(deleteResults, 5);
+        assertEquals(
+            List.of(1, 1, 1, 1, 1),
+            fixture.serviceSet.requestSizes(Operation.DELETE),
+            "Delete must immediately reuse the limit learned by Create");
+        assertEquals(
+            fixture.serviceSet.requests(Operation.DELETE).stream()
+                .flatMap(List::stream)
+                .map(itemsById::get)
+                .toList(),
+            resultItems(deleteResults),
+            "Delete results must retain request order even though successful deletion clears ids");
+      } finally {
+        subscription.delete();
+      }
+    }
+  }
+
+  // A subscription may first encounter the hidden limit while modifying existing items.
+  @Test
+  void modifyIndependentlyFallsBackToSingletonRequests() throws Exception {
+    try (var fixture = new Fixture()) {
+      var subscription = new OpcUaSubscription(fixture.client);
+      subscription.create();
+
+      try {
+        List<OpcUaMonitoredItem> items = prepareCreatedItems(subscription, 3);
+        for (int i = 0; i < items.size(); i++) {
+          items.get(i).setSamplingInterval(200.0 + i);
+        }
+        fixture.serviceSet.clearRequests();
+
+        List<MonitoredItemServiceOperationResult> results = subscription.modifyMonitoredItems();
+
+        assertGood(results, 3);
+        assertEquals(List.of(2, 1, 1, 1), fixture.serviceSet.requestSizes(Operation.MODIFY));
+        assertEquals(
+            fixture.serviceSet.requests(Operation.MODIFY).stream()
+                .skip(1)
+                .flatMap(List::stream)
+                .toList(),
+            monitoredItemIds(results));
+      } finally {
+        subscription.delete();
+      }
+    }
+  }
+
+  // A subscription may first encounter the hidden limit while deleting existing items.
+  @Test
+  void deleteIndependentlyFallsBackToSingletonRequests() throws Exception {
+    try (var fixture = new Fixture()) {
+      var subscription = new OpcUaSubscription(fixture.client);
+      subscription.create();
+
+      try {
+        List<OpcUaMonitoredItem> items = prepareCreatedItems(subscription, 3);
+        Map<UInteger, OpcUaMonitoredItem> itemsById = itemsByMonitoredItemId(items);
+        subscription.removeMonitoredItems(items);
+        fixture.serviceSet.clearRequests();
+
+        List<MonitoredItemServiceOperationResult> results = subscription.deleteMonitoredItems();
+
+        assertGood(results, 3);
+        assertEquals(List.of(2, 1, 1, 1), fixture.serviceSet.requestSizes(Operation.DELETE));
+        assertEquals(
+            fixture.serviceSet.requests(Operation.DELETE).stream()
+                .skip(1)
+                .flatMap(List::stream)
+                .map(itemsById::get)
+                .toList(),
+            resultItems(results));
+      } finally {
+        subscription.delete();
+      }
+    }
+  }
+
+  // A subscription may first encounter the hidden limit while changing MonitoringMode.
+  @Test
+  void setMonitoringModeIndependentlyFallsBackToSingletonRequests() throws Exception {
+    try (var fixture = new Fixture()) {
+      var subscription = new OpcUaSubscription(fixture.client);
+      subscription.create();
+
+      try {
+        List<OpcUaMonitoredItem> items = prepareCreatedItems(subscription, 3);
+        fixture.serviceSet.clearRequests();
+
+        List<MonitoredItemServiceOperationResult> results =
+            subscription.setMonitoringMode(MonitoringMode.Disabled, items);
+
+        assertGood(results, 3);
+        assertEquals(
+            List.of(2, 1, 1, 1), fixture.serviceSet.requestSizes(Operation.SET_MONITORING_MODE));
+        assertEquals(items, resultItems(results));
+        assertTrue(
+            items.stream().allMatch(item -> item.getMonitoringMode() == MonitoringMode.Disabled));
+      } finally {
+        subscription.delete();
+      }
+    }
+  }
+
+  // Ambiguous service failures must remain visible; replaying Create could duplicate server state.
+  @Test
+  void timeoutDoesNotTriggerSingletonRetries() throws Exception {
+    try (var fixture = new Fixture()) {
+      fixture.serviceSet.setRejectionStatus(StatusCodes.Bad_Timeout);
+
+      var subscription = new OpcUaSubscription(fixture.client);
+      subscription.setMaxMonitoredItemsPerCall(uint(2));
+      subscription.create();
+
+      try {
+        List<OpcUaMonitoredItem> items = addItems(subscription, 2);
+
+        List<MonitoredItemServiceOperationResult> results = subscription.createMonitoredItems();
+
+        assertServiceFailure(results, StatusCodes.Bad_Timeout, 2);
+        assertEquals(List.of(2), fixture.serviceSet.requestSizes(Operation.CREATE));
+        assertEquals(itemsByClientHandle(items), itemsByClientHandle(resultItems(results)));
+        assertTrue(
+            items.stream()
+                .allMatch(item -> item.getSyncState() == OpcUaMonitoredItem.SyncState.INITIAL));
+      } finally {
+        subscription.delete();
+      }
+    }
+  }
+
+  // Retrying a rejected singleton cannot reduce the request and would loop forever.
+  @Test
+  void singletonTooManyOperationsIsReportedWithoutRetry() throws Exception {
+    try (var fixture = new Fixture()) {
+      fixture.serviceSet.setMaximumAcceptedOperations(0);
+
+      var subscription = new OpcUaSubscription(fixture.client);
+      subscription.setMaxMonitoredItemsPerCall(uint(2));
+      subscription.create();
+
+      try {
+        addItems(subscription, 1);
+
+        List<MonitoredItemServiceOperationResult> results = subscription.createMonitoredItems();
+
+        assertServiceFailure(results, StatusCodes.Bad_TooManyOperations, 1);
+        assertEquals(List.of(1), fixture.serviceSet.requestSizes(Operation.CREATE));
+      } finally {
+        subscription.delete();
+      }
+    }
+  }
+
+  /**
+   * SetMonitoringMode partitions client items, but its operation limit applies only to ids sent on
+   * the wire. One valid id mixed with an invalid item is still a singleton service request.
+   */
+  @Test
+  void setMonitoringModeUsesTheActualWireOperationCountForTheRetryGuard() throws Exception {
+    try (var fixture = new Fixture()) {
+      var subscription = new OpcUaSubscription(fixture.client);
+      subscription.setMaxMonitoredItemsPerCall(uint(2));
+      subscription.create();
+
+      try {
+        OpcUaMonitoredItem validItem = addItems(subscription, 1).get(0);
+        assertGood(subscription.createMonitoredItems(), 1);
+
+        var invalidItem = OpcUaMonitoredItem.newDataItem(NodeIds.Server_ServerStatus_CurrentTime);
+        fixture.serviceSet.setMaximumAcceptedOperations(0);
+        fixture.serviceSet.clearRequests();
+
+        List<MonitoredItemServiceOperationResult> results =
+            subscription.setMonitoringMode(
+                MonitoringMode.Disabled, List.of(invalidItem, validItem));
+
+        assertEquals(List.of(1), fixture.serviceSet.requestSizes(Operation.SET_MONITORING_MODE));
+        assertEquals(2, results.size());
+        assertEquals(invalidItem, results.get(0).monitoredItem());
+        assertEquals(StatusCodes.Bad_InvalidState, results.get(0).serviceResult().value());
+        assertFalse(results.get(0).operationResult().isPresent());
+        assertEquals(validItem, results.get(1).monitoredItem());
+        assertEquals(StatusCodes.Bad_TooManyOperations, results.get(1).serviceResult().value());
+        assertFalse(results.get(1).operationResult().isPresent());
+        assertEquals(MonitoringMode.Reporting, validItem.getMonitoringMode());
+      } finally {
+        subscription.delete();
+      }
+    }
+  }
+
+  /**
+   * DeleteMonitoredItems also partitions client items while counting only ids sent on the wire. A
+   * concurrent item reset must not turn one transmitted id into a retryable multi-operation call.
+   */
+  @Test
+  void deleteUsesTheActualWireOperationCountForTheRetryGuard() throws Exception {
+    try (var fixture = new Fixture()) {
+      var subscription = new OpcUaSubscription(fixture.client);
+      subscription.setMaxMonitoredItemsPerCall(uint(1));
+      subscription.create();
+
+      try {
+        var validItem = OpcUaMonitoredItem.newDataItem(NodeIds.Server_ServerStatus_CurrentTime);
+        var resetItem = new ResetOnMonitoredItemIdRead();
+        subscription.addMonitoredItems(List.of(validItem, resetItem));
+        assertGood(subscription.createMonitoredItems(), 2);
+
+        subscription.setMaxMonitoredItemsPerCall(uint(2));
+        subscription.removeMonitoredItems(List.of(validItem, resetItem));
+        resetItem.resetOnNextMonitoredItemIdRead();
+        fixture.serviceSet.setMaximumAcceptedOperations(0);
+        fixture.serviceSet.clearRequests();
+
+        List<MonitoredItemServiceOperationResult> results = subscription.deleteMonitoredItems();
+
+        assertEquals(List.of(1), fixture.serviceSet.requestSizes(Operation.DELETE));
+        assertEquals(2, results.size());
+        assertEquals(
+            1,
+            results.stream()
+                .filter(
+                    result -> result.serviceResult().value() == StatusCodes.Bad_TooManyOperations)
+                .count());
+        assertEquals(
+            1,
+            results.stream()
+                .filter(result -> result.serviceResult().value() == StatusCodes.Bad_InvalidState)
+                .count());
+        assertTrue(results.stream().allMatch(result -> result.operationResult().isEmpty()));
+      } finally {
+        subscription.delete();
+      }
+    }
+  }
+
+  // The learned limit belongs to one server-side Subscription incarnation.
+  @Test
+  void recreatingTheSubscriptionClearsTheLearnedLimit() throws Exception {
+    try (var fixture = new Fixture()) {
+      var subscription = new OpcUaSubscription(fixture.client);
+      subscription.setMaxMonitoredItemsPerCall(uint(2));
+      subscription.create();
+
+      try {
+        addItems(subscription, 2);
+        assertGood(subscription.createMonitoredItems(), 2);
+        assertEquals(List.of(2, 1, 1), fixture.serviceSet.requestSizes(Operation.CREATE));
+
+        subscription.delete();
+        subscription.create();
+        fixture.serviceSet.clearRequests();
+
+        List<MonitoredItemServiceOperationResult> results = subscription.createMonitoredItems();
+
+        assertGood(results, 2);
+        assertEquals(
+            List.of(2, 1, 1),
+            fixture.serviceSet.requestSizes(Operation.CREATE),
+            "the replacement Subscription must be allowed one new optimistic attempt");
+      } finally {
+        subscription.delete();
+      }
+    }
+  }
+
+  // Changing the configured cap intentionally starts a new partition-size calculation.
+  @Test
+  void changingTheConfiguredLimitClearsTheLearnedLimit() throws Exception {
+    try (var fixture = new Fixture()) {
+      var subscription = new OpcUaSubscription(fixture.client);
+      subscription.setMaxMonitoredItemsPerCall(uint(2));
+      subscription.create();
+
+      try {
+        addItems(subscription, 2);
+        assertGood(subscription.createMonitoredItems(), 2);
+
+        fixture.serviceSet.clearRequests();
+        addItems(subscription, 2);
+        assertGood(subscription.createMonitoredItems(), 2);
+        assertEquals(
+            List.of(1, 1),
+            fixture.serviceSet.requestSizes(Operation.CREATE),
+            "control: the Subscription must have retained its learned singleton limit");
+
+        addItems(subscription, 2);
+        subscription.setMaxMonitoredItemsPerCall(uint(3));
+        fixture.serviceSet.clearRequests();
+
+        List<MonitoredItemServiceOperationResult> results = subscription.createMonitoredItems();
+
+        assertGood(results, 2);
+        assertEquals(
+            List.of(2, 1, 1),
+            fixture.serviceSet.requestSizes(Operation.CREATE),
+            "changing the configured cap must permit one new optimistic attempt");
+      } finally {
+        subscription.delete();
+      }
+    }
+  }
+
+  private static List<OpcUaMonitoredItem> addItems(OpcUaSubscription subscription, int itemCount) {
+
+    var items = new ArrayList<OpcUaMonitoredItem>(itemCount);
+    for (int i = 0; i < itemCount; i++) {
+      items.add(OpcUaMonitoredItem.newDataItem(NodeIds.Server_ServerStatus_CurrentTime));
+    }
+    subscription.addMonitoredItems(items);
+    return items;
+  }
+
+  private static List<OpcUaMonitoredItem> prepareCreatedItems(
+      OpcUaSubscription subscription, int itemCount) {
+
+    subscription.setMaxMonitoredItemsPerCall(uint(1));
+    addItems(subscription, itemCount);
+
+    List<MonitoredItemServiceOperationResult> results = subscription.createMonitoredItems();
+    assertGood(results, itemCount);
+
+    subscription.setMaxMonitoredItemsPerCall(uint(2));
+    return resultItems(results);
+  }
+
+  private static void assertGood(
+      List<MonitoredItemServiceOperationResult> results, int expectedCount) {
+
+    assertEquals(expectedCount, results.size());
+    assertTrue(results.stream().allMatch(MonitoredItemServiceOperationResult::isGood));
+  }
+
+  private static void assertServiceFailure(
+      List<MonitoredItemServiceOperationResult> results,
+      long expectedStatusCode,
+      int expectedCount) {
+
+    assertEquals(expectedCount, results.size());
+    assertTrue(
+        results.stream().allMatch(result -> result.serviceResult().value() == expectedStatusCode));
+    assertTrue(results.stream().allMatch(result -> result.operationResult().isEmpty()));
+  }
+
+  private static List<OpcUaMonitoredItem> resultItems(
+      List<MonitoredItemServiceOperationResult> results) {
+
+    return results.stream().map(MonitoredItemServiceOperationResult::monitoredItem).toList();
+  }
+
+  private static List<UInteger> monitoredItemIds(
+      List<MonitoredItemServiceOperationResult> results) {
+
+    return results.stream()
+        .map(result -> result.monitoredItem().getMonitoredItemId().orElseThrow())
+        .toList();
+  }
+
+  private static Map<UInteger, OpcUaMonitoredItem> itemsByMonitoredItemId(
+      List<OpcUaMonitoredItem> items) {
+
+    var itemsById = new HashMap<UInteger, OpcUaMonitoredItem>();
+    for (OpcUaMonitoredItem item : items) {
+      itemsById.put(item.getMonitoredItemId().orElseThrow(), item);
+    }
+    return itemsById;
+  }
+
+  private static Map<UInteger, OpcUaMonitoredItem> itemsByClientHandle(
+      List<OpcUaMonitoredItem> items) {
+
+    var itemsByHandle = new HashMap<UInteger, OpcUaMonitoredItem>();
+    for (OpcUaMonitoredItem item : items) {
+      itemsByHandle.put(item.getClientHandle().orElseThrow(), item);
+    }
+    return itemsByHandle;
+  }
+
+  private enum Operation {
+    CREATE,
+    MODIFY,
+    DELETE,
+    SET_MONITORING_MODE
+  }
+
+  /** A real MonitoredItem service set with a scriptable hidden per-request operation limit. */
+  private static final class OperationLimitingMonitoredItemServiceSet
+      extends DelegatingMonitoredItemServiceSet {
+
+    private final Map<Operation, List<List<UInteger>>> requests = new EnumMap<>(Operation.class);
+
+    private volatile int maximumAcceptedOperations = 1;
+    private volatile long rejectionStatus = StatusCodes.Bad_TooManyOperations;
+
+    OperationLimitingMonitoredItemServiceSet(OpcUaServer server) {
+      super(server);
+
+      for (Operation operation : Operation.values()) {
+        requests.put(operation, new ArrayList<>());
+      }
+    }
+
+    void setMaximumAcceptedOperations(int maximumAcceptedOperations) {
+      this.maximumAcceptedOperations = maximumAcceptedOperations;
+    }
+
+    void setRejectionStatus(long rejectionStatus) {
+      this.rejectionStatus = rejectionStatus;
+    }
+
+    synchronized void clearRequests() {
+      requests.values().forEach(List::clear);
+    }
+
+    synchronized List<List<UInteger>> requests(Operation operation) {
+      return requests.get(operation).stream().map(List::copyOf).toList();
+    }
+
+    List<Integer> requestSizes(Operation operation) {
+      return requests(operation).stream().map(List::size).toList();
+    }
+
+    @Override
+    public CreateMonitoredItemsResponse onCreateMonitoredItems(
+        ServiceRequestContext context, CreateMonitoredItemsRequest request) throws UaException {
+
+      List<UInteger> clientHandles =
+          Arrays.stream(requireNonNull(request.getItemsToCreate()))
+              .map(item -> item.getRequestedParameters().getClientHandle())
+              .toList();
+      recordAndRejectIfNecessary(Operation.CREATE, clientHandles);
+
+      return super.onCreateMonitoredItems(context, request);
+    }
+
+    @Override
+    public ModifyMonitoredItemsResponse onModifyMonitoredItems(
+        ServiceRequestContext context, ModifyMonitoredItemsRequest request) throws UaException {
+
+      List<UInteger> monitoredItemIds =
+          Arrays.stream(requireNonNull(request.getItemsToModify()))
+              .map(item -> item.getMonitoredItemId())
+              .toList();
+      recordAndRejectIfNecessary(Operation.MODIFY, monitoredItemIds);
+
+      return super.onModifyMonitoredItems(context, request);
+    }
+
+    @Override
+    public DeleteMonitoredItemsResponse onDeleteMonitoredItems(
+        ServiceRequestContext context, DeleteMonitoredItemsRequest request) throws UaException {
+
+      List<UInteger> monitoredItemIds =
+          Arrays.stream(requireNonNull(request.getMonitoredItemIds())).toList();
+      recordAndRejectIfNecessary(Operation.DELETE, monitoredItemIds);
+
+      return super.onDeleteMonitoredItems(context, request);
+    }
+
+    @Override
+    public SetMonitoringModeResponse onSetMonitoringMode(
+        ServiceRequestContext context, SetMonitoringModeRequest request) throws UaException {
+
+      List<UInteger> monitoredItemIds =
+          Arrays.stream(requireNonNull(request.getMonitoredItemIds())).toList();
+      recordAndRejectIfNecessary(Operation.SET_MONITORING_MODE, monitoredItemIds);
+
+      return super.onSetMonitoringMode(context, request);
+    }
+
+    private synchronized void recordAndRejectIfNecessary(
+        Operation operation, List<UInteger> operationKeys) throws UaException {
+
+      requests.get(operation).add(List.copyOf(operationKeys));
+
+      if (operationKeys.size() > maximumAcceptedOperations) {
+        throw new UaException(
+            rejectionStatus,
+            "scripted " + operation + " rejection for " + operationKeys.size() + " operations");
+      }
+    }
+  }
+
+  private static final class ResetOnMonitoredItemIdRead extends OpcUaMonitoredItem {
+
+    private boolean resetOnNextMonitoredItemIdRead;
+
+    private ResetOnMonitoredItemIdRead() {
+      super(
+          new ReadValueId(
+              NodeIds.Server_ServerStatus_CurrentTime,
+              AttributeId.Value.uid(),
+              null,
+              QualifiedName.NULL_VALUE));
+    }
+
+    void resetOnNextMonitoredItemIdRead() {
+      resetOnNextMonitoredItemIdRead = true;
+    }
+
+    @Override
+    public Optional<UInteger> getMonitoredItemId() {
+      if (resetOnNextMonitoredItemIdRead) {
+        resetOnNextMonitoredItemIdRead = false;
+        reset();
+      }
+
+      return super.getMonitoredItemId();
+    }
+  }
+
+  /** A running Server with the operation-limiting service set and a connected client. */
+  private static final class Fixture implements AutoCloseable {
+
+    private final OpcUaServer server;
+    private final OpcUaClient client;
+    private final OperationLimitingMonitoredItemServiceSet serviceSet;
+
+    Fixture() throws Exception {
+      TestServer testServer = TestServer.create();
+      server = testServer.getServer();
+
+      serviceSet = new OperationLimitingMonitoredItemServiceSet(server);
+      for (EndpointConfig endpoint : server.getConfig().getEndpoints()) {
+        server.addServiceSet(endpoint.getPath(), serviceSet);
+      }
+
+      server.startup().get();
+
+      client = TestClient.create(server, configBuilder -> {});
+      client.connect();
+    }
+
+    @Override
+    public void close() throws Exception {
+      try {
+        client.disconnectAsync().get(5, TimeUnit.SECONDS);
+      } finally {
+        server.shutdown().get(5, TimeUnit.SECONDS);
+      }
+    }
+  }
+}

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/typetree/ClientBrowseUtilsTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/typetree/ClientBrowseUtilsTest.java
@@ -10,21 +10,360 @@
 
 package org.eclipse.milo.opcua.sdk.client.typetree;
 
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.IntStream;
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.client.OperationLimits;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.TimestampsToReturn;
+import org.eclipse.milo.opcua.stack.core.types.structured.BrowseDescription;
 import org.eclipse.milo.opcua.stack.core.types.structured.BrowseNextResponse;
 import org.eclipse.milo.opcua.stack.core.types.structured.BrowseResult;
+import org.eclipse.milo.opcua.stack.core.types.structured.ReadResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.ReadValueId;
+import org.eclipse.milo.opcua.stack.core.types.structured.ReferenceDescription;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 class ClientBrowseUtilsTest {
+
+  @Test
+  void missingReadLimitUsesSingletonRequests() throws UaException {
+    assertReadLimitUsesSingletonRequests(null);
+  }
+
+  @Test
+  void zeroReadLimitUsesSingletonRequests() throws UaException {
+    assertReadLimitUsesSingletonRequests(uint(0));
+  }
+
+  private static void assertReadLimitUsesSingletonRequests(@Nullable UInteger operationLimit)
+      throws UaException {
+
+    var client = mock(OpcUaClient.class);
+    List<ReadValueId> requests = readRequests(3);
+    List<DataValue> values = dataValues(3);
+    var calls = new ArrayList<List<ReadValueId>>();
+
+    when(client.read(eq(0.0), eq(TimestampsToReturn.Neither), anyList()))
+        .thenAnswer(
+            invocation -> {
+              List<ReadValueId> partition = invocation.getArgument(2);
+              calls.add(List.copyOf(partition));
+              return readResponse(partition, requests, values);
+            });
+
+    List<DataValue> result =
+        ClientBrowseUtils.readWithOperationLimits(
+            client, requests, operationLimits(operationLimit, null));
+
+    assertEquals(values, result);
+    assertEquals(singletonPartitions(requests), calls);
+  }
+
+  @Test
+  void missingBrowseLimitUsesSingletonRequests() throws UaException {
+    assertBrowseLimitUsesSingletonRequests(null);
+  }
+
+  @Test
+  void zeroBrowseLimitUsesSingletonRequests() throws UaException {
+    assertBrowseLimitUsesSingletonRequests(uint(0));
+  }
+
+  private static void assertBrowseLimitUsesSingletonRequests(@Nullable UInteger operationLimit)
+      throws UaException {
+
+    var client = mock(OpcUaClient.class);
+    List<BrowseDescription> requests = browseRequests(3);
+    List<ReferenceDescription> references = references(3);
+    var calls = new ArrayList<List<BrowseDescription>>();
+
+    when(client.browse(anyList()))
+        .thenAnswer(
+            invocation -> {
+              List<BrowseDescription> partition = invocation.getArgument(0);
+              calls.add(List.copyOf(partition));
+              return browseResults(partition, requests, references);
+            });
+
+    List<List<ReferenceDescription>> result =
+        ClientBrowseUtils.browseWithOperationLimits(
+            client, requests, operationLimits(null, operationLimit));
+
+    assertEquals(wrapEach(references), result);
+    assertEquals(singletonPartitions(requests), calls);
+  }
+
+  // UInt32 limits above Integer.MAX_VALUE remain valid and must not overflow into an invalid
+  // partition size.
+  @Test
+  void maximumUnsignedReadLimitUsesOnePositivePartition() throws UaException {
+    var client = mock(OpcUaClient.class);
+    List<ReadValueId> requests = readRequests(3);
+    List<DataValue> values = dataValues(3);
+    var calls = new ArrayList<List<ReadValueId>>();
+
+    when(client.read(eq(0.0), eq(TimestampsToReturn.Neither), anyList()))
+        .thenAnswer(
+            invocation -> {
+              List<ReadValueId> partition = invocation.getArgument(2);
+              calls.add(List.copyOf(partition));
+              return readResponse(partition, requests, values);
+            });
+
+    List<DataValue> result =
+        ClientBrowseUtils.readWithOperationLimits(
+            client, requests, operationLimits(UInteger.MAX, null));
+
+    assertEquals(values, result);
+    assertEquals(List.of(requests), calls);
+  }
+
+  // UInt32 limits above Integer.MAX_VALUE remain valid and must not overflow into an invalid
+  // partition size.
+  @Test
+  void maximumUnsignedBrowseLimitUsesOnePositivePartition() throws UaException {
+    var client = mock(OpcUaClient.class);
+    List<BrowseDescription> requests = browseRequests(3);
+    List<ReferenceDescription> references = references(3);
+    var calls = new ArrayList<List<BrowseDescription>>();
+
+    when(client.browse(anyList()))
+        .thenAnswer(
+            invocation -> {
+              List<BrowseDescription> partition = invocation.getArgument(0);
+              calls.add(List.copyOf(partition));
+              return browseResults(partition, requests, references);
+            });
+
+    List<List<ReferenceDescription>> result =
+        ClientBrowseUtils.browseWithOperationLimits(
+            client, requests, operationLimits(null, UInteger.MAX));
+
+    assertEquals(wrapEach(references), result);
+    assertEquals(List.of(requests), calls);
+  }
+
+  // A stale advertised limit may reject one batch, but retrying it and the remaining Reads as
+  // singletons must retain the original result order.
+  @Test
+  void rejectedReadPartitionFallsBackToOrderedSingletonRequests() throws UaException {
+    var client = mock(OpcUaClient.class);
+    List<ReadValueId> requests = readRequests(5);
+    List<DataValue> values = dataValues(5);
+    var calls = new ArrayList<List<ReadValueId>>();
+
+    when(client.read(eq(0.0), eq(TimestampsToReturn.Neither), anyList()))
+        .thenAnswer(
+            invocation -> {
+              List<ReadValueId> partition = invocation.getArgument(2);
+              calls.add(List.copyOf(partition));
+              if (partition.size() > 1) {
+                throw new UaException(StatusCodes.Bad_TooManyOperations);
+              }
+              return readResponse(partition, requests, values);
+            });
+
+    List<DataValue> result =
+        ClientBrowseUtils.readWithOperationLimits(client, requests, operationLimits(uint(3), null));
+
+    var expectedCalls = new ArrayList<List<ReadValueId>>();
+    expectedCalls.add(List.copyOf(requests.subList(0, 3)));
+    expectedCalls.addAll(singletonPartitions(requests));
+
+    assertEquals(values, result);
+    assertEquals(expectedCalls, calls);
+  }
+
+  // A stale advertised limit may reject one batch, but retrying it and the remaining Browses as
+  // singletons must retain the original result order and one result per input.
+  @Test
+  void rejectedBrowsePartitionFallsBackToOrderedSingletonRequests() throws UaException {
+    var client = mock(OpcUaClient.class);
+    List<BrowseDescription> requests = browseRequests(5);
+    List<ReferenceDescription> references = references(5);
+    var calls = new ArrayList<List<BrowseDescription>>();
+
+    when(client.browse(anyList()))
+        .thenAnswer(
+            invocation -> {
+              List<BrowseDescription> partition = invocation.getArgument(0);
+              calls.add(List.copyOf(partition));
+              if (partition.size() > 1) {
+                throw new UaException(StatusCodes.Bad_TooManyOperations);
+              }
+              return browseResults(partition, requests, references);
+            });
+
+    List<List<ReferenceDescription>> result =
+        ClientBrowseUtils.browseWithOperationLimits(
+            client, requests, operationLimits(null, uint(3)));
+
+    var expectedCalls = new ArrayList<List<BrowseDescription>>();
+    expectedCalls.add(List.copyOf(requests.subList(0, 3)));
+    expectedCalls.addAll(singletonPartitions(requests));
+
+    assertEquals(wrapEach(references), result);
+    assertEquals(expectedCalls, calls);
+  }
+
+  // Only Bad_TooManyOperations identifies an oversized request; another Read service failure must
+  // propagate without replaying any operation.
+  @Test
+  void nonRetryableReadFailurePropagatesWithoutRetry() throws UaException {
+    var client = mock(OpcUaClient.class);
+    List<ReadValueId> requests = readRequests(3);
+    var calls = new ArrayList<List<ReadValueId>>();
+    var failure = new UaException(StatusCodes.Bad_Timeout);
+
+    when(client.read(eq(0.0), eq(TimestampsToReturn.Neither), anyList()))
+        .thenAnswer(
+            invocation -> {
+              List<ReadValueId> partition = invocation.getArgument(2);
+              calls.add(List.copyOf(partition));
+              throw failure;
+            });
+
+    UaException thrown =
+        assertThrows(
+            UaException.class,
+            () ->
+                ClientBrowseUtils.readWithOperationLimits(
+                    client, requests, operationLimits(uint(2), null)));
+
+    assertSame(failure, thrown);
+    assertEquals(List.of(requests.subList(0, 2)), calls);
+  }
+
+  // Only Bad_TooManyOperations identifies an oversized request; another Browse service failure
+  // must propagate without replaying any operation.
+  @Test
+  void nonRetryableBrowseFailurePropagatesWithoutRetry() throws UaException {
+    var client = mock(OpcUaClient.class);
+    List<BrowseDescription> requests = browseRequests(3);
+    var calls = new ArrayList<List<BrowseDescription>>();
+    var failure = new UaException(StatusCodes.Bad_Timeout);
+
+    when(client.browse(anyList()))
+        .thenAnswer(
+            invocation -> {
+              List<BrowseDescription> partition = invocation.getArgument(0);
+              calls.add(List.copyOf(partition));
+              throw failure;
+            });
+
+    UaException thrown =
+        assertThrows(
+            UaException.class,
+            () ->
+                ClientBrowseUtils.browseWithOperationLimits(
+                    client, requests, operationLimits(null, uint(2))));
+
+    assertSame(failure, thrown);
+    assertEquals(List.of(requests.subList(0, 2)), calls);
+  }
+
+  // BrowseNext already sends one continuation point per request. Its failure must not replay the
+  // successful multi-node Browse request that produced the continuation point.
+  @Test
+  void browseNextTooManyOperationsDoesNotRetryTheInitialBrowse() throws UaException {
+    var client = mock(OpcUaClient.class);
+    List<BrowseDescription> requests = browseRequests(2);
+    var continuationPoint = ByteString.of(new byte[] {1});
+    var failure = new UaException(StatusCodes.Bad_TooManyOperations);
+
+    when(client.browse(requests))
+        .thenReturn(
+            List.of(
+                new BrowseResult(StatusCode.GOOD, continuationPoint, null),
+                new BrowseResult(StatusCode.GOOD, ByteString.NULL_VALUE, null)));
+    when(client.browseNext(false, List.of(continuationPoint))).thenThrow(failure);
+
+    UaException thrown =
+        assertThrows(
+            UaException.class,
+            () ->
+                ClientBrowseUtils.browseWithOperationLimits(
+                    client, requests, operationLimits(null, uint(2))));
+
+    assertSame(failure, thrown);
+    verify(client).browse(requests);
+  }
+
+  // A singleton Bad_TooManyOperations cannot be reduced further and must not cause an infinite
+  // retry loop.
+  @Test
+  void singletonReadRejectionPropagatesWithoutRetry() throws UaException {
+    var client = mock(OpcUaClient.class);
+    List<ReadValueId> requests = readRequests(2);
+    var calls = new ArrayList<List<ReadValueId>>();
+    var failure = new UaException(StatusCodes.Bad_TooManyOperations);
+
+    when(client.read(eq(0.0), eq(TimestampsToReturn.Neither), anyList()))
+        .thenAnswer(
+            invocation -> {
+              List<ReadValueId> partition = invocation.getArgument(2);
+              calls.add(List.copyOf(partition));
+              throw failure;
+            });
+
+    UaException thrown =
+        assertThrows(
+            UaException.class,
+            () ->
+                ClientBrowseUtils.readWithOperationLimits(
+                    client, requests, operationLimits(null, null)));
+
+    assertSame(failure, thrown);
+    assertEquals(List.of(List.of(requests.get(0))), calls);
+  }
+
+  // A singleton Bad_TooManyOperations cannot be reduced further and must not cause an infinite
+  // retry loop.
+  @Test
+  void singletonBrowseRejectionPropagatesWithoutRetry() throws UaException {
+    var client = mock(OpcUaClient.class);
+    List<BrowseDescription> requests = browseRequests(2);
+    var calls = new ArrayList<List<BrowseDescription>>();
+    var failure = new UaException(StatusCodes.Bad_TooManyOperations);
+
+    when(client.browse(anyList()))
+        .thenAnswer(
+            invocation -> {
+              List<BrowseDescription> partition = invocation.getArgument(0);
+              calls.add(List.copyOf(partition));
+              throw failure;
+            });
+
+    UaException thrown =
+        assertThrows(
+            UaException.class,
+            () ->
+                ClientBrowseUtils.browseWithOperationLimits(
+                    client, requests, operationLimits(null, null)));
+
+    assertSame(failure, thrown);
+    assertEquals(List.of(List.of(requests.get(0))), calls);
+  }
 
   @Test
   void releasesContinuationPointWhenBrowseNextLimitIsReached() throws UaException {
@@ -42,5 +381,77 @@ class ClientBrowseUtilsTest {
 
     verify(client, times(1000)).browseNext(false, List.of(continuationPoint));
     verify(client).browseNext(true, List.of(continuationPoint));
+  }
+
+  private static OperationLimits operationLimits(
+      @Nullable UInteger maxNodesPerRead, @Nullable UInteger maxNodesPerBrowse) {
+
+    return new OperationLimits(
+        maxNodesPerRead,
+        null,
+        null,
+        maxNodesPerBrowse,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null);
+  }
+
+  private static List<ReadValueId> readRequests(int count) {
+    return IntStream.range(0, count).mapToObj(i -> mock(ReadValueId.class, "read-" + i)).toList();
+  }
+
+  private static List<DataValue> dataValues(int count) {
+    return IntStream.range(0, count).mapToObj(i -> DataValue.valueOnly(new Variant(i))).toList();
+  }
+
+  private static ReadResponse readResponse(
+      List<ReadValueId> partition, List<ReadValueId> requests, List<DataValue> values) {
+
+    DataValue[] results =
+        partition.stream()
+            .map(request -> values.get(requests.indexOf(request)))
+            .toArray(DataValue[]::new);
+
+    return new ReadResponse(null, results, null);
+  }
+
+  private static List<BrowseDescription> browseRequests(int count) {
+    return IntStream.range(0, count)
+        .mapToObj(i -> mock(BrowseDescription.class, "browse-" + i))
+        .toList();
+  }
+
+  private static List<ReferenceDescription> references(int count) {
+    return IntStream.range(0, count)
+        .mapToObj(i -> mock(ReferenceDescription.class, "reference-" + i))
+        .toList();
+  }
+
+  private static List<BrowseResult> browseResults(
+      List<BrowseDescription> partition,
+      List<BrowseDescription> requests,
+      List<ReferenceDescription> references) {
+
+    return partition.stream()
+        .map(
+            request ->
+                new BrowseResult(
+                    StatusCode.GOOD,
+                    ByteString.NULL_VALUE,
+                    new ReferenceDescription[] {references.get(requests.indexOf(request))}))
+        .toList();
+  }
+
+  private static <T> List<List<T>> singletonPartitions(List<T> values) {
+    return values.stream().map(List::of).toList();
+  }
+
+  private static <T> List<List<T>> wrapEach(List<T> values) {
+    return singletonPartitions(values);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClient.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClient.java
@@ -437,51 +437,7 @@ public class OpcUaClient {
 
     sessionFsm = SessionFsmFactory.newSessionFsm(this);
 
-    sessionFsm.addInitializer(
-        (client, session) -> {
-          logger.debug("SessionInitializer: NamespaceTable and ServerTable");
-          RequestHeader requestHeader = newRequestHeader(session.getAuthenticationToken());
-
-          ReadRequest readRequest =
-              new ReadRequest(
-                  requestHeader,
-                  0.0,
-                  TimestampsToReturn.Neither,
-                  new ReadValueId[] {
-                    new ReadValueId(
-                        NodeIds.Server_NamespaceArray,
-                        AttributeId.Value.uid(),
-                        null,
-                        QualifiedName.NULL_VALUE),
-                    new ReadValueId(
-                        NodeIds.Server_ServerArray,
-                        AttributeId.Value.uid(),
-                        null,
-                        QualifiedName.NULL_VALUE)
-                  });
-
-          return client
-              .sendRequestAsync(readRequest)
-              .thenApply(ReadResponse.class::cast)
-              .thenApply(response -> Objects.requireNonNull(response.getResults()))
-              .thenApply(
-                  results -> {
-                    String[] namespaceArray = (String[]) results[0].value().value();
-                    String[] serverArray = (String[]) results[1].value().value();
-                    if (namespaceArray != null) {
-                      updateNamespaceTable(namespaceArray);
-                    }
-                    if (serverArray != null) {
-                      updateServerTable(serverArray);
-                    }
-                    return Unit.VALUE;
-                  })
-              .exceptionally(
-                  ex -> {
-                    logger.warn("SessionInitializer: NamespaceTable", ex);
-                    return Unit.VALUE;
-                  });
-        });
+    sessionFsm.addInitializer(this::initializeNamespaceAndServerTables);
 
     addSessionInitializer(
         (client, session) -> {
@@ -502,6 +458,129 @@ public class OpcUaClient {
 
     ObjectTypeInitializer.initialize(namespaceTable, objectTypeManager);
     VariableTypeInitializer.initialize(namespaceTable, variableTypeManager);
+  }
+
+  private CompletableFuture<Unit> initializeNamespaceAndServerTables(
+      OpcUaClient client, OpcUaSession session) {
+
+    logger.debug("SessionInitializer: NamespaceTable and ServerTable");
+
+    return readNamespaceAndServerArrays(client, session.getAuthenticationToken())
+        .handle(
+            (unit, ex) -> {
+              if (ex == null) {
+                return CompletableFuture.completedFuture(unit);
+              }
+
+              boolean tooManyOperations =
+                  UaException.extractStatusCode(ex)
+                      .map(statusCode -> statusCode.value() == StatusCodes.Bad_TooManyOperations)
+                      .orElse(false);
+
+              if (tooManyOperations) {
+                return readNamespaceAndServerArraysIndividually(
+                    client, session.getAuthenticationToken());
+              }
+
+              logger.warn("SessionInitializer: NamespaceTable and ServerTable", ex);
+              return CompletableFuture.completedFuture(Unit.VALUE);
+            })
+        .thenCompose(Function.identity());
+  }
+
+  private CompletableFuture<Unit> readNamespaceAndServerArrays(
+      OpcUaClient client, NodeId authenticationToken) {
+
+    return readValuesDuringSessionInitialization(
+            client, authenticationToken, NodeIds.Server_NamespaceArray, NodeIds.Server_ServerArray)
+        .thenApply(
+            results -> {
+              if (results[0] != null) {
+                updateNamespaceTable(results[0]);
+              }
+              if (results[1] != null) {
+                updateServerTable(results[1]);
+              }
+
+              return Unit.VALUE;
+            });
+  }
+
+  private CompletableFuture<Unit> readNamespaceAndServerArraysIndividually(
+      OpcUaClient client, NodeId authenticationToken) {
+
+    CompletableFuture<Unit> namespaceArray =
+        readValuesDuringSessionInitialization(
+                client, authenticationToken, NodeIds.Server_NamespaceArray)
+            .thenApply(
+                results -> {
+                  if (results[0] != null) {
+                    updateNamespaceTable(results[0]);
+                  }
+                  return Unit.VALUE;
+                })
+            .exceptionally(
+                ex -> {
+                  logger.warn("SessionInitializer: NamespaceTable singleton Read", ex);
+                  return Unit.VALUE;
+                });
+
+    CompletableFuture<Unit> serverArray =
+        readValuesDuringSessionInitialization(
+                client, authenticationToken, NodeIds.Server_ServerArray)
+            .thenApply(
+                results -> {
+                  if (results[0] != null) {
+                    updateServerTable(results[0]);
+                  }
+                  return Unit.VALUE;
+                })
+            .exceptionally(
+                ex -> {
+                  logger.warn("SessionInitializer: ServerTable singleton Read", ex);
+                  return Unit.VALUE;
+                });
+
+    return CompletableFuture.allOf(namespaceArray, serverArray).thenApply(v -> Unit.VALUE);
+  }
+
+  private CompletableFuture<String[][]> readValuesDuringSessionInitialization(
+      OpcUaClient client, NodeId authenticationToken, NodeId... nodeIds) {
+
+    ReadValueId[] nodesToRead =
+        Stream.of(nodeIds)
+            .map(
+                nodeId ->
+                    new ReadValueId(
+                        nodeId, AttributeId.Value.uid(), null, QualifiedName.NULL_VALUE))
+            .toArray(ReadValueId[]::new);
+
+    ReadRequest readRequest =
+        new ReadRequest(
+            newRequestHeader(authenticationToken), 0.0, TimestampsToReturn.Neither, nodesToRead);
+
+    return client
+        .sendRequestAsync(readRequest)
+        .thenApply(ReadResponse.class::cast)
+        .thenCompose(
+            response -> {
+              DataValue[] results = response.getResults();
+
+              if (results == null || results.length != nodeIds.length) {
+                return CompletableFuture.failedFuture(
+                    new UaException(
+                        StatusCodes.Bad_UnexpectedError,
+                        "Read returned %s results, expected %s"
+                            .formatted(results == null ? "null" : results.length, nodeIds.length)));
+              }
+
+              String[][] values = new String[results.length][];
+              for (int i = 0; i < results.length; i++) {
+                values[i] = (String[]) results[i].value().value();
+              }
+
+              return CompletableFuture.completedFuture(values);
+            });
   }
 
   /**

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClient.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClient.java
@@ -489,6 +489,7 @@ public class OpcUaClient {
           // are refreshed (eagerly or lazily, depending on configuration). Resetting the tree
           // also resets the dynamic DataTypeManager and EncodingContext derived from it.
 
+          resetOperationLimits();
           resetDataTypeTree();
 
           return CompletableFuture.completedFuture(Unit.VALUE);

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OperationLimits.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OperationLimits.java
@@ -12,7 +12,6 @@ package org.eclipse.milo.opcua.sdk.client;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Function;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
@@ -200,18 +199,25 @@ public class OperationLimits {
     List<DataValue> values =
         client.readValues(0.0, TimestampsToReturn.Neither, OPERATION_LIMITS_NODES);
 
-    UInteger maxNodesPerRead = toUInteger(values.get(0).value().value());
-    UInteger maxNodesPerWrite = toUInteger(values.get(1).value().value());
-    UInteger maxNodesPerMethodCall = toUInteger(values.get(2).value().value());
-    UInteger maxNodesPerBrowse = toUInteger(values.get(3).value().value());
-    UInteger maxNodesPerRegisterNodes = toUInteger(values.get(4).value().value());
-    UInteger maxNodesPerTranslateBrowsePathsToNodeIds = toUInteger(values.get(5).value().value());
-    UInteger maxNodesPerNodeManagement = toUInteger(values.get(6).value().value());
-    UInteger maxMonitoredItemsPerCall = toUInteger(values.get(7).value().value());
-    UInteger maxNodesPerHistoryReadData = toUInteger(values.get(8).value().value());
-    UInteger maxNodesPerHistoryReadEvents = toUInteger(values.get(9).value().value());
-    UInteger maxNodesPerHistoryUpdateData = toUInteger(values.get(10).value().value());
-    UInteger maxNodesPerHistoryUpdateEvents = toUInteger(values.get(11).value().value());
+    if (values == null || values.size() != OPERATION_LIMITS_NODES.size()) {
+      throw new UaException(
+          StatusCodes.Bad_UnexpectedError,
+          "Read returned %s OperationLimits results, expected %s"
+              .formatted(values == null ? "null" : values.size(), OPERATION_LIMITS_NODES.size()));
+    }
+
+    UInteger maxNodesPerRead = toUInteger(values.get(0));
+    UInteger maxNodesPerWrite = toUInteger(values.get(1));
+    UInteger maxNodesPerMethodCall = toUInteger(values.get(2));
+    UInteger maxNodesPerBrowse = toUInteger(values.get(3));
+    UInteger maxNodesPerRegisterNodes = toUInteger(values.get(4));
+    UInteger maxNodesPerTranslateBrowsePathsToNodeIds = toUInteger(values.get(5));
+    UInteger maxNodesPerNodeManagement = toUInteger(values.get(6));
+    UInteger maxMonitoredItemsPerCall = toUInteger(values.get(7));
+    UInteger maxNodesPerHistoryReadData = toUInteger(values.get(8));
+    UInteger maxNodesPerHistoryReadEvents = toUInteger(values.get(9));
+    UInteger maxNodesPerHistoryUpdateData = toUInteger(values.get(10));
+    UInteger maxNodesPerHistoryUpdateEvents = toUInteger(values.get(11));
 
     return new OperationLimits(
         maxNodesPerRead,
@@ -229,43 +235,41 @@ public class OperationLimits {
   }
 
   private static OperationLimits readIndividualNodes(OpcUaClient client) throws UaException {
-    Function<NodeId, UInteger> read =
-        nodeId -> {
-          try {
-            return toUInteger(
-                client.readValue(0.0, TimestampsToReturn.Neither, nodeId).value().value());
-          } catch (UaException e) {
-            return null;
-          }
-        };
-
     // checkstyle:off
     UInteger maxNodesPerRead =
-        read.apply(NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerRead);
+        readNode(client, NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerRead);
     UInteger maxNodesPerWrite =
-        read.apply(NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerWrite);
+        readNode(client, NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerWrite);
     UInteger maxNodesPerMethodCall =
-        read.apply(NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerMethodCall);
+        readNode(client, NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerMethodCall);
     UInteger maxNodesPerBrowse =
-        read.apply(NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerBrowse);
+        readNode(client, NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerBrowse);
     UInteger maxNodesPerRegisterNodes =
-        read.apply(NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerRegisterNodes);
+        readNode(
+            client, NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerRegisterNodes);
     UInteger maxNodesPerTranslateBrowsePathsToNodeIds =
-        read.apply(
+        readNode(
+            client,
             NodeIds
                 .Server_ServerCapabilities_OperationLimits_MaxNodesPerTranslateBrowsePathsToNodeIds);
     UInteger maxNodesPerNodeManagement =
-        read.apply(NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerNodeManagement);
+        readNode(
+            client, NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerNodeManagement);
     UInteger maxMonitoredItemsPerCall =
-        read.apply(NodeIds.Server_ServerCapabilities_OperationLimits_MaxMonitoredItemsPerCall);
+        readNode(
+            client, NodeIds.Server_ServerCapabilities_OperationLimits_MaxMonitoredItemsPerCall);
     UInteger maxNodesPerHistoryReadData =
-        read.apply(NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerHistoryReadData);
+        readNode(
+            client, NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerHistoryReadData);
     UInteger maxNodesPerHistoryReadEvents =
-        read.apply(NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerHistoryReadEvents);
+        readNode(
+            client, NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerHistoryReadEvents);
     UInteger maxNodesPerHistoryUpdateData =
-        read.apply(NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerHistoryUpdateData);
+        readNode(
+            client, NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerHistoryUpdateData);
     UInteger maxNodesPerHistoryUpdateEvents =
-        read.apply(
+        readNode(
+            client,
             NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerHistoryUpdateEvents);
     // checkstyle:on
 
@@ -282,6 +286,20 @@ public class OperationLimits {
         maxNodesPerHistoryReadEvents,
         maxNodesPerHistoryUpdateData,
         maxNodesPerHistoryUpdateEvents);
+  }
+
+  private static @Nullable UInteger readNode(OpcUaClient client, NodeId nodeId) throws UaException {
+    DataValue value = client.readValue(0.0, TimestampsToReturn.Neither, nodeId);
+
+    return toUInteger(value);
+  }
+
+  private static @Nullable UInteger toUInteger(@Nullable DataValue value) {
+    if (value == null || value.statusCode().isBad()) {
+      return null;
+    }
+
+    return toUInteger(value.value().value());
   }
 
   /**

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscription.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscription.java
@@ -31,6 +31,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -55,13 +56,14 @@ import org.eclipse.milo.opcua.stack.core.types.structured.DeleteSubscriptionsRes
 import org.eclipse.milo.opcua.stack.core.types.structured.EventFieldList;
 import org.eclipse.milo.opcua.stack.core.types.structured.ModifyMonitoredItemsResponse;
 import org.eclipse.milo.opcua.stack.core.types.structured.ModifySubscriptionResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.MonitoredItemCreateRequest;
 import org.eclipse.milo.opcua.stack.core.types.structured.MonitoredItemCreateResult;
+import org.eclipse.milo.opcua.stack.core.types.structured.MonitoredItemModifyRequest;
 import org.eclipse.milo.opcua.stack.core.types.structured.MonitoredItemModifyResult;
 import org.eclipse.milo.opcua.stack.core.types.structured.MonitoredItemNotification;
 import org.eclipse.milo.opcua.stack.core.types.structured.SetMonitoringModeResponse;
 import org.eclipse.milo.opcua.stack.core.types.structured.SetPublishingModeResponse;
 import org.eclipse.milo.opcua.stack.core.util.Lazy;
-import org.eclipse.milo.opcua.stack.core.util.Lists;
 import org.eclipse.milo.opcua.stack.core.util.TaskQueue;
 import org.eclipse.milo.opcua.stack.core.util.Unit;
 import org.jspecify.annotations.Nullable;
@@ -229,6 +231,7 @@ public class OpcUaSubscription {
 
   private volatile UInteger maxMonitoredItemsPerCall = uint(DEFAULT_MAX_MONITORED_ITEMS_PER_CALL);
   private final Lazy<UInteger> monitoredItemPartitionSize = new Lazy<>();
+  private volatile long monitoredItemPartitionGeneration;
 
   private volatile @Nullable Object userObject;
 
@@ -958,13 +961,12 @@ public class OpcUaSubscription {
       return Collections.emptyList();
     }
 
-    var serviceOperationsResults =
-        new ArrayList<MonitoredItemServiceOperationResult>(itemsToCreate.size());
-
-    ServerState serverState = this.serverState;
-    if (serverState == null) {
+    MonitoredItemOperationContext context = getMonitoredItemOperationContext();
+    if (context == null) {
       logger.debug("Bad_InvalidState: subscription not created yet");
 
+      var serviceOperationsResults =
+          new ArrayList<MonitoredItemServiceOperationResult>(itemsToCreate.size());
       for (OpcUaMonitoredItem item : itemsToCreate) {
         serviceOperationsResults.add(
             new MonitoredItemServiceOperationResult(
@@ -974,27 +976,46 @@ public class OpcUaSubscription {
       return serviceOperationsResults;
     }
 
-    UInteger partitionSize = getMonitoredItemPartitionSize();
+    return executeMonitoredItemPartitions(
+        itemsToCreate, context, partition -> createMonitoredItems(context, partition));
+  }
 
-    List<List<OpcUaMonitoredItem>> partitions =
-        Lists.partition(itemsToCreate, partitionSize.intValue()).toList();
+  private MonitoredItemPartitionAttempt createMonitoredItems(
+      MonitoredItemOperationContext context, List<OpcUaMonitoredItem> partition) {
 
-    for (List<OpcUaMonitoredItem> partition : partitions) {
-      try {
-        logger.debug(
-            "id={}, createMonitoredItems partition.size(): {}",
-            serverState.getSubscriptionId(),
-            partition.size());
+    List<MonitoredItemCreateRequest> itemsToCreate;
+    synchronized (lifecycleLock) {
+      if (incarnation != context.incarnation()) {
+        return invalidStateAttempt(partition, partition.size());
+      }
 
-        CreateMonitoredItemsResponse response =
-            client.createMonitoredItems(
-                serverState.getSubscriptionId(),
-                TimestampsToReturn.Both,
-                partition.stream()
-                    .map(OpcUaMonitoredItem::newCreateRequest)
-                    .collect(Collectors.toList()));
+      itemsToCreate =
+          partition.stream().map(OpcUaMonitoredItem::newCreateRequest).collect(Collectors.toList());
+    }
 
-        MonitoredItemCreateResult[] results = requireNonNull(response.getResults());
+    try {
+      logger.debug(
+          "id={}, createMonitoredItems partition.size(): {}",
+          context.serverState().getSubscriptionId(),
+          partition.size());
+
+      CreateMonitoredItemsResponse response =
+          client.createMonitoredItems(
+              context.serverState().getSubscriptionId(), TimestampsToReturn.Both, itemsToCreate);
+
+      MonitoredItemCreateResult[] results = response.getResults();
+      if (results == null || results.length != partition.size()) {
+        throw unexpectedResultCount(
+            "CreateMonitoredItems", results == null ? null : results.length, partition.size());
+      }
+
+      var serviceOperationResults =
+          new ArrayList<MonitoredItemServiceOperationResult>(results.length);
+
+      synchronized (lifecycleLock) {
+        if (incarnation != context.incarnation()) {
+          return invalidStateAttempt(partition, partition.size());
+        }
 
         for (int i = 0; i < results.length; i++) {
           MonitoredItemCreateResult result = results[i];
@@ -1002,19 +1023,31 @@ public class OpcUaSubscription {
 
           monitoredItem.applyCreateResult(result);
 
-          serviceOperationsResults.add(
+          serviceOperationResults.add(
               new MonitoredItemServiceOperationResult(
                   monitoredItem, StatusCode.GOOD, result.getStatusCode()));
         }
-      } catch (UaException e) {
-        for (OpcUaMonitoredItem item : partition) {
-          serviceOperationsResults.add(
-              new MonitoredItemServiceOperationResult(item, e.getStatusCode(), null));
+      }
+
+      return new MonitoredItemPartitionAttempt(serviceOperationResults, null, partition.size());
+    } catch (UaException e) {
+      synchronized (lifecycleLock) {
+        if (incarnation != context.incarnation()) {
+          return invalidStateAttempt(partition, partition.size());
         }
       }
-    }
 
-    return serviceOperationsResults;
+      var serviceOperationResults =
+          new ArrayList<MonitoredItemServiceOperationResult>(partition.size());
+
+      for (OpcUaMonitoredItem item : partition) {
+        serviceOperationResults.add(
+            new MonitoredItemServiceOperationResult(item, e.getStatusCode(), null));
+      }
+
+      return new MonitoredItemPartitionAttempt(
+          serviceOperationResults, e.getStatusCode(), partition.size());
+    }
   }
 
   /**
@@ -1038,11 +1071,10 @@ public class OpcUaSubscription {
   private List<MonitoredItemServiceOperationResult> modifyMonitoredItems(
       List<OpcUaMonitoredItem> itemsToModify) {
 
-    var serviceOperationsResults =
-        new ArrayList<MonitoredItemServiceOperationResult>(itemsToModify.size());
-
-    ServerState serverState = this.serverState;
-    if (serverState == null) {
+    MonitoredItemOperationContext context = getMonitoredItemOperationContext();
+    if (context == null) {
+      var serviceOperationsResults =
+          new ArrayList<MonitoredItemServiceOperationResult>(itemsToModify.size());
       for (OpcUaMonitoredItem item : itemsToModify) {
         serviceOperationsResults.add(
             new MonitoredItemServiceOperationResult(
@@ -1052,27 +1084,46 @@ public class OpcUaSubscription {
       return serviceOperationsResults;
     }
 
-    UInteger partitionSize = getMonitoredItemPartitionSize();
+    return executeMonitoredItemPartitions(
+        itemsToModify, context, partition -> modifyMonitoredItems(context, partition));
+  }
 
-    List<List<OpcUaMonitoredItem>> partitions =
-        Lists.partition(itemsToModify, partitionSize.intValue()).toList();
+  private MonitoredItemPartitionAttempt modifyMonitoredItems(
+      MonitoredItemOperationContext context, List<OpcUaMonitoredItem> partition) {
 
-    for (List<OpcUaMonitoredItem> partition : partitions) {
-      try {
-        logger.debug(
-            "id={}, modifyMonitoredItems partition.size(): {}",
-            serverState.subscriptionId,
-            partition.size());
+    List<MonitoredItemModifyRequest> itemsToModify;
+    synchronized (lifecycleLock) {
+      if (incarnation != context.incarnation()) {
+        return invalidStateAttempt(partition, partition.size());
+      }
 
-        ModifyMonitoredItemsResponse response =
-            client.modifyMonitoredItems(
-                serverState.getSubscriptionId(),
-                TimestampsToReturn.Both,
-                partition.stream()
-                    .map(OpcUaMonitoredItem::newModifyRequest)
-                    .collect(Collectors.toList()));
+      itemsToModify =
+          partition.stream().map(OpcUaMonitoredItem::newModifyRequest).collect(Collectors.toList());
+    }
 
-        MonitoredItemModifyResult[] results = requireNonNull(response.getResults());
+    try {
+      logger.debug(
+          "id={}, modifyMonitoredItems partition.size(): {}",
+          context.serverState().subscriptionId,
+          partition.size());
+
+      ModifyMonitoredItemsResponse response =
+          client.modifyMonitoredItems(
+              context.serverState().getSubscriptionId(), TimestampsToReturn.Both, itemsToModify);
+
+      MonitoredItemModifyResult[] results = response.getResults();
+      if (results == null || results.length != partition.size()) {
+        throw unexpectedResultCount(
+            "ModifyMonitoredItems", results == null ? null : results.length, partition.size());
+      }
+
+      var serviceOperationResults =
+          new ArrayList<MonitoredItemServiceOperationResult>(results.length);
+
+      synchronized (lifecycleLock) {
+        if (incarnation != context.incarnation()) {
+          return invalidStateAttempt(partition, partition.size());
+        }
 
         for (int i = 0; i < results.length; i++) {
           MonitoredItemModifyResult result = results[i];
@@ -1080,19 +1131,31 @@ public class OpcUaSubscription {
 
           monitoredItem.applyModifyResult(result);
 
-          serviceOperationsResults.add(
+          serviceOperationResults.add(
               new MonitoredItemServiceOperationResult(
                   monitoredItem, StatusCode.GOOD, result.getStatusCode()));
         }
-      } catch (UaException e) {
-        for (OpcUaMonitoredItem item : partition) {
-          serviceOperationsResults.add(
-              new MonitoredItemServiceOperationResult(item, e.getStatusCode(), null));
+      }
+
+      return new MonitoredItemPartitionAttempt(serviceOperationResults, null, partition.size());
+    } catch (UaException e) {
+      synchronized (lifecycleLock) {
+        if (incarnation != context.incarnation()) {
+          return invalidStateAttempt(partition, partition.size());
         }
       }
-    }
 
-    return serviceOperationsResults;
+      var serviceOperationResults =
+          new ArrayList<MonitoredItemServiceOperationResult>(partition.size());
+
+      for (OpcUaMonitoredItem item : partition) {
+        serviceOperationResults.add(
+            new MonitoredItemServiceOperationResult(item, e.getStatusCode(), null));
+      }
+
+      return new MonitoredItemPartitionAttempt(
+          serviceOperationResults, e.getStatusCode(), partition.size());
+    }
   }
 
   /**
@@ -1132,11 +1195,10 @@ public class OpcUaSubscription {
   private List<MonitoredItemServiceOperationResult> deleteMonitoredItems(
       List<OpcUaMonitoredItem> itemsToDelete) {
 
-    var serviceOperationsResults =
-        new ArrayList<MonitoredItemServiceOperationResult>(itemsToDelete.size());
-
-    ServerState serverState = this.serverState;
-    if (serverState == null) {
+    MonitoredItemOperationContext context = getMonitoredItemOperationContext();
+    if (context == null) {
+      var serviceOperationsResults =
+          new ArrayList<MonitoredItemServiceOperationResult>(itemsToDelete.size());
       for (OpcUaMonitoredItem item : itemsToDelete) {
         serviceOperationsResults.add(
             new MonitoredItemServiceOperationResult(
@@ -1146,17 +1208,22 @@ public class OpcUaSubscription {
       return serviceOperationsResults;
     }
 
-    UInteger partitionSize = getMonitoredItemPartitionSize();
+    return executeMonitoredItemPartitions(
+        itemsToDelete, context, partition -> deleteMonitoredItems(context, partition));
+  }
 
-    List<List<OpcUaMonitoredItem>> partitions =
-        Lists.partition(itemsToDelete, partitionSize.intValue()).toList();
+  private MonitoredItemPartitionAttempt deleteMonitoredItems(
+      MonitoredItemOperationContext context, List<OpcUaMonitoredItem> partition) {
 
-    for (List<OpcUaMonitoredItem> partition : partitions) {
-      // Server state may be cleared concurrently, so read each item id only once.
-      //noinspection DuplicatedCode
-      var monitoredItemIds = new ArrayList<UInteger>(partition.size());
-      var itemIds = new ArrayList<Optional<UInteger>>(partition.size());
-      var clientHandles = new ArrayList<Optional<UInteger>>(partition.size());
+    // Server state may be cleared concurrently, so read each item id only once.
+    var monitoredItemIds = new ArrayList<UInteger>(partition.size());
+    var itemIds = new ArrayList<Optional<UInteger>>(partition.size());
+    var clientHandles = new ArrayList<Optional<UInteger>>(partition.size());
+
+    synchronized (lifecycleLock) {
+      if (incarnation != context.incarnation()) {
+        return invalidStateAttempt(partition, 0);
+      }
 
       synchronized (monitoredItemsLock) {
         for (OpcUaMonitoredItem item : partition) {
@@ -1167,27 +1234,45 @@ public class OpcUaSubscription {
           itemId.ifPresent(monitoredItemIds::add);
         }
       }
+    }
 
-      if (monitoredItemIds.isEmpty()) {
-        for (OpcUaMonitoredItem item : partition) {
-          serviceOperationsResults.add(
-              new MonitoredItemServiceOperationResult(
-                  item, new StatusCode(StatusCodes.Bad_InvalidState), null));
-        }
+    if (monitoredItemIds.isEmpty()) {
+      var serviceOperationResults =
+          new ArrayList<MonitoredItemServiceOperationResult>(partition.size());
 
-        continue;
+      for (OpcUaMonitoredItem item : partition) {
+        serviceOperationResults.add(
+            new MonitoredItemServiceOperationResult(
+                item, new StatusCode(StatusCodes.Bad_InvalidState), null));
       }
 
-      try {
-        logger.debug(
-            "id={}, deleteMonitoredItems partition.size(): {}",
-            serverState.subscriptionId,
-            partition.size());
+      return new MonitoredItemPartitionAttempt(serviceOperationResults, null, 0);
+    }
 
-        DeleteMonitoredItemsResponse response =
-            client.deleteMonitoredItems(serverState.getSubscriptionId(), monitoredItemIds);
+    try {
+      logger.debug(
+          "id={}, deleteMonitoredItems partition.size(): {}",
+          context.serverState().subscriptionId,
+          partition.size());
 
-        StatusCode[] results = requireNonNull(response.getResults());
+      DeleteMonitoredItemsResponse response =
+          client.deleteMonitoredItems(context.serverState().getSubscriptionId(), monitoredItemIds);
+
+      StatusCode[] results = response.getResults();
+      if (results == null || results.length != monitoredItemIds.size()) {
+        throw unexpectedResultCount(
+            "DeleteMonitoredItems",
+            results == null ? null : results.length,
+            monitoredItemIds.size());
+      }
+
+      var serviceOperationResults =
+          new ArrayList<MonitoredItemServiceOperationResult>(partition.size());
+
+      synchronized (lifecycleLock) {
+        if (incarnation != context.incarnation()) {
+          return invalidStateAttempt(partition, monitoredItemIds.size());
+        }
 
         int resultIndex = 0;
         for (int i = 0; i < partition.size(); i++) {
@@ -1198,31 +1283,44 @@ public class OpcUaSubscription {
 
             applyMonitoredItemDeleteResult(item, clientHandles.get(i), result);
 
-            serviceOperationsResults.add(
+            serviceOperationResults.add(
                 new MonitoredItemServiceOperationResult(item, StatusCode.GOOD, result));
           } else {
-            serviceOperationsResults.add(
-                new MonitoredItemServiceOperationResult(
-                    item, new StatusCode(StatusCodes.Bad_InvalidState), null));
-          }
-        }
-      } catch (UaException e) {
-        for (int i = 0; i < partition.size(); i++) {
-          OpcUaMonitoredItem item = partition.get(i);
-
-          if (itemIds.get(i).isPresent()) {
-            serviceOperationsResults.add(
-                new MonitoredItemServiceOperationResult(item, e.getStatusCode(), null));
-          } else {
-            serviceOperationsResults.add(
+            serviceOperationResults.add(
                 new MonitoredItemServiceOperationResult(
                     item, new StatusCode(StatusCodes.Bad_InvalidState), null));
           }
         }
       }
-    }
 
-    return serviceOperationsResults;
+      return new MonitoredItemPartitionAttempt(
+          serviceOperationResults, null, monitoredItemIds.size());
+    } catch (UaException e) {
+      synchronized (lifecycleLock) {
+        if (incarnation != context.incarnation()) {
+          return invalidStateAttempt(partition, monitoredItemIds.size());
+        }
+      }
+
+      var serviceOperationResults =
+          new ArrayList<MonitoredItemServiceOperationResult>(partition.size());
+
+      for (int i = 0; i < partition.size(); i++) {
+        OpcUaMonitoredItem item = partition.get(i);
+
+        if (itemIds.get(i).isPresent()) {
+          serviceOperationResults.add(
+              new MonitoredItemServiceOperationResult(item, e.getStatusCode(), null));
+        } else {
+          serviceOperationResults.add(
+              new MonitoredItemServiceOperationResult(
+                  item, new StatusCode(StatusCodes.Bad_InvalidState), null));
+        }
+      }
+
+      return new MonitoredItemPartitionAttempt(
+          serviceOperationResults, e.getStatusCode(), monitoredItemIds.size());
+    }
   }
 
   /**
@@ -1257,6 +1355,95 @@ public class OpcUaSubscription {
     }
   }
 
+  private List<MonitoredItemServiceOperationResult> executeMonitoredItemPartitions(
+      List<OpcUaMonitoredItem> items,
+      MonitoredItemOperationContext context,
+      Function<List<OpcUaMonitoredItem>, MonitoredItemPartitionAttempt> operation) {
+
+    var serviceOperationResults = new ArrayList<MonitoredItemServiceOperationResult>(items.size());
+
+    long partitionGeneration = monitoredItemPartitionGeneration;
+    int partitionSize = getMonitoredItemPartitionSize().intValue();
+    if (partitionSize == 0) {
+      throw new IllegalArgumentException("maxMonitoredItemsPerCall must be greater than zero");
+    }
+
+    int partitionStart = 0;
+
+    while (partitionStart < items.size()) {
+      synchronized (lifecycleLock) {
+        if (incarnation != context.incarnation()) {
+          serviceOperationResults.addAll(
+              invalidStateAttempt(items.subList(partitionStart, items.size()), 0).results());
+          break;
+        }
+      }
+
+      int remaining = items.size() - partitionStart;
+      int partitionEnd = partitionStart + Math.min(partitionSize, remaining);
+      List<OpcUaMonitoredItem> partition = items.subList(partitionStart, partitionEnd);
+
+      MonitoredItemPartitionAttempt attempt = operation.apply(partition);
+
+      if (attempt.operationCount() > 1
+          && attempt.serviceResult() != null
+          && attempt.serviceResult().value() == StatusCodes.Bad_TooManyOperations) {
+
+        synchronized (lifecycleLock) {
+          if (incarnation != context.incarnation()) {
+            serviceOperationResults.addAll(
+                invalidStateAttempt(items.subList(partitionStart, items.size()), 0).results());
+            break;
+          }
+
+          synchronized (monitoredItemPartitionSize) {
+            if (monitoredItemPartitionGeneration == partitionGeneration) {
+              monitoredItemPartitionSize.set(uint(1));
+            }
+          }
+        }
+
+        partitionSize = 1;
+      } else {
+        serviceOperationResults.addAll(attempt.results());
+        partitionStart = partitionEnd;
+      }
+    }
+
+    return serviceOperationResults;
+  }
+
+  private @Nullable MonitoredItemOperationContext getMonitoredItemOperationContext() {
+    synchronized (lifecycleLock) {
+      ServerState serverState = this.serverState;
+      return serverState != null
+          ? new MonitoredItemOperationContext(serverState, incarnation)
+          : null;
+    }
+  }
+
+  private static MonitoredItemPartitionAttempt invalidStateAttempt(
+      List<OpcUaMonitoredItem> items, int operationCount) {
+
+    var results = new ArrayList<MonitoredItemServiceOperationResult>(items.size());
+    StatusCode statusCode = new StatusCode(StatusCodes.Bad_InvalidState);
+
+    for (OpcUaMonitoredItem item : items) {
+      results.add(new MonitoredItemServiceOperationResult(item, statusCode, null));
+    }
+
+    return new MonitoredItemPartitionAttempt(results, statusCode, operationCount);
+  }
+
+  private static UaException unexpectedResultCount(
+      String serviceName, @Nullable Integer actual, int expected) {
+
+    return new UaException(
+        StatusCodes.Bad_UnexpectedError,
+        "%s returned %s results, expected %s"
+            .formatted(serviceName, actual == null ? "null" : actual, expected));
+  }
+
   private UInteger getMonitoredItemPartitionSize() {
     return monitoredItemPartitionSize.get(
         () -> {
@@ -1278,6 +1465,13 @@ public class OpcUaSubscription {
           return uint(Math.min(configuredMax, serverMax));
         });
   }
+
+  private record MonitoredItemPartitionAttempt(
+      List<MonitoredItemServiceOperationResult> results,
+      @Nullable StatusCode serviceResult,
+      int operationCount) {}
+
+  private record MonitoredItemOperationContext(ServerState serverState, long incarnation) {}
 
   // endregion
 
@@ -1302,11 +1496,10 @@ public class OpcUaSubscription {
       return Collections.emptyList();
     }
 
-    var serviceOperationResults =
-        new ArrayList<MonitoredItemServiceOperationResult>(monitoredItems.size());
-
-    ServerState serverState = this.serverState;
-    if (serverState == null) {
+    MonitoredItemOperationContext context = getMonitoredItemOperationContext();
+    if (context == null) {
+      var serviceOperationResults =
+          new ArrayList<MonitoredItemServiceOperationResult>(monitoredItems.size());
       for (OpcUaMonitoredItem item : monitoredItems) {
         serviceOperationResults.add(
             new MonitoredItemServiceOperationResult(
@@ -1315,16 +1508,25 @@ public class OpcUaSubscription {
       return serviceOperationResults;
     }
 
-    UInteger partitionSize = getMonitoredItemPartitionSize();
+    return executeMonitoredItemPartitions(
+        monitoredItems,
+        context,
+        partition -> setMonitoringMode(context, monitoringMode, partition));
+  }
 
-    List<List<OpcUaMonitoredItem>> partitions =
-        Lists.partition(monitoredItems, partitionSize.intValue()).toList();
+  private MonitoredItemPartitionAttempt setMonitoringMode(
+      MonitoredItemOperationContext context,
+      MonitoringMode monitoringMode,
+      List<OpcUaMonitoredItem> partition) {
 
-    for (List<OpcUaMonitoredItem> partition : partitions) {
-      // Server state may be cleared concurrently, so read each item id only once.
-      //noinspection DuplicatedCode
-      var monitoredItemIds = new ArrayList<UInteger>(partition.size());
-      var itemIds = new ArrayList<Optional<UInteger>>(partition.size());
+    // Server state may be cleared concurrently, so read each item id only once.
+    var monitoredItemIds = new ArrayList<UInteger>(partition.size());
+    var itemIds = new ArrayList<Optional<UInteger>>(partition.size());
+
+    synchronized (lifecycleLock) {
+      if (incarnation != context.incarnation()) {
+        return invalidStateAttempt(partition, 0);
+      }
 
       for (OpcUaMonitoredItem item : partition) {
         Optional<UInteger> itemId = item.getMonitoredItemId();
@@ -1332,28 +1534,44 @@ public class OpcUaSubscription {
         itemIds.add(itemId);
         itemId.ifPresent(monitoredItemIds::add);
       }
+    }
 
-      if (monitoredItemIds.isEmpty()) {
-        for (OpcUaMonitoredItem item : partition) {
-          serviceOperationResults.add(
-              new MonitoredItemServiceOperationResult(
-                  item, new StatusCode(StatusCodes.Bad_InvalidState), null));
-        }
+    if (monitoredItemIds.isEmpty()) {
+      var serviceOperationResults =
+          new ArrayList<MonitoredItemServiceOperationResult>(partition.size());
 
-        continue;
+      for (OpcUaMonitoredItem item : partition) {
+        serviceOperationResults.add(
+            new MonitoredItemServiceOperationResult(
+                item, new StatusCode(StatusCodes.Bad_InvalidState), null));
       }
 
-      try {
-        logger.debug(
-            "id={}, setMonitoringMode partition.size(): {}",
-            serverState.subscriptionId,
-            partition.size());
+      return new MonitoredItemPartitionAttempt(serviceOperationResults, null, 0);
+    }
 
-        SetMonitoringModeResponse response =
-            client.setMonitoringMode(
-                serverState.getSubscriptionId(), monitoringMode, monitoredItemIds);
+    try {
+      logger.debug(
+          "id={}, setMonitoringMode partition.size(): {}",
+          context.serverState().subscriptionId,
+          partition.size());
 
-        StatusCode[] results = requireNonNull(response.getResults());
+      SetMonitoringModeResponse response =
+          client.setMonitoringMode(
+              context.serverState().getSubscriptionId(), monitoringMode, monitoredItemIds);
+
+      StatusCode[] results = response.getResults();
+      if (results == null || results.length != monitoredItemIds.size()) {
+        throw unexpectedResultCount(
+            "SetMonitoringMode", results == null ? null : results.length, monitoredItemIds.size());
+      }
+
+      var serviceOperationResults =
+          new ArrayList<MonitoredItemServiceOperationResult>(partition.size());
+
+      synchronized (lifecycleLock) {
+        if (incarnation != context.incarnation()) {
+          return invalidStateAttempt(partition, monitoredItemIds.size());
+        }
 
         int resultIndex = 0;
         for (int i = 0; i < partition.size(); i++) {
@@ -1374,12 +1592,27 @@ public class OpcUaSubscription {
                     item, new StatusCode(StatusCodes.Bad_InvalidState), null));
           }
         }
-      } catch (UaException e) {
+      }
+
+      return new MonitoredItemPartitionAttempt(
+          serviceOperationResults, null, monitoredItemIds.size());
+    } catch (UaException e) {
+      var serviceOperationResults =
+          new ArrayList<MonitoredItemServiceOperationResult>(partition.size());
+
+      synchronized (lifecycleLock) {
+        if (incarnation != context.incarnation()) {
+          return invalidStateAttempt(partition, monitoredItemIds.size());
+        }
+
         for (int i = 0; i < partition.size(); i++) {
           OpcUaMonitoredItem item = partition.get(i);
 
           if (itemIds.get(i).isPresent()) {
-            item.applySetMonitoringModeResult(e.getStatusCode());
+            if (monitoredItemIds.size() == 1
+                || e.getStatusCode().value() != StatusCodes.Bad_TooManyOperations) {
+              item.applySetMonitoringModeResult(e.getStatusCode());
+            }
 
             serviceOperationResults.add(
                 new MonitoredItemServiceOperationResult(item, e.getStatusCode(), null));
@@ -1390,9 +1623,10 @@ public class OpcUaSubscription {
           }
         }
       }
-    }
 
-    return serviceOperationResults;
+      return new MonitoredItemPartitionAttempt(
+          serviceOperationResults, e.getStatusCode(), monitoredItemIds.size());
+    }
   }
 
   // endregion
@@ -1911,10 +2145,13 @@ public class OpcUaSubscription {
    *     created/modified/deleted in a single service call.
    */
   public void setMaxMonitoredItemsPerCall(UInteger maxMonitoredItemsPerCall) {
-    this.maxMonitoredItemsPerCall = maxMonitoredItemsPerCall;
+    synchronized (monitoredItemPartitionSize) {
+      this.maxMonitoredItemsPerCall = maxMonitoredItemsPerCall;
+      monitoredItemPartitionGeneration++;
 
-    // next service call will re-calculate the partition size
-    monitoredItemPartitionSize.reset();
+      // next service call will re-calculate the partition size
+      monitoredItemPartitionSize.reset();
+    }
   }
 
   /**

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/typetree/ClientBrowseUtils.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/typetree/ClientBrowseUtils.java
@@ -12,9 +12,9 @@ package org.eclipse.milo.opcua.sdk.client.typetree;
 
 import static java.util.Objects.requireNonNullElse;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
-import static org.eclipse.milo.opcua.stack.core.util.Lists.partition;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -113,25 +113,31 @@ final class ClientBrowseUtils {
     int partitionSize =
         limits
             .maxNodesPerRead()
-            .map(UInteger::intValue)
+            .map(ClientBrowseUtils::toPartitionSize)
             .filter(v -> v > 0)
-            .orElse(Integer.MAX_VALUE);
+            .orElse(1);
 
-    var values = new ArrayList<DataValue>();
+    return executeWithOperationLimit(
+        readValueIds,
+        partitionSize,
+        partitionList -> {
+          ReadResponse response;
+          try {
+            response = client.read(0.0, TimestampsToReturn.Neither, partitionList);
+          } catch (UaException e) {
+            throw retryableTooManyOperations(partitionList, e);
+          }
 
-    for (List<ReadValueId> partitionList : partition(readValueIds, partitionSize).toList()) {
-      ReadResponse response = client.read(0.0, TimestampsToReturn.Neither, partitionList);
-      DataValue[] results = response.getResults();
-      if (results == null || results.length != partitionList.size()) {
-        throw new UaException(
-            StatusCodes.Bad_UnexpectedError,
-            "Read returned %s results, expected %s"
-                .formatted(results == null ? "null" : results.length, partitionList.size()));
-      }
-      Collections.addAll(values, results);
-    }
+          DataValue[] results = response.getResults();
+          if (results == null || results.length != partitionList.size()) {
+            throw new UaException(
+                StatusCodes.Bad_UnexpectedError,
+                "Read returned %s results, expected %s"
+                    .formatted(results == null ? "null" : results.length, partitionList.size()));
+          }
 
-    return values;
+          return Arrays.asList(results);
+        });
   }
 
   /**
@@ -156,18 +162,62 @@ final class ClientBrowseUtils {
     int partitionSize =
         limits
             .maxNodesPerBrowse()
-            .map(UInteger::intValue)
+            .map(ClientBrowseUtils::toPartitionSize)
             .filter(v -> v > 0)
-            .orElse(Integer.MAX_VALUE);
+            .orElse(1);
 
-    var references = new ArrayList<List<ReferenceDescription>>();
+    return executeWithOperationLimit(
+        browseDescriptions, partitionSize, partitionList -> browsePartition(client, partitionList));
+  }
 
-    for (List<BrowseDescription> partitionList :
-        partition(browseDescriptions, partitionSize).toList()) {
-      references.addAll(browse(client, partitionList));
+  private static int toPartitionSize(UInteger operationLimit) {
+    return (int) Math.min(operationLimit.longValue(), Integer.MAX_VALUE);
+  }
+
+  private static <T, R> List<R> executeWithOperationLimit(
+      List<T> inputs, int partitionSize, PartitionOperation<T, R> operation) throws UaException {
+
+    var results = new ArrayList<R>(inputs.size());
+
+    int index = 0;
+    int currentPartitionSize = partitionSize;
+
+    while (index < inputs.size()) {
+      int count = Math.min(currentPartitionSize, inputs.size() - index);
+      List<T> partitionList = inputs.subList(index, index + count);
+
+      try {
+        results.addAll(operation.apply(partitionList));
+        index += count;
+      } catch (RetryableTooManyOperationsException e) {
+        currentPartitionSize = 1;
+      }
     }
 
-    return references;
+    return results;
+  }
+
+  @FunctionalInterface
+  private interface PartitionOperation<T, R> {
+
+    List<R> apply(List<T> partitionList) throws UaException;
+  }
+
+  private static UaException retryableTooManyOperations(List<?> partition, UaException failure) {
+    if (partition.size() > 1
+        && failure.getStatusCode().value() == StatusCodes.Bad_TooManyOperations) {
+
+      return new RetryableTooManyOperationsException(failure);
+    }
+
+    return failure;
+  }
+
+  private static final class RetryableTooManyOperationsException extends UaException {
+
+    private RetryableTooManyOperationsException(UaException cause) {
+      super(cause);
+    }
   }
 
   /**
@@ -185,15 +235,38 @@ final class ClientBrowseUtils {
       return List.of();
     }
 
-    final var referenceDescriptionLists = new ArrayList<List<ReferenceDescription>>();
-
     List<BrowseResult> browseResults = client.browse(browseDescriptions);
+
+    return collectBrowseResults(client, browseDescriptions, browseResults);
+  }
+
+  private static List<List<ReferenceDescription>> browsePartition(
+      OpcUaClient client, List<BrowseDescription> browseDescriptions) throws UaException {
+
+    List<BrowseResult> browseResults;
+    try {
+      browseResults = client.browse(browseDescriptions);
+    } catch (UaException e) {
+      throw retryableTooManyOperations(browseDescriptions, e);
+    }
+
+    return collectBrowseResults(client, browseDescriptions, browseResults);
+  }
+
+  private static List<List<ReferenceDescription>> collectBrowseResults(
+      OpcUaClient client,
+      List<BrowseDescription> browseDescriptions,
+      List<BrowseResult> browseResults)
+      throws UaException {
+
     if (browseResults.size() != browseDescriptions.size()) {
       throw new UaException(
           StatusCodes.Bad_UnexpectedError,
           "Browse returned %d results, expected %d"
               .formatted(browseResults.size(), browseDescriptions.size()));
     }
+
+    final var referenceDescriptionLists = new ArrayList<List<ReferenceDescription>>();
 
     for (BrowseResult result : browseResults) {
       if (result.getStatusCode().isGood()) {


### PR DESCRIPTION
A server that omits the OperationLimits nodes, or enforces a lower limit than it advertises, rejects batched requests with `Bad_TooManyOperations`. Milo's client-owned batching had no answer to that. The type-tree builders treated an absent limit as unlimited and put every operation in one request, so building the DataTypeTree failed outright against such a server. That is the 1.1.6 failure that prompted this. The session bootstrap's two-node NamespaceArray and ServerArray Read failed silently and left both local tables at their initial values. Monitored-item operations reported every item in a rejected partition as failed and moved on.

This makes each SDK-owned batching path recover, and keeps the recovery inside those paths. The raw `OpcUaClient` service methods still send exactly what they are given; changing that would alter request identity, timeouts and response semantics for every caller.

- **OperationLimits discovery** propagates service failures from the singleton fallback instead of caching them as absent limits, validates the bulk result count, and is cleared by the session initializer so a reconnect cannot reuse limits read from a previous session.
- **Session bootstrap** keeps the two-node Read as the fast path and, on exact `Bad_TooManyOperations`, reads NamespaceArray and ServerArray in two independent one-node requests. Other failures stay best-effort and are not retried.
- **Type-tree Read and Browse** treat an absent or zero limit as one operation per request, convert advertised UInt32 values without overflowing, and on a rejected multi-operation partition replay it and the rest of the call as singletons, preserving order.
- **Monitored-item Create, Modify, Delete and SetMonitoringMode** share one partition loop that replays a rejected multi-operation request as singletons and records one as the partition size for the rest of the subscription incarnation. `reset()` and `setMaxMonitoredItemsPerCall()` clear the learned value as they already did the advertised one. These paths also now check the subscription incarnation before applying a response, so a reply that lands after a concurrent reset is reported as `Bad_InvalidState` rather than applied to the replacement subscription.

In every path only an exact service-level `Bad_TooManyOperations` on a request with more than one operation triggers a retry. The recovery target is one, not the rejected size minus one and not a probe. It is the only size every server must accept, and it keeps the interim behavior deterministic. A timeout, channel loss, operation-level failure, or a rejected singleton is reported as before, since replaying Create or Delete after an ambiguous failure could duplicate or contradict server state.

Deliberately left out: `AddressSpace.readAttributes()`, `UaNode.refresh()` and `UaNode.synchronize()` are also SDK-owned compound Reads and Writes, but they belong with a broader async batching and configuration design. `SetTriggering` has no higher-level batching owner. Per-service client configuration and carrying a learned type-tree limit across calls remain future work.

## Testing

`OperationLimitsTest` and `ClientBrowseUtilsTest` gain mock-backed cases for property order, failure propagation, absent versus failed values, result cardinality, order-preserving fallback, and the no-retry cases. `SessionInitializerOperationLimitTest` and `MonitoredItemOperationLimitFallbackTest` run against a real in-process server behind a delegating service set that rejects the exact requests under test and records what was sent, so they check both the retry shape and the client state produced by the accepted responses.

Verification:

- `mise exec -- mvn -q spotless:apply` (no changes)
- `mise exec -- mvn -q clean compile`
- `mise exec -- mvn -q -pl opc-ua-sdk/integration-tests -am test -Dtest=OperationLimitsTest,SessionInitializerOperationLimitTest,ClientBrowseUtilsTest,DataTypeTreeBuilderTest,ObjectTypeTreeBuilderTest,VariableTypeTreeBuilderTest,LazyClientDataTypeTreeTest,MonitoredItemOperationLimitFallbackTest,OpcUaSubscriptionTest` (82 tests, all pass)
- `mise exec -- mvn -q clean verify` (full suite, all pass)
