### PR TITLE
Preserve dynamic values and complete type discovery correctly

### DIFF
--- a/opc-ua-sdk/codec-json/src/main/java/org/eclipse/milo/sdk/core/types/json/JsonStructCodec.java
+++ b/opc-ua-sdk/codec-json/src/main/java/org/eclipse/milo/sdk/core/types/json/JsonStructCodec.java
@@ -606,8 +606,11 @@ public class JsonStructCodec extends GenericDataTypeCodec<JsonStruct> {
     if (definition.getStructureType() == StructureType.StructureWithOptionalFields) {
       int optionalFieldIndex = 0;
       for (StructureField field : fields) {
-        if (field.getIsOptional() && value.getJsonObject().has(requireNonNull(field.getName()))) {
-          switchField = switchField | (1L << optionalFieldIndex++);
+        if (field.getIsOptional()) {
+          if (value.getJsonObject().has(requireNonNull(field.getName()))) {
+            switchField |= 1L << optionalFieldIndex;
+          }
+          optionalFieldIndex++;
         }
       }
       encoder.encodeUInt32("SwitchField", UInteger.valueOf(switchField));

--- a/opc-ua-sdk/codec-json/src/main/java/org/eclipse/milo/sdk/core/types/json/package-info.java
+++ b/opc-ua-sdk/codec-json/src/main/java/org/eclipse/milo/sdk/core/types/json/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/**
+ * Represents dynamic OPC UA structures as JSON objects while preserving their declared wire types.
+ *
+ * <p>A DataType tree supplies field definitions and inheritance information. Codecs map JSON
+ * members to those fields and use the encoding context for nested structured values. The JSON
+ * object holds application data; the definition determines field order, optional-field mask
+ * positions, and union selection when serializing through an OPC UA encoder.
+ *
+ * <p>Absent optional members remain absent after decoding and re-encoding. Their omission does not
+ * move the mask bits assigned to later fields.
+ */
+package org.eclipse.milo.sdk.core.types.json;

--- a/opc-ua-sdk/codec-json/src/test/java/org/eclipse/milo/sdk/core/types/json/JsonStructCodecTest.java
+++ b/opc-ua-sdk/codec-json/src/test/java/org/eclipse/milo/sdk/core/types/json/JsonStructCodecTest.java
@@ -658,6 +658,27 @@ class JsonStructCodecTest {
 
   private static Stream<Arguments> structWithOptionalScalarFieldsProvider() {
     return Stream.of(
+        // An omitted earlier optional field must not shift a later field's wire mask bit.
+        Arguments.of(
+            new StructWithOptionalScalarFields(
+                "required",
+                null,
+                1,
+                7,
+                2.0,
+                null,
+                new ConcreteTestType((short) 0, 0.0, "", false),
+                null)),
+        Arguments.of(
+            new StructWithOptionalScalarFields(
+                "required",
+                "present",
+                1,
+                null,
+                2.0,
+                3.0,
+                new ConcreteTestType((short) 0, 0.0, "", false),
+                null)),
         Arguments.of(
             new StructWithOptionalScalarFields(
                 "",
@@ -682,6 +703,17 @@ class JsonStructCodecTest {
 
   private static Stream<Arguments> structWithOptionalArrayFieldsProvider() {
     return Stream.of(
+        // Sparse optional arrays use the same mask positions as the declared field order.
+        Arguments.of(
+            new StructWithOptionalArrayFields(
+                new Integer[] {1},
+                null,
+                new String[] {"required"},
+                new String[] {"present"},
+                new Double[] {2.0},
+                null,
+                new ConcreteTestType[0],
+                null)),
         Arguments.of(
             new StructWithOptionalArrayFields(
                 new Integer[] {0, 0},

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/typetree/ClientBrowseUtilsTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/typetree/ClientBrowseUtilsTest.java
@@ -10,10 +10,13 @@
 
 package org.eclipse.milo.opcua.sdk.client.typetree;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -25,6 +28,34 @@ import org.eclipse.milo.opcua.stack.core.types.structured.BrowseResult;
 import org.junit.jupiter.api.Test;
 
 class ClientBrowseUtilsTest {
+
+  // Empty and null tokens both mean Browse is complete and must never reach BrowseNext.
+  @Test
+  void terminalContinuationPointsDoNotSendAnotherRequest() throws UaException {
+    var client = mock(OpcUaClient.class);
+
+    assertEquals(List.of(), ClientBrowseUtils.maybeBrowseNext(client, null));
+    assertEquals(List.of(), ClientBrowseUtils.maybeBrowseNext(client, ByteString.NULL_VALUE));
+    assertEquals(List.of(), ClientBrowseUtils.maybeBrowseNext(client, ByteString.of(new byte[0])));
+    verifyNoInteractions(client);
+  }
+
+  // A final empty token must stop the loop after the valid continuation request.
+  @Test
+  void emptyContinuationPointInResponseFinishesBrowse() throws UaException {
+    var client = mock(OpcUaClient.class);
+    var response = mock(BrowseNextResponse.class);
+    var result = mock(BrowseResult.class);
+    var continuationPoint = ByteString.of(new byte[] {1});
+    when(client.browseNext(false, List.of(continuationPoint))).thenReturn(response);
+    when(response.getResults()).thenReturn(new BrowseResult[] {result});
+    when(result.getContinuationPoint()).thenReturn(ByteString.of(new byte[0]));
+
+    assertEquals(List.of(), ClientBrowseUtils.maybeBrowseNext(client, continuationPoint));
+
+    verify(client).browseNext(false, List.of(continuationPoint));
+    verifyNoMoreInteractions(client);
+  }
 
   @Test
   void releasesContinuationPointWhenBrowseNextLimitIsReached() throws UaException {

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/typetree/ClientDataTypeEncodingTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/typetree/ClientDataTypeEncodingTest.java
@@ -12,6 +12,7 @@ package org.eclipse.milo.opcua.sdk.client.typetree;
 
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.stream.Stream;
 import org.eclipse.milo.opcua.sdk.core.types.DynamicStructType;
@@ -35,8 +36,30 @@ import org.eclipse.milo.opcua.stack.core.util.Tree;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class ClientDataTypeEncodingTest {
+
+  // Abstract and nested-only structures have no binary encoding; wire null must remain absent.
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void nullDefaultEncodingRemainsAbsent(boolean isAbstract) {
+    var definition =
+        new StructureDefinition(
+            NodeId.NULL_VALUE, NodeIds.Structure, StructureType.Structure, new StructureField[0]);
+    var dataType =
+        new ClientDataType(
+            new QualifiedName(1, "NoEncoding"),
+            new NodeId(1, 3002),
+            null,
+            null,
+            null,
+            definition,
+            isAbstract);
+    var tree = new DataTypeTree(new Tree<DataType>(null, dataType));
+
+    assertNull(tree.getBinaryEncodingId(dataType.getNodeId()));
+  }
 
   // The encoding ID used for codec registration must also survive in decoded value metadata.
   @ParameterizedTest

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/typetree/ClientDataTypeEncodingTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/typetree/ClientDataTypeEncodingTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.typetree;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.stream.Stream;
+import org.eclipse.milo.opcua.sdk.core.types.DynamicStructType;
+import org.eclipse.milo.opcua.sdk.core.types.DynamicUnionType;
+import org.eclipse.milo.opcua.sdk.core.typetree.DataType;
+import org.eclipse.milo.opcua.sdk.core.typetree.DataTypeTree;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
+import org.eclipse.milo.opcua.stack.core.types.DataTypeManager;
+import org.eclipse.milo.opcua.stack.core.types.DefaultDataTypeManager;
+import org.eclipse.milo.opcua.stack.core.types.UaStructuredType;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.StructureType;
+import org.eclipse.milo.opcua.stack.core.types.structured.StructureDefinition;
+import org.eclipse.milo.opcua.stack.core.types.structured.StructureField;
+import org.eclipse.milo.opcua.stack.core.util.Tree;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ClientDataTypeEncodingTest {
+
+  // The encoding ID used for codec registration must also survive in decoded value metadata.
+  @ParameterizedTest
+  @MethodSource("encodingCases")
+  void decodedValuesCanBeReencoded(
+      StructureType structureType, NodeId advertisedEncodingId, NodeId effectiveEncodingId) {
+    var manager = new DefaultDataTypeManager();
+    var context =
+        new DefaultEncodingContext() {
+          @Override
+          public DataTypeManager getDataTypeManager() {
+            return manager;
+          }
+        };
+    context.getNamespaceTable().add("urn:test:encoding-fallback");
+
+    var definition =
+        new StructureDefinition(
+            new NodeId(1, 5001),
+            NodeIds.Structure,
+            structureType,
+            new StructureField[] {
+              new StructureField(
+                  "Value", LocalizedText.NULL_VALUE, NodeIds.Int32, -1, null, uint(0), false)
+            });
+    var dataType =
+        new ClientDataType(
+            new QualifiedName(1, "TestType"),
+            new NodeId(1, 3001),
+            advertisedEncodingId,
+            null,
+            null,
+            definition,
+            false);
+    var root =
+        new Tree<DataType>(
+            null,
+            new ClientDataType(
+                new QualifiedName(0, "Structure"),
+                NodeIds.Structure,
+                null,
+                null,
+                null,
+                null,
+                true));
+    root.addChild(dataType);
+    var tree = new DataTypeTree(root);
+    new DataTypeManagerFactory.DefaultInitializer()
+        .initialize(context.getNamespaceTable(), tree, manager);
+
+    byte[] body =
+        structureType == StructureType.Union
+            ? new byte[] {1, 0, 0, 0, 7, 0, 0, 0}
+            : new byte[] {7, 0, 0, 0};
+    var encoded = ExtensionObject.of(ByteString.of(body), effectiveEncodingId);
+    UaStructuredType decoded = encoded.decode(context);
+
+    if (decoded instanceof DynamicStructType struct) {
+      assertEquals(7, struct.getMembers().get("Value"));
+    } else {
+      assertEquals(
+          new DynamicUnionType.UnionValue("Value", 7),
+          ((DynamicUnionType) decoded).getValue().orElseThrow());
+    }
+    assertEquals(encoded, ExtensionObject.encode(context, decoded));
+    assertEquals(effectiveEncodingId, tree.getBinaryEncodingId(dataType.getNodeId()));
+  }
+
+  static Stream<Arguments> encodingCases() {
+    return Stream.of(StructureType.Structure, StructureType.Union)
+        .flatMap(
+            type ->
+                Stream.of(
+                    Arguments.of(type, null, new NodeId(1, 5001)),
+                    Arguments.of(type, NodeId.NULL_VALUE, new NodeId(1, 5001)),
+                    Arguments.of(type, new NodeId(1, 5002), new NodeId(1, 5002))));
+  }
+}

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/typetree/ClientBrowseUtils.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/typetree/ClientBrowseUtils.java
@@ -231,7 +231,7 @@ final class ClientBrowseUtils {
 
     int iterations = 0;
 
-    while (continuationPoint != null && continuationPoint.isNotNull()) {
+    while (continuationPoint != null && !continuationPoint.isNullOrEmpty()) {
       if (++iterations > MAX_BROWSE_NEXT_ITERATIONS) {
         var limitException =
             new UaException(

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/typetree/ClientDataType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/typetree/ClientDataType.java
@@ -54,11 +54,13 @@ class ClientDataType implements DataType {
     this.nodeId = nodeId;
     // Keep codec registration and decoded values on the same effective encoding ID, even when
     // a server omits its HasEncoding references.
+    NodeId effectiveEncodingId = binaryEncodingId;
+    if ((effectiveEncodingId == null || effectiveEncodingId.isNull())
+        && dataTypeDefinition instanceof StructureDefinition definition) {
+      effectiveEncodingId = definition.getDefaultEncodingId();
+    }
     this.binaryEncodingId =
-        (binaryEncodingId == null || binaryEncodingId.isNull())
-                && dataTypeDefinition instanceof StructureDefinition definition
-            ? definition.getDefaultEncodingId()
-            : binaryEncodingId;
+        effectiveEncodingId == null || effectiveEncodingId.isNull() ? null : effectiveEncodingId;
     this.xmlEncodingId = xmlEncodingId;
     this.jsonEncodingId = jsonEncodingId;
     this.dataTypeDefinition = dataTypeDefinition;

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/typetree/ClientDataType.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/typetree/ClientDataType.java
@@ -16,6 +16,7 @@ import org.eclipse.milo.opcua.sdk.core.typetree.DataType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
 import org.eclipse.milo.opcua.stack.core.types.structured.DataTypeDefinition;
+import org.eclipse.milo.opcua.stack.core.types.structured.StructureDefinition;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -51,7 +52,13 @@ class ClientDataType implements DataType {
 
     this.browseName = browseName;
     this.nodeId = nodeId;
-    this.binaryEncodingId = binaryEncodingId;
+    // Keep codec registration and decoded values on the same effective encoding ID, even when
+    // a server omits its HasEncoding references.
+    this.binaryEncodingId =
+        (binaryEncodingId == null || binaryEncodingId.isNull())
+                && dataTypeDefinition instanceof StructureDefinition definition
+            ? definition.getDefaultEncodingId()
+            : binaryEncodingId;
     this.xmlEncodingId = xmlEncodingId;
     this.jsonEncodingId = jsonEncodingId;
     this.dataTypeDefinition = dataTypeDefinition;

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/typetree/package-info.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/typetree/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/**
+ * Discovers server type metadata and makes it available to client codecs and address-space APIs.
+ *
+ * <p>Type-tree factories select eager discovery or lazy resolution. Builders read definitions and
+ * browse inheritance and encoding references within a session, honoring operation limits and
+ * following continuation points until the server returns a null or empty token. Lazy trees resolve
+ * types on demand and discard stale work when their session or cache generation changes.
+ *
+ * <p>DataType managers register codecs from the resolved metadata. A structure's DefaultEncodingId
+ * supplies its binary encoding ID when the server omits HasEncoding references. The effective ID
+ * belongs to the metadata as well as the registration, allowing decoded dynamic values to be
+ * encoded again. Definitions and codec registrations must describe the same type-tree generation.
+ */
+package org.eclipse.milo.opcua.sdk.client.typetree;

--- a/opc-ua-sdk/sdk-core/src/main/java/org/eclipse/milo/opcua/sdk/core/types/codec/DynamicStructCodec.java
+++ b/opc-ua-sdk/sdk-core/src/main/java/org/eclipse/milo/opcua/sdk/core/types/codec/DynamicStructCodec.java
@@ -112,9 +112,11 @@ public class DynamicStructCodec extends GenericDataTypeCodec<DynamicStructType> 
     if (definition.getStructureType() == StructureType.StructureWithOptionalFields) {
       int optionalFieldIndex = 0;
       for (StructureField field : fields) {
-        if (field.getIsOptional()
-            && struct.getMembers().containsKey(requireNonNull(field.getName()))) {
-          encodingMask = encodingMask | (1L << optionalFieldIndex++);
+        if (field.getIsOptional()) {
+          if (struct.getMembers().containsKey(requireNonNull(field.getName()))) {
+            encodingMask |= 1L << optionalFieldIndex;
+          }
+          optionalFieldIndex++;
         }
       }
       encoder.encodeUInt32("EncodingMask", UInteger.valueOf(encodingMask));

--- a/opc-ua-sdk/sdk-core/src/main/java/org/eclipse/milo/opcua/sdk/core/types/codec/package-info.java
+++ b/opc-ua-sdk/sdk-core/src/main/java/org/eclipse/milo/opcua/sdk/core/types/codec/package-info.java
@@ -8,6 +8,18 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
+/**
+ * Encodes and decodes dynamic values using the definitions in a DataType tree.
+ *
+ * <p>{@link org.eclipse.milo.opcua.sdk.core.types.codec.DynamicCodecFactory} selects a codec for
+ * each definition. The encoding context supplies nested codecs, while the tree resolves field types
+ * and their inherited builtin representation. Decoded values retain their DataType metadata so they
+ * can later be encoded through the same context.
+ *
+ * <p>Structure definitions determine wire field order and optional-field mask positions. Omitting a
+ * value does not change the position of any later optional field. Applications supply members by
+ * name; codecs translate those members into the declared wire layout.
+ */
 @NullMarked
 package org.eclipse.milo.opcua.sdk.core.types.codec;
 

--- a/opc-ua-sdk/sdk-core/src/test/java/org/eclipse/milo/opcua/sdk/core/types/DynamicTypeSerializationTest.java
+++ b/opc-ua-sdk/sdk-core/src/test/java/org/eclipse/milo/opcua/sdk/core/types/DynamicTypeSerializationTest.java
@@ -771,6 +771,27 @@ class DynamicTypeSerializationTest {
 
   private static Stream<Arguments> structWithOptionalScalarFieldsProvider() {
     return Stream.of(
+        // An omitted earlier optional field must not shift a later field's wire mask bit.
+        Arguments.of(
+            new StructWithOptionalScalarFields(
+                "required",
+                null,
+                1,
+                7,
+                2.0,
+                null,
+                new ConcreteTestType((short) 0, 0.0, "", false),
+                null)),
+        Arguments.of(
+            new StructWithOptionalScalarFields(
+                "required",
+                "present",
+                1,
+                null,
+                2.0,
+                3.0,
+                new ConcreteTestType((short) 0, 0.0, "", false),
+                null)),
         Arguments.of(
             new StructWithOptionalScalarFields(
                 "",
@@ -795,6 +816,17 @@ class DynamicTypeSerializationTest {
 
   private static Stream<Arguments> structWithOptionalArrayFieldsProvider() {
     return Stream.of(
+        // Sparse optional arrays use the same mask positions as the declared field order.
+        Arguments.of(
+            new StructWithOptionalArrayFields(
+                new Integer[] {1},
+                null,
+                new String[] {"required"},
+                new String[] {"present"},
+                new Double[] {2.0},
+                null,
+                new ConcreteTestType[0],
+                null)),
         Arguments.of(
             new StructWithOptionalArrayFields(
                 new Integer[] {0, 0},

--- a/opc-ua-stack/encoding-xml/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlDecoder.java
+++ b/opc-ua-stack/encoding-xml/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlDecoder.java
@@ -607,7 +607,8 @@ public class OpcUaXmlDecoder implements UaDecoder, AutoCloseable {
       Node node = currentNode;
 
       try {
-        currentNode = node.getFirstChild().getFirstChild();
+        Node valueNode = firstElementChild(node);
+        currentNode = valueNode != null ? firstElementChild(valueNode) : null;
 
         if (currentNode == null) {
           return Variant.NULL_VALUE;
@@ -652,39 +653,21 @@ public class OpcUaXmlDecoder implements UaDecoder, AutoCloseable {
 
         return array;
       } else if (nodeName.equals("Matrix")) {
-        List<Integer> dimensions = new ArrayList<>();
-        Node child = node.getFirstChild();
-        for (int i = 0; i < child.getChildNodes().getLength(); i++) {
-          currentNode = child.getChildNodes().item(i);
-
-          if (currentNode.getNodeType() == Node.ELEMENT_NODE) {
-            dimensions.add(decodeInt32("Int32"));
-          }
+        Node dimensionsNode = firstElementChild(node);
+        if (dimensionsNode == null) {
+          return Matrix.ofNull();
         }
 
-        List<Object> elements = new ArrayList<>();
-        child = child.getNextSibling();
-        for (int i = 0; i < child.getChildNodes().getLength(); i++) {
-          currentNode = child.getChildNodes().item(i);
-
-          if (currentNode.getNodeType() == Node.ELEMENT_NODE) {
-            String type = currentNode.getLocalName();
-            elements.add(readBuiltinType(type, type));
-          }
+        Node elementsNode = nextElementSibling(dimensionsNode);
+        Node element = elementsNode != null ? firstElementChild(elementsNode) : null;
+        if (element == null) {
+          throw new UaSerializationException(
+              StatusCodes.Bad_DecodingError, "Matrix has dimensions but no elements");
         }
 
-        Class<?> clazz = elements.get(0).getClass();
-        Object array = Array.newInstance(clazz, elements.size());
-        for (int i = 0; i < elements.size(); i++) {
-          Array.set(array, i, elements.get(i));
-        }
-
-        int[] dims = new int[dimensions.size()];
-        for (int i = 0; i < dimensions.size(); i++) {
-          dims[i] = dimensions.get(i);
-        }
-
-        return new Matrix(array, dims);
+        OpcUaDataType dataType = OpcUaDataType.valueOf(element.getLocalName());
+        currentNode = node;
+        return decodeMatrix("Matrix", dataType);
       } else {
         return readBuiltinType(nodeName, nodeName);
       }

--- a/opc-ua-stack/encoding-xml/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlDecoder.java
+++ b/opc-ua-stack/encoding-xml/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlDecoder.java
@@ -665,7 +665,12 @@ public class OpcUaXmlDecoder implements UaDecoder, AutoCloseable {
               StatusCodes.Bad_DecodingError, "Matrix has dimensions but no elements");
         }
 
-        OpcUaDataType dataType = OpcUaDataType.valueOf(element.getLocalName());
+        OpcUaDataType dataType;
+        try {
+          dataType = OpcUaDataType.valueOf(element.getLocalName());
+        } catch (IllegalArgumentException e) {
+          throw new UaSerializationException(StatusCodes.Bad_DecodingError, e);
+        }
         currentNode = node;
         return decodeMatrix("Matrix", dataType);
       } else {

--- a/opc-ua-stack/encoding-xml/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/xml/package-info.java
+++ b/opc-ua-stack/encoding-xml/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/xml/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/**
+ * Converts OPC UA values between XML and the stack's Java value types.
+ *
+ * <p>Encoders and decoders use an encoding context for namespaces, limits, and structured-type
+ * codecs. A decoder owns its XML cursor and should be used for one input at a time. Element
+ * boundaries determine the value layout; indentation and comments between elements do not carry
+ * values.
+ *
+ * <p>Variants identify their contained builtin type from the XML element name. Matrix decoding
+ * validates dimensions, element types, and element counts for both Variants and directly decoded
+ * matrices. Structured values are delegated to the codecs registered in the context.
+ */
+package org.eclipse.milo.opcua.stack.core.encoding.xml;

--- a/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlVariantWhitespaceTest.java
+++ b/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlVariantWhitespaceTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.core.encoding.xml;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.eclipse.milo.opcua.stack.core.UaSerializationException;
+import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Matrix;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class OpcUaXmlVariantWhitespaceTest {
+
+  // Formatting and comments around Value must not turn a valid scalar into a null Variant.
+  @ParameterizedTest
+  @ValueSource(strings = {"", "\n  ", "\n<!-- comment -->\n"})
+  void scalarIgnoresWhitespaceBetweenElements(String spacing) throws Exception {
+    String xml = "<Test>" + spacing + "<Value>" + spacing + "<Int32>7</Int32></Value></Test>";
+    try (var decoder = new OpcUaXmlDecoder(DefaultEncodingContext.INSTANCE, xml)) {
+      assertEquals(new Variant(7), decoder.decodeVariant("Test"));
+    }
+  }
+
+  // Matrix dimensions and elements have the same meaning in compact and indented XML.
+  @ParameterizedTest
+  @ValueSource(strings = {"", "\n  ", "\n<!-- comment -->\n"})
+  void matrixIgnoresWhitespaceBetweenElements(String spacing) throws Exception {
+    String xml = matrixXml(spacing, "<Int32>7</Int32><Int32>8</Int32>");
+    try (var decoder = new OpcUaXmlDecoder(DefaultEncodingContext.INSTANCE, xml)) {
+      assertEquals(
+          new Variant(new Matrix(new Integer[] {7, 8}, new int[] {1, 2})),
+          decoder.decodeVariant("Test"));
+    }
+  }
+
+  // Variant matrices must use the same shape validation as direct matrix decoding.
+  @ParameterizedTest
+  @ValueSource(strings = {"<Int32>7</Int32>", "<Int32>7</Int32><String>8</String>"})
+  void malformedMatrixFailsDecoding(String elements) throws Exception {
+    try (var decoder =
+        new OpcUaXmlDecoder(DefaultEncodingContext.INSTANCE, matrixXml("\n  ", elements))) {
+      assertThrows(UaSerializationException.class, () -> decoder.decodeVariant("Test"));
+    }
+  }
+
+  private static String matrixXml(String spacing, String elements) {
+    return "<Test><Value><Matrix>"
+        + spacing
+        + "<Dimensions><Int32>1</Int32><Int32>2</Int32></Dimensions>"
+        + spacing
+        + "<Elements>"
+        + elements
+        + "</Elements></Matrix></Value></Test>";
+  }
+}

--- a/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlVariantWhitespaceTest.java
+++ b/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlVariantWhitespaceTest.java
@@ -13,14 +13,29 @@ package org.eclipse.milo.opcua.stack.core.encoding.xml;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaSerializationException;
 import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Matrix;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class OpcUaXmlVariantWhitespaceTest {
+
+  // The public value decoder must report malformed matrix element names as decoding failures.
+  @Test
+  void unknownMatrixElementFailsWithDecodingStatus() throws Exception {
+    String xml =
+        "<Matrix><Dimensions><Int32>1</Int32></Dimensions>"
+            + "<Elements><Unknown>7</Unknown></Elements></Matrix>";
+    try (var decoder = new OpcUaXmlDecoder(DefaultEncodingContext.INSTANCE, xml)) {
+      UaSerializationException failure =
+          assertThrows(UaSerializationException.class, decoder::decodeVariantValue);
+      assertEquals(StatusCodes.Bad_DecodingError, failure.getStatusCode().value());
+    }
+  }
 
   // Formatting and comments around Value must not turn a valid scalar into a null Variant.
   @ParameterizedTest


### PR DESCRIPTION
This PR fixes four serialization and type-discovery issues that can lose values, break round trips, or prevent type-tree construction.

### Keep optional-field mask positions stable

When an earlier optional field was absent, both dynamic structure codecs assigned the next present field the wrong mask bit. The binary codec silently wrote the wrong field; the JSON-backed codec could throw while reading an absent member. Both now advance the optional index for every declared optional field. Part 6 §5.2.7 assigns positions independently of presence: "The first optional field is assigned bit '0', the second optional field is assigned bit '1'". Its worked example also uses mask `0x02` when only the second optional field is present. [OPC 10000-6 §5.2.7](https://reference.opcfoundation.org/specs/OPC-10000-6/5.2.7).

### Decode XML Variants with whitespace and comments

XML Variant decoding now skips whitespace and comments between elements, and uses the existing matrix decoder to validate shapes and element types. Previously, indentation could turn an Int32 Variant into null or make matrix traversal read the wrong nodes. Part 6 §5.3.1.17 specifies that a scalar Variant "shall contain a single child element with the name of the built-in type"; the same clause defines the Matrix Dimensions/Elements layout. [OPC 10000-6 §5.3.1.17](https://reference.opcfoundation.org/specs/OPC-10000-6/5.3.1.17).

### Retain fallback encoding IDs for decoded structures

When a server omits HasEncoding references, ClientDataType now retains the StructureDefinition fallback encoding ID. Previously, registration used the fallback but decoded values reported a null encoding ID, so re-encoding failed. Explicit encoding references still take precedence, and absent encoding IDs remain null for abstract or nested-only structures. Part 3 §8.48 specifies, after its abstract/nested-type exceptions: "In all other cases the DefaultEncodingId in the StructureDefinition shall be the Default Binary encoding for the DataType". [OPC 10000-3 §8.48](https://reference.opcfoundation.org/specs/OPC-10000-3/8.48).

### Stop browsing when the continuation token is empty

Type-tree browsing now stops for an empty continuation token as well as a null token. A completed Browse previously caused an unnecessary BrowseNext and could repeat until tree construction failed. Part 4 §7.9 explains the continuation contract: "The Server allocates a ContinuationPoint if there are more results to return." The fix also follows the helper's existing null-or-empty terminal contract. [OPC 10000-4 §7.9](https://reference.opcfoundation.org/specs/OPC-10000-4/7.9).

### Verification

Regression tests failed against the original production code for all four defects. They cover sparse optional scalar and array fields against an independent encoder, compact versus indented/commented XML, malformed matrix shapes, structure and union decode/re-encode with fallback or explicit IDs, and initial/final empty continuation tokens.

Verification passed: `mise exec -- mvn -q spotless:apply`, `mise exec -- mvn -q clean compile`, and targeted reactor `verify` for dynamic serialization, JSON codecs, XML codecs, and client type-tree tests (zero failures, errors, or skips). No foreign-server interoperability run was performed.

Existing empty-matrix and BrowseResult status-handling limitations are unchanged.
