### PR TITLE
Keep subscription recovery and delayed responses with their lifecycle

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/session/SessionActivityOrderingTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/session/SessionActivityOrderingTest.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.session;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ubyte;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import com.digitalpetri.fsm.Fsm;
+import io.netty.util.HashedWheelTimer;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClientConfig;
+import org.eclipse.milo.opcua.sdk.client.SessionActivityListener;
+import org.eclipse.milo.opcua.sdk.client.UaSession;
+import org.eclipse.milo.opcua.sdk.client.subscriptions.OpcUaSubscription;
+import org.eclipse.milo.opcua.sdk.client.subscriptions.PublishingManager;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
+import org.eclipse.milo.opcua.stack.core.types.UaRequestMessageType;
+import org.eclipse.milo.opcua.stack.core.types.UaResponseMessageType;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.ApplicationType;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.MessageSecurityMode;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.UserTokenType;
+import org.eclipse.milo.opcua.stack.core.types.structured.ActivateSessionRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.ActivateSessionResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.ApplicationDescription;
+import org.eclipse.milo.opcua.stack.core.types.structured.CloseSessionRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.CloseSessionResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.CreateSessionRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.CreateSessionResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.CreateSubscriptionRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.CreateSubscriptionResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
+import org.eclipse.milo.opcua.stack.core.types.structured.PublishRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.ReadRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.ReadResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.ResponseHeader;
+import org.eclipse.milo.opcua.stack.core.types.structured.SignatureData;
+import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
+import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.transport.client.ClientApplicationContext;
+import org.eclipse.milo.opcua.stack.transport.client.OpcClientTransport;
+import org.eclipse.milo.opcua.stack.transport.client.OpcClientTransportConfig;
+import org.eclipse.milo.opcua.stack.transport.client.tcp.OpcTcpClientTransportConfig;
+import org.junit.jupiter.api.Test;
+
+/** Session listener ordering across reactivation of the same Session object. */
+class SessionActivityOrderingTest {
+  private static class QueueExecutor extends AbstractExecutorService {
+    public void shutdown() {}
+
+    public List<Runnable> shutdownNow() {
+      return List.of();
+    }
+
+    public boolean isShutdown() {
+      return false;
+    }
+
+    public boolean isTerminated() {
+      return false;
+    }
+
+    public boolean awaitTermination(long timeout, TimeUnit unit) {
+      return false;
+    }
+
+    final Deque<Runnable> q = new ArrayDeque<>();
+
+    public void execute(Runnable r) {
+      q.addLast(r);
+    }
+
+    void drain() {
+      int count = 0;
+      while (!q.isEmpty()) {
+        if (++count > 1000) throw new AssertionError("loop");
+        q.removeFirst().run();
+      }
+    }
+  }
+
+  private static class Transport implements OpcClientTransport {
+    final QueueExecutor executor = new QueueExecutor();
+    final HashedWheelTimer timer = new HashedWheelTimer();
+    final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+    final OpcClientTransportConfig config =
+        OpcTcpClientTransportConfig.newBuilder()
+            .setExecutor(executor)
+            .setWheelTimer(timer)
+            .setScheduledExecutor(scheduler)
+            .build();
+    int publishes;
+
+    public OpcClientTransportConfig getConfig() {
+      return config;
+    }
+
+    public CompletableFuture<Unit> connect(ClientApplicationContext context) {
+      return CompletableFuture.completedFuture(Unit.VALUE);
+    }
+
+    public CompletableFuture<Unit> disconnect() {
+      return CompletableFuture.completedFuture(Unit.VALUE);
+    }
+
+    public CompletableFuture<UaResponseMessageType> sendRequestMessage(UaRequestMessageType req) {
+      ResponseHeader h =
+          new ResponseHeader(
+              DateTime.now(),
+              req.getRequestHeader().getRequestHandle(),
+              StatusCode.GOOD,
+              null,
+              null,
+              null);
+      UaResponseMessageType resp;
+      if (req instanceof CreateSessionRequest)
+        resp =
+            new CreateSessionResponse(
+                h,
+                new NodeId(1, 1),
+                new NodeId(1, 2),
+                120000.0,
+                ByteString.NULL_VALUE,
+                ByteString.NULL_VALUE,
+                null,
+                null,
+                new SignatureData(null, null),
+                uint(0));
+      else if (req instanceof ActivateSessionRequest)
+        resp = new ActivateSessionResponse(h, ByteString.NULL_VALUE, null, null);
+      else if (req instanceof ReadRequest)
+        resp =
+            new ReadResponse(
+                h,
+                new DataValue[] {
+                  new DataValue(new Variant(new String[] {"http://opcfoundation.org/UA/"})),
+                  new DataValue(new Variant(new String[] {"urn:test:server"}))
+                },
+                null);
+      else if (req instanceof CreateSubscriptionRequest)
+        resp = new CreateSubscriptionResponse(h, uint(1), 1000.0, uint(50), uint(10));
+      else if (req instanceof PublishRequest) {
+        publishes++;
+        return new CompletableFuture<>();
+      } else if (req instanceof CloseSessionRequest) resp = new CloseSessionResponse(h);
+      else throw new AssertionError(req.getClass());
+      return CompletableFuture.completedFuture(resp);
+    }
+  }
+
+  private static EndpointDescription endpoint() {
+    var app =
+        new ApplicationDescription(
+            "urn:test:server",
+            "urn:test",
+            LocalizedText.english("test"),
+            ApplicationType.Server,
+            null,
+            null,
+            null);
+    return new EndpointDescription(
+        "opc.tcp://localhost:12685",
+        app,
+        ByteString.NULL_VALUE,
+        MessageSecurityMode.None,
+        SecurityPolicy.None.getUri(),
+        new UserTokenPolicy[] {
+          new UserTokenPolicy("anon", UserTokenType.Anonymous, null, null, null)
+        },
+        org.eclipse.milo.opcua.stack.core.Stack.TCP_UASC_UABINARY_TRANSPORT_URI,
+        ubyte(0));
+  }
+
+  @Test
+  void delayedInactiveNotificationCannotOvertakeReactivation() throws Exception {
+    var transport = new Transport();
+    try {
+      var client =
+          new OpcUaClient(
+              OpcUaClientConfig.builder()
+                  .setEndpoint(endpoint())
+                  .setDiscoveryEndpoints(List.of())
+                  .setKeepAliveInterval(uint(1000000))
+                  .build(),
+              transport);
+      var notifications = new ArrayList<String>();
+      client.addSessionActivityListener(
+          new SessionActivityListener() {
+            @Override
+            public void onSessionActive(UaSession session) {
+              notifications.add("active");
+            }
+
+            @Override
+            public void onSessionInactive(UaSession session) {
+              notifications.add("inactive");
+            }
+          });
+      var connected = client.connectAsync();
+      transport.executor.drain();
+      if (!connected.isDone() || connected.isCompletedExceptionally())
+        throw new AssertionError("connect failed");
+      var sf = client.getSessionFsm();
+      Field f = SessionFsm.class.getDeclaredField("fsm");
+      f.setAccessible(true);
+      @SuppressWarnings("unchecked")
+      Fsm<State, Event> fsm = (Fsm<State, Event>) f.get(sf);
+      var pm = client.getPublishingManager();
+      Method suspended = PublishingManager.class.getDeclaredMethod("isPublishingSuspended");
+      suspended.setAccessible(true);
+      if ((boolean) suspended.invoke(pm)) throw new AssertionError("initial gate shut");
+      var session = sf.getSession().join();
+      // Run the FSM's inactive transition while deferring the separate listener-dispatch runnable.
+      fsm.fireEvent(new Event.ServiceFault(new StatusCode(StatusCodes.Bad_SessionIdInvalid)));
+      while (sf.getState() != State.ReactivatingWait) transport.executor.q.removeFirst().run();
+      if (transport.executor.q.size() != 1)
+        throw new AssertionError("unexpected queued tasks " + transport.executor.q.size());
+      Runnable delayedInactive = transport.executor.q.removeFirst();
+
+      // The FSM executor continues on another worker while its inactive callback is delayed.
+      fsm.fireEvent(new Event.ReactivatingWaitExpired());
+      transport.executor.drain();
+      if (sf.getState() != State.Active || sf.getSession().join() != session)
+        throw new AssertionError("reactivation failed");
+      delayedInactive.run();
+      transport.executor.drain();
+      assertFalse(
+          (boolean) suspended.invoke(pm),
+          "an inactive callback from before reactivation must not leave publishing suspended");
+      var subscription = new OpcUaSubscription(client);
+      var created = subscription.createAsync().toCompletableFuture();
+      transport.executor.drain();
+      if (!created.isDone() || created.isCompletedExceptionally())
+        throw new AssertionError("subscription failed");
+      assertEquals(List.of("active", "inactive", "active"), notifications);
+      assertEquals(
+          2, transport.publishes, "the recovered Session must resume its Publish pipeline");
+    } finally {
+      transport.scheduler.shutdownNow();
+      transport.timer.stop();
+    }
+  }
+}

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/PublishRegistrationReuseTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/PublishRegistrationReuseTest.java
@@ -1,0 +1,332 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.subscriptions;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ubyte;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.netty.util.HashedWheelTimer;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClientConfig;
+import org.eclipse.milo.opcua.sdk.client.OpcUaSession;
+import org.eclipse.milo.opcua.stack.core.Stack;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
+import org.eclipse.milo.opcua.stack.core.types.UaRequestMessageType;
+import org.eclipse.milo.opcua.stack.core.types.UaResponseMessageType;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.MessageSecurityMode;
+import org.eclipse.milo.opcua.stack.core.types.structured.CreateSubscriptionResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
+import org.eclipse.milo.opcua.stack.core.types.structured.NotificationMessage;
+import org.eclipse.milo.opcua.stack.core.types.structured.PublishRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.PublishResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.ResponseHeader;
+import org.eclipse.milo.opcua.stack.core.types.structured.SignedSoftwareCertificate;
+import org.eclipse.milo.opcua.stack.core.types.structured.StatusChangeNotification;
+import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
+import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.transport.client.ClientApplicationContext;
+import org.eclipse.milo.opcua.stack.transport.client.OpcClientTransport;
+import org.eclipse.milo.opcua.stack.transport.client.OpcClientTransportConfig;
+import org.eclipse.milo.opcua.stack.transport.client.tcp.OpcTcpClientTransportConfig;
+import org.junit.jupiter.api.Test;
+
+/** A response belongs to the subscription registration that existed when its request was sent. */
+class PublishRegistrationReuseTest {
+  @Test
+  void delayedTimeoutCannotResetRecreatedObjectWithSameId() throws Exception {
+    assertTimeoutOwnership(true, true);
+  }
+
+  @Test
+  void delayedTimeoutCannotResetReplacementObjectWithSameId() throws Exception {
+    assertTimeoutOwnership(true, false);
+  }
+
+  @Test
+  void currentTimeoutStillResetsItsSubscription() throws Exception {
+    assertTimeoutOwnership(false, true);
+  }
+
+  @Test
+  void requestQueuedBeforeFirstRegistrationCanServeThatSubscription() throws Exception {
+    assertRegistrationChurnDoesNotDiscardResponse(false);
+  }
+
+  @Test
+  void unrelatedRegistrationDoesNotDiscardExistingSubscriptionsResponse() throws Exception {
+    assertRegistrationChurnDoesNotDiscardResponse(true);
+  }
+
+  private void assertRegistrationChurnDoesNotDiscardResponse(boolean originalAlreadyRegistered)
+      throws Exception {
+    try (var transport = new Transport()) {
+      var client = new Client(transport);
+      var original = new OpcUaSubscription(client);
+      if (originalAlreadyRegistered)
+        original.createAsync().toCompletableFuture().get(5, TimeUnit.SECONDS);
+      var session =
+          new OpcUaSession(
+              new NodeId(1, "token"),
+              new NodeId(1, "session"),
+              "session",
+              60000,
+              uint(0),
+              ByteString.NULL_VALUE,
+              new SignedSoftwareCertificate[0]);
+      var pendingCount = new AtomicLong(1);
+      client.getPublishingManager().sendPublishRequest(session, pendingCount);
+      var response = client.pending;
+      if (originalAlreadyRegistered) {
+        client.nextSubscriptionId = 8;
+        new OpcUaSubscription(client).createAsync().toCompletableFuture().get(5, TimeUnit.SECONDS);
+      } else {
+        original.createAsync().toCompletableFuture().get(5, TimeUnit.SECONDS);
+      }
+      var status = new StatusChangeNotification(new StatusCode(StatusCodes.Bad_Timeout), null);
+      response.complete(
+          new PublishResponse(
+              header(),
+              uint(7),
+              new UInteger[] {uint(1)},
+              false,
+              new NotificationMessage(
+                  uint(1),
+                  DateTime.now(),
+                  new ExtensionObject[] {
+                    ExtensionObject.encode(client.getStaticEncodingContext(), status)
+                  }),
+              new StatusCode[0],
+              null));
+      transport.executor.drain();
+      assertEquals(0, pendingCount.get());
+      assertTrue(
+          original.getSubscriptionId().isEmpty(),
+          "valid timeout must reach its owner despite a registration after the request was sent");
+    }
+  }
+
+  private void assertTimeoutOwnership(boolean replace, boolean reuseObject) throws Exception {
+    try (var transport = new Transport()) {
+      var client = new Client(transport);
+      var statuses = new ArrayList<StatusCode>();
+      var original = new OpcUaSubscription(client);
+      original.setSubscriptionListener(
+          new OpcUaSubscription.SubscriptionListener() {
+            @Override
+            public void onStatusChanged(OpcUaSubscription s, StatusCode status) {
+              statuses.add(status);
+            }
+          });
+      original.createAsync().toCompletableFuture().get(5, TimeUnit.SECONDS);
+      var session =
+          new OpcUaSession(
+              new NodeId(1, "token"),
+              new NodeId(1, "session"),
+              "session",
+              60000,
+              uint(0),
+              ByteString.NULL_VALUE,
+              new SignedSoftwareCertificate[0]);
+      var pendingCount = new AtomicLong(1);
+      client.getPublishingManager().sendPublishRequest(session, pendingCount);
+      var response = client.pending;
+      OpcUaSubscription current = original;
+      if (replace) {
+        original.reset();
+        if (!reuseObject) {
+          current = new OpcUaSubscription(client);
+          current.setSubscriptionListener(
+              new OpcUaSubscription.SubscriptionListener() {
+                @Override
+                public void onStatusChanged(OpcUaSubscription s, StatusCode status) {
+                  statuses.add(status);
+                }
+              });
+        }
+        current.createAsync().toCompletableFuture().get(5, TimeUnit.SECONDS);
+      }
+      long incarnation = current.getIncarnation();
+      var status = new StatusChangeNotification(new StatusCode(StatusCodes.Bad_Timeout), null);
+      response.complete(
+          new PublishResponse(
+              header(),
+              uint(7),
+              new UInteger[] {uint(1)},
+              false,
+              new NotificationMessage(
+                  uint(1),
+                  DateTime.now(),
+                  new ExtensionObject[] {
+                    ExtensionObject.encode(client.getStaticEncodingContext(), status)
+                  }),
+              new StatusCode[0],
+              null));
+      transport.executor.drain();
+      assertEquals(
+          0, pendingCount.get(), "discarding a response must still release its pipeline slot");
+      if (replace) {
+        assertEquals(uint(7), current.getSubscriptionId().orElseThrow());
+        assertEquals(incarnation, current.getIncarnation());
+        assertTrue(
+            statuses.isEmpty(), "the replacement must not receive its predecessor's timeout");
+      } else {
+        assertTrue(current.getSubscriptionId().isEmpty());
+        assertEquals(List.of(new StatusCode(StatusCodes.Bad_Timeout)), statuses);
+      }
+    }
+  }
+
+  private static ResponseHeader header() {
+    return new ResponseHeader(DateTime.now(), uint(1), StatusCode.GOOD, null, null, null);
+  }
+
+  private static class ManualExecutor extends AbstractExecutorService {
+    final Deque<Runnable> tasks = new ArrayDeque<>();
+
+    @Override
+    public void execute(Runnable command) {
+      tasks.addLast(command);
+    }
+
+    void drain() {
+      int count = 0;
+      while (!tasks.isEmpty()) {
+        assertTrue(++count < 1000, "executor did not quiesce");
+        tasks.removeFirst().run();
+      }
+    }
+
+    @Override
+    public void shutdown() {}
+
+    @Override
+    public List<Runnable> shutdownNow() {
+      return List.of();
+    }
+
+    @Override
+    public boolean isShutdown() {
+      return false;
+    }
+
+    @Override
+    public boolean isTerminated() {
+      return false;
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) {
+      return false;
+    }
+  }
+
+  private static class Transport implements OpcClientTransport, AutoCloseable {
+    final ManualExecutor executor = new ManualExecutor();
+    final HashedWheelTimer timer = new HashedWheelTimer();
+    final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+    final OpcClientTransportConfig config =
+        OpcTcpClientTransportConfig.newBuilder()
+            .setExecutor(executor)
+            .setWheelTimer(timer)
+            .setScheduledExecutor(scheduler)
+            .build();
+
+    @Override
+    public OpcClientTransportConfig getConfig() {
+      return config;
+    }
+
+    @Override
+    public CompletableFuture<Unit> connect(ClientApplicationContext c) {
+      return CompletableFuture.completedFuture(Unit.VALUE);
+    }
+
+    @Override
+    public CompletableFuture<Unit> disconnect() {
+      return CompletableFuture.completedFuture(Unit.VALUE);
+    }
+
+    @Override
+    public CompletableFuture<UaResponseMessageType> sendRequestMessage(UaRequestMessageType r) {
+      throw new AssertionError(r);
+    }
+
+    @Override
+    public void close() {
+      scheduler.shutdownNow();
+      timer.stop();
+    }
+  }
+
+  private static class Client extends OpcUaClient {
+    CompletableFuture<UaResponseMessageType> pending;
+    int nextSubscriptionId = 7;
+
+    Client(Transport transport) {
+      super(
+          OpcUaClientConfig.builder()
+              .setEndpoint(
+                  new EndpointDescription(
+                      "opc.tcp://localhost:4840",
+                      null,
+                      ByteString.NULL_VALUE,
+                      MessageSecurityMode.None,
+                      SecurityPolicy.None.getUri(),
+                      new UserTokenPolicy[0],
+                      Stack.TCP_UASC_UABINARY_TRANSPORT_URI,
+                      ubyte(0)))
+              .setDiscoveryEndpoints(List.of())
+              .build(),
+          transport);
+    }
+
+    // Automatic Publish replenishment waits here. Each test sends exactly one controlled request.
+    @Override
+    public CompletableFuture<OpcUaSession> getSessionAsync() {
+      return new CompletableFuture<>();
+    }
+
+    @Override
+    public CompletableFuture<CreateSubscriptionResponse> createSubscriptionAsync(
+        double p, UInteger l, UInteger k, UInteger n, boolean enabled, UByte priority) {
+      return CompletableFuture.completedFuture(
+          new CreateSubscriptionResponse(header(), uint(nextSubscriptionId), p, l, k));
+    }
+
+    @Override
+    public CompletableFuture<UaResponseMessageType> sendRequestAsync(UaRequestMessageType request) {
+      assertInstanceOf(PublishRequest.class, request);
+      pending = new CompletableFuture<>();
+      return pending;
+    }
+  }
+}

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/PublishingManagerSessionIsolationTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/PublishingManagerSessionIsolationTest.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -202,7 +203,7 @@ public class PublishingManagerSessionIsolationTest {
       subscriptionDetailsClass =
           Class.forName(PublishingManager.class.getName() + "$SubscriptionDetails");
 
-      Map<UInteger, Object> details = subscriptionDetails(manager);
+      var details = new HashMap<UInteger, Object>();
 
       primaryDetails = newSubscriptionDetails(subscriptionId);
 
@@ -210,6 +211,7 @@ public class PublishingManagerSessionIsolationTest {
         UInteger id = uint(i + 1L);
         details.put(id, i == 0 ? primaryDetails : newSubscriptionDetails(id));
       }
+      setSubscriptionDetails(Map.copyOf(details));
     }
 
     UaSession newSession() {
@@ -227,8 +229,7 @@ public class PublishingManagerSessionIsolationTest {
     }
 
     void retainOnlyPrimarySubscription() throws Exception {
-      Map<UInteger, Object> details = subscriptionDetails(manager);
-      details.keySet().removeIf(id -> !id.equals(subscriptionId));
+      setSubscriptionDetails(Map.of(subscriptionId, primaryDetails));
     }
 
     void setResponder(
@@ -327,14 +328,12 @@ public class PublishingManagerSessionIsolationTest {
           subscription, id, (java.util.concurrent.Executor) Runnable::run);
     }
 
-    @SuppressWarnings("unchecked")
-    private static Map<UInteger, Object> subscriptionDetails(PublishingManager manager)
-        throws Exception {
+    private void setSubscriptionDetails(Map<UInteger, Object> details) throws Exception {
 
       Field field = PublishingManager.class.getDeclaredField("subscriptionDetails");
       field.setAccessible(true);
 
-      return (Map<UInteger, Object>) field.get(manager);
+      field.set(manager, details);
     }
   }
 }

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/SubscriptionLifecycleRecoveryTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/SubscriptionLifecycleRecoveryTest.java
@@ -1,0 +1,392 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.subscriptions;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.client.OperationLimits;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.MonitoringMode;
+import org.eclipse.milo.opcua.stack.core.types.structured.CreateMonitoredItemsResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.CreateSubscriptionResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.DeleteMonitoredItemsResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.ModifyMonitoredItemsResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.MonitoredItemCreateRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.MonitoredItemCreateResult;
+import org.eclipse.milo.opcua.stack.core.types.structured.MonitoredItemModifyResult;
+import org.eclipse.milo.opcua.stack.core.types.structured.ReadValueId;
+import org.eclipse.milo.opcua.stack.core.types.structured.SetMonitoringModeResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.SetPublishingModeResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/** Deterministic response, reset, and executor boundaries in the subscription lifecycle. */
+class SubscriptionLifecycleRecoveryTest {
+  private final ExecutorService workers = Executors.newCachedThreadPool();
+
+  @AfterEach
+  void stopWorkers() throws InterruptedException {
+    workers.shutdownNow();
+    assertTrue(workers.awaitTermination(5, TimeUnit.SECONDS));
+  }
+
+  @Test
+  void resetAndReaddPreserveTheMappedItemsClientHandle() throws Exception {
+    var fixture = new Fixture(Runnable::run);
+    fixture.create();
+    var item = new GatedResetItem();
+    fixture.subscription.addMonitoredItem(item);
+    item.applyCreateResult(createdItem(41));
+    fixture.subscription.removeMonitoredItem(item);
+
+    var reset = workers.submit(fixture.subscription::reset);
+    assertTrue(item.entered.await(5, TimeUnit.SECONDS));
+    var readded = new CompletableFuture<Void>();
+    Thread adding =
+        new Thread(
+            () -> {
+              try {
+                fixture.subscription.addMonitoredItem(item);
+                readded.complete(null);
+              } catch (Throwable t) {
+                readded.completeExceptionally(t);
+              }
+            });
+    adding.start();
+    try {
+      // Wait until add either acquires the collection lock or is blocked on reset's ownership.
+      // Releasing the reset before add reaches this boundary would miss the original interleaving.
+      long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+      while (!readded.isDone()
+          && adding.getState() != Thread.State.BLOCKED
+          && System.nanoTime() < deadline) {
+        Thread.yield();
+      }
+      assertTrue(readded.isDone() || adding.getState() == Thread.State.BLOCKED);
+    } finally {
+      item.release.countDown();
+      adding.join(5000);
+    }
+    reset.get(5, TimeUnit.SECONDS);
+    readded.get(5, TimeUnit.SECONDS);
+    assertTrue(fixture.subscription.getMonitoredItems().contains(item));
+    assertTrue(item.getClientHandle().isPresent(), "mapped items must retain a requestable handle");
+    fixture.create();
+    when(fixture.client.createMonitoredItems(any(), any(), anyList()))
+        .thenReturn(
+            new CreateMonitoredItemsResponse(
+                null, new MonitoredItemCreateResult[] {createdItem(42)}, null));
+    assertTrue(fixture.subscription.createMonitoredItems().get(0).isGood());
+  }
+
+  @Test
+  void rejectedTransitionHandoffPreservesSuccessAndDrainsWaiters() throws Exception {
+    assertHandoffCompletes(
+        command -> {
+          throw new RejectedExecutionException("executor stopped");
+        });
+  }
+
+  @Test
+  void directTransitionHandoffDrainsWithoutRecursion() throws Exception {
+    assertHandoffCompletes(Runnable::run);
+  }
+
+  private void assertHandoffCompletes(Executor executor) throws Exception {
+    var fixture = new Fixture(executor);
+    var response = new CompletableFuture<CreateSubscriptionResponse>();
+    when(fixture.client.createSubscriptionAsync(
+            anyDouble(), any(), any(), any(), anyBoolean(), any()))
+        .thenReturn(response);
+    var create = fixture.subscription.createAsync().toCompletableFuture();
+    var queued = new ArrayList<CompletableFuture<?>>();
+    for (int i = 0; i < 10_000; i++) {
+      queued.add(fixture.subscription.modifyAsync().toCompletableFuture());
+    }
+    response.complete(Fixture.created(21));
+    create.get(5, TimeUnit.SECONDS);
+    CompletableFuture.allOf(queued.toArray(CompletableFuture[]::new)).get(5, TimeUnit.SECONDS);
+    fixture
+        .subscription
+        .setPublishingModeAsync(false)
+        .toCompletableFuture()
+        .get(5, TimeUnit.SECONDS);
+  }
+
+  @Test
+  void transferCleanupDoesNotWaitForLimitsThatNeedSessionActivation() throws Exception {
+    var fixture = new Fixture(Runnable::run);
+    fixture.create();
+    fixture.addItem();
+    var limitsEntered = new CountDownLatch(1);
+    var sessionActive = new CompletableFuture<OperationLimits>();
+    when(fixture.client.getOperationLimits())
+        .thenAnswer(
+            invocation -> {
+              limitsEntered.countDown();
+              return sessionActive.get(10, TimeUnit.SECONDS);
+            });
+    var create =
+        workers.submit(
+            () -> {
+              return fixture.subscription.createMonitoredItems();
+            });
+    assertTrue(limitsEntered.await(5, TimeUnit.SECONDS));
+    var cleanup =
+        workers.submit(
+            () -> {
+              fixture.subscription.handleTransferFailure(
+                  new StatusCode(StatusCodes.Bad_SubscriptionIdInvalid));
+              // Session initialization must finish transfer cleanup before publishing its active
+              // Session.
+              sessionActive.complete(Fixture.limits());
+            });
+    try {
+      cleanup.get(5, TimeUnit.SECONDS);
+      assertTrue(sessionActive.isDone());
+      assertEquals(
+          new StatusCode(StatusCodes.Bad_InvalidState),
+          create.get(5, TimeUnit.SECONDS).get(0).serviceResult());
+    } finally {
+      sessionActive.complete(Fixture.limits());
+      cleanup.get(5, TimeUnit.SECONDS);
+      create.get(5, TimeUnit.SECONDS);
+    }
+
+    // Completing the discarded lookup must not restore its old cached partition size.
+    when(fixture.client.getOperationLimits())
+        .thenReturn(
+            new OperationLimits(
+                null, null, null, null, null, null, null, uint(1), null, null, null, null));
+    fixture.create();
+    fixture.addItem();
+    var calls = new AtomicInteger();
+    when(fixture.client.createMonitoredItems(any(), any(), anyList()))
+        .thenAnswer(
+            invocation -> {
+              calls.incrementAndGet();
+              List<MonitoredItemCreateRequest> requests = invocation.getArgument(2);
+              var results = new MonitoredItemCreateResult[requests.size()];
+              for (int i = 0; i < results.length; i++) results[i] = createdItem(100 + i);
+              return new CreateMonitoredItemsResponse(null, results, null);
+            });
+    assertEquals(2, fixture.subscription.createMonitoredItems().size());
+    assertEquals(2, calls.get(), "replacement must discover the current singleton server limit");
+  }
+
+  @Test
+  void delayedCreateCannotPopulateRecreatedSubscription() throws Exception {
+    assertDelayedResponseIgnored(Operation.CREATE);
+  }
+
+  @Test
+  void delayedModifyCannotOverwriteRecreatedItem() throws Exception {
+    assertDelayedResponseIgnored(Operation.MODIFY);
+  }
+
+  @Test
+  void delayedDeleteCannotDetachRecreatedItem() throws Exception {
+    assertDelayedResponseIgnored(Operation.DELETE);
+  }
+
+  @Test
+  void delayedMonitoringModeCannotChangeRecreatedItem() throws Exception {
+    assertDelayedResponseIgnored(Operation.MODE);
+  }
+
+  private void assertDelayedResponseIgnored(Operation operation) throws Exception {
+    var fixture = new Fixture(Runnable::run);
+    fixture.create();
+    var item = fixture.addItem();
+    if (operation != Operation.CREATE) item.applyCreateResult(createdItem(41));
+    if (operation == Operation.MODIFY) item.setSamplingInterval(250.0);
+    if (operation == Operation.DELETE) fixture.subscription.removeMonitoredItem(item);
+    var entered = new CountDownLatch(1);
+    var release = new CountDownLatch(1);
+    var firstCall = new AtomicBoolean(true);
+    org.mockito.stubbing.Answer<Object> gate =
+        invocation -> {
+          if (firstCall.getAndSet(false)) {
+            entered.countDown();
+            assertTrue(release.await(5, TimeUnit.SECONDS));
+          }
+          return switch (operation) {
+            case CREATE ->
+                new CreateMonitoredItemsResponse(
+                    null, new MonitoredItemCreateResult[] {createdItem(41)}, null);
+            case MODIFY ->
+                new ModifyMonitoredItemsResponse(
+                    null,
+                    new MonitoredItemModifyResult[] {
+                      new MonitoredItemModifyResult(StatusCode.GOOD, 250.0, uint(1), null)
+                    },
+                    null);
+            case DELETE ->
+                new DeleteMonitoredItemsResponse(null, new StatusCode[] {StatusCode.GOOD}, null);
+            case MODE ->
+                new SetMonitoringModeResponse(null, new StatusCode[] {StatusCode.GOOD}, null);
+          };
+        };
+    switch (operation) {
+      case CREATE ->
+          when(fixture.client.createMonitoredItems(any(), any(), anyList())).thenAnswer(gate);
+      case MODIFY ->
+          when(fixture.client.modifyMonitoredItems(any(), any(), anyList())).thenAnswer(gate);
+      case DELETE -> when(fixture.client.deleteMonitoredItems(any(), anyList())).thenAnswer(gate);
+      case MODE -> when(fixture.client.setMonitoringMode(any(), any(), anyList())).thenAnswer(gate);
+    }
+    var oldId = fixture.subscription.getSubscriptionId().orElseThrow();
+    var pending =
+        workers.submit(
+            () ->
+                switch (operation) {
+                  case CREATE -> fixture.subscription.createMonitoredItems();
+                  case MODIFY -> fixture.subscription.modifyMonitoredItems();
+                  case DELETE -> fixture.subscription.deleteMonitoredItems();
+                  case MODE ->
+                      fixture.subscription.setMonitoringMode(
+                          MonitoringMode.Disabled, List.of(item));
+                });
+    assertTrue(entered.await(5, TimeUnit.SECONDS));
+    try {
+      fixture.subscription.reset();
+      fixture.create();
+      assertNotEquals(oldId, fixture.subscription.getSubscriptionId().orElseThrow());
+      if (operation == Operation.DELETE) fixture.subscription.addMonitoredItem(item);
+      if (operation != Operation.CREATE) item.applyCreateResult(createdItem(99));
+    } finally {
+      release.countDown();
+    }
+    var results = pending.get(5, TimeUnit.SECONDS);
+    assertEquals(1, results.size());
+    assertEquals(new StatusCode(StatusCodes.Bad_InvalidState), results.get(0).serviceResult());
+    assertTrue(item.getClientHandle().isPresent());
+    if (operation == Operation.CREATE) {
+      assertEquals(OpcUaMonitoredItem.SyncState.INITIAL, item.getSyncState());
+      assertTrue(item.getMonitoredItemId().isEmpty());
+      assertTrue(fixture.subscription.createMonitoredItems().get(0).isGood());
+    } else {
+      assertEquals(OpcUaMonitoredItem.SyncState.SYNCHRONIZED, item.getSyncState());
+      assertEquals(uint(99), item.getMonitoredItemId().orElseThrow());
+      assertEquals(1000.0, item.getRevisedSamplingInterval().orElseThrow());
+      assertEquals(MonitoringMode.Reporting, item.getMonitoringMode());
+    }
+  }
+
+  private enum Operation {
+    CREATE,
+    MODIFY,
+    DELETE,
+    MODE
+  }
+
+  private static MonitoredItemCreateResult createdItem(int id) {
+    return new MonitoredItemCreateResult(StatusCode.GOOD, uint(id), 1000.0, uint(1), null);
+  }
+
+  private static ReadValueId readValueId() {
+    return new ReadValueId(new NodeId(2, "value"), uint(13), null, QualifiedName.NULL_VALUE);
+  }
+
+  private static class GatedResetItem extends OpcUaMonitoredItem {
+    final CountDownLatch entered = new CountDownLatch(1);
+    final CountDownLatch release = new CountDownLatch(1);
+
+    GatedResetItem() {
+      super(readValueId());
+    }
+
+    @Override
+    void reset() {
+      entered.countDown();
+      try {
+        assertTrue(release.await(5, TimeUnit.SECONDS));
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new AssertionError(e);
+      }
+      super.reset();
+    }
+  }
+
+  private static class Fixture {
+    final OpcUaClient client = mock(OpcUaClient.class, RETURNS_DEEP_STUBS);
+    final AtomicInteger ids = new AtomicInteger(10);
+    final OpcUaSubscription subscription;
+
+    Fixture(Executor executor) throws Exception {
+      var executorService = mock(ExecutorService.class);
+      doAnswer(
+              invocation -> {
+                executor.execute(invocation.getArgument(0));
+                return null;
+              })
+          .when(executorService)
+          .execute(any());
+      when(client.getTransport().getConfig().getExecutor()).thenReturn(executorService);
+      when(client.getPublishingManager().isPublishingSuspended()).thenReturn(true);
+      when(client.getOperationLimits()).thenReturn(limits());
+      when(client.createSubscriptionAsync(anyDouble(), any(), any(), any(), anyBoolean(), any()))
+          .thenAnswer(
+              invocation -> CompletableFuture.completedFuture(created(ids.incrementAndGet())));
+      when(client.setPublishingModeAsync(anyBoolean(), anyList()))
+          .thenReturn(
+              CompletableFuture.completedFuture(
+                  new SetPublishingModeResponse(null, new StatusCode[] {StatusCode.GOOD}, null)));
+      subscription = new OpcUaSubscription(client);
+    }
+
+    static OperationLimits limits() {
+      return new OperationLimits(
+          null, null, null, null, null, null, null, uint(100), null, null, null, null);
+    }
+
+    static CreateSubscriptionResponse created(int id) {
+      return new CreateSubscriptionResponse(null, uint(id), 1000.0, uint(50), uint(10));
+    }
+
+    void create() throws Exception {
+      subscription.createAsync().toCompletableFuture().get(5, TimeUnit.SECONDS);
+    }
+
+    OpcUaMonitoredItem addItem() {
+      var item = new OpcUaMonitoredItem(readValueId());
+      subscription.addMonitoredItem(item);
+      return item;
+    }
+  }
+}

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsm.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsm.java
@@ -13,9 +13,12 @@ package org.eclipse.milo.opcua.sdk.client.session;
 import com.digitalpetri.fsm.Fsm;
 import com.digitalpetri.fsm.FsmContext;
 import com.digitalpetri.netty.fsm.ChannelFsm;
