### PR TITLE
Fix trust-list removal persistence and keystore file watching

### DIFF
--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/FileBasedTrustListManager.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/FileBasedTrustListManager.java
@@ -469,6 +469,9 @@ public class FileBasedTrustListManager implements TrustListManager, Closeable {
     // failure cannot destroy the unrelated CRLs that it also contains.
     Path temporary = Files.createTempFile(file.getParent(), ".crl-", ".tmp");
     try {
+      if (file.getFileSystem().supportedFileAttributeViews().contains("posix")) {
+        Files.setPosixFilePermissions(temporary, Files.getPosixFilePermissions(file));
+      }
       try (var output = Files.newOutputStream(temporary)) {
         for (X509CRL crl : crls) {
           output.write(crl.getEncoded());

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/FileBasedTrustListManager.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/FileBasedTrustListManager.java
@@ -20,9 +20,11 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardWatchEventKinds;
 import java.nio.file.WatchKey;
 import java.nio.file.WatchService;
@@ -176,25 +178,25 @@ public class FileBasedTrustListManager implements TrustListManager, Closeable {
           updated.issuerCertificates(),
           issuerCertsDir,
           FileBasedTrustListManager::writeCertificateToDir,
-          FileBasedTrustListManager::deleteCertificateFromDir);
+          FileBasedTrustListManager::deleteCertificatesFromDir);
       updateFiles(
           current.issuerCrls(),
           updated.issuerCrls(),
           issuerCrlDir,
           FileBasedTrustListManager::writeCrlToDir,
-          FileBasedTrustListManager::deleteCrlFromDir);
+          FileBasedTrustListManager::deleteCrlsFromDir);
       updateFiles(
           current.trustedCertificates(),
           updated.trustedCertificates(),
           trustedCertsDir,
           FileBasedTrustListManager::writeCertificateToDir,
-          FileBasedTrustListManager::deleteCertificateFromDir);
+          FileBasedTrustListManager::deleteCertificatesFromDir);
       updateFiles(
           current.trustedCrls(),
           updated.trustedCrls(),
           trustedCrlDir,
           FileBasedTrustListManager::writeCrlToDir,
-          FileBasedTrustListManager::deleteCrlFromDir);
+          FileBasedTrustListManager::deleteCrlsFromDir);
 
       TrustListSnapshot committed = updated.withLastUpdateTime(DateTime.now());
       snapshot.set(committed);
