### PR TITLE
Preserve server startup cleanup and shutdown ordering

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/LifecycleManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/LifecycleManager.java
@@ -11,6 +11,8 @@
 package org.eclipse.milo.opcua.sdk.server;
 
 import com.google.common.collect.Lists;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
@@ -22,6 +24,10 @@ import java.util.concurrent.CopyOnWriteArrayList;
  *
  * <p>The order that sub-Lifecycles are shutdown can be controlled with the optional {@link
  * ShutdownOrder} parameter provided in {@link LifecycleManager#LifecycleManager(ShutdownOrder)}.
+ *
+ * <p>If a child fails during startup, successfully started children are shut down in reverse order.
+ * Cleanup failures are suppressed on the original startup failure. The failing child remains
+ * responsible for cleaning up resources acquired by its own incomplete startup.
  */
 public final class LifecycleManager extends AbstractLifecycle {
 
@@ -48,7 +54,24 @@ public final class LifecycleManager extends AbstractLifecycle {
 
   @Override
   protected void onStartup() {
-    lifecycles.forEach(Lifecycle::startup);
+    List<Lifecycle> started = new ArrayList<>();
+    try {
+      for (Lifecycle lifecycle : lifecycles) {
+        lifecycle.startup();
+        started.add(lifecycle);
+      }
+    } catch (Throwable startupFailure) {
+      for (int i = started.size() - 1; i >= 0; i--) {
+        try {
+          started.get(i).shutdown();
+        } catch (Throwable cleanupFailure) {
+          if (cleanupFailure != startupFailure) {
+            startupFailure.addSuppressed(cleanupFailure);
+          }
+        }
+      }
+      throw startupFailure;
+    }
   }
 
   @Override

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServer.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServer.java
@@ -201,17 +201,18 @@ public class OpcUaServer extends AbstractServiceHandler {
 
   private final Map<TransportProfile, OpcServerTransport> transports = new ConcurrentHashMap<>();
 
-  // lifecycleState, startupFuture, and shutdownFuture are guarded by lifecycleLock.
+  // lifecycleState and the lifecycle futures are guarded by lifecycleLock.
   // lifecycleParticipants is mutated under the lock and only while state is NEW, so the startup
   // thread may iterate it unlocked once the state leaves NEW and registration is closed.
   // startedParticipants is confined to the thread executing startup; teardown reads it only after
-  // startupFuture completes, which orders the accesses.
+  // the private startupCompletion completes, which orders the accesses.
   private final Object lifecycleLock = new Object();
   private final List<Lifecycle> lifecycleParticipants = new ArrayList<>();
   private final List<Lifecycle> startedParticipants = new ArrayList<>();
 
   private ServerLifecycleState lifecycleState = ServerLifecycleState.NEW;
   private @Nullable CompletableFuture<OpcUaServer> startupFuture;
+  private @Nullable CompletableFuture<OpcUaServer> startupCompletion;
   private @Nullable CompletableFuture<OpcUaServer> shutdownFuture;
 
   private final EventBus eventBus = new EventBus("server");
@@ -384,6 +385,8 @@ public class OpcUaServer extends AbstractServiceHandler {
    *
    * <p>Startup is single-flight. Concurrent or subsequent calls return the same future. Once
    * startup begins, the server is terminal: a failed or shut-down server cannot be started again.
+   * Cancelling or completing the returned future does not stop startup or release shutdown's wait
+   * for the startup work to finish.
    *
    * <p>A {@link #shutdown()} requested before endpoints are bound abandons startup and fails this
    * future; a later request lets startup complete and then tears the server down.
@@ -392,6 +395,7 @@ public class OpcUaServer extends AbstractServiceHandler {
    */
   public CompletableFuture<OpcUaServer> startup() {
     CompletableFuture<OpcUaServer> future;
+    CompletableFuture<OpcUaServer> result;
 
     synchronized (lifecycleLock) {
       if (startupFuture != null) {
@@ -405,7 +409,10 @@ public class OpcUaServer extends AbstractServiceHandler {
       }
 
       lifecycleState = ServerLifecycleState.STARTING;
-      startupFuture = future = new CompletableFuture<>();
+      startupCompletion = future = new CompletableFuture<>();
+      // The public result may be cancelled or completed by a caller. Only the private future
+      // establishes when shutdown can safely inspect participants and release core facilities.
+      startupFuture = result = future.copy();
     }
 
     try {
@@ -432,7 +439,7 @@ public class OpcUaServer extends AbstractServiceHandler {
       future.completeExceptionally(t);
     }
 
-    return future;
+    return result;
   }
 
   private void startupInternal() throws UaException {
@@ -614,7 +621,7 @@ public class OpcUaServer extends AbstractServiceHandler {
       }
 
       shutdownFuture = newShutdownFuture = new CompletableFuture<>();
-      startupToAwait = startupFuture;
+      startupToAwait = startupCompletion;
       lifecycleState = ServerLifecycleState.SHUTTING_DOWN;
     }
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServer.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServer.java
@@ -412,7 +412,7 @@ public class OpcUaServer extends AbstractServiceHandler {
       startupCompletion = future = new CompletableFuture<>();
       // The public result may be cancelled or completed by a caller. Only the private future
       // establishes when shutdown can safely inspect participants and release core facilities.
-      startupFuture = result = future.copy();
+      startupFuture = result = new CompletableFuture<>();
     }
 
     try {
@@ -427,6 +427,7 @@ public class OpcUaServer extends AbstractServiceHandler {
       }
 
       future.complete(this);
+      result.complete(this);
     } catch (Throwable t) {
       rollbackStartup(t);
 
@@ -437,6 +438,7 @@ public class OpcUaServer extends AbstractServiceHandler {
       }
 
       future.completeExceptionally(t);
+      result.completeExceptionally(t);
     }
 
     return result;

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/package-info.java
@@ -44,7 +44,14 @@
  * reverse-connect endpoints. Startup rollback and terminal shutdown stop only successfully started
  * participants, in reverse order. On normal shutdown, transports and sessions are quiesced first;
  * participant shutdown therefore runs without external server visibility but before the standard
- * address space and event facilities are torn down.
+ * address space and event facilities are torn down. Shutdown waits for the actual startup work,
+ * even if an application cancels or completes the public startup result.
+ *
+ * <p>{@link org.eclipse.milo.opcua.sdk.server.LifecycleManager} applies the same ownership rule
+ * within composite components: failed child startup unwinds successfully started children in
+ * reverse order. A managed namespace therefore releases its base address-space registrations when a
+ * later child fails. Each failing child cleans up its own partial startup before propagating the
+ * failure.
  *
  * <h2>Runtime boundaries</h2>
  *

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/LifecycleManagerTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/LifecycleManagerTest.java
@@ -11,11 +11,64 @@
 package org.eclipse.milo.opcua.sdk.server;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 public class LifecycleManagerTest {
+
+  // Startup failure must unwind acquired children even though subsequent shutdown is a no-op.
+  @ParameterizedTest
+  @EnumSource(LifecycleManager.ShutdownOrder.class)
+  void failedStartupRollsBackSuccessfulChildren(LifecycleManager.ShutdownOrder order) {
+    var manager = new LifecycleManager(order);
+    var events = new ArrayList<String>();
+    var startupFailure = new IllegalStateException("startup");
+    var cleanupFailure = new IllegalStateException("cleanup");
+    manager.addLifecycle(recordingLifecycle("a", events, null, null));
+    manager.addLifecycle(recordingLifecycle("b", events, null, cleanupFailure));
+    manager.addLifecycle(recordingLifecycle("c", events, startupFailure, null));
+    manager.addLifecycle(recordingLifecycle("d", events, null, null));
+
+    assertSame(startupFailure, assertThrows(IllegalStateException.class, manager::startup));
+    assertEquals(List.of("start-a", "start-b", "start-c", "stop-b", "stop-a"), events);
+    assertEquals(List.of(cleanupFailure), List.of(startupFailure.getSuppressed()));
+    assertFalse(manager.isRunning());
+
+    manager.shutdown();
+    assertEquals(List.of("start-a", "start-b", "start-c", "stop-b", "stop-a"), events);
+  }
+
+  private static Lifecycle recordingLifecycle(
+      String name,
+      List<String> events,
+      RuntimeException startupFailure,
+      RuntimeException cleanupFailure) {
+    return new Lifecycle() {
+      @Override
+      public void startup() {
+        events.add("start-" + name);
+        if (startupFailure != null) {
+          throw startupFailure;
+        }
+      }
+
+      @Override
+      public void shutdown() {
+        events.add("stop-" + name);
+        if (cleanupFailure != null) {
+          throw cleanupFailure;
+        }
+      }
+    };
+  }
 
   @Test
   public void testStartupShutdown() {

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/OpcUaServerLifecycleParticipantTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/OpcUaServerLifecycleParticipantTest.java
@@ -30,6 +30,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.eclipse.milo.opcua.sdk.server.items.DataItem;
+import org.eclipse.milo.opcua.sdk.server.items.MonitoredItem;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.security.DefaultCertificateManager;
@@ -40,6 +42,8 @@ import org.eclipse.milo.opcua.stack.transport.server.OpcServerTransport;
 import org.eclipse.milo.opcua.stack.transport.server.ServerApplicationContext;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class OpcUaServerLifecycleParticipantTest {
 
@@ -446,6 +450,87 @@ class OpcUaServerLifecycleParticipantTest {
       releaseStartup.countDown();
       executor.shutdownNow();
     }
+  }
+
+  // A cancelled or externally completed result is not evidence that the startup callback returned.
+  @ParameterizedTest
+  @ValueSource(strings = {"cancel", "complete", "fail"})
+  void publicStartupCompletionCannotReleaseShutdownBarrier(String completion) throws Exception {
+    var startupEntered = new CountDownLatch(1);
+    var releaseStartup = new CountDownLatch(1);
+    var participantStopped = new AtomicBoolean();
+    OpcUaServer server = newServer(new RecordingTransport());
+    server.addLifecycleParticipant(
+        participant(
+            () -> {
+              startupEntered.countDown();
+              await(releaseStartup);
+            },
+            () -> {
+              assertTrue(server.getEventInstantiator().isRunning());
+              assertTrue(
+                  server
+                      .getAddressSpaceManager()
+                      .isRegistered(server.getOpcUaNamespace().getNodeManager()));
+              participantStopped.set(true);
+            }));
+
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    try {
+      Future<CompletableFuture<OpcUaServer>> firstCall = executor.submit(server::startup);
+      assertTrue(startupEntered.await(5, TimeUnit.SECONDS));
+      CompletableFuture<OpcUaServer> result = server.startup();
+      switch (completion) {
+        case "cancel" -> assertTrue(result.cancel(false));
+        case "complete" -> assertTrue(result.complete(server));
+        case "fail" ->
+            assertTrue(result.completeExceptionally(new IllegalStateException("caller")));
+        default -> throw new AssertionError(completion);
+      }
+
+      CompletableFuture<OpcUaServer> shutdown = server.shutdown();
+      assertFalse(shutdown.isDone(), "shutdown must await the participant callback");
+      assertTrue(server.getEventInstantiator().isRunning());
+      releaseStartup.countDown();
+      assertSame(result, firstCall.get(5, TimeUnit.SECONDS));
+      shutdown.get(5, TimeUnit.SECONDS);
+      assertTrue(participantStopped.get());
+    } finally {
+      releaseStartup.countDown();
+      executor.shutdown();
+      assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
+    }
+  }
+
+  // Namespace registration is an earlier child lifecycle and must be removed on later failure.
+  @Test
+  void failedNamespaceStartupUnregistersItsNodeManager() {
+    OpcUaServer server = newServer(new RecordingTransport());
+    var failure = new IllegalStateException("namespace child startup");
+    var namespace =
+        new ManagedNamespaceWithLifecycle(server, "urn:test:failed-namespace") {
+          @Override
+          public void onDataItemsCreated(List<DataItem> dataItems) {}
+
+          @Override
+          public void onDataItemsModified(List<DataItem> dataItems) {}
+
+          @Override
+          public void onDataItemsDeleted(List<DataItem> dataItems) {}
+
+          @Override
+          public void onMonitoringModeChanged(List<MonitoredItem> monitoredItems) {}
+        };
+    namespace
+        .getLifecycleManager()
+        .addStartupTask(
+            () -> {
+              throw failure;
+            });
+
+    assertSame(failure, assertThrows(IllegalStateException.class, namespace::startup));
+    assertFalse(server.getAddressSpaceManager().isRegistered(namespace.getNodeManager()));
+    namespace.shutdown();
   }
 
   private OpcUaServer newServer(RecordingTransport transport) {

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/OpcUaServerLifecycleParticipantTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/OpcUaServerLifecycleParticipantTest.java
@@ -150,10 +150,14 @@ class OpcUaServerLifecycleParticipantTest {
     server.addLifecycleParticipant(
         participant(() -> events.add("start-c"), () -> events.add("stop-c")));
 
+    CompletableFuture<OpcUaServer> startup = server.startup();
+    CompletableFuture<Throwable> callbackFailure = new CompletableFuture<>();
+    startup.whenComplete((result, failure) -> callbackFailure.complete(failure));
     ExecutionException ex =
-        assertThrows(ExecutionException.class, () -> server.startup().get(5, TimeUnit.SECONDS));
+        assertThrows(ExecutionException.class, () -> startup.get(5, TimeUnit.SECONDS));
 
     assertSame(startupFailure, ex.getCause());
+    assertSame(startupFailure, callbackFailure.get(5, TimeUnit.SECONDS));
     assertEquals(List.of("start-a", "start-b", "stop-a"), events);
     assertFalse(transport.bound);
 


### PR DESCRIPTION
This PR fixes two server lifecycle failures that can leave namespace resources registered or tear them down while startup is still running.

### Roll back children after a failed startup

LifecycleManager previously let a child startup failure escape without stopping earlier children. It then became stopped and ignored subsequent shutdown, which could leave an address space and node manager registered.

It now unwinds successfully started children in reverse order, continues cleanup after individual failures, and attaches those failures to the original startup exception. The child whose own startup fails remains responsible for its partial initialization.

### Keep public future completion separate from shutdown ordering

Concurrent callers could cancel or complete the shared server startup future while a participant callback was still running. Shutdown treated that future as proof that startup had finished and removed core facilities before participant cleanup.

A private completion future now controls shutdown ordering, while callers still share the same public result. Changing that result cannot release the internal wait. Direct completion preserves the original startup exception for callback users.

### Verification

Regression tests cover child rollback under both shutdown-order configurations, preserved cleanup exceptions, real namespace registration cleanup, and premature shutdown after cancellation or external completion of the public future. They produced six assertion failures against the original production code.

Formatting, a full clean compile, and selected lifecycle tests passed. Verification used `mise exec -- mvn -q spotless:apply`, `mise exec -- mvn -q clean compile`, and SDK server reactor `verify` covering LifecycleManagerTest, AbstractLifecycleTest, and OpcUaServerLifecycleParticipantTest.