+import com.google.common.util.concurrent.MoreExecutors;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.atomic.AtomicLong;
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
@@ -33,7 +36,7 @@ public class SessionFsm {
 
   private final Fsm<State, Event> fsm;
 
-  SessionFsm(Fsm<State, Event> fsm) {
+  SessionFsm(Fsm<State, Event> fsm, Executor executor) {
     this.fsm = fsm;
 
     sessionInitializers =
@@ -46,7 +49,7 @@ public class SessionFsm {
     sessionActivityListeners =
         fsm.getFromContext(
             ctx -> {
-              KEY_SESSION_ACTIVITY_LISTENERS.set(ctx, new SessionActivityListeners());
+              KEY_SESSION_ACTIVITY_LISTENERS.set(ctx, new SessionActivityListeners(executor));
               return KEY_SESSION_ACTIVITY_LISTENERS.get(ctx).sessionActivityListeners;
             });
   }
@@ -185,7 +188,21 @@ public class SessionFsm {
   }
 
   static class SessionActivityListeners {
-    private SessionActivityListeners() {}
+    final Executor executor;
+
+    private SessionActivityListeners(Executor delegate) {
+      executor =
+          MoreExecutors.newSequentialExecutor(
+              command -> {
+                try {
+                  delegate.execute(command);
+                } catch (RejectedExecutionException e) {
+                  // Lifecycle notifications must remain ordered even when dispatch falls back
+                  // inline.
+                  command.run();
+                }
+              });
+    }
 
     final List<SessionActivityListener> sessionActivityListeners = new CopyOnWriteArrayList<>();
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmFactory.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmFactory.java
@@ -145,7 +145,7 @@ public class SessionFsmFactory {
 
     client.addFaultListener(new SessionFaultListener(fsm));
 
-    return new SessionFsm(fsm);
+    return new SessionFsm(fsm, client.getTransport().getConfig().getExecutor());
   }
 
   private static void configureSessionFsm(FsmBuilder<State, Event> fb, OpcUaClient client) {
@@ -773,14 +773,10 @@ public class SessionFsmFactory {
               SessionFsm.SessionActivityListeners sessionActivityListeners =
                   KEY_SESSION_ACTIVITY_LISTENERS.get(ctx);
 
-              client
-                  .getTransport()
-                  .getConfig()
-                  .getExecutor()
-                  .execute(
-                      () ->
-                          sessionActivityListeners.sessionActivityListeners.forEach(
-                              listener -> listener.onSessionActive(session)));
+              sessionActivityListeners.executor.execute(
+                  () ->
+                      sessionActivityListeners.sessionActivityListeners.forEach(
+                          listener -> listener.onSessionActive(session)));
             });
 
     // onSessionInactive() callbacks
@@ -794,14 +790,10 @@ public class SessionFsmFactory {
               SessionFsm.SessionActivityListeners sessionActivityListeners =
                   KEY_SESSION_ACTIVITY_LISTENERS.get(ctx);
 
-              client
-                  .getTransport()
-                  .getConfig()
-                  .getExecutor()
-                  .execute(
-                      () ->
-                          sessionActivityListeners.sessionActivityListeners.forEach(
-                              listener -> listener.onSessionInactive(session)));
+              sessionActivityListeners.executor.execute(
+                  () ->
+                      sessionActivityListeners.sessionActivityListeners.forEach(
+                          listener -> listener.onSessionInactive(session)));
             });
 
     /* Internal Transition Actions */

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/package-info.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/**
+ * Establishes and recovers the Session used by {@link
+ * org.eclipse.milo.opcua.sdk.client.OpcUaClient}. The state machine creates and activates Sessions,
+ * runs initializers, and monitors connectivity. A reactivation can reuse the same Session object,
+ * so object identity alone does not identify an activation.
+ *
+ * <p>Session activity notifications run in transition order on a serial executor backed by the
+ * transport's caller-owned executor. The state machine can continue while an earlier notification
+ * waits to run. Consumers such as the publishing manager observe inactive before the subsequent
+ * active notification, which lets them suspend and recover their work in that order. Rejected
+ * dispatch runs inline to preserve this lifecycle ordering; the client does not shut down the
+ * caller's executor.
+ *
+ * <p>Initializers participate in Session activation. They must complete before operations waiting
+ * for an active Session can proceed. Cleanup during initialization must therefore avoid waiting on
+ * work that itself needs an active Session.
+ */
+package org.eclipse.milo.opcua.sdk.client.session;

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscription.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscription.java
@@ -15,6 +15,7 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
 
 import com.google.common.primitives.Ints;
+import com.google.common.util.concurrent.MoreExecutors;
 import java.math.BigInteger;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -29,6 +30,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -63,7 +66,7 @@ import org.eclipse.milo.opcua.stack.core.types.structured.MonitoredItemModifyRes
 import org.eclipse.milo.opcua.stack.core.types.structured.MonitoredItemNotification;
 import org.eclipse.milo.opcua.stack.core.types.structured.SetMonitoringModeResponse;
 import org.eclipse.milo.opcua.stack.core.types.structured.SetPublishingModeResponse;
-import org.eclipse.milo.opcua.stack.core.util.Lazy;
+import org.eclipse.milo.opcua.stack.core.util.NonBlockingLazy;
 import org.eclipse.milo.opcua.stack.core.util.TaskQueue;
 import org.eclipse.milo.opcua.stack.core.util.Unit;
 import org.jspecify.annotations.Nullable;
@@ -230,7 +233,7 @@ public class OpcUaSubscription {
   private volatile double watchdogMultiplier = 1.5;
 
   private volatile UInteger maxMonitoredItemsPerCall = uint(DEFAULT_MAX_MONITORED_ITEMS_PER_CALL);
-  private final Lazy<UInteger> monitoredItemPartitionSize = new Lazy<>();
+  private final NonBlockingLazy<UInteger> monitoredItemPartitionSize = new NonBlockingLazy<>();
   private volatile long monitoredItemPartitionGeneration;
 
   private volatile @Nullable Object userObject;
@@ -238,13 +241,26 @@ public class OpcUaSubscription {
   private volatile @Nullable SubscriptionListener listener;
 
   private final TaskQueue deliveryQueue;
+  private final Executor transitionHandoffExecutor;
 
   private final OpcUaClient client;
 
   public OpcUaSubscription(OpcUaClient client) {
     this.client = client;
 
-    deliveryQueue = new TaskQueue(client.getTransport().getConfig().getExecutor());
+    Executor executor = client.getTransport().getConfig().getExecutor();
+    deliveryQueue = new TaskQueue(executor);
+    transitionHandoffExecutor =
+        MoreExecutors.newSequentialExecutor(
+            command -> {
+              try {
+                executor.execute(command);
+              } catch (RejectedExecutionException e) {
+                // Finishing a transition must release its successor even when the executor shuts
+                // down.
+                command.run();
+              }
+            });
   }
 
   /**
@@ -732,11 +748,9 @@ public class OpcUaSubscription {
     }
 
     if (next != null) {
-      // Completed asynchronously rather than on this stack: a queued transition that completes
-      // synchronously — nothing pending to send, or an immediate Bad_InvalidState — would re-enter
-      // this method inline, one frame per waiter, and enough waiters is a StackOverflowError that
-      // leaves the slot claimed forever.
-      next.completeAsync(() -> Unit.VALUE, client.getTransport().getConfig().getExecutor());
+      // The sequential executor trampolines direct execution and rejected handoffs. A long queue
+      // of synchronous transitions cannot recurse, and no completion runs under lifecycleLock.
+      transitionHandoffExecutor.execute(() -> next.complete(Unit.VALUE));
     }
   }
 
@@ -2248,17 +2262,21 @@ public class OpcUaSubscription {
         modifications = null;
 
         monitoredItemPartitionSize.reset();
-        monitoredItems.values().forEach(OpcUaMonitoredItem::reset);
+        // Keep reset's handle cleanup atomic with add/remove, in the same lock order used
+        // when applying monitored-item service results.
+        synchronized (monitoredItemsLock) {
+          monitoredItems.values().forEach(OpcUaMonitoredItem::reset);
 
-        // MonitoredItemIds are scoped to the Subscription that no longer exists, so the items
-        // pending deletion are already gone and their ids must never be sent again. Detach them
-        // completely, including the ClientHandle, so they can be added to a Subscription again.
-        itemsToDelete.forEach(
-            item -> {
-              item.reset();
-              item.setClientHandle(null);
-            });
-        itemsToDelete.clear();
+          // MonitoredItemIds are scoped to the Subscription that no longer exists, so the items
+          // pending deletion are already gone and their ids must never be sent again. Detach them
+          // completely, including the ClientHandle, so they can be added to a Subscription again.
+          itemsToDelete.forEach(
+              item -> {
+                item.reset();
+                item.setClientHandle(null);
+              });
+          itemsToDelete.clear();
+        }
 
         syncState = SyncState.INITIAL;
       }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/PublishingManager.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/PublishingManager.java
@@ -15,6 +15,7 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -139,7 +140,11 @@ public class PublishingManager {
 
   private final ConcurrentMap<NodeId, AtomicLong> pendingCountMap = new ConcurrentHashMap<>();
 
-  private final Map<UInteger, SubscriptionDetails> subscriptionDetails = new ConcurrentHashMap<>();
+  private final Object registrationLock = new Object();
+
+  // Replace the immutable map only when registration changes. Each Publish request can retain
+  // its identity snapshot with one volatile read instead of copying the registry on the hot path.
+  private volatile Map<UInteger, SubscriptionDetails> subscriptionDetails = Map.of();
 
   /**
    * Incremented every time a Subscription is registered with or unregistered from this manager.
@@ -258,18 +263,17 @@ public class PublishingManager {
         .getSubscriptionId()
         .ifPresent(
             id -> {
-              SubscriptionDetails displaced =
-                  subscriptionDetails.put(id, new SubscriptionDetails(subscription, id, executor));
-
-              if (displaced != null) {
-                // The Server has reused this SubscriptionId while an entry was still registered
-                // under it. Displacement removed that entry from the map, so unregister() — which
-                // matches by (key, value) — can never succeed for it again; without this, work
-                // still queued for it would be applied as if its Subscription existed, forever.
-                displaced.registered = false;
+              // Construct outside registrationLock because this reads the subscription lifecycle.
+              var details = new SubscriptionDetails(subscription, id, executor);
+              synchronized (registrationLock) {
+                var updated = new HashMap<>(subscriptionDetails);
+                SubscriptionDetails displaced = updated.put(id, details);
+                if (displaced != null) {
+                  displaced.registered = false;
+                }
+                subscriptionDetails = Map.copyOf(updated);
+                subscriptionGeneration.incrementAndGet();
               }
-
-              subscriptionGeneration.incrementAndGet();
             });
 
     // The client wants a deeper pipeline than it did when any ceiling was learned, and Part 4
@@ -310,15 +314,18 @@ public class PublishingManager {
    *     it; {@code false} if something else unregistered it first.
    */
   private boolean unregister(SubscriptionDetails details) {
-    if (subscriptionDetails.remove(details.subscriptionId, details)) {
+    synchronized (registrationLock) {
+      if (subscriptionDetails.get(details.subscriptionId) != details) {
+        return false;
+      }
+
+      var updated = new HashMap<>(subscriptionDetails);
+      updated.remove(details.subscriptionId);
       details.registered = false;
-
+      subscriptionDetails = Map.copyOf(updated);
       subscriptionGeneration.incrementAndGet();
-
       return true;
     }
-
-    return false;
   }
 
   /**
@@ -876,6 +883,7 @@ public class PublishingManager {
     // Read before the request is built, so that a Subscription registered or unregistered while it
     // is in flight is seen as a change by the failure handler rather than missed.
     long generation = subscriptionGeneration.get();
+    Map<UInteger, SubscriptionDetails> requestRegistrations = subscriptionDetails;
 
     // Read for the same reason: a Session-level failure describes the Session the request was sent
     // on, and once another activation has been counted it no longer describes the client.
@@ -957,7 +965,12 @@ public class PublishingManager {
 
                   boolean queued = false;
 
-                  if (details != null) {
+                  SubscriptionDetails requestedDetails = requestRegistrations.get(subscriptionId);
+                  if (details != null
+                      && (requestedDetails == null || requestedDetails == details)) {
+                    // A queued Publish may serve a subscription created after the request. Only
+                    // reject a known id that now belongs to another registration: its delayed
+                    // response cannot safely be attributed to the replacement incarnation.
                     // Cheap and non-blocking: cancels and re-schedules a timer. The watchdog
                     // watches for the Server going quiet, so it is reset when the response is
                     // received rather than when it is eventually processed.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/package-info.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/package-info.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/**
+ * Maintains client-side Subscriptions, their desired MonitoredItems, and ordered notification
+ * delivery. {@link org.eclipse.milo.opcua.sdk.client.subscriptions.OpcUaSubscription} owns the
+ * desired configuration and server-assigned state. The publishing manager maintains the Session's
+ * Publish pipeline and routes responses to registered Subscriptions.
+ *
+ * <p>A reset starts a new incarnation of a Subscription object. Service responses captured for an
+ * earlier incarnation cannot update its replacement, and pending Publish responses retain their
+ * registration identities when server-assigned ids are reused. Publish requests may also serve a
+ * Subscription first registered after the request was sent. Registration changes publish an
+ * immutable registry snapshot; retaining it for each Publish request needs no registry lock or map
+ * copy. Per-subscription processing and delivery queues preserve the order received from the
+ * transport.
+ *
+ * <p>Lifecycle operations claim a serial transition slot without holding a lock across service
+ * calls. Completing a transition hands the slot to the next waiter through a serial executor, with
+ * inline fallback when the caller-owned transport executor rejects dispatch. Reset and item
+ * add/remove operations coordinate collection membership and ClientHandle ownership; code requiring
+ * both locks takes the lifecycle lock before the item collection lock.
+ *
+ * <p>Discovering a monitored-item partition limit may wait for Session activation and server I/O.
+ * Reset invalidates that cache without waiting for an in-progress lookup, because Session recovery
+ * itself may need to reset Subscriptions before activation can finish.
+ */
+package org.eclipse.milo.opcua.sdk.client.subscriptions;


### PR DESCRIPTION
This PR addresses six client recovery and concurrency issues that can stop publishing, apply stale responses, or stall lifecycle transitions. It is stacked on #1863, which supplies the monitored-item response guards tested here.

### Preserve session callback order during reactivation

A delayed inactive notification could arrive after the same Session reactivated and close its recovered publishing pipeline. Session activity callbacks now execute in order through a sequential executor.

### Reject Publish responses for a replaced registration

A pending Publish response could resolve a reused subscription ID to a replacement registration. Each request now captures the registration map, and response processing checks the original registration's identity before applying the result.

Subscriptions first registered after dispatch and unrelated registration changes remain valid. [Part 4 §5.14.5.1](https://reference.opcfoundation.org/Core/Part4/v105/docs/5.14.5) explains why: "Since Publish requests are not directed to a specific Subscription, they may be used by any Subscription." The wire identifier does not distinguish successive Java registrations.

### Synchronize reset with monitored-item changes

Reset could race with monitored-item add/remove and leave a retained item without its client handle. Reset now uses the same collection lock as add/remove, in the established lifecycle-to-items lock order.

### Protect recreated items from delayed service responses

New concurrent regressions cover delayed CreateMonitoredItems, ModifyMonitoredItems, DeleteMonitoredItems, and SetMonitoringMode responses after reset and recreation. The production guards are already in #1863; these tests verify that each rejects a stale response and preserves the replacement item's state.

[Part 4 §5.13.2.2](https://reference.opcfoundation.org/specs/OPC-10000-4/5.13.2.2) scopes monitored-item identifiers: "This id is unique within the Subscription, but might not be unique within the Server or Session."

### Complete lifecycle transitions when an executor rejects work

Rejected completion handoffs could strand queued subscription operations. Direct execution could also recurse through enough handoffs to stall the queue. A per-subscription sequential executor now drains transitions iteratively, with a caller-thread fallback when dispatch is rejected.

### Invalidate operation limits without blocking session recovery

Transfer cleanup could wait for an operation-limits Read whose completion depended on session activation finishing. The cache now uses NonBlockingLazy, so reset invalidates an in-progress generation without waiting for its supplier.

### Verification

Formatting, a full clean compile, and selected session, subscription, monitored-item, and publishing tests passed. The new tests reproduce the defects present on the stacked base. Removing the four existing monitored-item response guards in an isolated baseline makes all four corresponding regressions fail. Transition tests cover 10,000 queued operations under both rejected and direct execution.
