### PR TITLE
Preserve UASC sequence state and validate Abort chunk recovery

### DIFF
--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/channel/ChunkEncoder.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/channel/ChunkEncoder.java
@@ -278,6 +278,21 @@ public final class ChunkEncoder {
 
       assert (maxPlainTextSize + securityHeaderSize + SECURE_MESSAGE_HEADER_SIZE <= maxChunkSize);
 
+      if (messageBuffer.isReadable() && maxBodySize <= 0) {
+        throw new UaException(
+            StatusCodes.Bad_EncodingLimitsExceeded, "send buffer cannot fit a message body");
+      }
+
+      // No chunk has been emitted yet. Reject the complete message before reserving sequence
+      // numbers or AEAD nonces so a following ServiceFault uses the peer's expected stream state.
+      int remoteMaxChunkCount = parameters.getRemoteMaxChunkCount();
+      if (remoteMaxChunkCount > 0
+          && messageBuffer.readableBytes() > (long) maxBodySize * remoteMaxChunkCount) {
+        throw new UaException(
+            StatusCodes.Bad_EncodingLimitsExceeded,
+            "remote chunk count exceeded: " + remoteMaxChunkCount);
+      }
+
       byte[] lastSignature = null;
 
       while (messageBuffer.readableBytes() > 0) {
@@ -307,13 +322,6 @@ public final class ChunkEncoder {
         ByteBuf chunkBuffer = BufferUtil.pooledBuffer(chunkSize);
 
         chunks.add(chunkBuffer);
-
-        int remoteMaxChunkCount = parameters.getRemoteMaxChunkCount();
-        if (remoteMaxChunkCount > 0 && chunks.size() > remoteMaxChunkCount) {
-          throw new UaException(
-              StatusCodes.Bad_EncodingLimitsExceeded,
-              "remote chunk count exceeded: " + remoteMaxChunkCount);
-        }
 
         /* Message Header */
         SecureMessageHeader messageHeader =

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/channel/package-info.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/channel/package-info.java
@@ -26,6 +26,12 @@
  * They frame message headers, security headers, sequence headers, message bodies, signatures,
  * padding, and encrypted payload bytes according to the selected security policy profile.
  *
+ * <p>The encoder owns one outbound sequence stream across asymmetric and symmetric messages. A
+ * message that exceeds the peer's chunk count is rejected before reserving sequence numbers or AEAD
+ * nonces, leaving the stream usable for an error response. The decoder checks every chunk's
+ * security and sequence state, including Abort chunks. A valid Abort consumes its sequence number
+ * and discards that message while preserving the stream for subsequent messages.
+ *
  * <h2>Runtime boundaries</h2>
  *
  * <p>SecureChannel cryptography is resolved from security policy profiles into authentication,

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/channel/ChunkEncoderLimitTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/channel/ChunkEncoderLimitTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.core.channel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import java.util.List;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.channel.messages.MessageType;
+import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.MessageSecurityMode;
+import org.junit.jupiter.api.Test;
+
+class ChunkEncoderLimitTest {
+  private static final ChannelParameters PARAMETERS =
+      new ChannelParameters(0, 8192, 8192, 0, 0, 8192, 8192, 1);
+
+  // SecurityPolicy.None has a 12-byte message header, 4-byte security header and 8-byte sequence
+  // header. The exact payload boundary must be accepted; one byte more must fail before encoding.
+  @Test
+  void chunkCountLimitIsCheckedBeforeConsumingTheMessageOrSequence() throws Exception {
+    var channel = new ServerSecureChannel();
+    channel.setSecurityPolicy(SecurityPolicy.None);
+    channel.setMessageSecurityMode(MessageSecurityMode.None);
+    var encoder = new ChunkEncoder(PARAMETERS);
+    var decoder = new ChunkDecoder(PARAMETERS, EncodingLimits.DEFAULT);
+    ByteBuf exact = Unpooled.buffer().writeZero(8192 - 24);
+    ByteBuf oversized = Unpooled.buffer().writeZero(8192 - 24 + 1);
+    ByteBuf following = Unpooled.buffer().writeIntLE(42);
+    try {
+      List<ByteBuf> chunks =
+          encoder.encodeSymmetric(channel, 1, exact, MessageType.SecureMessage).getMessageChunks();
+      assertEquals(1, chunks.size());
+      decoder.decodeSymmetric(channel, chunks).getMessage().release();
+      int originalIndex = oversized.readerIndex();
+      MessageEncodeException failure =
+          assertThrows(
+              MessageEncodeException.class,
+              () -> encoder.encodeSymmetric(channel, 2, oversized, MessageType.SecureMessage));
+      assertEquals(
+          StatusCodes.Bad_EncodingLimitsExceeded,
+          ((UaException) failure.getCause()).getStatusCode().value());
+      assertEquals(
+          originalIndex, oversized.readerIndex(), "a rejected message must not be partly encoded");
+      var decoded =
+          decoder.decodeSymmetric(
+              channel,
+              encoder
+                  .encodeSymmetric(channel, 3, following, MessageType.SecureMessage)
+                  .getMessageChunks());
+      try {
+        assertEquals(42, decoded.getMessage().readIntLE());
+      } finally {
+        decoded.getMessage().release();
+      }
+    } finally {
+      exact.release();
+      oversized.release();
+      following.release();
+    }
+  }
+}

--- a/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/client/uasc/UascClientMessageHandler.java
+++ b/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/client/uasc/UascClientMessageHandler.java
@@ -638,13 +638,13 @@ public class UascClientMessageHandler extends ByteToMessageCodec<UascRequest> {
 
     chunkBuffers.add(buffer.retain());
 
-    if (maxChunkCount > 0 && chunkBuffers.size() > maxChunkCount) {
+    char chunkType = (char) buffer.getByte(3);
+
+    if (chunkType != 'A' && maxChunkCount > 0 && chunkBuffers.size() > maxChunkCount) {
       throw new UaException(
           StatusCodes.Bad_TcpMessageTooLarge,
           String.format("max chunk count exceeded (%s)", maxChunkCount));
     }
-
-    char chunkType = (char) buffer.getByte(3);
 
     return (chunkType == 'A' || chunkType == 'F');
   }

--- a/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/client/uasc/UascClientMessageHandler.java
+++ b/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/client/uasc/UascClientMessageHandler.java
@@ -155,6 +155,8 @@ public class UascClientMessageHandler extends ByteToMessageCodec<UascRequest> {
 
   @Override
   public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+    releaseChunkBuffers();
+
     if (renewFuture != null) {
       renewFuture.cancel(false);
     }
@@ -174,8 +176,7 @@ public class UascClientMessageHandler extends ByteToMessageCodec<UascRequest> {
         cause.getMessage(),
         cause);
 
-    chunkBuffers.forEach(ReferenceCountUtil::safeRelease);
-    chunkBuffers.clear();
+    releaseChunkBuffers();
 
     // If the handshake hasn't completed yet this cause will be more
     // accurate than the generic "connection closed" exception that
@@ -183,6 +184,17 @@ public class UascClientMessageHandler extends ByteToMessageCodec<UascRequest> {
     handshakeFuture.completeExceptionally(cause);
 
     ctx.close();
+  }
+
+  @Override
+  public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
+    releaseChunkBuffers();
+    super.handlerRemoved(ctx);
+  }
+
+  private void releaseChunkBuffers() {
+    chunkBuffers.forEach(ReferenceCountUtil::safeRelease);
+    chunkBuffers.clear();
   }
 
   @Override

--- a/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/client/uasc/package-info.java
+++ b/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/client/uasc/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/**
+ * Establishes and renews client SecureChannels and carries service messages over UASC. The client
+ * message handler owns its connection's chunk encoder, decoder, and partial-response buffers.
+ * OpenSecureChannel and symmetric service traffic share the directional sequence stream across
+ * token renewals.
+ *
+ * <p>Intermediate response chunks remain retained until a final or Abort chunk arrives. The core
+ * decoder then validates security and sequence state and takes ownership of those buffers. An
+ * authenticated Abort fails the affected request without invalidating the channel's sequence
+ * stream. Disconnect, handler removal, and exception cleanup release any partial message that can
+ * no longer complete.
+ *
+ * <p>Channel state and buffer ownership follow the Netty event loop. The transport receives decoded
+ * responses and owns their request-future completion; this package handles framing, cryptographic
+ * state, handshake completion, and renewal scheduling.
+ */
+package org.eclipse.milo.opcua.stack.transport.client.uasc;

--- a/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/client/uasc/package-info.java
+++ b/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/client/uasc/package-info.java
@@ -17,8 +17,9 @@
  * <p>Intermediate response chunks remain retained until a final or Abort chunk arrives. The core
  * decoder then validates security and sequence state and takes ownership of those buffers. An
  * authenticated Abort fails the affected request without invalidating the channel's sequence
- * stream. Disconnect, handler removal, and exception cleanup release any partial message that can
- * no longer complete.
+ * stream. An Abort may follow the maximum allowed number of intermediate chunks; its size and
+ * security checks still apply, and the decoder releases the accumulated message. Disconnect,
+ * handler removal, and exception cleanup release any partial message that can no longer complete.
  *
  * <p>Channel state and buffer ownership follow the Netty event loop. The transport receives decoded
  * responses and owns their request-future completion; this package handles framing, cryptographic

--- a/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/server/uasc/UascServerAsymmetricHandler.java
+++ b/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/server/uasc/UascServerAsymmetricHandler.java
@@ -216,231 +216,226 @@ public class UascServerAsymmetricHandler extends ByteToMessageDecoder implements
 
     char chunkType = (char) buffer.readByte();
 
-    if (chunkType == 'A') {
-      chunkBuffers.releaseAll();
-      headerRef.set(null);
-    } else {
-      buffer.skipBytes(4); // Skip messageSize
+    buffer.skipBytes(4); // Skip messageSize
 
-      final long secureChannelId = buffer.readUnsignedIntLE();
+    final long secureChannelId = buffer.readUnsignedIntLE();
 
-      final AsymmetricSecurityHeader header =
-          AsymmetricSecurityHeader.decode(
-              buffer, application.getEncodingContext().getEncodingLimits());
+    final AsymmetricSecurityHeader header =
+        AsymmetricSecurityHeader.decode(
+            buffer, application.getEncodingContext().getEncodingLimits());
 
-      if (!headerRef.compareAndSet(null, header)) {
-        if (!header.equals(headerRef.get())) {
+    if (!headerRef.compareAndSet(null, header)) {
+      if (!header.equals(headerRef.get())) {
+        throw new UaException(
+            StatusCodes.Bad_SecurityChecksFailed,
+            "subsequent AsymmetricSecurityHeader did not match");
+      }
+    }
+
+    if (secureChannelId != 0) {
+      if (secureChannel == null) {
+        throw new UaException(
+            StatusCodes.Bad_TcpSecureChannelUnknown,
+            "unknown secure channel id: " + secureChannelId);
+      }
+
+      if (secureChannelId != secureChannel.getChannelId()) {
+        throw new UaException(
+            StatusCodes.Bad_TcpSecureChannelUnknown,
+            "unknown secure channel id: " + secureChannelId);
+      }
+    }
+
+    if (secureChannel == null) {
+      secureChannel = new ServerSecureChannel();
+      secureChannel.setChannelId(application.getNextSecureChannelId());
+
+      String securityPolicyUri = header.getSecurityPolicyUri();
+      SecurityPolicy securityPolicy = SecurityPolicy.fromUri(securityPolicyUri);
+
+      secureChannel.setSecurityPolicy(securityPolicy);
+
+      if (securityPolicy != SecurityPolicy.None) {
+        if (header.getReceiverThumbprint().isNullOrEmpty()) {
+          // Part 6 6.7.2.3: the receiver certificate thumbprint identifies the public key used
+          // to encrypt the message and is required whenever the OPN is asymmetrically secured.
+          // Reject explicitly rather than relying on certificate or endpoint lookups to fail,
+          // so the client receives an ERR message identifying the actual problem.
           throw new UaException(
               StatusCodes.Bad_SecurityChecksFailed,
-              "subsequent AsymmetricSecurityHeader did not match");
+              "receiverCertificateThumbprint must be present when SecurityPolicy is not None");
+        }
+
+        CertificateManager certificateManager = application.getCertificateManager();
+
+        Optional<X509Certificate[]> localCertificateChain =
+            certificateManager.getCertificateChain(header.getReceiverThumbprint());
+
+        Optional<KeyPair> keyPair = certificateManager.getKeyPair(header.getReceiverThumbprint());
+
+        if (localCertificateChain.isPresent() && keyPair.isPresent()) {
+          secureChannel.setRemoteCertificate(header.getSenderCertificate().bytesOrEmpty());
+
+          CertificateGroup certificateGroup =
+              application
+                  .getCertificateManager()
+                  .getCertificateGroup(header.getReceiverThumbprint())
+                  .orElseThrow(
+                      () ->
+                          new UaException(
+                              StatusCodes.Bad_SecurityChecksFailed,
+                              "no certificate group for provided thumbprint"));
+
+          CertificateValidator certificateValidator = certificateGroup.getCertificateValidator();
+
+          certificateValidator.validateCertificateChain(
+              secureChannel.getRemoteCertificateChain(), null, null, securityPolicy.getProfile());
+
+          X509Certificate[] chain = localCertificateChain.get();
+          if (securityPolicy.getProfile().secureChannelEnhancements()) {
+            CertificateCompatibility.checkCompatible(securityPolicy.getProfile(), chain[0]);
+          }
+
+          secureChannel.setLocalCertificate(chain[0]);
+          secureChannel.setLocalCertificateChain(chain);
+          secureChannel.setKeyPair(keyPair.get());
+        } else {
+          throw new UaException(
+              StatusCodes.Bad_SecurityChecksFailed, "no certificate for provided thumbprint");
         }
       }
+    }
 
-      if (secureChannelId != 0) {
-        if (secureChannel == null) {
-          throw new UaException(
-              StatusCodes.Bad_TcpSecureChannelUnknown,
-              "unknown secure channel id: " + secureChannelId);
-        }
+    // Before attempting decryption, ensure the SecurityPolicy used in the
+    // AsymmetricSecurityHeader is one that is supported by the configured
+    // endpoints.
 
-        if (secureChannelId != secureChannel.getChannelId()) {
-          throw new UaException(
-              StatusCodes.Bad_TcpSecureChannelUnknown,
-              "unknown secure channel id: " + secureChannelId);
-        }
+    String endpointUrl = ctx.channel().attr(UascServerHelloHandler.ENDPOINT_URL_KEY).get();
+
+    if (application.getEndpointDescriptions().stream()
+        .noneMatch(
+            e -> {
+              boolean transportMatch =
+                  Objects.equals(e.getTransportProfileUri(), transportProfile.getUri());
+
+              boolean pathMatch =
+                  Objects.equals(
+                      EndpointUtil.getPath(e.getEndpointUrl()), EndpointUtil.getPath(endpointUrl));
+
+              boolean securityPolicyMatch =
+                  Objects.equals(
+                      e.getSecurityPolicyUri(), secureChannel.getSecurityPolicy().getUri());
+
+              boolean thumbprintMatch = true;
+              if (!header.getReceiverThumbprint().isNullOrEmpty()) {
+                thumbprintMatch =
+                    Arrays.equals(
+                        DigestUtil.sha1(e.getServerCertificate().bytesOrEmpty()),
+                        header.getReceiverThumbprint().bytesOrEmpty());
+              }
+
+              // allow a matched endpoint OR any unsecured connection, regardless of the
+              // endpoint security, so that the receiving ServerApplication can decide if
+              // it wants to allow unsecured Discovery services.
+              return transportMatch
+                  && pathMatch
+                  && thumbprintMatch
+                  && (securityPolicyMatch
+                      || secureChannel.getSecurityPolicy() == SecurityPolicy.None);
+            })) {
+
+      String message =
+          String.format(
+              "no matching endpoint found: "
+                  + "transportProfile=%s, endpointUrl=%s, securityPolicy=%s",
+              transportProfile, endpointUrl, secureChannel.getSecurityPolicy());
+
+      throw new UaException(StatusCodes.Bad_SecurityChecksFailed, message);
+    }
+
+    //noinspection DuplicatedCode
+    int chunkSize = buffer.readerIndex(0).readableBytes();
+
+    if (chunkSize > maxChunkSize) {
+      throw new UaException(
+          StatusCodes.Bad_TcpMessageTooLarge,
+          String.format("max chunk size exceeded (%s)", maxChunkSize));
+    }
+
+    chunkBuffers.add(buffer);
+
+    if (maxChunkCount > 0 && chunkBuffers.size() > maxChunkCount) {
+      throw new UaException(
+          StatusCodes.Bad_TcpMessageTooLarge,
+          String.format("max chunk count exceeded (%s)", maxChunkCount));
+    }
+
+    // Abort terminates a message only after all accumulated chunks pass security and sequence
+    // checks. The decoder consumes the Abort sequence number before reporting
+    // MessageAbortException.
+    if (chunkType == 'F' || chunkType == 'A') {
+      final List<ByteBuf> buffersToDecode = chunkBuffers.takeAll();
+      headerRef.set(null);
+
+      ByteBuf message;
+      long requestId;
+      byte[] requestSignature;
+
+      try {
+        ChunkDecoder.DecodedMessage decodedMessage =
+            chunkDecoder.decodeAsymmetric(secureChannel, buffersToDecode);
+
+        message = decodedMessage.getMessage();
+        requestId = decodedMessage.getRequestId();
+        requestSignature = decodedMessage.getSignature();
+      } catch (MessageAbortException e) {
+        logger.warn(
+            "Received message abort chunk; error={}, reason={}", e.getStatusCode(), e.getMessage());
+        return;
+      } catch (MessageDecodeException e) {
+        logger.error("Error decoding asymmetric message", e);
+
+        ctx.executor()
+            .schedule(() -> ctx.close(), new Random().nextInt(1000), TimeUnit.MILLISECONDS);
+
+        return;
       }
 
-      if (secureChannel == null) {
-        secureChannel = new ServerSecureChannel();
-        secureChannel.setChannelId(application.getNextSecureChannelId());
+      try {
+        OpenSecureChannelRequest request =
+            (OpenSecureChannelRequest) binaryDecoder.setBuffer(message).decodeMessage(null);
 
-        String securityPolicyUri = header.getSecurityPolicyUri();
-        SecurityPolicy securityPolicy = SecurityPolicy.fromUri(securityPolicyUri);
+        logger.debug(
+            "Received OpenSecureChannelRequest ({}, id={}).",
+            request.getRequestType(),
+            secureChannelId);
 
-        secureChannel.setSecurityPolicy(securityPolicy);
-
-        if (securityPolicy != SecurityPolicy.None) {
-          if (header.getReceiverThumbprint().isNullOrEmpty()) {
-            // Part 6 6.7.2.3: the receiver certificate thumbprint identifies the public key used
-            // to encrypt the message and is required whenever the OPN is asymmetrically secured.
-            // Reject explicitly rather than relying on certificate or endpoint lookups to fail,
-            // so the client receives an ERR message identifying the actual problem.
+        if (request.getRequestType() == SecurityTokenRequestType.Renew) {
+          if (secureChannelId == 0L) {
             throw new UaException(
                 StatusCodes.Bad_SecurityChecksFailed,
-                "receiverCertificateThumbprint must be present when SecurityPolicy is not None");
+                "secure channel renewal for secureChannelId=0");
           }
-
-          CertificateManager certificateManager = application.getCertificateManager();
-
-          Optional<X509Certificate[]> localCertificateChain =
-              certificateManager.getCertificateChain(header.getReceiverThumbprint());
-
-          Optional<KeyPair> keyPair = certificateManager.getKeyPair(header.getReceiverThumbprint());
-
-          if (localCertificateChain.isPresent() && keyPair.isPresent()) {
-            secureChannel.setRemoteCertificate(header.getSenderCertificate().bytesOrEmpty());
-
-            CertificateGroup certificateGroup =
-                application
-                    .getCertificateManager()
-                    .getCertificateGroup(header.getReceiverThumbprint())
-                    .orElseThrow(
-                        () ->
-                            new UaException(
-                                StatusCodes.Bad_SecurityChecksFailed,
-                                "no certificate group for provided thumbprint"));
-
-            CertificateValidator certificateValidator = certificateGroup.getCertificateValidator();
-
-            certificateValidator.validateCertificateChain(
-                secureChannel.getRemoteCertificateChain(), null, null, securityPolicy.getProfile());
-
-            X509Certificate[] chain = localCertificateChain.get();
-            if (securityPolicy.getProfile().secureChannelEnhancements()) {
-              CertificateCompatibility.checkCompatible(securityPolicy.getProfile(), chain[0]);
-            }
-
-            secureChannel.setLocalCertificate(chain[0]);
-            secureChannel.setLocalCertificateChain(chain);
-            secureChannel.setKeyPair(keyPair.get());
-          } else {
-            throw new UaException(
-                StatusCodes.Bad_SecurityChecksFailed, "no certificate for provided thumbprint");
-          }
-        }
-      }
-
-      // Before attempting decryption, ensure the SecurityPolicy used in the
-      // AsymmetricSecurityHeader is one that is supported by the configured
-      // endpoints.
-
-      String endpointUrl = ctx.channel().attr(UascServerHelloHandler.ENDPOINT_URL_KEY).get();
-
-      if (application.getEndpointDescriptions().stream()
-          .noneMatch(
-              e -> {
-                boolean transportMatch =
-                    Objects.equals(e.getTransportProfileUri(), transportProfile.getUri());
-
-                boolean pathMatch =
-                    Objects.equals(
-                        EndpointUtil.getPath(e.getEndpointUrl()),
-                        EndpointUtil.getPath(endpointUrl));
-
-                boolean securityPolicyMatch =
-                    Objects.equals(
-                        e.getSecurityPolicyUri(), secureChannel.getSecurityPolicy().getUri());
-
-                boolean thumbprintMatch = true;
-                if (!header.getReceiverThumbprint().isNullOrEmpty()) {
-                  thumbprintMatch =
-                      Arrays.equals(
-                          DigestUtil.sha1(e.getServerCertificate().bytesOrEmpty()),
-                          header.getReceiverThumbprint().bytesOrEmpty());
-                }
-
-                // allow a matched endpoint OR any unsecured connection, regardless of the
-                // endpoint security, so that the receiving ServerApplication can decide if
-                // it wants to allow unsecured Discovery services.
-                return transportMatch
-                    && pathMatch
-                    && thumbprintMatch
-                    && (securityPolicyMatch
-                        || secureChannel.getSecurityPolicy() == SecurityPolicy.None);
-              })) {
-
-        String message =
-            String.format(
-                "no matching endpoint found: "
-                    + "transportProfile=%s, endpointUrl=%s, securityPolicy=%s",
-                transportProfile, endpointUrl, secureChannel.getSecurityPolicy());
-
-        throw new UaException(StatusCodes.Bad_SecurityChecksFailed, message);
-      }
-
-      //noinspection DuplicatedCode
-      int chunkSize = buffer.readerIndex(0).readableBytes();
-
-      if (chunkSize > maxChunkSize) {
-        throw new UaException(
-            StatusCodes.Bad_TcpMessageTooLarge,
-            String.format("max chunk size exceeded (%s)", maxChunkSize));
-      }
-
-      chunkBuffers.add(buffer);
-
-      if (maxChunkCount > 0 && chunkBuffers.size() > maxChunkCount) {
-        throw new UaException(
-            StatusCodes.Bad_TcpMessageTooLarge,
-            String.format("max chunk count exceeded (%s)", maxChunkCount));
-      }
-
-      if (chunkType == 'F') {
-        final List<ByteBuf> buffersToDecode = chunkBuffers.takeAll();
-        headerRef.set(null);
-
-        ByteBuf message;
-        long requestId;
-        byte[] requestSignature;
-
-        try {
-          ChunkDecoder.DecodedMessage decodedMessage =
-              chunkDecoder.decodeAsymmetric(secureChannel, buffersToDecode);
-
-          message = decodedMessage.getMessage();
-          requestId = decodedMessage.getRequestId();
-          requestSignature = decodedMessage.getSignature();
-        } catch (MessageAbortException e) {
-          logger.warn(
-              "Received message abort chunk; error={}, reason={}",
-              e.getStatusCode(),
-              e.getMessage());
-          return;
-        } catch (MessageDecodeException e) {
-          logger.error("Error decoding asymmetric message", e);
-
-          ctx.executor()
-              .schedule(() -> ctx.close(), new Random().nextInt(1000), TimeUnit.MILLISECONDS);
-
-          return;
+        } else if (request.getRequestType() == SecurityTokenRequestType.Issue
+            && secureChannel.getChannelSecurity() != null) {
+          // An established channel can only be renewed, never re-issued. A second Issue would be
+          // chained off the current input key material on the renewal derivation path while the
+          // peer believes it performed a fresh issue, and would re-bind the channel
+          // thumbprint/security-mode contrary to the first-response-only binding of Part 6 6.7.5.
+          // Reject here, before any such mutation, so the original binding stays effective.
+          throw new UaException(
+              StatusCodes.Bad_SecurityChecksFailed,
+              "secure channel issue for an already-established channel");
         }
 
-        try {
-          OpenSecureChannelRequest request =
-              (OpenSecureChannelRequest) binaryDecoder.setBuffer(message).decodeMessage(null);
+        sendOpenSecureChannelResponse(ctx, requestId, header, request, requestSignature);
+      } catch (Throwable t) {
+        logger.error("Error decoding OpenSecureChannelRequest", t);
 
-          logger.debug(
-              "Received OpenSecureChannelRequest ({}, id={}).",
-              request.getRequestType(),
-              secureChannelId);
-
-          if (request.getRequestType() == SecurityTokenRequestType.Renew) {
-            if (secureChannelId == 0L) {
-              throw new UaException(
-                  StatusCodes.Bad_SecurityChecksFailed,
-                  "secure channel renewal for secureChannelId=0");
-            }
-          } else if (request.getRequestType() == SecurityTokenRequestType.Issue
-              && secureChannel.getChannelSecurity() != null) {
-            // An established channel can only be renewed, never re-issued. A second Issue would be
-            // chained off the current input key material on the renewal derivation path while the
-            // peer believes it performed a fresh issue, and would re-bind the channel
-            // thumbprint/security-mode contrary to the first-response-only binding of Part 6 6.7.5.
-            // Reject here, before any such mutation, so the original binding stays effective.
-            throw new UaException(
-                StatusCodes.Bad_SecurityChecksFailed,
-                "secure channel issue for an already-established channel");
-          }
-
-          sendOpenSecureChannelResponse(ctx, requestId, header, request, requestSignature);
-        } catch (Throwable t) {
-          logger.error("Error decoding OpenSecureChannelRequest", t);
-
-          ctx.close();
-        } finally {
-          message.release();
-          buffersToDecode.clear();
-        }
+        ctx.close();
+      } finally {
+        message.release();
+        buffersToDecode.clear();
       }
     }
   }

--- a/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/server/uasc/UascServerAsymmetricHandler.java
+++ b/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/server/uasc/UascServerAsymmetricHandler.java
@@ -364,7 +364,7 @@ public class UascServerAsymmetricHandler extends ByteToMessageDecoder implements
 
     chunkBuffers.add(buffer);
 
-    if (maxChunkCount > 0 && chunkBuffers.size() > maxChunkCount) {
+    if (chunkType != 'A' && maxChunkCount > 0 && chunkBuffers.size() > maxChunkCount) {
       throw new UaException(
           StatusCodes.Bad_TcpMessageTooLarge,
           String.format("max chunk count exceeded (%s)", maxChunkCount));

--- a/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/server/uasc/UascServerSymmetricHandler.java
+++ b/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/server/uasc/UascServerSymmetricHandler.java
@@ -163,80 +163,76 @@ public class UascServerSymmetricHandler extends ByteToMessageCodec<UascServiceRe
 
     char chunkType = (char) buffer.readByte();
 
-    if (chunkType == 'A') {
-      chunkBuffers.releaseAll();
-    } else {
-      buffer.skipBytes(4); // Skip messageSize
+    buffer.skipBytes(4); // Skip messageSize
 
-      long secureChannelId = buffer.readUnsignedIntLE();
-      if (secureChannelId != secureChannel.getChannelId()) {
-        throw new UaException(
-            StatusCodes.Bad_SecureChannelIdInvalid,
-            "invalid secure channel id: " + secureChannelId);
-      }
+    long secureChannelId = buffer.readUnsignedIntLE();
+    if (secureChannelId != secureChannel.getChannelId()) {
+      throw new UaException(
+          StatusCodes.Bad_SecureChannelIdInvalid, "invalid secure channel id: " + secureChannelId);
+    }
 
-      int chunkSize = buffer.readerIndex(0).readableBytes();
-      if (chunkSize > maxChunkSize) {
-        throw new UaException(
-            StatusCodes.Bad_TcpMessageTooLarge,
-            String.format("max chunk size exceeded (%s)", maxChunkSize));
-      }
+    int chunkSize = buffer.readerIndex(0).readableBytes();
+    if (chunkSize > maxChunkSize) {
+      throw new UaException(
+          StatusCodes.Bad_TcpMessageTooLarge,
+          String.format("max chunk size exceeded (%s)", maxChunkSize));
+    }
 
-      chunkBuffers.add(buffer);
+    chunkBuffers.add(buffer);
 
-      if (maxChunkCount > 0 && chunkBuffers.size() > maxChunkCount) {
-        throw new UaException(
-            StatusCodes.Bad_TcpMessageTooLarge,
-            String.format("max chunk count exceeded (%s)", maxChunkCount));
-      }
+    if (maxChunkCount > 0 && chunkBuffers.size() > maxChunkCount) {
+      throw new UaException(
+          StatusCodes.Bad_TcpMessageTooLarge,
+          String.format("max chunk count exceeded (%s)", maxChunkCount));
+    }
 
-      if (chunkType == 'F') {
-        final List<ByteBuf> buffersToDecode = chunkBuffers.takeAll();
+    // Abort terminates a message only after all accumulated chunks pass security and sequence
+    // checks. The decoder consumes the Abort sequence number before reporting
+    // MessageAbortException.
+    if (chunkType == 'F' || chunkType == 'A') {
+      final List<ByteBuf> buffersToDecode = chunkBuffers.takeAll();
 
-        ByteBuf message = null;
+      ByteBuf message = null;
 
-        try {
-          DecodedMessage decodedMessage =
-              chunkDecoder.decodeSymmetric(secureChannel, buffersToDecode);
+      try {
+        DecodedMessage decodedMessage =
+            chunkDecoder.decodeSymmetric(secureChannel, buffersToDecode);
 
-          message = decodedMessage.getMessage();
-          long requestId = decodedMessage.getRequestId();
+        message = decodedMessage.getMessage();
+        long requestId = decodedMessage.getRequestId();
 
-          binaryDecoder.setBuffer(message);
-          UaRequestMessageType requestMessage =
-              (UaRequestMessageType) binaryDecoder.decodeMessage(null);
+        binaryDecoder.setBuffer(message);
+        UaRequestMessageType requestMessage =
+            (UaRequestMessageType) binaryDecoder.decodeMessage(null);
 
-          String endpointUrl = ctx.channel().attr(UascServerHelloHandler.ENDPOINT_URL_KEY).get();
+        String endpointUrl = ctx.channel().attr(UascServerHelloHandler.ENDPOINT_URL_KEY).get();
 
-          EndpointDescription endpoint =
-              ctx.channel().attr(UascServerAsymmetricHandler.ENDPOINT_KEY).get();
+        EndpointDescription endpoint =
+            ctx.channel().attr(UascServerAsymmetricHandler.ENDPOINT_KEY).get();
 
-          var serviceRequest =
-              new UascServiceRequest(
-                  endpointUrl,
-                  transportProfile,
-                  ctx.channel(),
-                  secureChannel,
-                  endpoint,
-                  requestMessage,
-                  requestId);
+        var serviceRequest =
+            new UascServiceRequest(
+                endpointUrl,
+                transportProfile,
+                ctx.channel(),
+                secureChannel,
+                endpoint,
+                requestMessage,
+                requestId);
 
-          out.add(serviceRequest);
-        } catch (MessageAbortException e) {
-          logger.warn(
-              "Received message abort chunk; error={}, reason={}",
-              e.getStatusCode(),
-              e.getMessage());
-        } catch (MessageDecodeException e) {
-          logger.error("Error decoding symmetric message", e);
+        out.add(serviceRequest);
+      } catch (MessageAbortException e) {
+        logger.warn(
+            "Received message abort chunk; error={}, reason={}", e.getStatusCode(), e.getMessage());
+      } catch (MessageDecodeException e) {
+        logger.error("Error decoding symmetric message", e);
 
-          ctx.close();
-        } finally {
-          if (message != null) {
-            message.release();
-          }
-          buffersToDecode.clear();
+        ctx.close();
+      } finally {
+        if (message != null) {
+          message.release();
         }
+        buffersToDecode.clear();
       }
     }
   }

--- a/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/server/uasc/UascServerSymmetricHandler.java
+++ b/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/server/uasc/UascServerSymmetricHandler.java
@@ -180,7 +180,7 @@ public class UascServerSymmetricHandler extends ByteToMessageCodec<UascServiceRe
 
     chunkBuffers.add(buffer);
 
-    if (maxChunkCount > 0 && chunkBuffers.size() > maxChunkCount) {
+    if (chunkType != 'A' && maxChunkCount > 0 && chunkBuffers.size() > maxChunkCount) {
       throw new UaException(
           StatusCodes.Bad_TcpMessageTooLarge,
           String.format("max chunk count exceeded (%s)", maxChunkCount));

--- a/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/server/uasc/package-info.java
+++ b/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/server/uasc/package-info.java
@@ -17,7 +17,9 @@
  * <p>Handlers retain partial-message buffers until a final or Abort chunk completes the message.
  * Both terminal chunk types pass through the core decoder, which authenticates the accumulated
  * chunks and advances sequence state. A valid Abort discards the message while leaving the channel
- * open; malformed or unauthenticated chunks follow the decoding-error path.
+ * open; malformed or unauthenticated chunks follow the decoding-error path. An Abort may follow the
+ * maximum allowed number of intermediate chunks, adding at most one size-limited chunk before the
+ * decoder releases the accumulated message.
  *
  * <p>Buffer ownership stays on the channel's event loop. Accumulation transfers retained buffers to
  * the decoder for message completion, and disconnect, handler removal, and exception cleanup

--- a/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/server/uasc/package-info.java
+++ b/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/server/uasc/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/**
+ * Establishes server SecureChannels and translates UASC chunks into service requests and responses.
+ * The asymmetric handler validates OpenSecureChannel messages and installs the symmetric handler
+ * after a token is established. Both handlers share the connection's chunk encoder and decoder, so
+ * asymmetric renewals and symmetric service messages use the same directional sequence streams.
+ *
+ * <p>Handlers retain partial-message buffers until a final or Abort chunk completes the message.
+ * Both terminal chunk types pass through the core decoder, which authenticates the accumulated
+ * chunks and advances sequence state. A valid Abort discards the message while leaving the channel
+ * open; malformed or unauthenticated chunks follow the decoding-error path.
+ *
+ * <p>Buffer ownership stays on the channel's event loop. Accumulation transfers retained buffers to
+ * the decoder for message completion, and disconnect, handler removal, and exception cleanup
+ * release buffers still owned by the handler. Service dispatch begins only after successful
+ * decoding and uses the executor supplied by the server transport configuration.
+ */
+package org.eclipse.milo.opcua.stack.transport.server.uasc;

--- a/opc-ua-stack/transport/src/test/java/org/eclipse/milo/opcua/stack/transport/client/uasc/UascClientChunkLifecycleTest.java
+++ b/opc-ua-stack/transport/src/test/java/org/eclipse/milo/opcua/stack/transport/client/uasc/UascClientChunkLifecycleTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.transport.client.uasc;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ubyte;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.util.HashedWheelTimer;
+import io.netty.util.ReferenceCountUtil;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicLong;
+import org.eclipse.milo.opcua.stack.core.channel.ChannelParameters;
+import org.eclipse.milo.opcua.stack.core.channel.messages.MessageType;
+import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
+import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
+import org.eclipse.milo.opcua.stack.core.security.CertificateIdentity;
+import org.eclipse.milo.opcua.stack.core.security.CertificateValidator;
+import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
+import org.eclipse.milo.opcua.stack.core.security.SecurityPolicyProfile;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.ApplicationType;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.MessageSecurityMode;
+import org.eclipse.milo.opcua.stack.core.types.structured.ApplicationDescription;
+import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
+import org.eclipse.milo.opcua.stack.transport.client.ClientApplicationContext;
+
+/**
+ * Retained partial responses must be released when their owning handler can no longer finish them.
+ */
+class UascClientChunkLifecycleTest {
+
+  private static final ChannelParameters CHANNEL_PARAMETERS =
+      new ChannelParameters(65535, 65535, 8196, 0, 65535, 65535, 8196, 0);
+
+  @org.junit.jupiter.params.ParameterizedTest
+  @org.junit.jupiter.params.provider.EnumSource(Cleanup.class)
+  void partialResponseIsReleasedAtEveryTerminationBoundary(Cleanup cleanup) throws Exception {
+    var wheelTimer = new HashedWheelTimer();
+    var channel = new EmbeddedChannel();
+    ByteBuf chunk = PooledByteBufAllocator.DEFAULT.directBuffer();
+    try {
+      var handler =
+          new UascClientMessageHandler(
+              config(wheelTimer),
+              application(),
+              new AtomicLong(1L)::getAndIncrement,
+              new CompletableFuture<>(),
+              List.of(),
+              CHANNEL_PARAMETERS);
+      channel.pipeline().addLast(handler);
+      channel.runPendingTasks();
+      Object outbound;
+      while ((outbound = channel.readOutbound()) != null) ReferenceCountUtil.release(outbound);
+
+      chunk.writeMediumLE(MessageType.toMediumInt(MessageType.SecureMessage));
+      chunk.writeByte('C').writeIntLE(112).writeIntLE(0).writeZero(100);
+      channel.writeInbound(chunk);
+      assertEquals(1, chunk.refCnt(), "the partial response must be retained before termination");
+      switch (cleanup) {
+        case CLOSE -> channel.close().syncUninterruptibly();
+        case REMOVE -> channel.pipeline().remove(handler);
+        case EXCEPTION ->
+            channel.pipeline().fireExceptionCaught(new RuntimeException("test failure"));
+      }
+      channel.runPendingTasks();
+      assertEquals(0, chunk.refCnt(), "termination must release the retained pooled response");
+      channel.close().syncUninterruptibly();
+      assertEquals(0, chunk.refCnt(), "a second cleanup boundary must not double-release");
+    } finally {
+      channel.finishAndReleaseAll();
+      if (chunk.refCnt() > 0) chunk.release();
+      wheelTimer.stop();
+    }
+  }
+
+  private enum Cleanup {
+    CLOSE,
+    REMOVE,
+    EXCEPTION
+  }
+
+  static UascClientConfig config(HashedWheelTimer wheelTimer) {
+    return new UascClientConfig() {
+      public UInteger getAcknowledgeTimeout() {
+        return uint(60000);
+      }
+
+      public UInteger getChannelLifetime() {
+        return uint(3600000);
+      }
+
+      public HashedWheelTimer getWheelTimer() {
+        return wheelTimer;
+      }
+    };
+  }
+
+  static ClientApplicationContext application() {
+    EndpointDescription endpoint =
+        new EndpointDescription(
+            "opc.tcp://localhost:0/test",
+            new ApplicationDescription(
+                "urn:eclipse:milo:test",
+                "urn:eclipse:milo:test",
+                LocalizedText.english("test"),
+                ApplicationType.Client,
+                null,
+                null,
+                null),
+            ByteString.NULL_VALUE,
+            MessageSecurityMode.None,
+            SecurityPolicy.None.getUri(),
+            null,
+            null,
+            ubyte(0));
+    return new ClientApplicationContext() {
+      public EndpointDescription getEndpoint() {
+        return endpoint;
+      }
+
+      public Optional<CertificateIdentity> getCertificateIdentity(SecurityPolicyProfile p) {
+        return Optional.empty();
+      }
+
+      public CertificateValidator getCertificateValidator() {
+        return (chain, uri, hosts) -> {};
+      }
+
+      public EncodingContext getEncodingContext() {
+        return new DefaultEncodingContext();
+      }
+
+      public UInteger getRequestTimeout() {
+        return uint(60000);
+      }
+    };
+  }
+}

--- a/opc-ua-stack/transport/src/test/java/org/eclipse/milo/opcua/stack/transport/client/uasc/UascClientChunkLifecycleTest.java
+++ b/opc-ua-stack/transport/src/test/java/org/eclipse/milo/opcua/stack/transport/client/uasc/UascClientChunkLifecycleTest.java
@@ -13,32 +13,54 @@ package org.eclipse.milo.opcua.stack.transport.client.uasc;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ubyte;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.util.HashedWheelTimer;
 import io.netty.util.ReferenceCountUtil;
+import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicLong;
+import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.channel.ChannelParameters;
+import org.eclipse.milo.opcua.stack.core.channel.ChannelSecurity;
+import org.eclipse.milo.opcua.stack.core.channel.ChunkDecoder;
 import org.eclipse.milo.opcua.stack.core.channel.messages.MessageType;
 import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
 import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
+import org.eclipse.milo.opcua.stack.core.encoding.binary.OpcUaBinaryEncoder;
 import org.eclipse.milo.opcua.stack.core.security.CertificateIdentity;
 import org.eclipse.milo.opcua.stack.core.security.CertificateValidator;
 import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
 import org.eclipse.milo.opcua.stack.core.security.SecurityPolicyProfile;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.ApplicationType;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.MessageSecurityMode;
 import org.eclipse.milo.opcua.stack.core.types.structured.ApplicationDescription;
+import org.eclipse.milo.opcua.stack.core.types.structured.ChannelSecurityToken;
 import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
+import org.eclipse.milo.opcua.stack.core.types.structured.GetEndpointsResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.ResponseHeader;
+import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateBuilder;
+import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateGenerator;
 import org.eclipse.milo.opcua.stack.transport.client.ClientApplicationContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 /**
  * Retained partial responses must be released when their owning handler can no longer finish them.
@@ -48,8 +70,8 @@ class UascClientChunkLifecycleTest {
   private static final ChannelParameters CHANNEL_PARAMETERS =
       new ChannelParameters(65535, 65535, 8196, 0, 65535, 65535, 8196, 0);
 
-  @org.junit.jupiter.params.ParameterizedTest
-  @org.junit.jupiter.params.provider.EnumSource(Cleanup.class)
+  @ParameterizedTest
+  @EnumSource(Cleanup.class)
   void partialResponseIsReleasedAtEveryTerminationBoundary(Cleanup cleanup) throws Exception {
     var wheelTimer = new HashedWheelTimer();
     var channel = new EmbeddedChannel();
@@ -66,7 +88,9 @@ class UascClientChunkLifecycleTest {
       channel.pipeline().addLast(handler);
       channel.runPendingTasks();
       Object outbound;
-      while ((outbound = channel.readOutbound()) != null) ReferenceCountUtil.release(outbound);
+      while ((outbound = channel.readOutbound()) != null) {
+        ReferenceCountUtil.release(outbound);
+      }
 
       chunk.writeMediumLE(MessageType.toMediumInt(MessageType.SecureMessage));
       chunk.writeByte('C').writeIntLE(112).writeIntLE(0).writeZero(100);
@@ -84,9 +108,155 @@ class UascClientChunkLifecycleTest {
       assertEquals(0, chunk.refCnt(), "a second cleanup boundary must not double-release");
     } finally {
       channel.finishAndReleaseAll();
-      if (chunk.refCnt() > 0) chunk.release();
+      if (chunk.refCnt() > 0) {
+        chunk.release();
+      }
       wheelTimer.stop();
     }
+  }
+
+  // A response Abort may follow every permitted C chunk. It must release the message, report the
+  // request failure, and preserve the authenticated stream for the next response.
+  @ParameterizedTest
+  @EnumSource(
+      value = SecurityPolicy.class,
+      names = {"None", "ECC_nistP256_AesGcm"})
+  void abortAfterChunkCountLimitPreservesTheFollowingResponse(SecurityPolicy policy)
+      throws Exception {
+    var parameters = new ChannelParameters(65535, 8192, 8192, 1, 65535, 8192, 8192, 1);
+    var wheelTimer = new HashedWheelTimer();
+    var channel = new EmbeddedChannel();
+    try {
+      var handler =
+          new UascClientMessageHandler(
+              config(wheelTimer),
+              application(),
+              new AtomicLong(1L)::getAndIncrement,
+              new CompletableFuture<>(),
+              List.of(),
+              parameters);
+      channel.pipeline().addLast(handler);
+      channel.runPendingTasks();
+      Object outbound;
+      while ((outbound = channel.readOutbound()) != null) {
+        ReferenceCountUtil.release(outbound);
+      }
+
+      var keyPair = SelfSignedCertificateGenerator.generateNistP256KeyPair();
+      var certificate =
+          new SelfSignedCertificateBuilder(keyPair)
+              .setCommonName("abort-test")
+              .setApplicationUri("urn:test:client")
+              .build();
+      var secureChannel =
+          new ClientSecureChannel(
+              keyPair,
+              certificate,
+              List.of(certificate),
+              certificate,
+              List.of(certificate),
+              policy,
+              policy == SecurityPolicy.None
+                  ? MessageSecurityMode.None
+                  : MessageSecurityMode.SignAndEncrypt);
+      secureChannel.setChannelId(1);
+      secureChannel.setChannelSecurity(
+          new ChannelSecurity(
+              policy == SecurityPolicy.None
+                  ? null
+                  : ChannelSecurity.createAeadKeyPair(
+                      new byte[16], new byte[12], new byte[16], new byte[12]),
+              new ChannelSecurityToken(uint(1), uint(1), DateTime.now(), uint(60_000))));
+      Field channelField = UascClientMessageHandler.class.getDeclaredField("secureChannel");
+      channelField.setAccessible(true);
+      channelField.set(handler, secureChannel);
+      Field decoderField = UascClientMessageHandler.class.getDeclaredField("chunkDecoder");
+      decoderField.setAccessible(true);
+      Field sequenceField = ChunkDecoder.class.getDeclaredField("lastSequenceNumber");
+      sequenceField.setAccessible(true);
+      sequenceField.setLong(decoderField.get(handler), 0);
+
+      ByteBuf partial = symmetricChunk(policy, 'C', 1, 0, new byte[] {1, 2, 3});
+      byte[] errorBody =
+          ByteBuffer.allocate(8)
+              .order(ByteOrder.LITTLE_ENDIAN)
+              .putInt((int) StatusCodes.Bad_EncodingLimitsExceeded)
+              .putInt(-1)
+              .array();
+      ByteBuf abort = symmetricChunk(policy, 'A', 2, 1, errorBody);
+      channel.writeInbound(partial);
+      assertEquals(1, partial.refCnt());
+      channel.writeInbound(abort);
+      assertTrue(channel.isOpen());
+      assertEquals(0, partial.refCnt());
+      assertEquals(0, abort.refCnt());
+      UascResponse failure = channel.readInbound();
+      assertTrue(failure.isFailure());
+      assertEquals(
+          StatusCodes.Bad_EncodingLimitsExceeded, failure.getException().getStatusCode().value());
+
+      ByteBuf body = Unpooled.buffer();
+      try {
+        var response =
+            new GetEndpointsResponse(
+                new ResponseHeader(DateTime.now(), uint(1), StatusCode.GOOD, null, null, null),
+                new EndpointDescription[0]);
+        new OpcUaBinaryEncoder(DefaultEncodingContext.INSTANCE)
+            .setBuffer(body)
+            .encodeMessage(null, response);
+        byte[] bytes = new byte[body.readableBytes()];
+        body.readBytes(bytes);
+        ByteBuf following = symmetricChunk(policy, 'F', 3, 2, bytes);
+        channel.writeInbound(following);
+        UascResponse success = channel.readInbound();
+        assertInstanceOf(GetEndpointsResponse.class, success.getResponseMessage());
+        assertEquals(0, following.refCnt());
+        assertTrue(channel.isOpen());
+      } finally {
+        body.release();
+      }
+    } finally {
+      channel.finishAndReleaseAll();
+      wheelTimer.stop();
+    }
+  }
+
+  // Independent wire construction covers the Abort type, which the production encoder does not
+  // emit.
+  private static ByteBuf symmetricChunk(
+      SecurityPolicy policy, char type, int sequence, int last, byte[] body) throws Exception {
+    boolean encrypted = policy != SecurityPolicy.None;
+    ByteBuf chunk = PooledByteBufAllocator.DEFAULT.directBuffer();
+    chunk.writeBytes(new byte[] {'M', 'S', 'G', (byte) type});
+    chunk.writeIntLE(24 + body.length + (encrypted ? 16 : 0)).writeIntLE(1).writeIntLE(1);
+    byte[] plaintext =
+        ByteBuffer.allocate(8 + body.length)
+            .order(ByteOrder.LITTLE_ENDIAN)
+            .putInt(sequence)
+            .putInt(1)
+            .put(body)
+            .array();
+    if (encrypted) {
+      byte[] nonce =
+          ByteBuffer.allocate(12)
+              .order(ByteOrder.LITTLE_ENDIAN)
+              .putInt(1)
+              .putInt(last)
+              .putInt(0)
+              .array();
+      Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+      cipher.init(
+          Cipher.ENCRYPT_MODE,
+          new SecretKeySpec(new byte[16], "AES"),
+          new GCMParameterSpec(128, nonce));
+      byte[] aad = new byte[16];
+      chunk.getBytes(0, aad);
+      cipher.updateAAD(aad);
+      chunk.writeBytes(cipher.doFinal(plaintext));
+    } else {
+      chunk.writeBytes(plaintext);
+    }
+    return chunk;
   }
 
   private enum Cleanup {

--- a/opc-ua-stack/transport/src/test/java/org/eclipse/milo/opcua/stack/transport/server/uasc/UascChunkRecoveryTest.java
+++ b/opc-ua-stack/transport/src/test/java/org/eclipse/milo/opcua/stack/transport/server/uasc/UascChunkRecoveryTest.java
@@ -84,6 +84,8 @@ class UascChunkRecoveryTest {
   private static final String ENDPOINT_URL = "opc.tcp://localhost:4840";
   private static final ChannelParameters PARAMETERS =
       new ChannelParameters(100_000, 8192, 8192, 20, 0, 8192, 8192, 1);
+  private static final ChannelParameters ABORT_PARAMETERS =
+      new ChannelParameters(100_000, 8192, 8192, 1, 0, 8192, 8192, 1);
 
   // A peer may advertise unlimited message size but limit the number of chunks. The fallback
   // ServiceFault must use the next sequence number the peer expects, including its AEAD nonce.
@@ -125,7 +127,8 @@ class UascChunkRecoveryTest {
     }
   }
 
-  // Part 6 §6.7.3 requires Abort to pass security checks and leave the SecureChannel open.
+  // The peer may discover overflow after sending the permitted C chunks. Abort must still pass
+  // security checks, discard those chunks and leave the SecureChannel open (Part 6 §6.7.3).
   @ParameterizedTest
   @EnumSource(
       value = SecurityPolicy.class,
@@ -136,7 +139,8 @@ class UascChunkRecoveryTest {
     var encoder = new ChunkEncoder(PARAMETERS);
     var decoder = new ChunkDecoder(PARAMETERS, EncodingLimits.DEFAULT);
     startAfterOpen(encoder, decoder, policy);
-    EmbeddedChannel channel = fixture.symmetricChannel(new ChunkEncoder(PARAMETERS), decoder);
+    EmbeddedChannel channel =
+        fixture.symmetricChannel(new ChunkEncoder(PARAMETERS), decoder, ABORT_PARAMETERS);
     try {
       channel.writeInbound(encodeRequest(encoder, fixture.client));
       assertInstanceOf(UascServiceRequest.class, channel.readInbound());
@@ -169,7 +173,8 @@ class UascChunkRecoveryTest {
     var fixture = new Fixture(SecurityPolicy.ECC_nistP256_AesGcm);
     var decoder = new ChunkDecoder(PARAMETERS, EncodingLimits.DEFAULT);
     setLong(decoder, "lastSequenceNumber", 1);
-    EmbeddedChannel channel = fixture.symmetricChannel(new ChunkEncoder(PARAMETERS), decoder);
+    EmbeddedChannel channel =
+        fixture.symmetricChannel(new ChunkEncoder(PARAMETERS), decoder, ABORT_PARAMETERS);
     try {
       ByteBuf partial = symmetricChunk(fixture.policy, 'C', 2, 1, new byte[] {1, 2, 3});
       ByteBuf abort = symmetricChunk(fixture.policy, 'A', 3, 2, abortBody());
@@ -221,7 +226,7 @@ class UascChunkRecoveryTest {
     var fixture = new Fixture(SecurityPolicy.None);
     var handler =
         new UascServerAsymmetricHandler(
-            CONFIG, fixture.application(), TransportProfile.TCP_UASC_UABINARY, PARAMETERS);
+            CONFIG, fixture.application(), TransportProfile.TCP_UASC_UABINARY, ABORT_PARAMETERS);
     EmbeddedChannel channel = new EmbeddedChannel(handler);
     try {
       channel.attr(UascServerHelloHandler.ENDPOINT_URL_KEY).set(ENDPOINT_URL);
@@ -265,7 +270,9 @@ class UascChunkRecoveryTest {
           decoded.getMessage().release();
         }
       } finally {
-        if (response.refCnt() > 0) response.release();
+        if (response.refCnt() > 0) {
+          response.release();
+        }
       }
       assertTrue(channel.isOpen());
     } finally {
@@ -287,24 +294,29 @@ class UascChunkRecoveryTest {
     var fixture = new Fixture(SecurityPolicy.ECC_nistP256_AesGcm);
     var handler =
         new UascServerAsymmetricHandler(
-            CONFIG, fixture.application(), TransportProfile.TCP_UASC_UABINARY, PARAMETERS);
+            CONFIG, fixture.application(), TransportProfile.TCP_UASC_UABINARY, ABORT_PARAMETERS);
     Field field = UascServerAsymmetricHandler.class.getDeclaredField("secureChannel");
     field.setAccessible(true);
     field.set(handler, fixture.server);
     EmbeddedChannel channel = new EmbeddedChannel(handler);
     try {
       channel.attr(UascServerHelloHandler.ENDPOINT_URL_KEY).set(ENDPOINT_URL);
-      ByteBuf abort = fixture.asymmetricChunk('A', 0, abortBody());
-      if (tamper)
+      ByteBuf partial = fixture.asymmetricChunk('C', 0, new byte[] {1, 2, 3});
+      ByteBuf abort = fixture.asymmetricChunk('A', 1, abortBody());
+      if (tamper) {
         abort.setByte(abort.writerIndex() - 1, abort.getByte(abort.writerIndex() - 1) ^ 1);
+      }
+      channel.writeInbound(partial);
+      assertEquals(1, partial.refCnt());
       channel.writeInbound(abort);
       channel.advanceTimeBy(1, TimeUnit.SECONDS);
       channel.runScheduledPendingTasks();
       assertEquals(
           !tamper, channel.isOpen(), "only an authenticated OPN Abort may leave the channel open");
+      assertEquals(0, partial.refCnt());
       assertEquals(0, abort.refCnt());
       if (!tamper) {
-        channel.writeInbound(fixture.asymmetricChunk('A', 1, abortBody()));
+        channel.writeInbound(fixture.asymmetricChunk('A', 2, abortBody()));
         assertTrue(channel.isOpen());
       }
     } finally {
@@ -339,7 +351,9 @@ class UascChunkRecoveryTest {
   private static ByteBuf outbound(EmbeddedChannel channel) {
     ByteBuf buffer;
     while ((buffer = channel.readOutbound()) != null) {
-      if (buffer.isReadable()) return buffer;
+      if (buffer.isReadable()) {
+        return buffer;
+      }
       buffer.release();
     }
     throw new AssertionError("no response was sent");
@@ -506,13 +520,18 @@ class UascChunkRecoveryTest {
     }
 
     EmbeddedChannel symmetricChannel(ChunkEncoder encoder, ChunkDecoder decoder) {
+      return symmetricChannel(encoder, decoder, PARAMETERS);
+    }
+
+    EmbeddedChannel symmetricChannel(
+        ChunkEncoder encoder, ChunkDecoder decoder, ChannelParameters parameters) {
       var channel =
           new EmbeddedChannel(
               new UascServerSymmetricHandler(
                   CONFIG,
                   application(),
                   TransportProfile.TCP_UASC_UABINARY,
-                  PARAMETERS,
+                  parameters,
                   encoder,
                   decoder,
                   server));

--- a/opc-ua-stack/transport/src/test/java/org/eclipse/milo/opcua/stack/transport/server/uasc/UascChunkRecoveryTest.java
+++ b/opc-ua-stack/transport/src/test/java/org/eclipse/milo/opcua/stack/transport/server/uasc/UascChunkRecoveryTest.java
@@ -1,0 +1,598 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.transport.server.uasc;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ubyte;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.embedded.EmbeddedChannel;
+import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.security.KeyPair;
+import java.security.Signature;
+import java.security.cert.X509Certificate;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.channel.ChannelParameters;
+import org.eclipse.milo.opcua.stack.core.channel.ChannelSecurity;
+import org.eclipse.milo.opcua.stack.core.channel.ChunkDecoder;
+import org.eclipse.milo.opcua.stack.core.channel.ChunkEncoder;
+import org.eclipse.milo.opcua.stack.core.channel.EncodingLimits;
+import org.eclipse.milo.opcua.stack.core.channel.ServerSecureChannel;
+import org.eclipse.milo.opcua.stack.core.channel.headers.AsymmetricSecurityHeader;
+import org.eclipse.milo.opcua.stack.core.channel.messages.MessageType;
+import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
+import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
+import org.eclipse.milo.opcua.stack.core.encoding.binary.OpcUaBinaryDecoder;
+import org.eclipse.milo.opcua.stack.core.encoding.binary.OpcUaBinaryEncoder;
+import org.eclipse.milo.opcua.stack.core.security.CertificateManager;
+import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
+import org.eclipse.milo.opcua.stack.core.transport.TransportProfile;
+import org.eclipse.milo.opcua.stack.core.types.UaRequestMessageType;
+import org.eclipse.milo.opcua.stack.core.types.UaResponseMessageType;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.MessageSecurityMode;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.SecurityTokenRequestType;
+import org.eclipse.milo.opcua.stack.core.types.structured.ChannelSecurityToken;
+import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
+import org.eclipse.milo.opcua.stack.core.types.structured.GetEndpointsRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.OpenSecureChannelRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.OpenSecureChannelResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.RequestHeader;
+import org.eclipse.milo.opcua.stack.core.types.structured.ResponseHeader;
+import org.eclipse.milo.opcua.stack.core.types.structured.ServiceFault;
+import org.eclipse.milo.opcua.stack.core.util.DigestUtil;
+import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateBuilder;
+import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateGenerator;
+import org.eclipse.milo.opcua.stack.transport.client.uasc.ClientSecureChannel;
+import org.eclipse.milo.opcua.stack.transport.server.ServerApplicationContext;
+import org.eclipse.milo.opcua.stack.transport.server.ServiceRequestContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+/** Chunk failures must preserve the authenticated sequence stream for the next message. */
+class UascChunkRecoveryTest {
+  private static final EncodingContext ENCODING = DefaultEncodingContext.INSTANCE;
+  private static final String ENDPOINT_URL = "opc.tcp://localhost:4840";
+  private static final ChannelParameters PARAMETERS =
+      new ChannelParameters(100_000, 8192, 8192, 20, 0, 8192, 8192, 1);
+
+  // A peer may advertise unlimited message size but limit the number of chunks. The fallback
+  // ServiceFault must use the next sequence number the peer expects, including its AEAD nonce.
+  @ParameterizedTest
+  @EnumSource(
+      value = SecurityPolicy.class,
+      names = {"None", "Basic256Sha256", "ECC_nistP256_AesGcm", "ECC_nistP256_ChaChaPoly"})
+  void oversizedResponseStillDeliversItsServiceFault(SecurityPolicy policy) throws Exception {
+    var fixture = new Fixture(policy);
+    var encoder = new ChunkEncoder(PARAMETERS);
+    var decoder = new ChunkDecoder(PARAMETERS, EncodingLimits.DEFAULT);
+    startAfterOpen(encoder, decoder, policy);
+    EmbeddedChannel channel =
+        fixture.symmetricChannel(encoder, new ChunkDecoder(PARAMETERS, EncodingLimits.DEFAULT));
+    try {
+      channel.writeOutbound(response(0));
+      assertEquals(
+          StatusCode.GOOD,
+          decodeResponse(decoder, fixture.client, outbound(channel))
+              .getResponseHeader()
+              .getServiceResult());
+
+      channel.writeOutbound(response(9000));
+      UaResponseMessageType fault = decodeResponse(decoder, fixture.client, outbound(channel));
+      assertInstanceOf(ServiceFault.class, fault);
+      assertEquals(
+          new StatusCode(StatusCodes.Bad_EncodingLimitsExceeded),
+          fault.getResponseHeader().getServiceResult());
+      assertTrue(channel.isOpen());
+
+      channel.writeOutbound(response(0));
+      assertEquals(
+          StatusCode.GOOD,
+          decodeResponse(decoder, fixture.client, outbound(channel))
+              .getResponseHeader()
+              .getServiceResult());
+    } finally {
+      channel.finishAndReleaseAll();
+    }
+  }
+
+  // Part 6 §6.7.3 requires Abort to pass security checks and leave the SecureChannel open.
+  @ParameterizedTest
+  @EnumSource(
+      value = SecurityPolicy.class,
+      names = {"None", "ECC_nistP256_AesGcm"})
+  void authenticatedSymmetricAbortPreservesTheFollowingRequest(SecurityPolicy policy)
+      throws Exception {
+    var fixture = new Fixture(policy);
+    var encoder = new ChunkEncoder(PARAMETERS);
+    var decoder = new ChunkDecoder(PARAMETERS, EncodingLimits.DEFAULT);
+    startAfterOpen(encoder, decoder, policy);
+    EmbeddedChannel channel = fixture.symmetricChannel(new ChunkEncoder(PARAMETERS), decoder);
+    try {
+      channel.writeInbound(encodeRequest(encoder, fixture.client));
+      assertInstanceOf(UascServiceRequest.class, channel.readInbound());
+      ByteBuf partial = symmetricChunk(policy, 'C', 2, 1, new byte[] {1, 2, 3});
+      ByteBuf abort = symmetricChunk(policy, 'A', 3, 2, abortBody());
+      channel.writeInbound(partial);
+      assertEquals(1, partial.refCnt());
+      channel.writeInbound(abort);
+      assertEquals(0, partial.refCnt());
+      assertEquals(0, abort.refCnt());
+      assertTrue(channel.isOpen());
+
+      if (policy == SecurityPolicy.None) {
+        encodeRequest(encoder, fixture.client).release();
+        encodeRequest(encoder, fixture.client).release();
+      } else {
+        setLong(encoder, "nonLegacyNextSequenceNumber", 4);
+        setLong(encoder, "nonLegacyLastSequenceNumber", 3);
+      }
+      channel.writeInbound(encodeRequest(encoder, fixture.client));
+      assertInstanceOf(UascServiceRequest.class, channel.readInbound());
+      assertTrue(channel.isOpen());
+    } finally {
+      channel.finishAndReleaseAll();
+    }
+  }
+
+  @Test
+  void tamperedSymmetricAbortFailsAuthentication() throws Exception {
+    var fixture = new Fixture(SecurityPolicy.ECC_nistP256_AesGcm);
+    var decoder = new ChunkDecoder(PARAMETERS, EncodingLimits.DEFAULT);
+    setLong(decoder, "lastSequenceNumber", 1);
+    EmbeddedChannel channel = fixture.symmetricChannel(new ChunkEncoder(PARAMETERS), decoder);
+    try {
+      ByteBuf partial = symmetricChunk(fixture.policy, 'C', 2, 1, new byte[] {1, 2, 3});
+      ByteBuf abort = symmetricChunk(fixture.policy, 'A', 3, 2, abortBody());
+      abort.setByte(abort.writerIndex() - 1, abort.getByte(abort.writerIndex() - 1) ^ 1);
+      channel.writeInbound(partial);
+      channel.writeInbound(abort);
+      assertFalse(channel.isOpen(), "an invalid tag must not be accepted as an Abort");
+      assertEquals(0, partial.refCnt());
+      assertEquals(0, abort.refCnt());
+    } finally {
+      channel.finishAndReleaseAll();
+    }
+  }
+
+  @Test
+  void headerOnlySymmetricAbortCannotDiscardAnAccumulatingMessage() throws Exception {
+    var fixture = new Fixture(SecurityPolicy.None);
+    EmbeddedChannel channel =
+        fixture.symmetricChannel(
+            new ChunkEncoder(PARAMETERS), new ChunkDecoder(PARAMETERS, EncodingLimits.DEFAULT));
+    try {
+      channel
+          .pipeline()
+          .addLast(
+              new ChannelInboundHandlerAdapter() {
+                @Override
+                public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                  ctx.close();
+                }
+              });
+      ByteBuf partial = symmetricChunk(SecurityPolicy.None, 'C', 1, 0, new byte[] {1});
+      ByteBuf abort =
+          Unpooled.buffer()
+              .writeBytes(new byte[] {'M', 'S', 'G', 'A'})
+              .writeIntLE(12)
+              .writeIntLE(1);
+      channel.writeInbound(partial);
+      channel.writeInbound(abort);
+      assertFalse(channel.isOpen(), "a header without security or sequence fields is not an Abort");
+      assertEquals(0, partial.refCnt());
+      assertEquals(0, abort.refCnt());
+    } finally {
+      channel.finishAndReleaseAll();
+    }
+  }
+
+  @Test
+  void asymmetricAbortPreservesTheFollowingOpenRequest() throws Exception {
+    var fixture = new Fixture(SecurityPolicy.None);
+    var handler =
+        new UascServerAsymmetricHandler(
+            CONFIG, fixture.application(), TransportProfile.TCP_UASC_UABINARY, PARAMETERS);
+    EmbeddedChannel channel = new EmbeddedChannel(handler);
+    try {
+      channel.attr(UascServerHelloHandler.ENDPOINT_URL_KEY).set(ENDPOINT_URL);
+      ByteBuf partial = fixture.asymmetricChunk('C', 1, new byte[] {1, 2, 3});
+      ByteBuf abort = fixture.asymmetricChunk('A', 2, abortBody());
+      channel.writeInbound(partial);
+      channel.writeInbound(abort);
+      assertEquals(0, partial.refCnt());
+      assertEquals(0, abort.refCnt());
+      assertTrue(channel.isOpen());
+
+      ByteBuf body = Unpooled.buffer();
+      try {
+        new OpcUaBinaryEncoder(ENCODING)
+            .setBuffer(body)
+            .encodeMessage(
+                null,
+                new OpenSecureChannelRequest(
+                    requestHeader(),
+                    uint(0),
+                    SecurityTokenRequestType.Issue,
+                    MessageSecurityMode.None,
+                    ByteString.NULL_VALUE,
+                    uint(60_000)));
+        byte[] bytes = new byte[body.readableBytes()];
+        body.readBytes(bytes);
+        channel.writeInbound(fixture.asymmetricChunk('F', 3, bytes));
+      } finally {
+        body.release();
+      }
+      ByteBuf response = outbound(channel);
+      try {
+        var decoded =
+            new ChunkDecoder(PARAMETERS, EncodingLimits.DEFAULT)
+                .decodeAsymmetric(fixture.client, List.of(response));
+        try {
+          assertInstanceOf(
+              OpenSecureChannelResponse.class,
+              new OpcUaBinaryDecoder(ENCODING).setBuffer(decoded.getMessage()).decodeMessage(null));
+        } finally {
+          decoded.getMessage().release();
+        }
+      } finally {
+        if (response.refCnt() > 0) response.release();
+      }
+      assertTrue(channel.isOpen());
+    } finally {
+      channel.finishAndReleaseAll();
+    }
+  }
+
+  @Test
+  void asymmetricAbortMustHaveAValidSignature() throws Exception {
+    assertAsymmetricAbortAuthentication(true);
+  }
+
+  @Test
+  void authenticatedAsymmetricAbortsKeepTheChannelOpen() throws Exception {
+    assertAsymmetricAbortAuthentication(false);
+  }
+
+  private void assertAsymmetricAbortAuthentication(boolean tamper) throws Exception {
+    var fixture = new Fixture(SecurityPolicy.ECC_nistP256_AesGcm);
+    var handler =
+        new UascServerAsymmetricHandler(
+            CONFIG, fixture.application(), TransportProfile.TCP_UASC_UABINARY, PARAMETERS);
+    Field field = UascServerAsymmetricHandler.class.getDeclaredField("secureChannel");
+    field.setAccessible(true);
+    field.set(handler, fixture.server);
+    EmbeddedChannel channel = new EmbeddedChannel(handler);
+    try {
+      channel.attr(UascServerHelloHandler.ENDPOINT_URL_KEY).set(ENDPOINT_URL);
+      ByteBuf abort = fixture.asymmetricChunk('A', 0, abortBody());
+      if (tamper)
+        abort.setByte(abort.writerIndex() - 1, abort.getByte(abort.writerIndex() - 1) ^ 1);
+      channel.writeInbound(abort);
+      channel.advanceTimeBy(1, TimeUnit.SECONDS);
+      channel.runScheduledPendingTasks();
+      assertEquals(
+          !tamper, channel.isOpen(), "only an authenticated OPN Abort may leave the channel open");
+      assertEquals(0, abort.refCnt());
+      if (!tamper) {
+        channel.writeInbound(fixture.asymmetricChunk('A', 1, abortBody()));
+        assertTrue(channel.isOpen());
+      }
+    } finally {
+      channel.finishAndReleaseAll();
+    }
+  }
+
+  private static UascServiceResponse response(int textLength) {
+    return new UascServiceResponse(
+        new ServiceFault(
+            new ResponseHeader(
+                DateTime.now(),
+                uint(1),
+                StatusCode.GOOD,
+                null,
+                textLength == 0 ? null : new String[] {"x".repeat(textLength)},
+                null)),
+        1);
+  }
+
+  private static UaResponseMessageType decodeResponse(
+      ChunkDecoder decoder, ClientSecureChannel client, ByteBuf chunk) throws Exception {
+    var decoded = decoder.decodeSymmetric(client, List.of(chunk));
+    try {
+      return (UaResponseMessageType)
+          new OpcUaBinaryDecoder(ENCODING).setBuffer(decoded.getMessage()).decodeMessage(null);
+    } finally {
+      decoded.getMessage().release();
+    }
+  }
+
+  private static ByteBuf outbound(EmbeddedChannel channel) {
+    ByteBuf buffer;
+    while ((buffer = channel.readOutbound()) != null) {
+      if (buffer.isReadable()) return buffer;
+      buffer.release();
+    }
+    throw new AssertionError("no response was sent");
+  }
+
+  private static RequestHeader requestHeader() {
+    return new RequestHeader(
+        NodeId.NULL_VALUE, DateTime.now(), uint(1), uint(0), null, uint(1000), null);
+  }
+
+  private static ByteBuf encodeRequest(ChunkEncoder encoder, ClientSecureChannel channel)
+      throws Exception {
+    ByteBuf body = Unpooled.buffer();
+    try {
+      new OpcUaBinaryEncoder(ENCODING)
+          .setBuffer(body)
+          .encodeMessage(null, new GetEndpointsRequest(requestHeader(), ENDPOINT_URL, null, null));
+      return encoder
+          .encodeSymmetric(channel, 1, body, MessageType.SecureMessage)
+          .getMessageChunks()
+          .get(0);
+    } finally {
+      body.release();
+    }
+  }
+
+  private static byte[] abortBody() {
+    return ByteBuffer.allocate(8)
+        .order(ByteOrder.LITTLE_ENDIAN)
+        .putInt((int) StatusCodes.Bad_EncodingLimitsExceeded)
+        .putInt(-1)
+        .array();
+  }
+
+  // Assemble independently because production encoders only emit C/F chunks. With a zero IV base,
+  // the GCM nonce is token id, previous sequence number, zero, all UInt32 little endian (Part 6).
+  private static ByteBuf symmetricChunk(
+      SecurityPolicy policy, char type, int sequence, int last, byte[] body) throws Exception {
+    boolean encrypted = policy != SecurityPolicy.None;
+    ByteBuf chunk = Unpooled.buffer();
+    chunk.writeBytes(new byte[] {'M', 'S', 'G', (byte) type});
+    chunk.writeIntLE(24 + body.length + (encrypted ? 16 : 0)).writeIntLE(1).writeIntLE(1);
+    byte[] plaintext =
+        ByteBuffer.allocate(8 + body.length)
+            .order(ByteOrder.LITTLE_ENDIAN)
+            .putInt(sequence)
+            .putInt(1)
+            .put(body)
+            .array();
+    if (encrypted) {
+      byte[] nonce =
+          ByteBuffer.allocate(12)
+              .order(ByteOrder.LITTLE_ENDIAN)
+              .putInt(1)
+              .putInt(last)
+              .putInt(0)
+              .array();
+      Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+      cipher.init(
+          Cipher.ENCRYPT_MODE,
+          new SecretKeySpec(new byte[16], "AES"),
+          new GCMParameterSpec(128, nonce));
+      byte[] aad = new byte[16];
+      chunk.getBytes(0, aad);
+      cipher.updateAAD(aad);
+      chunk.writeBytes(cipher.doFinal(plaintext));
+    } else {
+      chunk.writeBytes(plaintext);
+    }
+    return chunk;
+  }
+
+  private static void startAfterOpen(
+      ChunkEncoder encoder, ChunkDecoder decoder, SecurityPolicy policy) throws Exception {
+    if (policy.getProfile().secureChannelEnhancements()) {
+      setLong(encoder, "nonLegacyNextSequenceNumber", 1);
+      setLong(encoder, "nonLegacyLastSequenceNumber", 0);
+      setLong(decoder, "lastSequenceNumber", 0);
+    }
+  }
+
+  private static void setLong(Object target, String name, long value) throws Exception {
+    Field field = target.getClass().getDeclaredField(name);
+    field.setAccessible(true);
+    field.setLong(target, value);
+  }
+
+  private static final UascServerConfig CONFIG =
+      new UascServerConfig() {
+        @Override
+        public ExecutorService getExecutor() {
+          return null;
+        }
+
+        @Override
+        public UInteger getHelloDeadline() {
+          return uint(60_000);
+        }
+
+        @Override
+        public UInteger getMinimumSecureChannelLifetime() {
+          return uint(1000);
+        }
+
+        @Override
+        public UInteger getMaximumSecureChannelLifetime() {
+          return uint(60_000);
+        }
+      };
+
+  private static class Fixture {
+    final SecurityPolicy policy;
+    final KeyPair keyPair;
+    final X509Certificate certificate;
+    final ServerSecureChannel server = new ServerSecureChannel();
+    final ClientSecureChannel client;
+
+    Fixture(SecurityPolicy policy) throws Exception {
+      this.policy = policy;
+      keyPair = SelfSignedCertificateGenerator.generateNistP256KeyPair();
+      certificate =
+          new SelfSignedCertificateBuilder(keyPair)
+              .setCommonName("chunk-test")
+              .setApplicationUri("urn:test:server")
+              .build();
+      MessageSecurityMode mode =
+          policy == SecurityPolicy.None
+              ? MessageSecurityMode.None
+              : MessageSecurityMode.SignAndEncrypt;
+      server.setChannelId(1);
+      server.setSecurityPolicy(policy);
+      server.setMessageSecurityMode(mode);
+      server.setKeyPair(keyPair);
+      server.setLocalCertificate(certificate);
+      server.setRemoteCertificate(certificate.getEncoded());
+      client =
+          new ClientSecureChannel(
+              keyPair,
+              certificate,
+              List.of(certificate),
+              certificate,
+              List.of(certificate),
+              policy,
+              mode);
+      client.setChannelId(1);
+      server.setChannelSecurity(security());
+      client.setChannelSecurity(security());
+    }
+
+    private ChannelSecurity security() {
+      ChannelSecurity.SecurityKeys keys = null;
+      if (policy.getProfile().secureChannelEnhancements()) {
+        int keySize = policy == SecurityPolicy.ECC_nistP256_ChaChaPoly ? 32 : 16;
+        keys =
+            ChannelSecurity.createAeadKeyPair(
+                new byte[keySize], new byte[12], new byte[keySize], new byte[12]);
+      } else if (policy != SecurityPolicy.None) {
+        keys =
+            ChannelSecurity.generateKeyPair(
+                server, ByteString.of(new byte[32]), ByteString.of(new byte[32]));
+      }
+      return new ChannelSecurity(
+          keys, new ChannelSecurityToken(uint(1), uint(1), DateTime.now(), uint(60_000)));
+    }
+
+    EmbeddedChannel symmetricChannel(ChunkEncoder encoder, ChunkDecoder decoder) {
+      var channel =
+          new EmbeddedChannel(
+              new UascServerSymmetricHandler(
+                  CONFIG,
+                  application(),
+                  TransportProfile.TCP_UASC_UABINARY,
+                  PARAMETERS,
+                  encoder,
+                  decoder,
+                  server));
+      channel.pipeline().remove(UascServiceRequestHandler.class);
+      return channel;
+    }
+
+    ByteBuf asymmetricChunk(char type, int sequence, byte[] body) throws Exception {
+      ByteBuf chunk = Unpooled.buffer();
+      chunk
+          .writeBytes(new byte[] {'O', 'P', 'N', (byte) type})
+          .writeIntLE(0)
+          .writeIntLE(policy == SecurityPolicy.None ? 0 : 1);
+      AsymmetricSecurityHeader.encode(
+          new AsymmetricSecurityHeader(
+              policy.getUri(),
+              policy == SecurityPolicy.None
+                  ? ByteString.NULL_VALUE
+                  : ByteString.of(certificate.getEncoded()),
+              policy == SecurityPolicy.None
+                  ? ByteString.NULL_VALUE
+                  : ByteString.of(DigestUtil.sha1(certificate.getEncoded()))),
+          chunk);
+      chunk.writeIntLE(sequence).writeIntLE(1).writeBytes(body);
+      chunk.setIntLE(4, chunk.writerIndex() + (policy == SecurityPolicy.None ? 0 : 64));
+      if (policy != SecurityPolicy.None) {
+        Signature signature = Signature.getInstance("SHA256withECDSAinP1363Format");
+        signature.initSign(keyPair.getPrivate());
+        signature.update(chunk.nioBuffer());
+        chunk.writeBytes(signature.sign());
+      }
+      return chunk;
+    }
+
+    ServerApplicationContext application() {
+      return new ServerApplicationContext() {
+        @Override
+        public List<EndpointDescription> getEndpointDescriptions() {
+          try {
+            return List.of(
+                new EndpointDescription(
+                    ENDPOINT_URL,
+                    null,
+                    ByteString.of(certificate.getEncoded()),
+                    server.getMessageSecurityMode(),
+                    policy.getUri(),
+                    null,
+                    TransportProfile.TCP_UASC_UABINARY.getUri(),
+                    ubyte(0)));
+          } catch (Exception e) {
+            throw new AssertionError(e);
+          }
+        }
+
+        @Override
+        public CertificateManager getCertificateManager() {
+          throw new AssertionError("identity already installed");
+        }
+
+        @Override
+        public EncodingContext getEncodingContext() {
+          return ENCODING;
+        }
+
+        @Override
+        public Long getNextSecureChannelId() {
+          return 1L;
+        }
+
+        @Override
+        public Long getNextSecureChannelTokenId() {
+          return 1L;
+        }
+
+        @Override
+        public CompletableFuture<UaResponseMessageType> handleServiceRequest(
+            ServiceRequestContext context, UaRequestMessageType request) {
+          throw new AssertionError(request);
+        }
+      };
+    }
+  }
+}

--- a/opc-ua-stack/transport/src/test/java/org/eclipse/milo/opcua/stack/transport/server/uasc/UascServerChunkLifecycleTest.java
+++ b/opc-ua-stack/transport/src/test/java/org/eclipse/milo/opcua/stack/transport/server/uasc/UascServerChunkLifecycleTest.java
@@ -22,6 +22,7 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.DecoderException;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.channel.ChannelParameters;
 import org.eclipse.milo.opcua.stack.core.channel.ChannelSecurity;
@@ -203,8 +204,8 @@ class UascServerChunkLifecycleTest {
     UascServerSymmetricHandler handler = newSymmetricHandler();
     var channel = new EmbeddedChannel(handler);
 
-    ByteBuf partialChunk = newSymmetricPartialChunk();
-    ByteBuf abortChunk = newSymmetricChunk('A');
+    ByteBuf partialChunk = newValidatedSymmetricChunk('C', 1);
+    ByteBuf abortChunk = newValidatedSymmetricChunk('A', 2);
 
     channel.writeInbound(partialChunk);
     assertEquals(1, partialChunk.refCnt());
@@ -337,6 +338,20 @@ class UascServerChunkLifecycleTest {
       SequenceHeader.encode(new SequenceHeader(1L, 1L), buffer);
     }
     buffer.setIntLE(chunkStart + 4, buffer.writerIndex() - chunkStart);
+  }
+
+  private static ByteBuf newValidatedSymmetricChunk(char chunkType, long sequence) {
+    ByteBuf buffer = PooledByteBufAllocator.DEFAULT.directBuffer();
+    buffer.writeMediumLE(MessageType.toMediumInt(MessageType.SecureMessage));
+    buffer.writeByte(chunkType).writeIntLE(0).writeIntLE(1).writeIntLE(1);
+    SequenceHeader.encode(new SequenceHeader(sequence, 1), buffer);
+    if (chunkType == 'A') {
+      buffer.writeIntLE((int) StatusCodes.Bad_EncodingLimitsExceeded).writeIntLE(-1);
+    } else {
+      buffer.writeByte(0);
+    }
+    buffer.setIntLE(4, buffer.writerIndex());
+    return buffer;
   }
 
   private static ByteBuf newSymmetricPartialChunk() {


### PR DESCRIPTION
Preserve the UASC sequence stream after message-size failures and Abort, and release client buffers when partial responses can no longer complete.

## Oversized messages corrupt the sequence stream

Exceeding the peer's chunk-count limit could consume sequence numbers and AEAD nonces for chunks that were never sent. The following fallback response then failed sequence or authentication checks. The encoder now checks the complete message before reserving either value; the fallback and subsequent responses remain decodable under None, CBC, GCM, and ChaCha20-Poly1305.

Part 6 §6.7.2.4 says the sequence number "shall be incremented by exactly one for each MessageChunk sent." [Sequence Header](https://reference.opcfoundation.org/specs/OPC-10000-6/6.7.2.4)

The existing fallback ServiceFault/status choice is preserved. This change does not revise the separate wire error-form/status mapping for oversized responses.

## Abort authentication and recovery

Server handlers previously discarded accumulated chunks on Abort without authenticating it or advancing sequence state. Abort now passes through the existing decoder's security and sequence checks. Invalid signatures, authentication tags, and malformed headers follow the error path.

A valid Abort also remains accepted after the permitted intermediate chunks have arrived, on both server and client. Its size and security checks still apply; the exemption admits at most one additional size-limited chunk before releasing the accumulated message.

Part 6 §6.7.3 says, "The receiver shall check the security on the abort MessageChunk before processing it." It also says the receiver "shall not close the SecureChannel" after a valid Abort. [MessageChunks and error handling](https://reference.opcfoundation.org/specs/OPC-10000-6/6.7.3)

## Client partial chunks survive disconnect

Closing a client channel or removing its handler could leave pooled partial-response buffers retained. Both boundaries now use the same idempotent release-and-clear operation as exception handling. Package documentation explains the buffer transfer and sequence ownership boundaries. Buffer release is a Milo/Netty ownership requirement.

## Verification

Regression tests cover corrupted fallback responses, unauthenticated Abort acceptance, skipped Abort sequence state, retained client buffers, and rejection of valid Abort at the chunk-count boundary. Controls verify valid signed Abort, subsequent requests/responses, and buffer release under None and GCM.

Formatting and full clean compile passed. The selected chunk, UASC, security, and Session tests passed, including ECC Session integration cases, with no failures, errors, or skips. Sensitive regressions failed on their corresponding unchanged implementations. No third-party interoperability run was performed.
