### PR TITLE
Preserve Reverse Connect ownership and queued callback delivery

### DIFF
--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseConnectAcceptor.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseConnectAcceptor.java
@@ -351,11 +351,7 @@ public final class ReverseConnectAcceptor implements AutoCloseable {
 
     ChannelStateObservable.TransitionListener listener =
         connected -> {
-          // After acceptor.stop() the listener is no longer removed from the transport, but it
-          // must not mutate bookkeeping for a stopped acceptor.
-          if (!running.get()) {
-            return;
-          }
+          // Delivered clients outlive stop(); keep ownership current across acceptor restarts.
           if (connected) {
             activeKeys.add(key);
           } else {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseConnectCandidateSnapshot.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseConnectCandidateSnapshot.java
@@ -38,7 +38,7 @@ import org.jspecify.annotations.Nullable;
  * @param completedAt the time the candidate reached a terminal manager state, or {@code null} while
  *     it can still be matched or claimed.
  * @param rejectionReason the manager-level reason the candidate was rejected, expired, or closed,
- *     or {@code null} for non-terminal and successfully claimed candidates.
+ *     or {@code null} for non-terminal and claimed candidates.
  * @param rejectionStatusCode the TCP error status associated with a rejected or expired candidate,
  *     or {@code null} when no error status applies.
  * @param diagnostic a human-readable diagnostic associated with rejection, expiry, or close events,

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseConnectCandidateState.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseConnectCandidateState.java
@@ -18,7 +18,7 @@ public enum ReverseConnectCandidateState {
   /** {@code ReverseHello} was decoded and verified, but no selector has claimed the socket yet. */
   PENDING,
 
-  /** A selector claimed the socket and ownership has been transferred to the caller. */
+  /** A selector reserved ownership of the socket; connection delivery may still be pending. */
   CLAIMED,
 
   /** The manager rejected the socket before it could be claimed. */

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseConnectManager.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseConnectManager.java
@@ -211,6 +211,10 @@ public final class ReverseConnectManager implements AutoCloseable {
           listenerQueue.pause();
           lock.lock();
           try {
+            if (!running) {
+              throw new CancellationException("ReverseConnectManager stopped during startup");
+            }
+
             ChannelFuture bindFuture = bootstrap.bind(listenerState.bindAddress).sync();
 
             listenerState.bindChannel = bindFuture.channel();
@@ -344,6 +348,13 @@ public final class ReverseConnectManager implements AutoCloseable {
     } finally {
       lock.unlock();
     }
+
+    registration.connectionFuture.whenComplete(
+        (connection, failure) -> {
+          if (failure != null) {
+            unregisterSelector(registration.id);
+          }
+        });
 
     if (stoppedException != null) {
       registration.connectionFuture.completeExceptionally(stoppedException);
@@ -1245,7 +1256,9 @@ public final class ReverseConnectManager implements AutoCloseable {
 
     void completeAndFire(ReverseConnectManager manager) {
       if (connection != null && registration != null && snapshot != null) {
-        registration.connectionFuture.complete(connection);
+        if (!registration.connectionFuture.complete(connection)) {
+          connection.close();
+        }
         manager.fireCandidateClaimed(snapshot);
       }
     }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseConnectManager.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseConnectManager.java
@@ -1257,6 +1257,10 @@ public final class ReverseConnectManager implements AutoCloseable {
     void completeAndFire(ReverseConnectManager manager) {
       if (connection != null && registration != null && snapshot != null) {
         if (!registration.connectionFuture.complete(connection)) {
+          manager.logger.debug(
+              "Closing claimed reverse-connect candidate {} because its registration future no"
+                  + " longer accepts delivery.",
+              snapshot.id());
           connection.close();
         }
         manager.fireCandidateClaimed(snapshot);

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseConnectRegistration.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseConnectRegistration.java
@@ -49,7 +49,9 @@ public final class ReverseConnectRegistration implements AutoCloseable {
    * <p>The future completes with a {@link ReverseConnectConnection} after the first matching
    * candidate is claimed. It completes exceptionally if the registration is closed before a match,
    * if the selector throws while matching, or if the manager shuts down while the registration is
-   * still waiting.
+   * still waiting. Cancelling this future or completing it exceptionally (including through {@link
+   * CompletableFuture#orTimeout(long, java.util.concurrent.TimeUnit)}) unregisters the selector. If
+   * cancellation races a claim, the undeliverable connection is closed.
    *
    * @return the claim future.
    */

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseTcpClientTransport.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseTcpClientTransport.java
@@ -13,10 +13,13 @@ package org.eclipse.milo.opcua.sdk.client.reverse;
 import static java.util.Objects.requireNonNull;
 
 import io.netty.channel.Channel;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.RejectedExecutionException;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.util.Unit;
@@ -67,6 +70,9 @@ public final class ReverseTcpClientTransport extends AbstractUascClientTransport
   private final OpcTcpClientTransportConfig config;
   private final List<ChannelStateObservable.TransitionListener> transitionListeners =
       new CopyOnWriteArrayList<>();
+
+  private final Deque<Boolean> pendingTransitions = new ArrayDeque<>();
+  private boolean notifyingTransitions = false;
 
   private CompletableFuture<Channel> channelFuture = new CompletableFuture<>();
 
@@ -175,6 +181,9 @@ public final class ReverseTcpClientTransport extends AbstractUascClientTransport
               && !channelFuture.isCancelled();
 
       currentChannel = null;
+      if (emitSyntheticDisconnect) {
+        pendingTransitions.add(false);
+      }
 
       if (channelFuture.isDone()) {
         channelFuture = new CompletableFuture<>();
@@ -189,7 +198,7 @@ public final class ReverseTcpClientTransport extends AbstractUascClientTransport
     }
 
     if (emitSyntheticDisconnect) {
-      notifyTransitionListeners(false);
+      drainTransitionNotifications();
     }
 
     if (futureToRegister != null) {
@@ -280,6 +289,9 @@ public final class ReverseTcpClientTransport extends AbstractUascClientTransport
         directConnectionConsumed = true;
       }
       currentChannel = null;
+      if (notifyDisconnected) {
+        pendingTransitions.add(false);
+      }
 
       if (directConnection != null) {
         enterDirectTerminalStateLocked(
@@ -315,7 +327,7 @@ public final class ReverseTcpClientTransport extends AbstractUascClientTransport
             future -> {
               if (future.isSuccess()) {
                 if (notifyDisconnected) {
-                  notifyTransitionListeners(false);
+                  drainTransitionNotifications();
                 }
                 disconnectFuture.complete(Unit.VALUE);
               } else {
@@ -382,13 +394,21 @@ public final class ReverseTcpClientTransport extends AbstractUascClientTransport
     nextRegistration
         .connectionFuture()
         .whenComplete(
-            (connection, ex) ->
+            (connection, ex) -> {
+              try {
                 config
                     .getExecutor()
                     .execute(
                         () ->
                             handleClaimedConnection(
-                                nextRegistration, targetFuture, connection, ex)));
+                                nextRegistration, targetFuture, connection, ex));
+              } catch (RejectedExecutionException rejected) {
+                if (connection != null) {
+                  connection.close();
+                }
+                handleClaimedConnection(nextRegistration, targetFuture, null, rejected);
+              }
+            });
 
     if (stale) {
       nextRegistration.close();
@@ -546,26 +566,31 @@ public final class ReverseTcpClientTransport extends AbstractUascClientTransport
             });
 
     handshakeFuture.whenComplete(
-        (secureChannel, ex) ->
-            config
-                .getExecutor()
-                .execute(
-                    () -> {
-                      if (secureChannel != null) {
-                        completeHandshake(targetFuture, secureChannel.getChannel());
-                      } else {
-                        Throwable failure = unwrap(ex);
-                        CompletableFuture<Channel> nextFuture =
-                            rearmOnFailure ? rearmAfterFailedClaim(targetFuture, channel) : null;
+        (secureChannel, ex) -> {
+          Runnable completion =
+              () -> {
+                if (secureChannel != null) {
+                  completeHandshake(targetFuture, secureChannel.getChannel());
+                } else {
+                  Throwable failure = unwrap(ex);
+                  CompletableFuture<Channel> nextFuture =
+                      rearmOnFailure ? rearmAfterFailedClaim(targetFuture, channel) : null;
 
-                        targetFuture.completeExceptionally(failure);
-                        channel.close();
+                  targetFuture.completeExceptionally(failure);
+                  channel.close();
 
-                        if (nextFuture != null) {
-                          registerForNextChannel(nextFuture);
-                        }
-                      }
-                    }));
+                  if (nextFuture != null) {
+                    registerForNextChannel(nextFuture);
+                  }
+                }
+              };
+          try {
+            config.getExecutor().execute(completion);
+          } catch (RejectedExecutionException rejected) {
+            // The handshake is finished; no remaining handshake deadline can settle connect.
+            completion.run();
+          }
+        });
   }
 
   private @Nullable CompletableFuture<Channel> rearmAfterFailedClaim(
@@ -594,11 +619,8 @@ public final class ReverseTcpClientTransport extends AbstractUascClientTransport
       stale = disconnecting || targetFuture != channelFuture;
       if (!stale) {
         currentChannel = channel;
-        // Complete inside the lock so a concurrent disconnect() observes futureToCancel.isDone()
-        // and emits a matching connected=false transition. Completing outside the lock allows the
-        // disconnect to interleave between the publish of currentChannel and the future
-        // completion, suppressing its matching disconnect notification and producing an orphan
-        // connected=true event.
+        // Reserve the notification before completion can invoke a reentrant close callback.
+        pendingTransitions.add(true);
         targetFuture.complete(channel);
       }
     }
@@ -606,7 +628,7 @@ public final class ReverseTcpClientTransport extends AbstractUascClientTransport
     if (stale) {
       channel.close();
     } else {
-      notifyTransitionListeners(true);
+      drainTransitionNotifications();
     }
   }
 
@@ -625,6 +647,10 @@ public final class ReverseTcpClientTransport extends AbstractUascClientTransport
             channelFuture.isDone()
                 && !channelFuture.isCompletedExceptionally()
                 && !channelFuture.isCancelled();
+
+        if (notifyDisconnected) {
+          pendingTransitions.add(false);
+        }
 
         if (started && !disconnecting) {
           closedFuture = channelFuture;
@@ -648,7 +674,7 @@ public final class ReverseTcpClientTransport extends AbstractUascClientTransport
     }
 
     if (notifyDisconnected) {
-      notifyTransitionListeners(false);
+      drainTransitionNotifications();
     }
   }
 
@@ -680,12 +706,36 @@ public final class ReverseTcpClientTransport extends AbstractUascClientTransport
     channelFuture = CompletableFuture.failedFuture(failure);
   }
 
-  private void notifyTransitionListeners(boolean connected) {
-    for (ChannelStateObservable.TransitionListener listener : transitionListeners) {
-      try {
-        listener.onStateTransition(connected);
-      } catch (Throwable t) {
-        logger.warn("Channel state transition listener failed.", t);
+  private void drainTransitionNotifications() {
+    // Future completion under lock can reenter connect/disconnect. The outer operation drains
+    // after unlocking so user listeners never run inside the transport's state critical section.
+    if (Thread.holdsLock(lock)) {
+      return;
+    }
+
+    synchronized (lock) {
+      if (notifyingTransitions) {
+        return;
+      }
+      notifyingTransitions = true;
+    }
+
+    while (true) {
+      Boolean connected;
+      synchronized (lock) {
+        connected = pendingTransitions.poll();
+        if (connected == null) {
+          notifyingTransitions = false;
+          return;
+        }
+      }
+
+      for (ChannelStateObservable.TransitionListener listener : transitionListeners) {
+        try {
+          listener.onStateTransition(connected);
+        } catch (Throwable t) {
+          logger.warn("Channel state transition listener failed.", t);
+        }
       }
     }
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/package-info.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/package-info.java
@@ -49,6 +49,11 @@
  * application rejected it, the pending limit was exceeded, the hold time expired, the manager
  * stopped, the peer closed the channel, or a selector threw.
  *
+ * <p>Claimed snapshots, callbacks, and counters record ownership reserved for a selector. Delivery
+ * to its registration future happens afterward. If cancellation or another exceptional completion
+ * prevents delivery, the manager closes the undelivered connection and logs a debug diagnostic; the
+ * recorded claim remains part of the manager's history.
+ *
  * <p>Listener callbacks are serialized on the manager callback executor. For a successfully claimed
  * candidate the callback order is accepted, then claimed if a selector was already waiting, or
  * accepted, pending, then claimed when the candidate first has to be parked. Rejected, expired, and

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/package-info.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/package-info.java
@@ -96,6 +96,17 @@
  * consumes one pre-claimed connection directly, installs the standard client UASC pipeline, and
  * then lets the Session FSM create and maintain the Session as it would for outbound TCP.
  *
+ * <p>Shutdown fences listener installation, including a startup still in application bootstrap
+ * customization. A selector owns only its pending claim: cancelling or exceptionally completing the
+ * registration future removes the selector, and a claim that races that completion closes its
+ * undeliverable channel. A transport dispatch failure also releases the claimed channel and fails
+ * the waiting connect operation. Channel observers receive connected and disconnected transitions
+ * serially in state-change order, including when a callback itself disconnects the transport.
+ *
+ * <p>Stopping an acceptor suppresses new discovery work while preserving ownership of delivered
+ * clients. Their channel transitions continue updating the reserved keys so restart can discover
+ * servers whose delivered clients disconnected during the stopped interval.
+ *
  * <h2>Security boundary</h2>
  *
  * <p>{@code ReverseHello} is only a routing and resource-admission hint. The types here

--- a/opc-ua-sdk/sdk-client/src/test/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseConnectAcceptorTest.java
+++ b/opc-ua-sdk/sdk-client/src/test/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseConnectAcceptorTest.java
@@ -126,6 +126,42 @@ class ReverseConnectAcceptorTest {
     }
   }
 
+  // Delivered clients remain caller-owned while stopped, but disconnected keys must be reusable.
+  @Test
+  void disconnectWhileStoppedAllowsRediscoveryAfterRestart() throws Exception {
+    ReverseConnectManager manager = newManager();
+    List<UUID> discovered = new ArrayList<>();
+    ReverseConnectAcceptor acceptor =
+        ReverseConnectAcceptor.builder(manager)
+            .setDiscoveryTransport(
+                builder -> {
+                  throw new IllegalStateException("discovery observed");
+                })
+            .setErrorListener((candidate, failure) -> discovered.add(candidate.id()))
+            .build();
+    EmbeddedChannel channel = new EmbeddedChannel();
+    FakeClientTransport transport = new FakeClientTransport(channel);
+    OpcUaClient client = new OpcUaClient(clientConfig(), transport);
+    try {
+      acceptor.start();
+      addActiveKey(acceptor, SERVER_URI);
+      assertTrue(invokeObserveProductionTransportForKeyRelease(acceptor, SERVER_URI, client));
+      acceptor.stop();
+      assertEquals(1, activeKeyCount(acceptor), "stopping must retain the connected client's key");
+      UUID pendingId = addPendingCandidate(manager, new EmbeddedChannel());
+      channel.close();
+      transport.listeners.forEach(listener -> listener.onStateTransition(false));
+      assertTrue(discovered.isEmpty(), "a stopped acceptor must not start discovery");
+      acceptor.start();
+      assertEquals(List.of(pendingId), discovered);
+      assertEquals(0, activeKeyCount(acceptor));
+    } finally {
+      channel.close();
+      acceptor.stop();
+      manager.shutdown();
+    }
+  }
+
   private ReverseConnectManager newManager() {
     return ReverseConnectManager.builder()
         .addBindAddress(new InetSocketAddress("127.0.0.1", 0))

--- a/opc-ua-sdk/sdk-client/src/test/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseConnectManagerTest.java
+++ b/opc-ua-sdk/sdk-client/src/test/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseConnectManagerTest.java
@@ -108,6 +108,84 @@ class ReverseConnectManagerTest {
     assertFalse(stopped.listeners().get(0).bound());
   }
 
+  // A shutdown completed during application customization must fence the later listener bind.
+  @Test
+  void shutdownDuringStartupPreventsLateListenerBind() throws Exception {
+    CountDownLatch customizing = new CountDownLatch(1);
+    CountDownLatch resumeStartup = new CountDownLatch(1);
+    manager =
+        newManagerBuilder()
+            .setBootstrapCustomizer(
+                bootstrap -> {
+                  customizing.countDown();
+                  try {
+                    assertTrue(resumeStartup.await(5, TimeUnit.SECONDS));
+                  } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new AssertionError(e);
+                  }
+                })
+            .build();
+    ExecutorService startupExecutor = Executors.newSingleThreadExecutor();
+    try {
+      Future<?> startup =
+          startupExecutor.submit(
+              () -> {
+                manager.startup();
+                return null;
+              });
+      assertTrue(customizing.await(5, TimeUnit.SECONDS));
+      manager.shutdown();
+      resumeStartup.countDown();
+      ExecutionException failure =
+          assertThrows(ExecutionException.class, () -> startup.get(5, TimeUnit.SECONDS));
+      assertInstanceOf(CancellationException.class, failure.getCause());
+      assertFalse(manager.snapshot().running());
+      assertFalse(manager.snapshot().listeners().get(0).bound());
+    } finally {
+      resumeStartup.countDown();
+      startupExecutor.shutdownNow();
+    }
+  }
+
+  // A cancelled raw registration must leave later candidates available to another caller.
+  @Test
+  void cancelledRegistrationDoesNotClaimLaterCandidate() throws Exception {
+    manager = newManagerBuilder().build();
+    manager.startup();
+    ReverseConnectRegistration abandoned = manager.registerSelector(ReverseConnectSelector.any());
+    abandoned.connectionFuture().cancel(false);
+    ReverseConnectRegistration replacement = manager.registerSelector(ReverseConnectSelector.any());
+    try (Socket socket = sendReverseHello(boundAddress(manager), endpointUrl())) {
+      ReverseConnectConnection connection = replacement.connectionFuture().get(5, TimeUnit.SECONDS);
+      assertEquals(1, manager.snapshot().claimedCount());
+      connection.close();
+      assertPeerClosed(socket);
+    }
+  }
+
+  // Completing a claim future can race cancellation after the manager relinquishes ownership.
+  @Test
+  void cancellationAfterClaimClosesUndeliverableConnection() throws Exception {
+    manager = newManagerBuilder().build();
+    manager.startup();
+    ReverseConnectRegistration registration = manager.registerSelector(candidate -> false);
+    try (Socket socket = sendReverseHello(boundAddress(manager), endpointUrl())) {
+      waitUntil(() -> manager.snapshot().pendingCandidates().size() == 1);
+      UUID candidateId = manager.snapshot().pendingCandidates().get(0).id();
+      Method claim =
+          ReverseConnectManager.class.getDeclaredMethod("claimCandidate", UUID.class, UUID.class);
+      claim.setAccessible(true);
+      Object handoff = claim.invoke(manager, candidateId, registration.id());
+      registration.connectionFuture().cancel(false);
+      Method complete =
+          handoff.getClass().getDeclaredMethod("completeAndFire", ReverseConnectManager.class);
+      complete.setAccessible(true);
+      complete.invoke(handoff, manager);
+      assertPeerClosed(socket);
+    }
+  }
+
   @Test
   void shutdownCancelsPreStartupRegistrations() {
     manager = newManagerBuilder().build();

--- a/opc-ua-sdk/sdk-client/src/test/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseTcpClientTransportTest.java
+++ b/opc-ua-sdk/sdk-client/src/test/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseTcpClientTransportTest.java
@@ -16,11 +16,13 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.netty.channel.Channel;
 import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.util.HashedWheelTimer;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -39,6 +41,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
@@ -56,6 +59,8 @@ import org.eclipse.milo.opcua.stack.core.types.structured.ApplicationDescription
 import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
 import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
 import org.eclipse.milo.opcua.stack.transport.client.tcp.OpcTcpClientTransportConfig;
+import org.eclipse.milo.opcua.stack.transport.client.uasc.ClientSecureChannel;
+import org.eclipse.milo.opcua.stack.transport.client.uasc.UascClientAcknowledgeHandler;
 import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -262,6 +267,163 @@ class ReverseTcpClientTransportTest {
     return new ReverseTcpClientTransport(transportConfig(), newConnection(channel));
   }
 
+  // A listener can synchronously close the channel; every observer must see the same order.
+  @Test
+  void reentrantCloseDoesNotOvertakeConnectedNotification() throws Exception {
+    EmbeddedChannel channel = new EmbeddedChannel();
+    ReverseTcpClientTransport transport = newTransport(channel);
+    CompletableFuture<Channel> activeFuture = new CompletableFuture<>();
+    List<Boolean> transitions = new ArrayList<>();
+    setField(transport, "started", true);
+    setField(transport, "disconnecting", false);
+    setField(transport, "channelFuture", activeFuture);
+    transport.addTransitionListener(
+        connected -> {
+          if (connected) {
+            try {
+              invokeOnChannelClosed(transport, channel);
+            } catch (Exception e) {
+              throw new AssertionError(e);
+            }
+          }
+        });
+    transport.addTransitionListener(transitions::add);
+    try {
+      invokeCompleteHandshake(transport, activeFuture, channel);
+      assertEquals(List.of(true, false), transitions);
+      assertNull(transport.getCurrentChannel());
+    } finally {
+      channel.close();
+    }
+  }
+
+  // User future callbacks can close a channel before the handshake callback starts notifying.
+  @Test
+  void futureCompletionCloseDoesNotOvertakeConnectedNotification() throws Exception {
+    EmbeddedChannel channel = new EmbeddedChannel();
+    ReverseTcpClientTransport transport = newTransport(channel);
+    CompletableFuture<Channel> activeFuture = new CompletableFuture<>();
+    List<Boolean> transitions = new ArrayList<>();
+    setField(transport, "started", true);
+    setField(transport, "disconnecting", false);
+    setField(transport, "channelFuture", activeFuture);
+    transport.addTransitionListener(transitions::add);
+    activeFuture.thenRun(
+        () -> {
+          try {
+            invokeOnChannelClosed(transport, channel);
+          } catch (Exception e) {
+            throw new AssertionError(e);
+          }
+        });
+    try {
+      invokeCompleteHandshake(transport, activeFuture, channel);
+      assertEquals(List.of(true, false), transitions);
+      assertNull(transport.getCurrentChannel());
+    } finally {
+      channel.close();
+    }
+  }
+
+  // Once a manager hands off a channel, rejection must settle connect and close the socket.
+  @Test
+  void rejectedClaimDispatchClosesChannelAndFailsConnect() throws Exception {
+    QueuingExecutorService rejectingExecutor =
+        new QueuingExecutorService() {
+          @Override
+          public void execute(Runnable task) {
+            throw new RejectedExecutionException("saturated");
+          }
+        };
+    executor = rejectingExecutor;
+    ReverseConnectManager manager =
+        ReverseConnectManager.builder()
+            .addBindAddress(new InetSocketAddress("127.0.0.1", 0))
+            .setExecutor(Runnable::run)
+            .setScheduler(scheduledExecutor())
+            .build();
+    EmbeddedChannel channel = new EmbeddedChannel();
+    ReverseTcpClientTransport transport =
+        new ReverseTcpClientTransport(
+            transportConfig(rejectingExecutor), manager, ReverseConnectSelector.any());
+    CompletableFuture<Channel> target = new CompletableFuture<>();
+    try {
+      addPendingCandidate(manager, channel);
+      setField(transport, "started", true);
+      setField(transport, "disconnecting", false);
+      setField(transport, "channelFuture", target);
+      setField(transport, "waitingForReverseConnection", true);
+      Method register =
+          ReverseTcpClientTransport.class.getDeclaredMethod(
+              "registerForNextChannel", CompletableFuture.class);
+      register.setAccessible(true);
+      register.invoke(transport, target);
+      assertTrue(
+          target.isCompletedExceptionally(), "dispatch failure must settle connect immediately");
+      assertFalse(channel.isOpen(), "the manager no longer owns this claimed channel");
+      assertFalse(
+          (boolean)
+              declaredField(ReverseTcpClientTransport.class, "waitingForReverseConnection")
+                  .get(transport));
+    } finally {
+      channel.close();
+      manager.shutdown();
+    }
+  }
+
+  // A completed SecureChannel handshake must reach connect callers even if executor dispatch
+  // rejects.
+  @Test
+  @SuppressWarnings("unchecked")
+  void rejectedHandshakeDispatchStillCompletesConnect() throws Exception {
+    executor =
+        new QueuingExecutorService() {
+          @Override
+          public void execute(Runnable task) {
+            throw new RejectedExecutionException("saturated");
+          }
+        };
+    EmbeddedChannel channel = new EmbeddedChannel();
+    HashedWheelTimer timer = new HashedWheelTimer();
+    ReverseTcpClientTransport transport =
+        new ReverseTcpClientTransport(
+            OpcTcpClientTransportConfig.newBuilder()
+                .setExecutor(executor)
+                .setScheduledExecutor(scheduledExecutor())
+                .setWheelTimer(timer)
+                .build(),
+            newConnection(channel));
+    OpcUaClient client = new OpcUaClient(clientConfig(), transport);
+    CompletableFuture<Channel> target = new CompletableFuture<>();
+    setField(transport, "started", true);
+    setField(transport, "disconnecting", false);
+    setField(transport, "channelFuture", target);
+    setField(
+        transport,
+        "applicationContext",
+        declaredField(OpcUaClient.class, "applicationContext").get(client));
+    try {
+      invokeInitializeClaimedConnection(transport, newConnection(channel), target);
+      channel.runPendingTasks();
+      UascClientAcknowledgeHandler acknowledge =
+          channel.pipeline().get(UascClientAcknowledgeHandler.class);
+      CompletableFuture<ClientSecureChannel> handshake =
+          (CompletableFuture<ClientSecureChannel>)
+              declaredField(UascClientAcknowledgeHandler.class, "handshakeFuture").get(acknowledge);
+      ClientSecureChannel secureChannel =
+          new ClientSecureChannel(SecurityPolicy.None, MessageSecurityMode.None);
+      secureChannel.setChannel(channel);
+      handshake.complete(secureChannel);
+      assertTrue(target.isDone(), "executor rejection must not lose the completed handshake");
+      assertSame(channel, target.get(5, TimeUnit.SECONDS));
+      assertTrue(channel.isOpen(), "a successful handshake remains usable");
+    } finally {
+      transport.disconnect().get(5, TimeUnit.SECONDS);
+      channel.finishAndReleaseAll();
+      timer.stop();
+    }
+  }
+
   private OpcTcpClientTransportConfig transportConfig() {
     return transportConfig(executor());
   }
@@ -452,7 +614,7 @@ class ReverseTcpClientTransportTest {
     }
   }
 
-  private static final class QueuingExecutorService extends AbstractExecutorService {
+  private static class QueuingExecutorService extends AbstractExecutorService {
 
     private final List<Runnable> tasks = Collections.synchronizedList(new ArrayList<>());
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/reverse/ReverseConnectTargetManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/reverse/ReverseConnectTargetManager.java
@@ -185,7 +185,8 @@ public final class ReverseConnectTargetManager {
   /**
    * Add a listener for target and attempt lifecycle events.
    *
-   * <p>Callbacks are dispatched asynchronously on the server executor supplied to the manager.
+   * <p>Callbacks are serialized on the server executor supplied to the manager. If that executor
+   * rejects work, callbacks run on the submitting thread instead.
    *
    * @param listener the listener to register.
    */
@@ -438,7 +439,7 @@ public final class ReverseConnectTargetManager {
           // cleanup callback removes the key if the attempt actually fails.
           AttemptKey rescueKey = new AttemptKey(record.attemptCounter, attemptGeneration);
           record.pendingHandoffAttempts.add(rescueKey);
-          installHandoffRescueCleanup(target.getId(), attempt, rescueKey);
+          installHandoffRescueCleanup(record, attempt, rescueKey);
         }
 
         record.target = target;
@@ -535,7 +536,7 @@ public final class ReverseConnectTargetManager {
       // fails so the target does not remain stuck with phantom pending state.
       AttemptKey rescueKey = new AttemptKey(record.attemptCounter, attemptGeneration);
       record.pendingHandoffAttempts.add(rescueKey);
-      installHandoffRescueCleanup(record.target.getId(), attempt, rescueKey);
+      installHandoffRescueCleanup(record, attempt, rescueKey);
     }
     if (!handoffAccepted) {
       record.generation++;
@@ -545,7 +546,7 @@ public final class ReverseConnectTargetManager {
   }
 
   private void installHandoffRescueCleanup(
-      UUID targetId, OpcTcpServerReverseConnectAttempt attempt, AttemptKey rescueKey) {
+      TargetRecord owner, OpcTcpServerReverseConnectAttempt attempt, AttemptKey rescueKey) {
 
     attempt
         .channelFuture()
@@ -556,8 +557,8 @@ public final class ReverseConnectTargetManager {
               }
               ReverseConnectTargetSnapshot updatedSnapshot = null;
               synchronized (lock) {
-                TargetRecord record = records.get(targetId);
-                if (record == null) {
+                TargetRecord record = records.get(owner.target.getId());
+                if (record != owner) {
                   return;
                 }
                 if (!record.pendingHandoffAttempts.remove(rescueKey)) {
@@ -587,7 +588,7 @@ public final class ReverseConnectTargetManager {
     record.nextAttemptTime = Instant.now().plusMillis(normalizedDelayMillis);
     record.scheduledFuture =
         scheduler.schedule(
-            () -> runScheduledAttempt(record.target.getId(), generation),
+            () -> runScheduledAttempt(record, generation),
             normalizedDelayMillis,
             TimeUnit.MILLISECONDS);
   }
@@ -607,11 +608,11 @@ public final class ReverseConnectTargetManager {
         && !record.hasPendingAttempt();
   }
 
-  private void runScheduledAttempt(UUID targetId, long generation) {
+  private void runScheduledAttempt(TargetRecord owner, long generation) {
     AttemptStart start;
     synchronized (lock) {
-      TargetRecord record = records.get(targetId);
-      if (record == null
+      TargetRecord record = records.get(owner.target.getId());
+      if (record != owner
           || generation != record.generation
           || !running
           || shutdown
@@ -626,7 +627,8 @@ public final class ReverseConnectTargetManager {
       record.lastAttemptTime = Instant.now();
 
       start =
-          new AttemptStart(record.target, ++record.attemptCounter, generation, record.snapshot());
+          new AttemptStart(
+              record, record.target, ++record.attemptCounter, generation, record.snapshot());
     }
 
     notifyTargetUpdated(start.snapshot());
@@ -648,7 +650,7 @@ public final class ReverseConnectTargetManager {
                     start.target().getConnectTimeout().intValue(),
                     event ->
                         onTransportAttemptEvent(
-                            start.target().getId(), start.number(), start.generation(), event)));
+                            start.owner(), start.number(), start.generation(), event)));
       } else {
         throw new UaException(
             StatusCodes.Bad_ConfigurationError,
@@ -664,15 +666,14 @@ public final class ReverseConnectTargetManager {
         .whenComplete(
             (channel, ex) -> {
               if (ex == null) {
-                onAttemptChannel(
-                    start.target().getId(), start.number(), start.generation(), channel);
+                onAttemptChannel(start.owner(), start.number(), start.generation(), channel);
               }
             });
 
     boolean shouldClose = false;
     synchronized (lock) {
       TargetRecord record = records.get(start.target().getId());
-      if (record != null
+      if (record == start.owner()
           && record.attemptCounter == start.number()
           && record.generation == start.generation()
           && running
@@ -713,7 +714,7 @@ public final class ReverseConnectTargetManager {
     ReverseConnectTargetSnapshot snapshot = null;
     synchronized (lock) {
       TargetRecord record = records.get(start.target().getId());
-      if (record != null
+      if (record == start.owner()
           && record.attemptCounter == start.number()
           && record.generation == start.generation()) {
         record.attemptInProgress = false;
@@ -724,7 +725,12 @@ public final class ReverseConnectTargetManager {
         if (running && !shutdown && record.isSchedulable()) {
           retryContext =
               new RetryContext(
-                  start.target().getId(), start.number(), start.generation(), record.target, event);
+                  record,
+                  start.target().getId(),
+                  start.number(),
+                  start.generation(),
+                  record.target,
+                  event);
         }
 
         snapshot = record.snapshot();
@@ -742,11 +748,12 @@ public final class ReverseConnectTargetManager {
   }
 
   private void onTransportAttemptEvent(
-      UUID targetId,
+      TargetRecord owner,
       long attemptNumber,
       long attemptGeneration,
       OpcTcpServerReverseConnectAttemptEvent transportEvent) {
 
+    UUID targetId = owner.target.getId();
     ReverseConnectAttemptEvent event =
         new ReverseConnectAttemptEvent(
             targetId,
@@ -761,7 +768,7 @@ public final class ReverseConnectTargetManager {
     ReverseConnectTargetSnapshot snapshot = null;
     synchronized (lock) {
       TargetRecord record = records.get(targetId);
-      if (record != null && record.attemptCounter == attemptNumber && isTerminal(event.state())) {
+      if (record == owner && record.attemptCounter == attemptNumber && isTerminal(event.state())) {
         boolean handoff = event.state() == ReverseConnectAttemptState.HANDOFF;
         if (handoff && shutdown) {
           return;
@@ -783,7 +790,8 @@ public final class ReverseConnectTargetManager {
 
           if (shouldRetry(record, event)) {
             retryContext =
-                new RetryContext(targetId, attemptNumber, attemptGeneration, record.target, event);
+                new RetryContext(
+                    record, targetId, attemptNumber, attemptGeneration, record.target, event);
           }
 
           snapshot = record.snapshot();
@@ -802,13 +810,14 @@ public final class ReverseConnectTargetManager {
   }
 
   private void onAttemptChannel(
-      UUID targetId, long attemptNumber, long attemptGeneration, Channel channel) {
+      TargetRecord owner, long attemptNumber, long attemptGeneration, Channel channel) {
+    UUID targetId = owner.target.getId();
     ReverseConnectTargetSnapshot snapshot = null;
     boolean closeChannel = false;
 
     synchronized (lock) {
       TargetRecord record = records.get(targetId);
-      if (record == null || shutdown) {
+      if (record != owner || shutdown) {
         closeChannel = true;
       } else {
         var attemptKey = new AttemptKey(attemptNumber, attemptGeneration);
@@ -830,18 +839,19 @@ public final class ReverseConnectTargetManager {
       return;
     }
 
-    channel.closeFuture().addListener(f -> onActiveChannelClosed(targetId, channel));
+    channel.closeFuture().addListener(f -> onActiveChannelClosed(owner, channel));
 
     notifyTargetUpdated(snapshot);
   }
 
-  private void onActiveChannelClosed(UUID targetId, Channel channel) {
+  private void onActiveChannelClosed(TargetRecord owner, Channel channel) {
+    UUID targetId = owner.target.getId();
     PostCloseRetryContext retryContext = null;
     ReverseConnectTargetSnapshot snapshot;
 
     synchronized (lock) {
       TargetRecord record = records.get(targetId);
-      if (record == null) {
+      if (record != owner) {
         return;
       }
 
@@ -862,7 +872,8 @@ public final class ReverseConnectTargetManager {
                 null,
                 "reverse-connect active channel closed");
 
-        retryContext = new PostCloseRetryContext(targetId, record.generation, record.target, event);
+        retryContext =
+            new PostCloseRetryContext(record, targetId, record.generation, record.target, event);
       }
 
       snapshot = record.snapshot();
@@ -963,7 +974,8 @@ public final class ReverseConnectTargetManager {
   }
 
   private boolean isRetryCurrent(TargetRecord record, RetryContext retryContext) {
-    return record.attemptCounter == retryContext.attemptNumber()
+    return record == retryContext.owner()
+        && record.attemptCounter == retryContext.attemptNumber()
         && record.generation == retryContext.generation()
         && shouldRetry(record, retryContext.event());
   }
@@ -977,7 +989,8 @@ public final class ReverseConnectTargetManager {
 
   private boolean isPostCloseRetryCurrent(TargetRecord record, PostCloseRetryContext retryContext) {
 
-    return record.generation == retryContext.generation()
+    return record == retryContext.owner()
+        && record.generation == retryContext.generation()
         && running
         && !shutdown
         && record.isSchedulable()
@@ -1158,6 +1171,7 @@ public final class ReverseConnectTargetManager {
   }
 
   private record AttemptStart(
+      TargetRecord owner,
       ReverseConnectTarget target,
       long number,
       long generation,
@@ -1166,6 +1180,7 @@ public final class ReverseConnectTargetManager {
   private record AttemptKey(long number, long generation) {}
 
   private record RetryContext(
+      TargetRecord owner,
       UUID targetId,
       long attemptNumber,
       long generation,
@@ -1173,6 +1188,7 @@ public final class ReverseConnectTargetManager {
       ReverseConnectAttemptEvent event) {}
 
   private record PostCloseRetryContext(
+      TargetRecord owner,
       UUID targetId,
       long generation,
       ReverseConnectTarget target,

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/reverse/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/reverse/package-info.java
@@ -50,7 +50,10 @@
  * <p>Updating a target replaces the future-attempt configuration, including enabled and paused
  * state, without closing reverse-opened channels that have already been handed to the normal server
  * path. Removing a target is stronger: it cancels scheduled work, closes an in-flight attempt, and
- * closes active channels owned by that target.
+ * closes active channels owned by that target. Asynchronous callbacks belong to one registration
+ * instance; reusing a removed target's UUID creates a separate owner. Late handoffs from the
+ * removed registration close their channels, and stale timers or retry callbacks cannot change its
+ * replacement.
  *
  * <h2>Failure handling</h2>
  *
@@ -58,7 +61,9 @@
  * org.eclipse.milo.opcua.sdk.server.reverse.ReverseConnectAttemptEvent}s and retained on target
  * snapshots as the last status or a defensive copy of the last exception. Retry timing is delegated
  * to {@link org.eclipse.milo.opcua.sdk.server.reverse.ReverseConnectRetryPolicy}; the default
- * policy uses the target registration period.
+ * policy uses the target registration period. Listener dispatch uses a serial execution queue;
+ * executor rejection runs callbacks on the submitting thread so notification failures cannot
+ * abandon an attempt transition. Callbacks should return promptly even during executor overload.
  *
  * <p>Successful outbound UA-TCP connections are handed back to the normal server SecureChannel and
  * Session paths after the stack transport installs the standard server Hello handler. Client-side

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/reverse/ReverseConnectTargetManagerTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/reverse/ReverseConnectTargetManagerTest.java
@@ -21,15 +21,21 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.netty.channel.Channel;
 import io.netty.channel.embedded.EmbeddedChannel;
 import java.lang.reflect.Field;
+import java.time.Instant;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -38,15 +44,19 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import org.eclipse.milo.opcua.stack.core.transport.TransportProfile;
 import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
 import org.eclipse.milo.opcua.stack.transport.server.ServerApplicationContext;
 import org.eclipse.milo.opcua.stack.transport.server.tcp.OpcTcpServerReverseConnectAttempt;
+import org.eclipse.milo.opcua.stack.transport.server.tcp.OpcTcpServerReverseConnectAttemptEvent;
+import org.eclipse.milo.opcua.stack.transport.server.tcp.OpcTcpServerReverseConnectAttemptState;
 import org.eclipse.milo.opcua.stack.transport.server.tcp.OpcTcpServerReverseConnectParameters;
 import org.eclipse.milo.opcua.stack.transport.server.tcp.OpcTcpServerTransport;
 import org.eclipse.milo.opcua.stack.transport.server.tcp.OpcTcpServerTransportConfig;
@@ -376,6 +386,150 @@ class ReverseConnectTargetManagerTest {
     assertUnknownTargetFailure(handle::resume, target.getId());
     assertUnknownTargetFailure(handle::trigger, target.getId());
     assertUnknownTargetFailure(handle::remove, target.getId());
+  }
+
+  // State observers must not prevent an attempt from acquiring a transport when dispatch rejects.
+  @Test
+  void listenerExecutorRejectionDoesNotStrandScheduledAttempt() throws Exception {
+    try (ControlledAttempts fixture = new ControlledAttempts()) {
+      fixture.manager.addListener(new ReverseConnectTargetListener() {});
+      fixture.manager.startup();
+      fixture.rejectNotifications.set(true);
+      fixture.scheduled.remove().run();
+      assertEquals(1, fixture.transport.attempts.size());
+      fixture.rejectNotifications.set(false);
+      fixture.manager.trigger(fixture.target.getId()).get(5, TimeUnit.SECONDS);
+      assertEquals(
+          1, fixture.transport.attempts.size(), "the original attempt remains in progress");
+    }
+  }
+
+  // UUIDs identify public targets, but a removed registration must never own a replacement's
+  // channel.
+  @Test
+  void oldHandoffCannotAttachChannelToReplacementWithSameTargetId() throws Exception {
+    try (ControlledAttempts fixture = new ControlledAttempts()) {
+      fixture.manager.startup();
+      fixture.scheduled.remove().run();
+      fixture.transport.handoff(0);
+      fixture.manager.remove(fixture.target.getId()).get(5, TimeUnit.SECONDS);
+      fixture.manager.addTarget(fixture.target);
+      fixture.scheduled.remove().run();
+      EmbeddedChannel oldChannel = new EmbeddedChannel();
+      EmbeddedChannel newChannel = new EmbeddedChannel();
+      try {
+        fixture.transport.channels.get(0).complete(oldChannel);
+        assertFalse(oldChannel.isOpen(), "late channel from the removed registration must close");
+        assertEquals(0, fixture.manager.snapshots().get(0).activeChannelCount());
+        fixture.transport.handoff(1);
+        fixture.transport.channels.get(1).complete(newChannel);
+        assertTrue(newChannel.isOpen());
+        assertEquals(1, fixture.manager.snapshots().get(0).activeChannelCount());
+      } finally {
+        oldChannel.close();
+        newChannel.close();
+      }
+    }
+  }
+
+  // Removing in the HANDOFF/future-completion interval must still close the later channel.
+  @Test
+  void removalClosesChannelDeliveredAfterHandoffEvent() throws Exception {
+    try (ControlledAttempts fixture = new ControlledAttempts()) {
+      fixture.manager.startup();
+      fixture.scheduled.remove().run();
+      fixture.transport.handoff(0);
+      fixture.manager.remove(fixture.target.getId()).get(5, TimeUnit.SECONDS);
+      EmbeddedChannel channel = new EmbeddedChannel();
+      try {
+        fixture.transport.channels.get(0).complete(channel);
+        assertFalse(channel.isOpen());
+      } finally {
+        channel.close();
+      }
+    }
+  }
+
+  private static final class ControlledAttempts implements AutoCloseable {
+    final Queue<Runnable> scheduled = new ArrayDeque<>();
+    final AtomicBoolean rejectNotifications = new AtomicBoolean();
+    final ControlledTransport transport = new ControlledTransport();
+    final ReverseConnectTarget target =
+        target("opc.tcp://localhost:12686/reverse-target-test", "opc.tcp://localhost:12687");
+    final ReverseConnectTargetManager manager;
+
+    ControlledAttempts() {
+      ExecutorService executor = mock(ExecutorService.class);
+      doAnswer(
+              invocation -> {
+                if (rejectNotifications.get()) {
+                  throw new RejectedExecutionException("saturated");
+                }
+                invocation.<Runnable>getArgument(0).run();
+                return null;
+              })
+          .when(executor)
+          .execute(any(Runnable.class));
+      ScheduledExecutorService scheduler = mock(ScheduledExecutorService.class);
+      when(scheduler.schedule(any(Runnable.class), anyLong(), any(TimeUnit.class)))
+          .thenAnswer(
+              invocation -> {
+                scheduled.add(invocation.getArgument(0));
+                return mock(ScheduledFuture.class);
+              });
+      manager =
+          new ReverseConnectTargetManager(
+              mock(ServerApplicationContext.class),
+              () -> List.of(endpointDescription(target.getEndpointUrl())),
+              profile -> transport,
+              "urn:eclipse:milo:test:server:reverse-targets",
+              executor,
+              scheduler,
+              Set.of(target));
+    }
+
+    @Override
+    public void close() {
+      manager.shutdown();
+    }
+  }
+
+  private static final class ControlledTransport extends OpcTcpServerTransport {
+    final List<OpcTcpServerReverseConnectParameters> parameters = new ArrayList<>();
+    final List<OpcTcpServerReverseConnectAttempt> attempts = new ArrayList<>();
+    final List<CompletableFuture<Channel>> channels = new ArrayList<>();
+
+    ControlledTransport() {
+      super(OpcTcpServerTransportConfig.newBuilder().build());
+    }
+
+    @Override
+    public OpcTcpServerReverseConnectAttempt connectReverse(
+        OpcTcpServerReverseConnectParameters parameters) {
+      OpcTcpServerReverseConnectAttempt attempt = mock(OpcTcpServerReverseConnectAttempt.class);
+      CompletableFuture<Channel> channel = new CompletableFuture<>();
+      when(attempt.channelFuture()).thenReturn(channel);
+      when(attempt.state()).thenReturn(OpcTcpServerReverseConnectAttemptState.CONNECTING);
+      this.parameters.add(parameters);
+      attempts.add(attempt);
+      channels.add(channel);
+      return attempt;
+    }
+
+    void handoff(int index) {
+      when(attempts.get(index).state()).thenReturn(OpcTcpServerReverseConnectAttemptState.HANDOFF);
+      parameters
+          .get(index)
+          .observer()
+          .onStateTransition(
+              new OpcTcpServerReverseConnectAttemptEvent(
+                  UUID.randomUUID(),
+                  OpcTcpServerReverseConnectAttemptState.HANDOFF,
+                  Instant.now(),
+                  null,
+                  null,
+                  null));
+    }
   }
 
   private static void assertUnknownTargetFailure(

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/ExecutionQueue.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/ExecutionQueue.java
@@ -10,9 +10,9 @@
 
 package org.eclipse.milo.opcua.stack.core.util;
 
-import com.google.common.base.Preconditions;
 import java.util.ArrayDeque;
 import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,6 +25,9 @@ import org.slf4j.LoggerFactory;
  *
  * <p>When {@code concurrency > 1} there are no guarantees beyond the fact that tasks are still
  * pulled from a queue to be executed.
+ *
+ * <p>If the executor rejects execution, the submitting thread runs queued tasks synchronously.
+ * Callbacks should return promptly because this fallback may run on an I/O or timer thread.
  */
 public class ExecutionQueue {
 
@@ -56,9 +59,8 @@ public class ExecutionQueue {
   public void submit(Runnable runnable) {
     synchronized (queueLock) {
       queue.add(runnable);
-
-      maybePollAndExecute();
     }
+    maybePollAndExecute();
   }
 
   /**
@@ -69,9 +71,8 @@ public class ExecutionQueue {
   public void submitToHead(Runnable runnable) {
     synchronized (queueLock) {
       queue.addFirst(runnable);
-
-      maybePollAndExecute();
     }
+    maybePollAndExecute();
   }
 
   /** Pause execution of queued {@link java.lang.Runnable}s. */
@@ -85,81 +86,92 @@ public class ExecutionQueue {
   public void resume() {
     synchronized (queueLock) {
       paused = false;
-
-      maybePollAndExecute();
     }
+    maybePollAndExecute();
   }
 
   private void maybePollAndExecute() {
     synchronized (queueLock) {
-      if (pending < concurrencyLimit && !paused && !queue.isEmpty()) {
-        executor.execute(new Task(queue.poll()));
-        pending++;
+      if (pending >= concurrencyLimit || paused || queue.isEmpty()) {
+        return;
       }
+      // Reserve the worker before dispatch, including when the executor runs it inline.
+      pending++;
+    }
+
+    Task task = new Task();
+    try {
+      executor.execute(task);
+    } catch (RejectedExecutionException e) {
+      task.run();
     }
   }
 
   private class Task implements Runnable {
 
-    private final Runnable runnable;
-
-    Task(Runnable runnable) {
-      Preconditions.checkNotNull(runnable);
-
-      this.runnable = runnable;
-    }
+    // A continuation can run before execute() returns, either inline or on another worker.
+    // In that case the current invocation keeps ownership and drains the next batch itself.
+    private boolean running;
+    private boolean runAgain;
 
     @Override
     public void run() {
-      try {
-        runnable.run();
-      } catch (Throwable throwable) {
-        log.warn("Uncaught Throwable during execution.", throwable);
+      synchronized (this) {
+        if (running) {
+          runAgain = true;
+          return;
+        }
+        running = true;
       }
 
-      InlineTask inlineTask = null;
+      while (true) {
+        boolean moreTasks = runBatch();
+        if (moreTasks) {
+          try {
+            executor.execute(this);
+          } catch (RejectedExecutionException e) {
+            synchronized (this) {
+              runAgain = true;
+            }
+          }
+        }
 
-      synchronized (queueLock) {
-        if (queue.isEmpty() || paused) {
-          pending--;
-        } else {
-          // pending count remains the same
-          inlineTask = new InlineTask(queue.poll());
+        synchronized (this) {
+          if (moreTasks && runAgain) {
+            runAgain = false;
+          } else {
+            running = false;
+            return;
+          }
+        }
+      }
+    }
+
+    private boolean runBatch() {
+      for (int i = 0; i < 2; i++) {
+        Runnable runnable;
+        synchronized (queueLock) {
+          if (paused || queue.isEmpty()) {
+            pending--;
+            return false;
+          }
+          runnable = queue.remove();
+        }
+
+        try {
+          runnable.run();
+        } catch (Throwable throwable) {
+          log.warn("Uncaught Throwable during execution.", throwable);
         }
       }
 
-      if (inlineTask != null) {
-        inlineTask.run();
-      }
-    }
-  }
-
-  private class InlineTask implements Runnable {
-
-    private final Runnable runnable;
-
-    InlineTask(Runnable runnable) {
-      Preconditions.checkNotNull(runnable);
-
-      this.runnable = runnable;
-    }
-
-    @Override
-    public void run() {
-      try {
-        runnable.run();
-      } catch (Throwable throwable) {
-        log.warn("Uncaught Throwable during execution.", throwable);
-      }
-
       synchronized (queueLock) {
-        if (queue.isEmpty() || paused) {
+        if (paused || queue.isEmpty()) {
           pending--;
-        } else {
-          // pending count remains the same
-          executor.execute(new Task(queue.poll()));
+          return false;
         }
       }
+      return true;
     }
   }
 }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/ExecutionQueue.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/ExecutionQueue.java
@@ -12,7 +12,6 @@ package org.eclipse.milo.opcua.stack.core.util;
 
 import java.util.ArrayDeque;
 import java.util.concurrent.Executor;
-import java.util.concurrent.RejectedExecutionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,8 +25,9 @@ import org.slf4j.LoggerFactory;
  * <p>When {@code concurrency > 1} there are no guarantees beyond the fact that tasks are still
  * pulled from a queue to be executed.
  *
- * <p>If the executor rejects execution, the submitting thread runs queued tasks synchronously.
- * Callbacks should return promptly because this fallback may run on an I/O or timer thread.
+ * <p>If the executor throws a runtime exception during dispatch, the submitting thread runs queued
+ * tasks synchronously. Callbacks should return promptly because this fallback may run on an I/O or
+ * timer thread.
  */
 public class ExecutionQueue {
 
@@ -102,7 +102,7 @@ public class ExecutionQueue {
     Task task = new Task();
     try {
       executor.execute(task);
-    } catch (RejectedExecutionException e) {
+    } catch (RuntimeException e) {
       task.run();
     }
   }
@@ -113,10 +113,14 @@ public class ExecutionQueue {
     // In that case the current invocation keeps ownership and drains the next batch itself.
     private boolean running;
     private boolean runAgain;
+    private boolean completed;
 
     @Override
     public void run() {
       synchronized (this) {
+        if (completed) {
+          return;
+        }
         if (running) {
           runAgain = true;
           return;
@@ -129,7 +133,7 @@ public class ExecutionQueue {
         if (moreTasks) {
           try {
             executor.execute(this);
-          } catch (RejectedExecutionException e) {
+          } catch (RuntimeException e) {
             synchronized (this) {
               runAgain = true;
             }
@@ -141,6 +145,9 @@ public class ExecutionQueue {
             runAgain = false;
           } else {
             running = false;
+            // A decorating executor can run this worker before reporting a dispatch failure.
+            // Its fallback invocation must not release a finished worker's reservation twice.
+            completed = !moreTasks;
             return;
           }
         }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/package-info.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/package-info.java
@@ -16,10 +16,10 @@
  * resource lifecycles; utility objects do not own its channels, sessions, or executor shutdown.
  *
  * <p>{@link org.eclipse.milo.opcua.stack.core.util.ExecutionQueue} serializes callbacks by default
- * and can permit an explicit number of concurrent workers. It retains queued tasks through executor
- * rejection by running the rejected worker on the submitting thread. Pausing stops new task
- * execution after currently running callbacks finish; resuming makes queued tasks eligible again.
- * Callbacks run outside the queue lock, and normal asynchronous workers yield between small batches
- * so other users of the executor can make progress.
+ * and can permit an explicit number of concurrent workers. It retains queued tasks when executor
+ * dispatch throws a runtime exception by running the worker on the submitting thread. Pausing stops
+ * new task execution after currently running callbacks finish; resuming makes queued tasks eligible
+ * again. Callbacks run outside the queue lock. Workers submit a continuation between small batches;
+ * scheduling among executor users depends on the supplied executor.
  */
 package org.eclipse.milo.opcua.stack.core.util;

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/package-info.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/**
+ * Shared protocol utilities and asynchronous coordination primitives used by transports and SDKs.
+ *
+ * <p>These utilities support endpoint and value handling, cryptographic operations, and task
+ * coordination. The calling transport or SDK retains authority over protocol validation and
+ * resource lifecycles; utility objects do not own its channels, sessions, or executor shutdown.
+ *
+ * <p>{@link org.eclipse.milo.opcua.stack.core.util.ExecutionQueue} serializes callbacks by default
+ * and can permit an explicit number of concurrent workers. It retains queued tasks through executor
+ * rejection by running the rejected worker on the submitting thread. Pausing stops new task
+ * execution after currently running callbacks finish; resuming makes queued tasks eligible again.
+ * Callbacks run outside the queue lock, and normal asynchronous workers yield between small batches
+ * so other users of the executor can make progress.
+ */
+package org.eclipse.milo.opcua.stack.core.util;

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/util/ExecutionQueueTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/util/ExecutionQueueTest.java
@@ -77,6 +77,89 @@ public class ExecutionQueueTest {
     assertEquals(List.of(1, 2, 3, 4), completed);
   }
 
+  // A custom executor may translate rejection to another runtime exception. Its reserved worker
+  // must still finish, and later submissions must acquire a fresh worker normally.
+  @Test
+  void executorFailureDuringInitialDispatchDoesNotStrandLaterSubmissions() {
+    AtomicInteger dispatches = new AtomicInteger();
+    ExecutionQueue queue =
+        new ExecutionQueue(
+            task -> {
+              if (dispatches.getAndIncrement() == 0) {
+                throw new IllegalStateException("executor unavailable");
+              }
+              task.run();
+            });
+    List<Integer> completed = new ArrayList<>();
+    queue.submit(() -> completed.add(1));
+    queue.submit(() -> completed.add(2));
+    assertEquals(List.of(1, 2), completed);
+    assertEquals(2, dispatches.get());
+  }
+
+  // Failure to dispatch a continuation cannot retain the running flag or worker reservation.
+  @Test
+  void executorFailureDuringContinuationDoesNotStrandLaterSubmissions() {
+    AtomicReference<Runnable> worker = new AtomicReference<>();
+    ExecutionQueue queue =
+        new ExecutionQueue(
+            task -> {
+              if (!worker.compareAndSet(null, task)) {
+                throw new IllegalStateException("executor unavailable");
+              }
+            });
+    List<Integer> completed = new ArrayList<>();
+    queue.submit(() -> completed.add(1));
+    queue.submit(() -> completed.add(2));
+    queue.submit(() -> completed.add(3));
+    worker.get().run();
+    queue.submit(() -> completed.add(4));
+    assertEquals(List.of(1, 2, 3, 4), completed);
+  }
+
+  // An executor decorator can throw after running a worker. Retrying that completed worker must
+  // not release its reservation twice and permit a later callback to overtake a blocked callback.
+  @Test
+  void executorFailureAfterRunningWorkerPreservesSerialExecution() throws Exception {
+    ExecutionQueue queue =
+        new ExecutionQueue(
+            task -> {
+              task.run();
+              throw new IllegalStateException("executor failed after execution");
+            });
+    AtomicInteger completed = new AtomicInteger();
+    queue.submit(completed::incrementAndGet);
+    assertEquals(1, completed.get());
+
+    CountDownLatch firstStarted = new CountDownLatch(1);
+    CountDownLatch releaseFirst = new CountDownLatch(1);
+    try {
+      var first =
+          executor.submit(
+              () ->
+                  queue.submit(
+                      () -> {
+                        firstStarted.countDown();
+                        try {
+                          assertTrue(releaseFirst.await(5, TimeUnit.SECONDS));
+                        } catch (InterruptedException e) {
+                          Thread.currentThread().interrupt();
+                          throw new AssertionError(e);
+                        }
+                      }));
+      assertTrue(firstStarted.await(5, TimeUnit.SECONDS));
+      queue.submit(completed::incrementAndGet);
+      assertEquals(1, completed.get(), "the second callback must wait for the first callback");
+      releaseFirst.countDown();
+      first.get(5, TimeUnit.SECONDS);
+      assertEquals(2, completed.get());
+      queue.submit(completed::incrementAndGet);
+      assertEquals(3, completed.get());
+    } finally {
+      releaseFirst.countDown();
+    }
+  }
+
   // Direct executors and nested submissions must not recurse once per queued task.
   @Test
   void reentrantSubmissionWithDirectExecutorDrainsWithoutRecursion() {
@@ -95,9 +178,9 @@ public class ExecutionQueueTest {
     assertEquals(100_000, completed.get());
   }
 
-  // A busy queue must yield so unrelated tasks sharing its executor can make progress.
+  // A FIFO executor can run unrelated tasks between batches from a busy queue.
   @Test
-  void workersYieldToOtherExecutorTasksBetweenBatches() {
+  void fifoExecutorRunsOtherTasksBetweenBatches() {
     Queue<Runnable> executorTasks = new ArrayDeque<>();
     ExecutionQueue queue = new ExecutionQueue(executorTasks::add);
     List<String> completed = new ArrayList<>();

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/util/ExecutionQueueTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/util/ExecutionQueueTest.java
@@ -12,12 +12,22 @@ package org.eclipse.milo.opcua.stack.core.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,8 +38,109 @@ public class ExecutionQueueTest {
 
   private final ExecutorService executor = Executors.newCachedThreadPool();
 
+  @AfterEach
+  void tearDown() {
+    executor.shutdownNow();
+  }
+
+  // Delivery ownership cannot be lost when a configured bounded executor is temporarily full.
   @Test
-  public void testSubmitIsLinearWhenConcurrencyIs1() {
+  void rejectedSubmissionCompletesInline() {
+    ExecutionQueue queue =
+        new ExecutionQueue(
+            task -> {
+              throw new RejectedExecutionException("saturated");
+            });
+    AtomicInteger completed = new AtomicInteger();
+    queue.submit(completed::incrementAndGet);
+    queue.submit(completed::incrementAndGet);
+    assertEquals(2, completed.get());
+  }
+
+  // A worker must finish its backlog even if the executor rejects subsequent submissions.
+  @Test
+  void executorRejectionWhileDrainingDoesNotLoseQueuedTasks() {
+    AtomicReference<Runnable> worker = new AtomicReference<>();
+    ExecutionQueue queue =
+        new ExecutionQueue(
+            task -> {
+              if (!worker.compareAndSet(null, task)) {
+                throw new RejectedExecutionException("saturated");
+              }
+            });
+    List<Integer> completed = new ArrayList<>();
+    queue.submit(() -> completed.add(1));
+    queue.submit(() -> completed.add(2));
+    queue.submit(() -> completed.add(3));
+    worker.get().run();
+    queue.submit(() -> completed.add(4));
+    assertEquals(List.of(1, 2, 3, 4), completed);
+  }
+
+  // Direct executors and nested submissions must not recurse once per queued task.
+  @Test
+  void reentrantSubmissionWithDirectExecutorDrainsWithoutRecursion() {
+    ExecutionQueue queue = new ExecutionQueue(Runnable::run);
+    AtomicInteger completed = new AtomicInteger();
+    Runnable producer =
+        new Runnable() {
+          @Override
+          public void run() {
+            if (completed.incrementAndGet() < 100_000) {
+              queue.submit(this);
+            }
+          }
+        };
+    queue.submit(producer);
+    assertEquals(100_000, completed.get());
+  }
+
+  // A busy queue must yield so unrelated tasks sharing its executor can make progress.
+  @Test
+  void workersYieldToOtherExecutorTasksBetweenBatches() {
+    Queue<Runnable> executorTasks = new ArrayDeque<>();
+    ExecutionQueue queue = new ExecutionQueue(executorTasks::add);
+    List<String> completed = new ArrayList<>();
+    queue.submit(() -> completed.add("first"));
+    queue.submit(() -> completed.add("second"));
+    queue.submit(() -> completed.add("third"));
+    executorTasks.add(() -> completed.add("other"));
+    while (!executorTasks.isEmpty()) {
+      executorTasks.remove().run();
+    }
+    assertEquals(List.of("first", "second", "other", "third"), completed);
+  }
+
+  // Rejection fallback must not hold the queue lock across application callbacks.
+  @Test
+  void rejectedWorkerDoesNotBlockConcurrentSubmissionWhileCallbackRuns() throws Exception {
+    ExecutionQueue queue =
+        new ExecutionQueue(
+            task -> {
+              throw new RejectedExecutionException("saturated");
+            });
+    ExecutorService submitter = Executors.newSingleThreadExecutor();
+    AtomicInteger completed = new AtomicInteger();
+    try {
+      queue.submit(
+          () -> {
+            try {
+              submitter
+                  .submit(() -> queue.submit(completed::incrementAndGet))
+                  .get(5, TimeUnit.SECONDS);
+              completed.incrementAndGet();
+            } catch (Exception e) {
+              throw new AssertionError(e);
+            }
+          });
+      assertEquals(2, completed.get());
+    } finally {
+      submitter.shutdownNow();
+    }
+  }
+
+  @Test
+  public void testSubmitIsLinearWhenConcurrencyIs1() throws Exception {
     ExecutionQueue queue = new ExecutionQueue(executor, 1);
 
     AtomicBoolean failed = new AtomicBoolean(false);
@@ -48,6 +159,10 @@ public class ExecutionQueueTest {
           });
     }
 
+    CompletableFuture<Void> drained = new CompletableFuture<>();
+    queue.submit(() -> drained.complete(null));
+    drained.get(30, TimeUnit.SECONDS);
+    assertEquals(1_000_000, n.get());
     assertFalse(failed.get());
   }
 
@@ -66,7 +181,7 @@ public class ExecutionQueueTest {
           });
     }
 
-    latch.await();
+    assertTrue(latch.await(30, TimeUnit.SECONDS));
     assertEquals(100000, count.get());
   }
 }

--- a/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/client/package-info.java
+++ b/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/client/package-info.java
@@ -45,8 +45,10 @@
  *
  * <h2>Threading</h2>
  *
- * <p>Request futures complete on the transport config's executor, never inline on a Netty event
- * loop or wheel-timer thread, so caller continuations cannot stall I/O or timeouts. Publish
- * responses are serialized through a dedicated {@code ExecutionQueue} to preserve ordering.
+ * <p>Request futures normally complete on the transport config's executor. If that executor rejects
+ * work, completion runs on the submitting thread so requests do not remain pending after their
+ * response or failure has been consumed. Caller continuations should return promptly because this
+ * fallback may run on an I/O or timer thread. Publish responses pass through a dedicated {@code
+ * ExecutionQueue} that preserves their order across normal dispatch and rejection fallback.
  */
 package org.eclipse.milo.opcua.stack.transport.client;

--- a/opc-ua-stack/transport/src/test/java/org/eclipse/milo/opcua/stack/transport/client/PublishResponseDispatchTest.java
+++ b/opc-ua-stack/transport/src/test/java/org/eclipse/milo/opcua/stack/transport/client/PublishResponseDispatchTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.transport.client;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import io.netty.channel.Channel;
+import io.netty.channel.embedded.EmbeddedChannel;
+import java.util.ArrayDeque;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.eclipse.milo.opcua.stack.core.types.UaResponseMessageType;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.structured.PublishRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.PublishResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.RequestHeader;
+import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.transport.client.tcp.OpcTcpClientTransportConfig;
+import org.junit.jupiter.api.Test;
+
+class PublishResponseDispatchTest {
+
+  // Once the pending request is removed, only response dispatch owns completion of its future.
+  @Test
+  void rejectedPublishResponseDispatchStillCompletesPendingRequest() throws Exception {
+    try (Fixture fixture = new Fixture()) {
+      CompletableFuture<UaResponseMessageType> pending = fixture.sendPublish();
+      fixture.executor.reject = true;
+      PublishResponse response = response();
+      fixture.transport.handleResponse(1, response);
+      fixture.transport.handleChannelInactive(fixture.channel);
+      assertSame(response, pending.get(5, TimeUnit.SECONDS));
+    }
+  }
+
+  // Rejection during a queue continuation must not lose this response or block later responses.
+  @Test
+  void queuedPublishResponsesAndLaterResponsesSurviveExecutorRejection() throws Exception {
+    try (Fixture fixture = new Fixture()) {
+      CompletableFuture<UaResponseMessageType> first = fixture.sendPublish();
+      CompletableFuture<UaResponseMessageType> second = fixture.sendPublish();
+      CompletableFuture<UaResponseMessageType> third = fixture.sendPublish();
+      PublishResponse response = response();
+      fixture.transport.handleResponse(1, response);
+      fixture.transport.handleResponse(2, response);
+      fixture.transport.handleResponse(3, response);
+      assertEquals(1, fixture.executor.tasks.size());
+      fixture.executor.reject = true;
+      fixture.executor.tasks.remove().run();
+      assertSame(response, first.get(5, TimeUnit.SECONDS));
+      assertSame(response, second.get(5, TimeUnit.SECONDS));
+      assertSame(response, third.get(5, TimeUnit.SECONDS));
+      CompletableFuture<UaResponseMessageType> later = fixture.sendPublish();
+      fixture.transport.handleResponse(4, response);
+      assertSame(response, later.get(5, TimeUnit.SECONDS));
+    }
+  }
+
+  private static PublishResponse response() {
+    return new PublishResponse(null, uint(1), null, false, null, null, null);
+  }
+
+  private static final class Fixture implements AutoCloseable {
+    final ControlledExecutor executor = new ControlledExecutor();
+    final EmbeddedChannel channel = new EmbeddedChannel();
+    final Transport transport =
+        new Transport(
+            OpcTcpClientTransportConfig.newBuilder().setExecutor(executor).build(), channel);
+
+    CompletableFuture<UaResponseMessageType> sendPublish() {
+      var header =
+          new RequestHeader(
+              NodeId.NULL_VALUE, DateTime.now(), uint(0), uint(0), null, uint(0), null);
+      return transport.sendRequestMessage(new PublishRequest(header, null));
+    }
+
+    @Override
+    public void close() {
+      channel.finishAndReleaseAll();
+      executor.shutdown();
+    }
+  }
+
+  private static final class Transport extends AbstractUascClientTransport {
+    private final Channel channel;
+
+    Transport(OpcClientTransportConfig config, Channel channel) {
+      super(config);
+      this.channel = channel;
+    }
+
+    @Override
+    protected CompletableFuture<Channel> getChannel() {
+      return CompletableFuture.completedFuture(channel);
+    }
+
+    @Override
+    public OpcClientTransportConfig getConfig() {
+      return config;
+    }
+
+    @Override
+    public CompletableFuture<Unit> connect(ClientApplicationContext context) {
+      return CompletableFuture.completedFuture(Unit.VALUE);
+    }
+
+    @Override
+    public CompletableFuture<Unit> disconnect() {
+      return CompletableFuture.completedFuture(Unit.VALUE);
+    }
+  }
+
+  private static final class ControlledExecutor extends AbstractExecutorService {
+    final Queue<Runnable> tasks = new ArrayDeque<>();
+    boolean reject;
+
+    @Override
+    public void execute(Runnable task) {
+      if (reject) {
+        throw new RejectedExecutionException("saturated");
+      }
+      tasks.add(task);
+    }
+
+    @Override
+    public void shutdown() {
+      reject = true;
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+      shutdown();
+      return List.copyOf(tasks);
+    }
+
+    @Override
+    public boolean isShutdown() {
+      return reject;
+    }
+
+    @Override
+    public boolean isTerminated() {
+      return reject;
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) {
+      return reject;
+    }
+  }
+}


### PR DESCRIPTION
Preserve connection ownership, callback delivery, and lifecycle order across Reverse Connect cancellation and executor failures.

## Listener binds after shutdown

A startup paused in the bootstrap customizer could bind after shutdown completed. Startup now rechecks the running state under the listener lock immediately before binding.

## Rediscovery after stopping an acceptor

Disconnecting a previously delivered client while its acceptor was stopped left its server key marked active, preventing rediscovery after restart. Delivered-client tracking now continues while the acceptor is stopped.

## Cancelled registration ownership

A cancelled registration could claim a later socket, or cancellation could win after the socket was reserved but before delivery. Exceptional completion now unregisters the selector, and failed claim delivery closes the undelivered connection with a debug diagnostic. Claimed snapshots and counters describe ownership reserved for a selector.

## Channel notification order

Reentrant close from a connected callback or future completion could deliver `[false, true]` to another observer. Serialized transition delivery now preserves `[true, false]`. Milo's observer contract says, "Implementations should keep listener invocation ordered with their own channel lifecycle."

## Executor failures during connect

Rejected claim dispatch could leave connect pending, and rejected handshake-completion dispatch could lose a completed handshake. Claim dispatch failure now closes the socket and fails connect; completed handshakes retain their completion through synchronous fallback.

## Stranded server connection attempts

A rejected listener notification could stop an attempt before transport creation. The shared callback queue now retains delivery and allows the attempt to proceed. Part 6 §7.1.3 says, "Servers shall maintain at least one open socket without an active Session with each Client it is configured to connect to." [Establishing a connection](https://reference.opcfoundation.org/specs/OPC-10000-6/7.1.3)

## Stale attempts after target replacement

An old asynchronous attempt could attach its channel to a replacement target using the same UUID. Callbacks now retain the original registration identity and close channels delivered to a different registration.

## Lost Publish response delivery

Executor rejection after consuming a pending Publish entry could leave its future incomplete. The queue now retains the response callback through initial and continuation dispatch failures. Part 4 §5.14.5.1 describes the supported request flow: "Pipelining involves sending more than one Publish request for each Subscription before receiving a response." [Publish](https://reference.opcfoundation.org/specs/OPC-10000-4/5.14.5.1)

## Queue liveness and serial execution

Dispatch runtime exceptions now run the fallback on the dispatching thread. Finished workers ignore repeated invocations, including when an executor runs a worker before reporting failure, so worker accounting cannot permit overlapping callbacks at concurrency one. Direct executors drain without recursion, and workers submit continuations between bounded batches. Fallback callbacks can run on an I/O or timer thread and must return promptly. These are Milo executor contracts; the OPC UA specification does not prescribe Java cancellation or scheduling behavior.

## Verification

Deterministic regressions reproduced the ownership, dispatch, notification, and serial-execution failures before their fixes. An unfiltered verification run before the final executor guards passed with no failures or errors and three skips. The final state passed formatting, full clean compile, and the selected queue, Publish, and Reverse Connect tests, with no failures, errors, or skips.