@@ -290,7 +292,7 @@ public class FileBasedTrustListManager implements TrustListManager, Closeable {
       List<T> replacement,
       Path directory,
       BiConsumer<T, Path> write,
-      BiConsumer<T, Path> delete) {
+      BiConsumer<Set<T>, Path> delete) {
 
     if (current.equals(replacement)) {
       return;
@@ -300,7 +302,10 @@ public class FileBasedTrustListManager implements TrustListManager, Closeable {
     Set<T> replacementSet = Set.copyOf(replacement);
 
     Sets.difference(replacementSet, currentSet).forEach(entry -> write.accept(entry, directory));
-    Sets.difference(currentSet, replacementSet).forEach(entry -> delete.accept(entry, directory));
+    Set<T> removed = Sets.difference(currentSet, replacementSet);
+    if (!removed.isEmpty()) {
+      delete.accept(removed, directory);
+    }
   }
 
   private void synchronizeIssuerCertificates() {
@@ -400,18 +405,20 @@ public class FileBasedTrustListManager implements TrustListManager, Closeable {
     }
   }
 
-  private static void deleteCertificateFromDir(X509Certificate certificate, Path path) {
-    try {
-      String thumbprint = ByteBufUtil.hexDump(sha1(certificate.getEncoded()));
-      File file = path.resolve(String.format("%s.der", thumbprint)).toFile();
-
-      if (file.exists()) {
-        Files.delete(file.toPath());
-
-        LOGGER.debug("Deleted certificate: {}", file.getAbsolutePath());
+  private static void deleteCertificatesFromDir(Set<X509Certificate> certificates, Path directory) {
+    try (var files = Files.list(directory)) {
+      for (Path file : files.toList()) {
+        if (decodeCertificateFile(file).filter(certificates::contains).isPresent()) {
+          try {
+            Files.delete(file);
+            LOGGER.debug("Deleted certificate: {}", file);
+          } catch (IOException e) {
+            LOGGER.error("Error deleting certificate: {}", file, e);
+          }
+        }
       }
-    } catch (Exception e) {
-      LOGGER.error("Error deleting certificate", e);
+    } catch (IOException e) {
+      LOGGER.error("Error listing certificate directory: {}", directory, e);
     }
   }
 
@@ -432,18 +439,49 @@ public class FileBasedTrustListManager implements TrustListManager, Closeable {
     }
   }
 
-  private static void deleteCrlFromDir(X509CRL crl, Path path) {
-    try {
-      String thumbprint = ByteBufUtil.hexDump(sha1(crl.getEncoded()));
-      File file = path.resolve(String.format("%s.crl", thumbprint)).toFile();
-
-      if (file.exists()) {
-        Files.delete(file.toPath());
-
-        LOGGER.debug("Deleted CRL: {}", file.getAbsolutePath());
+  private static void deleteCrlsFromDir(Set<X509CRL> removed, Path directory) {
+    try (var files = Files.list(directory)) {
+      for (Path file : files.toList()) {
+        List<X509CRL> contents = decodeCrlFile(file).orElse(List.of());
+        List<X509CRL> retained = contents.stream().filter(crl -> !removed.contains(crl)).toList();
+        if (retained.size() == contents.size()) {
+          continue;
+        }
+        try {
+          if (retained.isEmpty()) {
+            Files.delete(file);
+            LOGGER.debug("Deleted CRL file: {}", file);
+          } else {
+            replaceCrlFile(file, retained);
+            LOGGER.debug("Removed CRLs from bundle: {}", file);
+          }
+        } catch (Exception e) {
+          LOGGER.error("Error removing CRLs from file: {}", file, e);
+        }
       }
-    } catch (Exception e) {
-      LOGGER.error("Error deleting CRL", e);
+    } catch (IOException e) {
+      LOGGER.error("Error listing CRL directory: {}", directory, e);
+    }
+  }
+
+  private static void replaceCrlFile(Path file, List<X509CRL> crls) throws Exception {
+    // Write the surviving members completely before replacing a bundle, so an encoding or write
+    // failure cannot destroy the unrelated CRLs that it also contains.
+    Path temporary = Files.createTempFile(file.getParent(), ".crl-", ".tmp");
+    try {
+      try (var output = Files.newOutputStream(temporary)) {
+        for (X509CRL crl : crls) {
+          output.write(crl.getEncoded());
+        }
+      }
+      try {
+        Files.move(
+            temporary, file, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+      } catch (AtomicMoveNotSupportedException e) {
+        Files.move(temporary, file, StandardCopyOption.REPLACE_EXISTING);
+      }
+    } finally {
+      Files.deleteIfExists(temporary);
     }
   }
 

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/KeyStoreCertificateStore.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/KeyStoreCertificateStore.java
@@ -454,54 +454,78 @@ public class KeyStoreCertificateStore implements CertificateStore, Closeable {
   }
 
   private void configureWatchService(File keyStoreFile) throws IOException {
-    Path keyStorePath = keyStoreFile.toPath();
-    Path watchedDirectory = keyStorePath.getParent();
-
+    Path keyStorePath = keyStoreFile.toPath().toAbsolutePath().normalize();
     watchService = FileSystems.getDefault().newWatchService();
 
-    // ENTRY_CREATE matters as much as ENTRY_MODIFY here: writing a file by renaming a temporary
-    // one over it is the usual way to replace a KeyStore safely, and a rename arrives as a
-    // creation. This store writes its own file that way.
-    WatchKey watchKey =
-        watchedDirectory.register(
-            watchService,
-            StandardWatchEventKinds.ENTRY_CREATE,
-            StandardWatchEventKinds.ENTRY_MODIFY);
-
-    watchThread = new Thread(() -> watchForChanges(watchKey, watchedDirectory, keyStorePath));
+    WatchedFile configured = watchFile(keyStorePath);
+    WatchedFile target = watchFile(keyStorePath.toRealPath());
+    watchThread = new Thread(() -> watchForChanges(configured, target));
     watchThread.setName("milo-key-store-watcher");
     watchThread.setDaemon(true);
     watchThread.start();
   }
 
-  private void watchForChanges(WatchKey watchKey, Path watchedDirectory, Path keyStorePath) {
+  private WatchedFile watchFile(Path path) throws IOException {
+    // Atomic replacement is reported as ENTRY_CREATE. ENTRY_DELETE keeps the current target
+    // watch active across a temporary disappearance while its replacement is being installed.
+    WatchKey key =
+        path.getParent()
+            .register(
+                watchService,
+                StandardWatchEventKinds.ENTRY_CREATE,
+                StandardWatchEventKinds.ENTRY_MODIFY,
+                StandardWatchEventKinds.ENTRY_DELETE);
+    return new WatchedFile(path, key);
+  }
+
+  private void watchForChanges(WatchedFile configured, WatchedFile initialTarget) {
+    WatchedFile target = initialTarget;
     while (true) {
       WatchKey key;
-
       try {
         key = watchService.take();
       } catch (ClosedWatchServiceException e) {
         return;
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
-
         return;
       }
 
-      if (key == watchKey
-          && key.pollEvents().stream()
-              .anyMatch(e -> isKeyStoreEvent(e, watchedDirectory, keyStorePath))) {
-
-        reload(keyStorePath);
+      List<WatchEvent<?>> events = key.pollEvents();
+      if (configured.matches(key, events) || target.matches(key, events)) {
+        try {
+          Path resolved = configured.path().toRealPath();
+          if (!resolved.equals(target.path()) || !target.key().isValid()) {
+            WatchedFile replacement = watchFile(resolved);
+            // Directory registrations share keys. Cancelling the old target must not cancel the
+            // configured-link watch or a replacement target in that same directory.
+            if (target.key() != configured.key() && target.key() != replacement.key()) {
+              target.key().cancel();
+            }
+            target = replacement;
+          }
+        } catch (IOException e) {
+          // Preserve the previous target watch while the file is missing or temporarily
+          // unreadable; its recreation can then trigger another resolution and reload.
+          logger.warn("Error resolving watched KeyStore at {}", configured.path(), e);
+        }
+        reload(configured.path());
       }
 
-      // A WatchKey stays signalled, and is never queued again, until it has been reset.
-      if (!key.reset()) {
-        logger.warn(
-            "No longer watching {} for changes: the watch key is no longer valid", keyStorePath);
-
-        return;
+      // Reset every delivered key, including obsolete target keys already cancelled above.
+      if (!key.reset() && (key == configured.key() || key == target.key())) {
+        logger.warn("KeyStore watch directory is no longer available: {}", key.watchable());
+        if (!configured.key().isValid() && !target.key().isValid()) {
+          return;
+        }
       }
+    }
+  }
+
+  private record WatchedFile(Path path, WatchKey key) {
+    boolean matches(WatchKey signalled, List<WatchEvent<?>> events) {
+      return signalled == key
+          && events.stream().anyMatch(event -> isKeyStoreEvent(event, path.getParent(), path));
     }
   }
 

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/KeyStoreCertificateStore.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/KeyStoreCertificateStore.java
@@ -504,6 +504,8 @@ public class KeyStoreCertificateStore implements CertificateStore, Closeable {
             }
             target = replacement;
           }
+        } catch (ClosedWatchServiceException e) {
+          return;
         } catch (IOException e) {
           // Preserve the previous target watch while the file is missing or temporarily
           // unreadable; its recreation can then trigger another resolution and reload.

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/package-info.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/package-info.java
@@ -125,7 +125,15 @@
  * identities with a read-modify-replace boundary. Each mutation incorporates KeyStore entries
  * committed before its disk read, including application-owned aliases, then atomically replaces the
  * file. Separate store instances and processes do not share a write lock, so applications must
- * coordinate writes that overlap.
+ * coordinate writes that overlap. When file watching is enabled, the store observes both the
+ * configured path and its resolved target. Replacing the configured symbolic link updates the
+ * target registration while retaining observation of the link itself.
+ *
+ * <p>{@link org.eclipse.milo.opcua.stack.core.security.FileBasedTrustListManager} accepts imported
+ * certificate and CRL files independently of their names. Removal finds those files by their
+ * decoded contents; removing CRLs from a bundle preserves its unrelated entries. Persistence
+ * remains best-effort on I/O failure, and a subsequent directory reload reconciles the published
+ * snapshot with the files that remain.
  *
  * <p>{@link org.eclipse.milo.opcua.stack.core.security.DefaultCertificateManager} provides a
  * thread-safe mutable group registry. Applications own the groups and their backing stores,

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/security/FileBasedTrustListPersistenceTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/security/FileBasedTrustListPersistenceTest.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.security.KeyPair;
 import java.security.cert.X509CRL;
 import java.security.cert.X509Certificate;
@@ -93,6 +94,10 @@ class FileBasedTrustListPersistenceTest {
             + pem("X509 CRL", retained.crl().getEncoded())
             + pem("X509 CRL", alsoRetained.crl().getEncoded()));
     Files.write(crls.resolve("duplicate.revocations"), removed.crl().getEncoded());
+    boolean posix = bundle.getFileSystem().supportedFileAttributeViews().contains("posix");
+    if (posix) {
+      Files.setPosixFilePermissions(bundle, PosixFilePermissions.fromString("rw-r-----"));
+    }
 
     try (var manager = FileBasedTrustListManager.createAndInitialize(directory)) {
       assertEquals(
@@ -109,6 +114,12 @@ class FileBasedTrustListPersistenceTest {
 
     try (var reopened = FileBasedTrustListManager.createAndInitialize(directory)) {
       assertEquals(List.of(retained.crl(), alsoRetained.crl()), crls(reopened, list));
+      if (posix) {
+        assertEquals(
+            PosixFilePermissions.fromString("rw-r-----"),
+            Files.getPosixFilePermissions(bundle),
+            "rewriting must preserve group read access");
+      }
     }
   }
 

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/security/FileBasedTrustListPersistenceTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/security/FileBasedTrustListPersistenceTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.core.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.cert.X509CRL;
+import java.security.cert.X509Certificate;
+import java.util.Base64;
+import java.util.List;
+import java.util.Set;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.util.CrlTestUtil;
+import org.eclipse.milo.opcua.stack.core.util.DigestUtil;
+import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateBuilder;
+import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateGenerator;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class FileBasedTrustListPersistenceTest {
+
+  @TempDir Path directory;
+
+  // Every filename accepted by import must participate in removal, including duplicate files.
+  // Checking a freshly opened manager distinguishes persistence from an in-memory snapshot edit.
+  @ParameterizedTest
+  @CsvSource({"trusted,remove", "trusted,replace", "issuer,remove", "issuer,replace"})
+  void removingImportedCertificatesSurvivesRestart(String list, String operation) throws Exception {
+    Material removed = material("Removed");
+    Material retained = material("Retained");
+    Path certificates = Files.createDirectories(directory.resolve(list).resolve("certs"));
+    Path imported = certificates.resolve("operator-certificate.pem");
+    Path duplicate = certificates.resolve("another-name.cer");
+    Files.writeString(imported, pem("CERTIFICATE", removed.certificate().getEncoded()));
+    Files.write(duplicate, removed.certificate().getEncoded());
+    Files.write(certificates.resolve("retained.cer"), retained.certificate().getEncoded());
+
+    try (var manager = FileBasedTrustListManager.createAndInitialize(directory)) {
+      assertEquals(
+          Set.of(removed.certificate(), retained.certificate()),
+          Set.copyOf(certificates(manager, list)),
+          "imports expose distinct certificate entries");
+      if (operation.equals("remove")) {
+        ByteString thumbprint = ByteString.of(DigestUtil.sha1(removed.certificate().getEncoded()));
+        boolean changed =
+            list.equals("trusted")
+                ? manager.removeTrustedCertificate(thumbprint)
+                : manager.removeIssuerCertificate(thumbprint);
+        assertTrue(changed);
+      } else if (list.equals("trusted")) {
+        manager.setTrustedCertificates(List.of(retained.certificate()));
+      } else {
+        manager.setIssuerCertificates(List.of(retained.certificate()));
+      }
+      assertEquals(List.of(retained.certificate()), certificates(manager, list));
+    }
+
+    try (var reopened = FileBasedTrustListManager.createAndInitialize(directory)) {
+      assertEquals(List.of(retained.certificate()), certificates(reopened, list));
+      assertFalse(Files.exists(imported));
+      assertFalse(Files.exists(duplicate));
+    }
+  }
+
+  // One accepted CRL file can contain multiple CRLs. Removing a member must persist without
+  // deleting unrelated members of that bundle or leaving another copy of the removed CRL.
+  @ParameterizedTest
+  @ValueSource(strings = {"trusted", "issuer"})
+  void replacingImportedCrlsPreservesOtherBundleMembersAcrossRestart(String list) throws Exception {
+    Material removed = material("Removed");
+    Material retained = material("Retained");
+    Material alsoRetained = material("AlsoRetained");
+    Path crls = Files.createDirectories(directory.resolve(list).resolve("crl"));
+    Path bundle = crls.resolve("operator-bundle.pem");
+    Files.writeString(
+        bundle,
+        pem("X509 CRL", removed.crl().getEncoded())
+            + pem("X509 CRL", retained.crl().getEncoded())
+            + pem("X509 CRL", alsoRetained.crl().getEncoded()));
+    Files.write(crls.resolve("duplicate.revocations"), removed.crl().getEncoded());
+
+    try (var manager = FileBasedTrustListManager.createAndInitialize(directory)) {
+      assertEquals(
+          Set.of(removed.crl(), retained.crl(), alsoRetained.crl()),
+          Set.copyOf(crls(manager, list)),
+          "imports expose distinct CRL entries");
+      if (list.equals("trusted")) {
+        manager.setTrustedCrls(List.of(retained.crl(), alsoRetained.crl()));
+      } else {
+        manager.setIssuerCrls(List.of(retained.crl(), alsoRetained.crl()));
+      }
+      assertEquals(List.of(retained.crl(), alsoRetained.crl()), crls(manager, list));
+    }
+
+    try (var reopened = FileBasedTrustListManager.createAndInitialize(directory)) {
+      assertEquals(List.of(retained.crl(), alsoRetained.crl()), crls(reopened, list));
+    }
+  }
+
+  private static List<X509Certificate> certificates(
+      FileBasedTrustListManager manager, String list) {
+    return list.equals("trusted")
+        ? manager.getTrustedCertificates()
+        : manager.getIssuerCertificates();
+  }
+
+  private static List<X509CRL> crls(FileBasedTrustListManager manager, String list) {
+    return list.equals("trusted") ? manager.getTrustedCrls() : manager.getIssuerCrls();
+  }
+
+  private static Material material(String name) throws Exception {
+    KeyPair keyPair = SelfSignedCertificateGenerator.generateRsaKeyPair(2048);
+    X509Certificate certificate =
+        new SelfSignedCertificateBuilder(keyPair)
+            .setCommonName(name)
+            .setApplicationUri("urn:eclipse:milo:test:" + name)
+            .build();
+    return new Material(certificate, CrlTestUtil.generateCrl(certificate, keyPair.getPrivate()));
+  }
+
+  private static String pem(String type, byte[] bytes) {
+    return "-----BEGIN "
+        + type
+        + "-----\n"
+        + Base64.getMimeEncoder(64, new byte[] {'\n'}).encodeToString(bytes)
+        + "\n-----END "
+        + type
+        + "-----\n";
+  }
+
+  private record Material(X509Certificate certificate, X509CRL crl) {}
+}

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/security/KeyStoreSymlinkWatchTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/security/KeyStoreSymlinkWatchTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.core.security;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class KeyStoreSymlinkWatchTest {
+
+  @TempDir Path directory;
+
+  // The configured symlink and its real target are independent rotation points. A shared parent
+  // means both registrations use the same WatchKey, which must survive a later link retarget.
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void watchesTargetRotationsAndLinkRetargeting(boolean sameDirectory) throws Exception {
+    Path config = Files.createDirectory(directory.resolve("config"));
+    Path firstDirectory =
+        sameDirectory ? config : Files.createDirectory(directory.resolve("first"));
+    Path secondDirectory = Files.createDirectory(directory.resolve("second"));
+    Path firstTarget = firstDirectory.resolve("first.pfx");
+    Path secondTarget = secondDirectory.resolve("second.pfx");
+    Path link = config.resolve("identity.pfx");
+    var factory = new TestCertificateFactory();
+    var keyPair = factory.createRsaSha256KeyPair();
+    var entry =
+        new CertificateStore.Entry(
+            keyPair.getPrivate(), factory.createRsaSha256CertificateChain(keyPair));
+    NodeId first = new NodeId(2, "first");
+    NodeId second = new NodeId(2, "second");
+    NodeId rotated = new NodeId(2, "rotated");
+
+    try (var firstWriter = new KeyStoreCertificateStore(settings(firstTarget, false));
+        var secondWriter = new KeyStoreCertificateStore(settings(secondTarget, false))) {
+      firstWriter.initialize();
+      secondWriter.initialize();
+      secondWriter.set(second, entry);
+      try {
+        Files.createSymbolicLink(link, firstTarget);
+      } catch (IOException | UnsupportedOperationException e) {
+        assumeTrue(false, "symbolic links unavailable: " + e);
+      }
+      try (var watcher = new ObservingStore(settings(link, true))) {
+        watcher.initialize();
+        assertFalse(watcher.contains(first));
+        CompletableFuture<Void> changed = watcher.expect(first);
+        firstWriter.set(first, entry);
+        changed.get(30, TimeUnit.SECONDS);
+        assertNotNull(watcher.get(first));
+
+        changed = watcher.expect(second);
+        retarget(link, secondTarget);
+        changed.get(30, TimeUnit.SECONDS);
+        assertFalse(watcher.contains(first), "retargeting must replace the cached KeyStore");
+        changed = watcher.expect(rotated);
+        secondWriter.set(rotated, entry);
+        changed.get(30, TimeUnit.SECONDS);
+        assertNotNull(watcher.get(rotated));
+
+        // Returning to the original directory proves the configured-link watch was not cancelled
+        // when its original target shared the same WatchKey.
+        changed = watcher.expect(first);
+        retarget(link, firstTarget);
+        changed.get(30, TimeUnit.SECONDS);
+        assertTrue(watcher.contains(first));
+        assertFalse(watcher.contains(second));
+      }
+    }
+  }
+
+  private static void retarget(Path link, Path target) throws IOException {
+    Path replacement = link.resolveSibling("replacement-link");
+    Files.createSymbolicLink(replacement, target);
+    Files.move(
+        replacement, link, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+  }
+
+  private static KeyStoreCertificateStore.Settings settings(Path path, boolean watch) {
+    return new KeyStoreCertificateStore.Settings(
+        path, "password"::toCharArray, alias -> "password".toCharArray(), watch);
+  }
+
+  private static final class ObservingStore extends KeyStoreCertificateStore {
+    private final AtomicReference<ExpectedEntry> expected = new AtomicReference<>();
+
+    ObservingStore(Settings settings) {
+      super(settings);
+    }
+
+    CompletableFuture<Void> expect(NodeId typeId) {
+      var changed = new CompletableFuture<Void>();
+      expected.set(new ExpectedEntry(typeId, changed));
+      return changed;
+    }
+
+    @Override
+    void reload(Path path) {
+      super.reload(path);
+      ExpectedEntry entry = expected.get();
+      if (entry != null) {
+        try {
+          if (contains(entry.typeId())) {
+            entry.changed().complete(null);
+          }
+        } catch (Exception e) {
+          entry.changed().completeExceptionally(e);
+        }
+      }
+    }
+  }
+
+  private record ExpectedEntry(NodeId typeId, CompletableFuture<Void> changed) {}
+}


### PR DESCRIPTION
This PR fixes two filesystem persistence problems in certificate management.

### Remove imported trust material durably

Removing imported trust material could leave its original file on disk, causing the entry to return after reload or restart. The trust-list manager now removes matching material from every accepted file, including arbitrary filenames and duplicates. Removing a CRL from a bundle preserves its unrelated entries and the original file's POSIX permissions. A rewritten CRL bundle uses concatenated DER, including when the original file contained PEM.

[Part 12 §7.8.2.7](https://reference.opcfoundation.org/specs/OPC-10000-12/7.8.2.7) describes the removal operation: "The RemoveCertificate Method allows a Client to remove a single Certificate from the TrustList." Disk durability follows Milo's file-backed trust-list contract; the specification does not prescribe filenames or a storage algorithm. File operations retain existing best-effort error handling.

### Follow keystore symlinks when watching for changes

The watcher previously watched only the configured file's directory, so replacement of a target in another directory could go unnoticed. It now follows both the configured path and its resolved symlink target, reloads after target-file replacement, follows link retargeting, and preserves a shared directory watch when both paths use the same directory. Closing the watcher during retargeting exits normally.

Intermediate symlink-chain changes and a newly dangling target in an unwatched directory remain outside this change.

### Verification

Formatting, a full clean compile, and the full stack-core suite passed. Real filesystem regressions cover close/reopen persistence, duplicate imports, multi-CRL bundles, target rotation, and retargeting. All eight new cases failed on the base branch and pass with the fixes; none were skipped on this Linux run. After the permission-preservation and watcher-close changes, formatting, a full clean compile, and selected certificate tests passed with no failures, errors, or skips.
