### PR TITLE
Fix node instantiation ownership, model freshness, and diagnostics IDs

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/AbstractNodeManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/AbstractNodeManager.java
@@ -13,7 +13,9 @@ package org.eclipse.milo.opcua.sdk.server;
 import com.google.common.collect.LinkedHashMultiset;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.concurrent.ConcurrentHashMap;
@@ -83,20 +85,37 @@ public class AbstractNodeManager<T extends Node> implements NodeManager<T> {
   }
 
   @Override
-  public synchronized Optional<T> addNode(T node) {
-    generation++;
-    return Optional.ofNullable(nodeMap.put(node.getNodeId(), node));
+  public Optional<T> addNode(T node) {
+    NodeId nodeId = node.getNodeId();
+    synchronized (this) {
+      generation++;
+      return Optional.ofNullable(nodeMap.put(nodeId, node));
+    }
   }
 
   @Override
-  public synchronized boolean addNodeIfAbsent(T node) {
-    if (nodeMap.containsKey(node.getNodeId())) {
-      return false;
-    } else {
-      nodeMap.put(node.getNodeId(), node);
-      generation++;
-      return true;
+  public boolean addNodeIfAbsent(T node) {
+    NodeId nodeId = node.getNodeId();
+    synchronized (this) {
+      if (nodeMap.containsKey(nodeId)) {
+        return false;
+      } else {
+        nodeMap.put(nodeId, node);
+        generation++;
+        return true;
+      }
     }
+  }
+
+  @Override
+  public synchronized boolean removeNodeIfSame(NodeId nodeId, T expectedNode) {
+    return NodeManager.super.removeNodeIfSame(nodeId, expectedNode);
+  }
+
+  @Override
+  public synchronized boolean removeReferenceIfSame(
+      Reference reference, Map<NodeId, T> expectedNodes, NamespaceTable namespaceTable) {
+    return NodeManager.super.removeReferenceIfSame(reference, expectedNodes, namespaceTable);
   }
 
   @Override
@@ -186,12 +205,8 @@ public class AbstractNodeManager<T extends Node> implements NodeManager<T> {
   }
 
   @Override
-  public synchronized List<Reference> getReferences(NodeId nodeId, Predicate<Reference> filter) {
-    LinkedHashMultiset<Reference> references = referenceMap.get(nodeId);
-
-    return references != null
-        ? references.stream().filter(filter).toList()
-        : Collections.emptyList();
+  public List<Reference> getReferences(NodeId nodeId, Predicate<Reference> filter) {
+    return getReferences(nodeId).stream().filter(filter).toList();
   }
 
   /**
@@ -203,9 +218,18 @@ public class AbstractNodeManager<T extends Node> implements NodeManager<T> {
    * monitor.
    */
   @Override
-  public synchronized CommitResult commit(NodeManagerBatch<T> batch)
-      throws NodeManagerBatchException {
+  public CommitResult commit(NodeManagerBatch<T> batch) throws NodeManagerBatchException {
+    Map<NodeId, T> additions = new LinkedHashMap<>();
+    for (T node : batch.getNodeAdditions()) {
+      additions.put(node.getNodeId(), node);
+    }
+    synchronized (this) {
+      return commit(batch, additions);
+    }
+  }
 
+  private CommitResult commit(NodeManagerBatch<T> batch, Map<NodeId, T> additions)
+      throws NodeManagerBatchException {
     CommitResult nothingApplied = new CommitResult(List.of(), List.of());
 
     OptionalLong expectedGeneration = batch.getExpectedGeneration();
@@ -220,9 +244,9 @@ public class AbstractNodeManager<T extends Node> implements NodeManager<T> {
       }
     }
 
-    for (T node : batch.getNodeAdditions()) {
-      if (nodeMap.containsKey(node.getNodeId())) {
-        throw NodeManagerBatchException.nodeExists(node.getNodeId(), nothingApplied);
+    for (NodeId nodeId : additions.keySet()) {
+      if (nodeMap.containsKey(nodeId)) {
+        throw NodeManagerBatchException.nodeExists(nodeId, nothingApplied);
       }
     }
 
@@ -248,9 +272,9 @@ public class AbstractNodeManager<T extends Node> implements NodeManager<T> {
     List<NodeId> addedNodes = new ArrayList<>();
     List<Reference> addedReferences = new ArrayList<>();
     try {
-      for (T node : batch.getNodeAdditions()) {
-        nodeMap.put(node.getNodeId(), node);
-        addedNodes.add(node.getNodeId());
+      for (Map.Entry<NodeId, T> entry : additions.entrySet()) {
+        nodeMap.put(entry.getKey(), entry.getValue());
+        addedNodes.add(entry.getKey());
       }
       // Logical deduplication: only References not already present get a new occurrence.
       for (Reference reference : batch.getReferenceAdditions()) {

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/NodeManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/NodeManager.java
@@ -12,6 +12,7 @@ package org.eclipse.milo.opcua.sdk.server;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.function.Predicate;
@@ -189,6 +190,57 @@ public interface NodeManager<T extends Node> {
    */
   default Optional<T> removeNode(T node) {
     return removeNode(node.getNodeId());
+  }
+
+  /**
+   * Remove the node only while the stored object is {@code expectedNode} by identity.
+   *
+   * <p>The default implementation requires a single writer. Atomic managers must override it.
+   *
+   * @param nodeId the node identifier.
+   * @param expectedNode the exact object owned by the caller.
+   * @return whether the node was removed.
+   */
+  default boolean removeNodeIfSame(NodeId nodeId, T expectedNode) {
+    if (getNode(nodeId).orElse(null) != expectedNode) {
+      return false;
+    }
+    return removeNode(nodeId).isPresent();
+  }
+
+  /**
+   * Remove a journaled reference only while the stored occurrence retains its identity and none of
+   * its journaled endpoints has been replaced.
+   *
+   * <p>The default implementation requires a single writer. Atomic managers must override it.
+   * Missing endpoints allow removal of dangling references left after a node was removed directly.
+   *
+   * @param reference the exact reference object added by a commit.
+   * @param expectedNodes the journal's node identifiers and object identities.
+   * @param namespaceTable the namespace table used to resolve the target identifier.
+   * @return whether the reference was removed.
+   */
+  default boolean removeReferenceIfSame(
+      Reference reference, Map<NodeId, T> expectedNodes, NamespaceTable namespaceTable) {
+    if (hasReplacement(reference.getSourceNodeId(), expectedNodes)
+        || reference
+            .getTargetNodeId()
+            .toNodeId(namespaceTable)
+            .map(nodeId -> hasReplacement(nodeId, expectedNodes))
+            .orElse(false)) {
+      return false;
+    }
+    if (getReferences(reference.getSourceNodeId()).stream().noneMatch(r -> r == reference)) {
+      return false;
+    }
+    removeReference(reference);
+    return true;
+  }
+
+  private boolean hasReplacement(NodeId nodeId, Map<NodeId, T> expectedNodes) {
+    T expected = expectedNodes.get(nodeId);
+    T current = getNode(nodeId).orElse(null);
+    return expected != null && current != null && current != expected;
   }
 
   /**

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/NodeManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/NodeManager.java
@@ -212,8 +212,12 @@ public interface NodeManager<T extends Node> {
    * Remove a journaled reference only while the stored occurrence retains its identity and none of
    * its journaled endpoints has been replaced.
    *
-   * <p>The default implementation requires a single writer. Atomic managers must override it.
-   * Missing endpoints allow removal of dangling references left after a node was removed directly.
+   * <p>The default implementation requires a single writer and retains ownership by object
+   * identity: {@link #getReferences(NodeId)} must return the same Reference instances supplied to
+   * {@link #addReference(Reference)}. Managers that reconstruct references from external storage
+   * must override this method with an equivalent ownership check. Atomic managers must also
+   * override it. Missing endpoints allow removal of dangling references left after a node was
+   * removed directly.
    *
    * @param reference the exact reference object added by a commit.
    * @param expectedNodes the journal's node identifiers and object identities.

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/SessionDiagnosticsVariableArray.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/SessionDiagnosticsVariableArray.java
@@ -17,6 +17,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import org.eclipse.milo.opcua.sdk.core.AccessLevel;
 import org.eclipse.milo.opcua.sdk.core.ValueRank;
 import org.eclipse.milo.opcua.sdk.server.AbstractLifecycle;
@@ -47,6 +48,8 @@ import org.slf4j.LoggerFactory;
 public class SessionDiagnosticsVariableArray extends AbstractLifecycle {
 
   private final Logger logger = LoggerFactory.getLogger(getClass());
+
+  private final AtomicLong nextElementId = new AtomicLong();
 
   private final AtomicBoolean diagnosticsEnabled = new AtomicBoolean(false);
 
@@ -161,7 +164,7 @@ public class SessionDiagnosticsVariableArray extends AbstractLifecycle {
 
   private void createSessionDiagnosticsVariable(Session session) {
     try {
-      int index = sessionDiagnosticsVariables.size();
+      long index = nextElementId.getAndIncrement();
       String id = Util.buildBrowseNamePath(node) + "[" + index + "]";
       NodeId elementNodeId = new NodeId(1, id);
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/SessionSecurityDiagnosticsVariableArray.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/SessionSecurityDiagnosticsVariableArray.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import org.eclipse.milo.opcua.sdk.core.AccessLevel;
 import org.eclipse.milo.opcua.sdk.core.ValueRank;
 import org.eclipse.milo.opcua.sdk.server.AbstractLifecycle;
@@ -60,6 +61,8 @@ import org.slf4j.LoggerFactory;
 public class SessionSecurityDiagnosticsVariableArray extends AbstractLifecycle {
 
   private final Logger logger = LoggerFactory.getLogger(getClass());
+
+  private final AtomicLong nextElementId = new AtomicLong();
 
   private final AtomicBoolean diagnosticsEnabled = new AtomicBoolean(false);
 
@@ -192,7 +195,7 @@ public class SessionSecurityDiagnosticsVariableArray extends AbstractLifecycle {
 
   private void createSessionSecurityDiagnosticsVariable(Session session) {
     try {
-      int index = sessionSecurityDiagnosticsVariables.size();
+      long index = nextElementId.getAndIncrement();
       String id = Util.buildBrowseNamePath(node) + "[" + index + "]";
       NodeId elementNodeId = new NodeId(1, id);
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/SubscriptionDiagnosticsVariableArray.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/SubscriptionDiagnosticsVariableArray.java
@@ -18,6 +18,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import org.eclipse.milo.opcua.sdk.core.AccessLevel;
 import org.eclipse.milo.opcua.sdk.core.ValueRank;
 import org.eclipse.milo.opcua.sdk.server.AbstractLifecycle;
@@ -48,6 +49,8 @@ import org.slf4j.LoggerFactory;
 public abstract class SubscriptionDiagnosticsVariableArray extends AbstractLifecycle {
 
   private final Logger logger = LoggerFactory.getLogger(getClass());
+
+  private final AtomicLong nextElementId = new AtomicLong();
 
   private final AtomicBoolean diagnosticsEnabled = new AtomicBoolean(false);
 
@@ -168,7 +171,7 @@ public abstract class SubscriptionDiagnosticsVariableArray extends AbstractLifec
 
   private void createSubscriptionDiagnosticsNode(Subscription subscription) {
     try {
-      int index = subscriptionDiagnosticsVariables.size();
+      long index = nextElementId.getAndIncrement();
       String id = Util.buildBrowseNamePath(node) + "[" + index + "]";
       NodeId elementNodeId = new NodeId(1, id);
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/**
+ * Connects standard diagnostics Variables to live server, Session, and Subscription state.
+ * Attribute filters obtain current diagnostic values when a Variable is read; the runtime objects
+ * remain the source of those values.
+ *
+ * <p>Array lifecycle components create typed child graphs through the node instantiator and store
+ * them in their supplied diagnostics node manager. They observe the diagnostics enabled flag and
+ * retire children as their owning Sessions or Subscriptions leave. Each array allocates child
+ * identifiers independently of its current element count, so removing an earlier entry does not
+ * reuse the identifier of a surviving child. These identifiers describe node identity, not an
+ * element's current position in the array Value.
+ *
+ * <p>Security diagnostics also carry the standard array's access metadata into each child graph. In
+ * restricted access mode, their attribute filters derive caller-visible access from the current
+ * Session's roles.
+ */
+package org.eclipse.milo.opcua.sdk.server.diagnostics.variables;

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/AttributeSnapshot.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/AttributeSnapshot.java
@@ -14,6 +14,7 @@ import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumMap;
+import java.util.HexFormat;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -25,6 +26,7 @@ import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectTypeNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableTypeNode;
 import org.eclipse.milo.opcua.stack.core.AttributeId;
+import org.eclipse.milo.opcua.stack.core.UaSerializationException;
 import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
 import org.eclipse.milo.opcua.stack.core.types.UaStructuredType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
@@ -62,7 +64,8 @@ import org.jspecify.annotations.Nullable;
  *
  * <p>Mutable attribute values — arrays (e.g. ArrayDimensions, RolePermissions) and array-valued
  * {@link DataValue}s, including standard OPC UA structures and their nested fields, are defensively
- * copied on ingress and egress. Custom Java values without a standard codec must be immutable.
+ * copied on ingress and egress. Custom Java values without a standard codec, and standard
+ * structures containing such values, pass through and must be immutable.
  */
 public final class AttributeSnapshot {
 
@@ -245,7 +248,9 @@ public final class AttributeSnapshot {
       return "N;";
     }
     StringBuilder contents = new StringBuilder();
-    if (value.getClass().isArray()) {
+    if (value instanceof byte[] bytes) {
+      contents.append(bytes.length).append(':').append(HexFormat.of().formatHex(bytes));
+    } else if (value.getClass().isArray()) {
       int length = Array.getLength(value);
       contents.append(length).append(':');
       for (int i = 0; i < length; i++) {
@@ -269,8 +274,13 @@ public final class AttributeSnapshot {
       contents.append(canonicalString(matrix.getElements()));
       contents.append(canonicalString(matrix.getDataTypeId().orElse(null)));
     } else if (value instanceof UaStructuredType structure && hasStandardCodec(structure)) {
-      contents.append(
-          canonicalString(ExtensionObject.encode(DefaultEncodingContext.INSTANCE, structure)));
+      try {
+        contents.append(
+            canonicalString(ExtensionObject.encode(DefaultEncodingContext.INSTANCE, structure)));
+      } catch (UaSerializationException e) {
+        // A standard outer structure may contain an application-defined value without a codec.
+        contents.append(value);
+      }
     } else if (value instanceof ExtensionObject extension) {
       contents.append(canonicalString(extension.getEncodingOrTypeId()));
       contents.append(canonicalString(extension.getBody()));
@@ -315,8 +325,13 @@ public final class AttributeSnapshot {
       return copied == contained ? variant : new Variant(copied);
     }
     if (value instanceof UaStructuredType structure && hasStandardCodec(structure)) {
-      return ExtensionObject.encode(DefaultEncodingContext.INSTANCE, structure)
-          .decode(DefaultEncodingContext.INSTANCE);
+      try {
+        return ExtensionObject.encode(DefaultEncodingContext.INSTANCE, structure)
+            .decode(DefaultEncodingContext.INSTANCE);
+      } catch (UaSerializationException e) {
+        // Preserve the opaque, caller-immutable contract for unencodable nested custom values.
+        return value;
+      }
     }
     if (value instanceof ByteString bytes) {
       byte[] data = bytes.bytes();
@@ -340,7 +355,7 @@ public final class AttributeSnapshot {
               copyArray(elements),
               matrix.getDimensions().clone(),
               matrix.getDataType().orElseThrow(),
-              matrix.getDataTypeId().orElseThrow());
+              matrix.getDataTypeId().orElse(null));
     }
     return value;
   }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/AttributeSnapshot.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/AttributeSnapshot.java
@@ -25,8 +25,15 @@ import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectTypeNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableTypeNode;
 import org.eclipse.milo.opcua.stack.core.AttributeId;
+import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
+import org.eclipse.milo.opcua.stack.core.types.UaStructuredType;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Matrix;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.jspecify.annotations.Nullable;
@@ -54,8 +61,8 @@ import org.jspecify.annotations.Nullable;
  * (the source-side constituents — Variant, StatusCode, sourceTime — are preserved verbatim).
  *
  * <p>Mutable attribute values — arrays (e.g. ArrayDimensions, RolePermissions) and array-valued
- * {@link DataValue}s — are defensively copied on ingress and egress, so neither later mutation of
- * the node-owned value nor mutation of a value read from this snapshot can change the snapshot.
+ * {@link DataValue}s, including standard OPC UA structures and their nested fields, are defensively
+ * copied on ingress and egress. Custom Java values without a standard codec must be immutable.
  */
 public final class AttributeSnapshot {
 
@@ -232,44 +239,56 @@ public final class AttributeSnapshot {
     return sb.toString();
   }
 
-  /**
-   * A canonical, content-complete string of an attribute value. Arrays render element-wise
-   * (identity-based {@code Object.toString} never leaks in: {@link DataValue} and {@link Variant}
-   * are decomposed so contained arrays also render element-wise).
-   */
+  /** Type tags and length prefixes keep values and array element boundaries unambiguous. */
   private static String canonicalString(@Nullable Object value) {
     if (value == null) {
-      return "null";
+      return "N;";
     }
-    if (value instanceof Object[] array) {
-      return Arrays.deepToString(array);
-    }
+    StringBuilder contents = new StringBuilder();
     if (value.getClass().isArray()) {
       int length = Array.getLength(value);
-      StringBuilder sb = new StringBuilder("[");
+      contents.append(length).append(':');
       for (int i = 0; i < length; i++) {
-        if (i > 0) {
-          sb.append(", ");
-        }
-        sb.append(Array.get(value, i));
+        contents.append(canonicalString(Array.get(value, i)));
       }
-      return sb.append(']').toString();
+    } else if (value instanceof DataValue dataValue) {
+      contents.append(canonicalString(dataValue.getValue()));
+      contents.append(canonicalString(dataValue.getStatusCode()));
+      contents.append(canonicalString(dataValue.getSourceTime()));
+      contents.append(canonicalString(dataValue.getSourcePicoseconds()));
+    } else if (value instanceof Variant variant) {
+      contents.append(canonicalString(variant.getValue()));
+    } else if (value instanceof LocalizedText text) {
+      contents.append(canonicalString(text.getLocale()));
+      contents.append(canonicalString(text.getText()));
+    } else if (value instanceof QualifiedName name) {
+      contents.append(canonicalString(name.getNamespaceIndex()));
+      contents.append(canonicalString(name.getName()));
+    } else if (value instanceof Matrix matrix) {
+      contents.append(canonicalString(matrix.getDimensions()));
+      contents.append(canonicalString(matrix.getElements()));
+      contents.append(canonicalString(matrix.getDataTypeId().orElse(null)));
+    } else if (value instanceof UaStructuredType structure && hasStandardCodec(structure)) {
+      contents.append(
+          canonicalString(ExtensionObject.encode(DefaultEncodingContext.INSTANCE, structure)));
+    } else if (value instanceof ExtensionObject extension) {
+      contents.append(canonicalString(extension.getEncodingOrTypeId()));
+      contents.append(canonicalString(extension.getBody()));
+    } else if (value instanceof ByteString bytes) {
+      contents.append(canonicalString(bytes.bytes()));
+    } else {
+      contents.append(value);
     }
-    if (value instanceof DataValue dataValue) {
-      return "DataValue{"
-          + canonicalString(dataValue.getValue().getValue())
-          + ", status="
-          + dataValue.getStatusCode()
-          + ", sourceTime="
-          + dataValue.getSourceTime()
-          + ", sourcePicoseconds="
-          + dataValue.getSourcePicoseconds()
-          + "}";
-    }
-    if (value instanceof Variant variant) {
-      return "Variant{" + canonicalString(variant.getValue()) + "}";
-    }
-    return String.valueOf(value);
+    String type = value.getClass().getName();
+    return type.length() + ":" + type + contents.length() + ":" + contents;
+  }
+
+  private static boolean hasStandardCodec(UaStructuredType structure) {
+    return structure
+        .getBinaryEncodingId()
+        .toNodeId(DefaultEncodingContext.INSTANCE.getNamespaceTable())
+        .map(id -> DefaultEncodingContext.INSTANCE.getDataTypeManager().getCodec(id) != null)
+        .orElse(false);
   }
 
   /** Array-aware, null-safe hash of an attribute value, used by {@link #hashCode}. */
@@ -287,11 +306,41 @@ public final class AttributeSnapshot {
       return copyArray(value);
     }
     if (value instanceof DataValue dataValue) {
-      Object contained = dataValue.getValue().getValue();
-      if (contained != null && contained.getClass().isArray()) {
-        Object containedCopy = copyArray(contained);
-        return dataValue.copy(b -> b.setValue(new Variant(containedCopy)));
-      }
+      Variant copied = (Variant) defensiveCopy(dataValue.getValue());
+      return copied == dataValue.getValue() ? dataValue : dataValue.copy(b -> b.setValue(copied));
+    }
+    if (value instanceof Variant variant) {
+      Object contained = variant.getValue();
+      Object copied = contained == null ? null : defensiveCopy(contained);
+      return copied == contained ? variant : new Variant(copied);
+    }
+    if (value instanceof UaStructuredType structure && hasStandardCodec(structure)) {
+      return ExtensionObject.encode(DefaultEncodingContext.INSTANCE, structure)
+          .decode(DefaultEncodingContext.INSTANCE);
+    }
+    if (value instanceof ByteString bytes) {
+      byte[] data = bytes.bytes();
+      return data == null ? ByteString.NULL_VALUE : ByteString.of(data.clone());
+    }
+    if (value instanceof ExtensionObject.Binary extension) {
+      return ExtensionObject.of(
+          (ByteString) defensiveCopy(extension.getBody()), extension.getEncodingOrTypeId());
+    }
+    if (value instanceof ExtensionObject.Xml extension) {
+      return ExtensionObject.of(extension.getBody(), extension.getEncodingOrTypeId());
+    }
+    if (value instanceof ExtensionObject.Json extension) {
+      return ExtensionObject.of(extension.getBody(), extension.getEncodingOrTypeId());
+    }
+    if (value instanceof Matrix matrix) {
+      Object elements = matrix.getElements();
+      return elements == null
+          ? new Matrix(null)
+          : new Matrix(
+              copyArray(elements),
+              matrix.getDimensions().clone(),
+              matrix.getDataType().orElseThrow(),
+              matrix.getDataTypeId().orElseThrow());
     }
     return value;
   }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/InstantiationResult.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/InstantiationResult.java
@@ -19,6 +19,7 @@ import org.eclipse.milo.opcua.sdk.server.NodeManager;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -182,13 +183,20 @@ public final class InstantiationResult<T extends UaNode> {
     }
 
     RuntimeException failure = null;
+    Map<NodeId, UaNode> expectedNodes = new LinkedHashMap<>();
+    for (MaterializedNode node : materializedNodes) {
+      expectedNodes.put(node.nodeId(), node.node());
+    }
 
     for (MaterializedReference reference : references) {
       if (!reference.added()) {
         continue;
       }
       try {
-        target.removeReference(reference.reference());
+        target.removeReferenceIfSame(
+            reference.reference(),
+            expectedNodes,
+            root.getNodeContext().getServer().getNamespaceTable());
       } catch (RuntimeException e) {
         failure = suppress(failure, e);
       }
@@ -199,7 +207,7 @@ public final class InstantiationResult<T extends UaNode> {
         continue;
       }
       try {
-        target.removeNode(node.nodeId());
+        target.removeNodeIfSame(node.nodeId(), node.node());
       } catch (RuntimeException e) {
         failure = suppress(failure, e);
       }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/NodeInstantiator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/NodeInstantiator.java
@@ -2310,10 +2310,14 @@ public final class NodeInstantiator {
      */
     private List<InstantiationDiagnostic> rollBack(NodeManager.CommitResult applied) {
       List<InstantiationDiagnostic> findings = new ArrayList<>();
+      Map<NodeId, UaNode> expectedNodes = new LinkedHashMap<>();
+      for (UaNode node : staged.values()) {
+        expectedNodes.put(node.getNodeId(), node);
+      }
 
       for (Reference reference : applied.addedReferences()) {
         try {
-          target.removeReference(reference);
+          target.removeReferenceIfSame(reference, expectedNodes, server.getNamespaceTable());
         } catch (Exception e) {
           findings.add(
               InstantiationDiagnostic.applyError(
@@ -2326,7 +2330,7 @@ public final class NodeInstantiator {
 
       for (NodeId nodeId : applied.addedNodes()) {
         try {
-          target.removeNode(nodeId);
+          target.removeNodeIfSame(nodeId, Objects.requireNonNull(expectedNodes.get(nodeId)));
         } catch (Exception e) {
           findings.add(
               InstantiationDiagnostic.applyError(

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/TypeModelCache.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/TypeModelCache.java
@@ -48,7 +48,7 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
  */
 public class TypeModelCache {
 
-  private final Cache<NodeId, TypeInstantiationModel> models = CacheBuilder.newBuilder().build();
+  private volatile Cache<NodeId, TypeInstantiationModel> models = CacheBuilder.newBuilder().build();
 
   private final Supplier<TypeModelCompiler> compilerFactory;
 
@@ -89,7 +89,16 @@ public class TypeModelCache {
       throws ModelCompilationException {
 
     try {
-      return models.get(typeDefinitionId, () -> compilerFactory.get().compile(typeDefinitionId));
+      while (true) {
+        Cache<NodeId, TypeInstantiationModel> current = models;
+        TypeInstantiationModel model =
+            current.get(typeDefinitionId, () -> compilerFactory.get().compile(typeDefinitionId));
+        synchronized (this) {
+          if (models == current) {
+            return model;
+          }
+        }
+      }
     } catch (ExecutionException e) {
       // compile(...)'s only checked exception; Guava wraps it here.
       throw (ModelCompilationException) e.getCause();
@@ -120,16 +129,23 @@ public class TypeModelCache {
    *
    * @param nodeId the {@link NodeId} of the changed node.
    */
-  public void invalidate(NodeId nodeId) {
+  public synchronized void invalidate(NodeId nodeId) {
+    Cache<NodeId, TypeInstantiationModel> retained = CacheBuilder.newBuilder().build();
     models
         .asMap()
-        .entrySet()
-        .removeIf(e -> e.getKey().equals(nodeId) || e.getValue().dependencies().contains(nodeId));
+        .forEach(
+            (typeId, model) -> {
+              if (!typeId.equals(nodeId) && !model.dependencies().contains(nodeId)) {
+                retained.put(typeId, model);
+              }
+            });
+    // Pending loads have unknown dependencies. Retiring the cache also retires their publication.
+    models = retained;
   }
 
   /** Invalidate every cached model. */
-  public void invalidateAll() {
-    models.invalidateAll();
+  public synchronized void invalidateAll() {
+    models = CacheBuilder.newBuilder().build();
   }
 
   /**

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/TypeModelCompiler.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/TypeModelCompiler.java
@@ -1502,6 +1502,13 @@ public class TypeModelCompiler {
       pathsByDeclarationId
           .computeIfAbsent(d.declarationNodeId(), k -> new ArrayList<>())
           .add(d.browsePath());
+      for (NodeId overriddenId : d.overriddenDeclarations()) {
+        List<BrowsePath> paths =
+            pathsByDeclarationId.computeIfAbsent(overriddenId, k -> new ArrayList<>());
+        if (!paths.contains(d.browsePath())) {
+          paths.add(d.browsePath());
+        }
+      }
     }
 
     List<Row> resolved = new ArrayList<>(table.rows.size());

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/package-info.java
@@ -21,6 +21,17 @@
  * org.eclipse.milo.opcua.sdk.server.nodes.instantiation.BrowsePath}, with every ModellingRule
  * classified and provenance preserved for diagnostics.
  *
+ * <p>The cache coordinates explicit invalidation with pending compilations. A load that overlaps
+ * invalidation retries against the current cache before returning a model. Attribute snapshots copy
+ * arrays and standard OPC UA structures on both ingress and egress; application values without a
+ * standard codec must be immutable. Fingerprints retain type and element boundaries so apply can
+ * reject plans compiled against different attribute values.
+ *
+ * <p>Instantiation results own the node and reference additions recorded by their commit. Cleanup
+ * and rollback check object identity before removing those additions, preserving replacements
+ * installed later under the same identifiers. Built-in node managers make those checks atomic with
+ * removal. Custom managers using the default storage primitives require a single writer.
+ *
  * <p><strong>Experimental:</strong> this package is new API, subject to adjustment for one minor
  * release based on experience from Milo's in-tree migrations and validation of the placeholder
  * surface against real companion-specification workloads, after which it freezes. The legacy {@code

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/package-info.java
@@ -24,8 +24,9 @@
  * <p>The cache coordinates explicit invalidation with pending compilations. A load that overlaps
  * invalidation retries against the current cache before returning a model. Attribute snapshots copy
  * arrays and standard OPC UA structures on both ingress and egress; application values without a
- * standard codec must be immutable. Fingerprints retain type and element boundaries so apply can
- * reject plans compiled against different attribute values.
+ * standard codec, including standard structures that contain them, must be immutable. Fingerprints
+ * retain type and element boundaries so apply can reject plans compiled against different attribute
+ * values.
  *
  * <p>Instantiation results own the node and reference additions recorded by their commit. Cleanup
  * and rollback check object identity before removing those additions, preserving replacements

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/package-info.java
@@ -46,6 +46,15 @@
  * participant shutdown therefore runs without external server visibility but before the standard
  * address space and event facilities are torn down.
  *
+ * <h2>Node storage</h2>
+ *
+ * <p>{@link org.eclipse.milo.opcua.sdk.server.NodeManager} owns node identity and reference
+ * storage. The built-in manager serializes mutations, batch commits, and identity-conditional
+ * cleanup on its monitor. It resolves node attributes and invokes reference filters outside that
+ * monitor because attribute observers may call back into the manager while holding a node's
+ * monitor. Application managers that use the default batch and cleanup primitives need a single
+ * writer.
+ *
  * <h2>Runtime boundaries</h2>
  *
  * <p>The SDK server package coordinates high-level server configuration and lifecycle. Certificate

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/NodeManagerLockingTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/NodeManagerLockingTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.milo.opcua.sdk.core.nodes.Node;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class NodeManagerLockingTest {
+
+  // Attribute observers run under the node monitor and may read manager references. Calling
+  // getNodeId while holding the manager monitor introduces the opposite lock order and deadlocks.
+  @ParameterizedTest
+  @ValueSource(strings = {"add", "conditional", "batch"})
+  void nodeIdentityIsResolvedOutsideTheManagerMonitor(String operation) throws Exception {
+    var manager = new AbstractNodeManager<Node>();
+    var node = mock(Node.class);
+    var nodeId = new NodeId(1, "Observed");
+    when(node.getNodeId())
+        .thenAnswer(
+            invocation -> {
+              assertFalse(
+                  Thread.holdsLock(manager),
+                  "node attribute access must not hold the manager monitor");
+              return nodeId;
+            });
+    switch (operation) {
+      case "add" -> manager.addNode(node);
+      case "conditional" -> manager.addNodeIfAbsent(node);
+      case "batch" -> manager.commit(NodeManagerBatch.<Node>builder().addNode(node).build());
+      default -> throw new AssertionError(operation);
+    }
+    assertSame(node, manager.getNode(nodeId).orElseThrow());
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/DiagnosticsArrayLifecycleTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/DiagnosticsArrayLifecycleTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.diagnostics.variables;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.List;
+import org.eclipse.milo.opcua.sdk.server.Lifecycle;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServerConfig;
+import org.eclipse.milo.opcua.sdk.server.Session;
+import org.eclipse.milo.opcua.sdk.server.UaNodeManager;
+import org.eclipse.milo.opcua.sdk.server.model.objects.ServerDiagnosticsTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
+import org.eclipse.milo.opcua.sdk.server.subscriptions.Subscription;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.security.DefaultCertificateManager;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class DiagnosticsArrayLifecycleTest {
+
+  // Removing element zero from a two-element array must not make the next allocation collide with
+  // the surviving element and starve all later diagnostics creation. Exercise real instantiation,
+  // field setup, node removal, and parent references for each diagnostics array implementation.
+  @ParameterizedTest
+  @ValueSource(strings = {"session", "security", "subscription"})
+  void removingAnEarlierElementDoesNotBlockLaterDiagnostics(String kind) throws Exception {
+    var config =
+        OpcUaServerConfig.builder().setCertificateManager(new DefaultCertificateManager()).build();
+    var server = new OpcUaServer(config, transportProfile -> null);
+    var target = new UaNodeManager();
+    server.getAddressSpaceManager().register(target);
+    var diagnostics =
+        (ServerDiagnosticsTypeNode)
+            server
+                .getAddressSpaceManager()
+                .getManagedNode(NodeIds.Server_ServerDiagnostics)
+                .orElseThrow();
+    var summary = diagnostics.getSessionsDiagnosticsSummaryNode();
+
+    Object array;
+    UaNode parent;
+    Class<?> arrayClass;
+    String createMethod;
+    String elementsField;
+    Class<?> ownerClass;
+    switch (kind) {
+      case "session" -> {
+        parent = summary.getSessionDiagnosticsArrayNode();
+        array =
+            new SessionDiagnosticsVariableArray(summary.getSessionDiagnosticsArrayNode(), target);
+        arrayClass = SessionDiagnosticsVariableArray.class;
+        createMethod = "createSessionDiagnosticsVariable";
+        elementsField = "sessionDiagnosticsVariables";
+        ownerClass = Session.class;
+      }
+      case "security" -> {
+        parent = summary.getSessionSecurityDiagnosticsArrayNode();
+        array =
+            new SessionSecurityDiagnosticsVariableArray(
+                summary.getSessionSecurityDiagnosticsArrayNode(), target);
+        arrayClass = SessionSecurityDiagnosticsVariableArray.class;
+        createMethod = "createSessionSecurityDiagnosticsVariable";
+        elementsField = "sessionSecurityDiagnosticsVariables";
+        ownerClass = Session.class;
+      }
+      case "subscription" -> {
+        parent = diagnostics.getSubscriptionDiagnosticsArrayNode();
+        array =
+            new SubscriptionDiagnosticsVariableArray(
+                diagnostics.getSubscriptionDiagnosticsArrayNode(), target) {
+              @Override
+              protected List<Subscription> getSubscriptions() {
+                return List.of();
+              }
+            };
+        arrayClass = SubscriptionDiagnosticsVariableArray.class;
+        createMethod = "createSubscriptionDiagnosticsNode";
+        elementsField = "subscriptionDiagnosticsVariables";
+        ownerClass = Subscription.class;
+      }
+      default -> throw new AssertionError(kind);
+    }
+
+    // Isolate allocation from event delivery: invoke the same creation entry point the listeners
+    // call, then retire the first element exactly as their close callbacks do.
+    Method create = arrayClass.getDeclaredMethod(createMethod, ownerClass);
+    create.setAccessible(true);
+    Field field = arrayClass.getDeclaredField(elementsField);
+    field.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    List<Lifecycle> elements = (List<Lifecycle>) field.get(array);
+    try {
+      create.invoke(array, owner(ownerClass, 0));
+      create.invoke(array, owner(ownerClass, 1));
+      assertEquals(2, elements.size(), "both initial elements must be created");
+      elements.remove(0).shutdown();
+      create.invoke(array, owner(ownerClass, 2));
+      create.invoke(array, owner(ownerClass, 3));
+      assertEquals(
+          3, elements.size(), "creation must continue after an earlier element is retired");
+      var references =
+          target.getReferences(parent.getNodeId()).stream()
+              .filter(r -> r.isForward() && r.getReferenceTypeId().equals(NodeIds.HasComponent))
+              .toList();
+      assertEquals(3, references.size());
+      assertEquals(3, references.stream().map(r -> r.getTargetNodeId()).distinct().count());
+      assertTrue(
+          references.stream()
+              .allMatch(
+                  r ->
+                      target.getNode(r.getTargetNodeId(), server.getNamespaceTable()).isPresent()));
+    } finally {
+      elements.forEach(Lifecycle::shutdown);
+      server.getAddressSpaceManager().unregister(target);
+    }
+  }
+
+  private static Object owner(Class<?> ownerClass, int index) {
+    if (ownerClass == Session.class) {
+      var session = mock(Session.class);
+      when(session.getSessionId()).thenReturn(new NodeId(1, "Session" + index));
+      return session;
+    }
+    var subscription = mock(Subscription.class);
+    when(subscription.getId()).thenReturn(uint(index + 1));
+    return subscription;
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/AttributeSnapshotCompatibilityTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/AttributeSnapshotCompatibilityTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
+
+import static org.eclipse.milo.opcua.sdk.server.nodes.instantiation.TypeFixtures.path;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.milo.opcua.stack.core.AttributeId;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.types.UaStructuredType;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Matrix;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.ApplicationType;
+import org.eclipse.milo.opcua.stack.core.types.structured.Argument;
+import org.eclipse.milo.opcua.stack.core.types.structured.KeyValuePair;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class AttributeSnapshotCompatibilityTest {
+  // A standard outer codec does not guarantee that nested application values have standard
+  // codecs. Such values retain the documented opaque, caller-immutable snapshot contract.
+  @Test
+  void standardStructureContainingCustomValueCanStillCompile() throws Exception {
+    var value = new KeyValuePair(new QualifiedName(0, "custom"), new Variant(new OpaqueValue(42)));
+    var fx = TypeFixtures.create();
+    var type = fx.addObjectType("CustomValue", NodeIds.BaseObjectType);
+    var declaration =
+        fx.addVariableDeclaration(
+            type, "V", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+    declaration.setDataType(NodeIds.KeyValuePair);
+    declaration.setValue(new DataValue(new Variant(value)));
+    AttributeSnapshot snapshot = AttributeSnapshot.of(declaration);
+    assertSame(value, snapshot.value().getValue().getValue());
+    assertEquals(snapshot.contentHash(), AttributeSnapshot.of(declaration).contentHash());
+    var model = fx.compiler().compile(type.getNodeId());
+    assertSame(
+        value, model.get(path("V")).orElseThrow().attributes().value().getValue().getValue());
+  }
+
+  // Empty enum/structure matrices have a known builtin type but no element from which to derive
+  // a namespace-qualified DataType id. Missing metadata must not prevent snapshots or copying.
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void emptyMatricesKeepDimensionsWithoutInventingADataTypeId(boolean enumeration) {
+    Object elements = enumeration ? new ApplicationType[0] : new Argument[0];
+    var matrix = new Matrix(elements, new int[] {0, 0});
+    var snapshot =
+        AttributeSnapshot.builder()
+            .put(AttributeId.Value, new DataValue(new Variant(matrix)))
+            .build();
+    var copy = (Matrix) snapshot.value().getValue().getValue();
+    assertNotSame(elements, copy.getElements());
+    assertArrayEquals(new int[] {0, 0}, copy.getDimensions());
+    assertTrue(copy.getDataTypeId().isEmpty());
+    assertEquals(matrix.getDataType(), copy.getDataType());
+    String originalContent = snapshot.contentHash();
+    matrix.getDimensions()[0] = 7;
+    copy.getDimensions()[1] = 9;
+    assertArrayEquals(
+        new int[] {0, 0}, ((Matrix) snapshot.value().getValue().getValue()).getDimensions());
+    assertEquals(originalContent, snapshot.contentHash());
+  }
+
+  // Binary bodies are common inside standard structures. Their fingerprint should scale with
+  // payload bytes, while retaining content, length, element-boundary, and Java-type distinctions.
+  @Test
+  void binaryFingerprintsStayCompactAndDistinguishContentAndFraming() {
+    byte[] bytes = new byte[4096];
+    String original = fingerprint(ByteString.of(bytes));
+    assertTrue(original.length() < bytes.length * 3, "binary payload should have compact framing");
+    bytes[bytes.length - 1] = 1;
+    assertNotEquals(original, fingerprint(ByteString.of(bytes)));
+    assertNotEquals(fingerprint(new byte[] {1, 23}), fingerprint(new byte[] {12, 3}));
+    assertNotEquals(fingerprint(new byte[] {1}), fingerprint(new byte[] {0, 1}));
+    assertNotEquals(fingerprint(new byte[] {1}), fingerprint(new Byte[] {1}));
+    assertNotEquals(fingerprint(new byte[] {1}), fingerprint(ByteString.of(new byte[] {1})));
+    assertNotEquals(fingerprint(ByteString.NULL_VALUE), fingerprint(ByteString.of(new byte[0])));
+  }
+
+  private static String fingerprint(Object value) {
+    return AttributeSnapshot.builder().put(AttributeId.Value, value).build().contentHash();
+  }
+
+  private record OpaqueValue(int value) implements UaStructuredType {
+    @Override
+    public ExpandedNodeId getTypeId() {
+      return ExpandedNodeId.parse("nsu=urn:custom;i=1");
+    }
+
+    @Override
+    public ExpandedNodeId getBinaryEncodingId() {
+      return ExpandedNodeId.parse("nsu=urn:custom;i=2");
+    }
+
+    @Override
+    public ExpandedNodeId getXmlEncodingId() {
+      return ExpandedNodeId.NULL_VALUE;
+    }
+
+    @Override
+    public ExpandedNodeId getJsonEncodingId() {
+      return ExpandedNodeId.NULL_VALUE;
+    }
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/InstantiationOwnershipTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/InstantiationOwnershipTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
+
+import static org.eclipse.milo.opcua.sdk.server.nodes.instantiation.TypeFixtures.path;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.eclipse.milo.opcua.sdk.core.Reference;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectNode;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.junit.jupiter.api.Test;
+
+class InstantiationOwnershipTest {
+
+  // A result retains historical provenance after ordinary node deletion. Reusing the same IDs
+  // must not transfer ownership of the replacement instance or its references to the old result.
+  @Test
+  void deletingAnOldResultPreservesReplacementNodesAndReferences() throws Exception {
+    var fx = TypeFixtures.create();
+    var type = fx.addObjectType("Type", NodeIds.BaseObjectType);
+    fx.addObjectDeclaration(type, "Child", NodeIds.BaseObjectType, NodeIds.ModellingRule_Mandatory);
+    var target = fx.newTargetManager();
+    fx.registerWithAddressSpace(target);
+    var instantiator = fx.instantiator();
+    var request =
+        InstantiationRequest.of(UaObjectNode.class, type.getNodeId())
+            .nodeId(fx.newNodeId("Instance"))
+            .target(target)
+            .build();
+    var original = instantiator.instantiate(request);
+    original.root().delete();
+    assertTrue(target.getNodes().isEmpty(), "ordinary deletion removes the old graph");
+    var replacement = instantiator.instantiate(request);
+    List<Reference> replacementReferences =
+        replacement.materializedNodes().stream()
+            .flatMap(node -> target.getReferences(node.nodeId()).stream())
+            .toList();
+
+    original.deleteCreated();
+
+    for (MaterializedNode node : replacement.materializedNodes()) {
+      assertSame(node.node(), target.getNode(node.nodeId()).orElseThrow());
+    }
+    assertEquals(
+        replacementReferences,
+        replacement.materializedNodes().stream()
+            .flatMap(node -> target.getReferences(node.nodeId()).stream())
+            .toList());
+    replacement.deleteCreated();
+    assertTrue(target.getNodes().isEmpty(), "the replacement result still owns its graph");
+  }
+
+  // Reference equality describes an edge, not ownership of a later remove/re-add occurrence.
+  @Test
+  void deletingAnOldResultPreservesAnEqualReplacementReference() throws Exception {
+    var fx = TypeFixtures.create();
+    var type = fx.addObjectType("Type", NodeIds.BaseObjectType);
+    var target = fx.newTargetManager();
+    var result =
+        fx.instantiator()
+            .instantiate(
+                InstantiationRequest.of(UaObjectNode.class, type.getNodeId())
+                    .nodeId(fx.newNodeId("Instance"))
+                    .target(target)
+                    .build());
+    Reference original =
+        result.references().stream()
+            .filter(MaterializedReference::added)
+            .map(MaterializedReference::reference)
+            .findFirst()
+            .orElseThrow();
+    target.removeReference(original);
+    Reference replacement =
+        new Reference(
+            original.getSourceNodeId(),
+            original.getReferenceTypeId(),
+            original.getTargetNodeId(),
+            original.getDirection());
+    target.addReference(replacement);
+    result.deleteCreated();
+    assertEquals(List.of(replacement), target.getReferences(replacement.getSourceNodeId()));
+  }
+
+  // Binders run after commit and can invoke ordinary node APIs. A failing binder must not roll
+  // back a replacement that another owner installed under one of the committed identifiers.
+  @Test
+  void rollbackPreservesANodeReplacedByAFailingBinder() throws Exception {
+    var fx = TypeFixtures.create();
+    var type = fx.addObjectType("Type", NodeIds.BaseObjectType);
+    fx.addMethodDeclaration(type, "M", NodeIds.ModellingRule_Mandatory);
+    var target = fx.newTargetManager();
+    var replacement =
+        new UaObjectNode(
+            fx.context(),
+            fx.newNodeId("Instance"),
+            TypeFixtures.qn("Replacement"),
+            LocalizedText.english("Replacement"),
+            LocalizedText.NULL_VALUE,
+            UInteger.MIN,
+            UInteger.MIN);
+    assertThrows(
+        InstantiationException.class,
+        () ->
+            fx.instantiator()
+                .instantiate(
+                    InstantiationRequest.of(UaObjectNode.class, type.getNodeId())
+                        .nodeId(replacement.getNodeId())
+                        .target(target)
+                        .bindMethod(
+                            path("M"),
+                            method -> {
+                              target.addNode(replacement);
+                              throw new IllegalStateException("binder failed after replacement");
+                            })
+                        .build()));
+    assertSame(replacement, target.getNode(replacement.getNodeId()).orElseThrow());
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/TypeModelConsistencyTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/TypeModelConsistencyTest.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
+
+import static org.eclipse.milo.opcua.sdk.server.nodes.instantiation.TypeFixtures.path;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.eclipse.milo.opcua.sdk.core.Reference;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectNode;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Matrix;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.structured.Argument;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class TypeModelConsistencyTest {
+
+  // An invalidation must fence loaders that already read the old declaration graph, including
+  // loaders of dependent types whose dependencies are not known until compilation returns.
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void invalidationDuringCompilationCannotPublishOrReturnTheOldModel(boolean invalidateAll)
+      throws Exception {
+    var fx = TypeFixtures.create();
+    var base = fx.addObjectType("Base", NodeIds.BaseObjectType);
+    var type = fx.addObjectType("Derived", base.getNodeId());
+    var compiled = new CountDownLatch(1);
+    var release = new CountDownLatch(1);
+    var pauseFirst = new AtomicBoolean(true);
+    fx.rebuildReferenceTypeTree();
+    var cache =
+        new TypeModelCache(
+            () ->
+                new TypeModelCompiler(fx.server()) {
+                  @Override
+                  public TypeInstantiationModel compile(NodeId typeId)
+                      throws ModelCompilationException {
+                    TypeInstantiationModel model = super.compile(typeId);
+                    if (pauseFirst.compareAndSet(true, false)) {
+                      compiled.countDown();
+                      try {
+                        if (!release.await(10, TimeUnit.SECONDS)) {
+                          throw new AssertionError("test did not release compilation");
+                        }
+                      } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new AssertionError(e);
+                      }
+                    }
+                    return model;
+                  }
+                });
+    when(fx.server().getTypeModelCache()).thenReturn(cache);
+    var executor = Executors.newSingleThreadExecutor();
+    try {
+      var pending = executor.submit(() -> cache.getOrCompile(type.getNodeId()));
+      assertTrue(compiled.await(10, TimeUnit.SECONDS));
+      fx.addVariableDeclaration(
+          base, "Added", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+      if (invalidateAll) {
+        cache.invalidateAll();
+      } else {
+        cache.invalidate(base.getNodeId());
+      }
+      release.countDown();
+      assertTrue(pending.get(10, TimeUnit.SECONDS).get(path("Added")).isPresent());
+      assertTrue(cache.getOrCompile(type.getNodeId()).get(path("Added")).isPresent());
+      var result =
+          fx.instantiator()
+              .instantiate(
+                  InstantiationRequest.of(UaObjectNode.class, type.getNodeId())
+                      .nodeId(fx.newNodeId("Instance"))
+                      .target(fx.newTargetManager())
+                      .build());
+      assertTrue(result.node(path("Added")).isPresent());
+    } finally {
+      release.countDown();
+      executor.shutdownNow();
+      assertTrue(executor.awaitTermination(10, TimeUnit.SECONDS));
+    }
+  }
+
+  // String rendering collapses {"a, b"} and {"a", "b"}; apply must still reject the stale plan.
+  @Test
+  void arrayElementBoundariesChangeTheRevisionAndRejectAStalePlan() throws Exception {
+    var fx = TypeFixtures.create();
+    var type = fx.addObjectType("Strings", NodeIds.BaseObjectType);
+    var declaration =
+        fx.addVariableDeclaration(
+            type, "V", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+    declaration.setDataType(NodeIds.String);
+    declaration.setValueRank(1);
+    declaration.setValue(
+        new DataValue(new Variant(new String[] {"a, b"}), StatusCode.GOOD, DateTime.MIN_VALUE));
+    var target = fx.newTargetManager();
+    var instantiator = fx.instantiator();
+    var plan =
+        instantiator.plan(
+            InstantiationRequest.of(UaObjectNode.class, type.getNodeId())
+                .nodeId(fx.newNodeId("Instance"))
+                .target(target)
+                .build());
+    long original = fx.typeModelCache().getOrCompile(type.getNodeId()).modelRevision();
+    declaration.setValue(
+        new DataValue(new Variant(new String[] {"a", "b"}), StatusCode.GOOD, DateTime.MIN_VALUE));
+    fx.typeModelCache().invalidate(declaration.getNodeId());
+    assertNotEquals(original, fx.typeModelCache().getOrCompile(type.getNodeId()).modelRevision());
+    var error = assertThrows(InstantiationException.class, () -> instantiator.apply(plan));
+    assertTrue(
+        error.getDiagnostics().stream()
+            .anyMatch(d -> d.code() == InstantiationDiagnostic.Code.MODEL_CHANGED));
+    assertTrue(target.getNodes().isEmpty());
+  }
+
+  // Method argument dimensions are nested inside structures. Each supported Variant container
+  // must isolate those dimensions from both declaration owners and snapshot readers.
+  @ParameterizedTest
+  @ValueSource(strings = {"scalar", "array", "matrix", "extension"})
+  void structuredValuesAreIsolatedOnIngressAndEgress(String container) {
+    var argument =
+        new Argument("A", NodeIds.Int32, 1, new UInteger[] {uint(3)}, LocalizedText.NULL_VALUE);
+    Object source =
+        switch (container) {
+          case "scalar" -> argument;
+          case "array" -> new Argument[] {argument};
+          case "matrix" -> new Matrix(new Argument[] {argument}, new int[] {1, 1});
+          case "extension" -> ExtensionObject.encode(DefaultEncodingContext.INSTANCE, argument);
+          default -> throw new AssertionError(container);
+        };
+    var fx = TypeFixtures.create();
+    var type = fx.addObjectType("Arguments", NodeIds.BaseObjectType);
+    var declaration =
+        fx.addVariableDeclaration(
+            type, "V", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+    declaration.setDataType(NodeIds.Argument);
+    declaration.setValue(new DataValue(new Variant(source)));
+    AttributeSnapshot snapshot = AttributeSnapshot.of(declaration);
+    String originalContent = snapshot.contentHash();
+    Argument sourceArgument = unwrapArgument(source);
+    unwrapArgument(snapshot.value().getValue().getValue()).getArrayDimensions()[0] = uint(7);
+    assertEquals(
+        uint(3),
+        unwrapArgument(declaration.getValue().getValue().getValue()).getArrayDimensions()[0]);
+    assertEquals(
+        uint(3), unwrapArgument(snapshot.value().getValue().getValue()).getArrayDimensions()[0]);
+    sourceArgument.getArrayDimensions()[0] = uint(9);
+    assertEquals(
+        uint(3), unwrapArgument(snapshot.value().getValue().getValue()).getArrayDimensions()[0]);
+    assertEquals(originalContent, snapshot.contentHash());
+  }
+
+  private static Argument unwrapArgument(Object value) {
+    if (value instanceof Argument argument) {
+      return argument;
+    }
+    if (value instanceof Argument[] arguments) {
+      return arguments[0];
+    }
+    if (value instanceof Matrix matrix) {
+      return ((Argument[]) matrix.getElements())[0];
+    }
+    return (Argument) ((ExtensionObject) value).decode(DefaultEncodingContext.INSTANCE);
+  }
+
+  // Part 3 declaration overrides change the effective instance at a path. References to any
+  // declaration in that chain must point to that instance, without an extra edge into type space.
+  @Test
+  void referencesToOverriddenDeclarationsResolveToTheEffectiveInstance() throws Exception {
+    var fx = TypeFixtures.create();
+    var referenceType = fx.addReferenceType("RelatedTo", NodeIds.NonHierarchicalReferences);
+    var base = fx.addObjectType("Base", NodeIds.BaseObjectType);
+    var original =
+        fx.addObjectDeclaration(base, "Y", NodeIds.BaseObjectType, NodeIds.ModellingRule_Mandatory);
+    var derived = fx.addObjectType("Derived", base.getNodeId());
+    fx.addObjectDeclaration(derived, "Y", NodeIds.BaseObjectType, NodeIds.ModellingRule_Mandatory);
+    var z =
+        fx.addObjectDeclaration(
+            derived, "Z", NodeIds.BaseObjectType, NodeIds.ModellingRule_Mandatory);
+    fx.nodeManager()
+        .addReferences(
+            new Reference(
+                z.getNodeId(), referenceType.getNodeId(), original.getNodeId().expanded(), true),
+            fx.namespaceTable());
+    var model = fx.compiler().compile(derived.getNodeId());
+    List<ReferenceRow> rows =
+        model.references().stream()
+            .filter(row -> row.referenceTypeId().equals(referenceType.getNodeId()))
+            .toList();
+    assertEquals(
+        List.of(ReferenceRow.relative(path("Z"), referenceType.getNodeId(), path("Y"))), rows);
+    var target = fx.newTargetManager();
+    var result =
+        fx.instantiator()
+            .instantiate(
+                InstantiationRequest.of(UaObjectNode.class, derived.getNodeId())
+                    .nodeId(fx.newNodeId("Instance"))
+                    .target(target)
+                    .build());
+    NodeId instanceY = result.node(path("Y")).orElseThrow().getNodeId();
+    NodeId instanceZ = result.node(path("Z")).orElseThrow().getNodeId();
+    var outgoing =
+        target.getReferences(instanceZ).stream()
+            .filter(r -> r.getReferenceTypeId().equals(referenceType.getNodeId()))
+            .toList();
+    assertEquals(
+        List.of(new Reference(instanceZ, referenceType.getNodeId(), instanceY.expanded(), true)),
+        outgoing);
+  }
+}


### PR DESCRIPTION
This PR fixes seven issues in node instantiation, cleanup, and diagnostics child allocation.

### Preserve replacement nodes during cleanup

Cleanup through an old instantiation result could remove a replacement node or reference with the same logical identity. Cleanup and rollback now remove entries only while they retain the recorded object identities. Custom NodeManager implementations must preserve reference object identity or override conditional removal for their storage model.

### Avoid lock inversion during node-manager callbacks

Reading node attributes or invoking reference predicates while holding the manager monitor could deadlock with attribute observers. Node identity reads and reference predicates now run outside that monitor.

### Retire pending cache loads during invalidation

A load started before invalidation could publish a stale compiled model afterward. Invalidation now retires pending loads, and callers retry against the current cache generation.

### Distinguish values in revision fingerprints

Ambiguous value concatenation could assign the same revision fingerprint to different declaration attributes. Fingerprints now encode type, length, and element boundaries. Binary values use compact hex encoding to retain that distinction without excessive expansion.

### Snapshot mutable declaration values

Compiled plans could retain mutable nested declaration values and change after compilation. Snapshots now copy nested standard OPC UA structures and arrays, including empty matrices without type metadata. Custom Java values that lack a usable standard codec remain opaque and must be immutable.

Part 3 §6.4.2 says, "If new copies are created, then the Attribute values of the InstanceDeclarations are used as the initial values." Snapshot isolation and cache freshness preserve the declaration values used by the selected plan. [Creating an instance](https://reference.opcfoundation.org/specs/OPC-10000-3/6.4.2).

### Resolve references through overridden declarations

References to an overridden declaration could resolve back into type space instead of to the effective instance occurrence. The compiler now maps ancestor declaration identities to that occurrence.

Part 3 §6.3.3.3 says, "A subtype overrides an InstanceDeclaration by specifying an InstanceDeclaration with the same BrowsePath." Replication of nonhierarchical references remains server-specific; this fix makes the references Milo chooses to copy resolve consistently. [Overriding InstanceDeclarations](https://reference.opcfoundation.org/specs/OPC-10000-3/6.3.3.3).

### Allocate diagnostics children independently of array size

Diagnostics arrays used live list size as a child identity, which could collide after an earlier entry was removed and prevent insertion. Subscription, session, and security diagnostics arrays now allocate monotonic child identities.

Part 5 §7.11 says, "For each entry of the array, instances of this type will provide a Variable of the SubscriptionDiagnosticsType VariableType". Distinct identities preserve that behavior as subscriptions enter and leave. Individual session and security diagnostics children remain optional. [SubscriptionDiagnosticsArrayType](https://reference.opcfoundation.org/specs/OPC-10000-5/7.11).

### Verification

The original 17 regression cases failed against the base production code. Formatting, a full clean compile, and unfiltered SDK server/dependency verification passed with zero failures or errors and two skips.

Four additional compatibility and fingerprint regressions failed against the intermediate implementation. After their corrections, formatting, a full clean compile, and selected tests passed with no failures, errors, or skips.
