### PR TITLE
Fix GDS module compatibility, dictionary registration, and Write results

### DIFF
--- a/docs/features/gds-client.md
+++ b/docs/features/gds-client.md
@@ -31,13 +31,14 @@ model does. It lives in subpackages of the existing modules:
 | `milo-stack-core` | `org.eclipse.milo.opcua.stack.core.gds`             | `GdsNodeIds` (one `ExpandedNodeId` per GDS node), `DataTypeInitializer`                          |
 | `milo-stack-core` | `org.eclipse.milo.opcua.stack.core.gds.types`       | `ApplicationRecordDataType` with its codec and `StructureDefinition`                             |
 | `milo-dtd-core`   | `org.eclipse.milo.opcua.sdk.core.dtd.gds`           | `BinaryDataTypeDictionaryInitializer` for the legacy type dictionary mechanism (deprecated)      |
-| `milo-sdk-client` | `org.eclipse.milo.opcua.sdk.client.gds`             | `ObjectTypeInitializer`, `VariableTypeInitializer`                                                |
+| `milo-sdk-client` | `org.eclipse.milo.opcua.sdk.client.gds.model`             | `ObjectTypeInitializer`, `VariableTypeInitializer`                                                |
 | `milo-sdk-client` | `org.eclipse.milo.opcua.sdk.client.gds.model.objects` | Client node classes for `DirectoryType`, `CertificateDirectoryType`, the KeyCredential and AuthorizationService types, and the GDS audit event types |
 | `milo-sdk-server` | `org.eclipse.milo.opcua.sdk.server.gds` and `.model.objects` | The server-side mirror of the same types, for a GDS hosted on Milo                        |
 
 The **client layer** is the module `opc-ua-sdk/sdk-client-gds` (artifact `milo-sdk-client-gds`,
-listed in `milo-bom`). It depends only on `milo-sdk-client` and shares the package
-`org.eclipse.milo.opcua.sdk.client.gds` with the generated client initializers:
+listed in `milo-bom`). It depends only on `milo-sdk-client` and owns the package
+`org.eclipse.milo.opcua.sdk.client.gds`. The generated initializers remain in the core SDK
+under `.gds.model`, so the two jars can be used together as Java modules:
 
 - `GdsClient` wraps a connected `OpcUaClient` and exposes every `DirectoryType` and
   `CertificateDirectoryType` method with a typed signature, plus reads of a CertificateGroup's
@@ -59,7 +60,10 @@ application-side Pull workflow tests. Tests can control registration and Certifi
 access, pre-register applications, change the advertised application certificate types, delay or
 reject requests, and inspect method counters and TrustList file calls. The artifact is listed in
 `milo-bom` and is separate from `milo-sdk-client-gds` to avoid adding server dependencies to the
-runtime client module.
+runtime client module. Its new-key requests return PKCS#8 PEM or PKCS#12 PFX according to
+`PrivateKeyFormat`, encrypt the private key when `PrivateKeyPassword` is supplied, and reject
+unsupported formats with `Bad_InvalidArgument`. PFX output includes the issued certificate and
+its issuer.
 
 * * *
 
@@ -248,9 +252,9 @@ administrator can approve the request.
 
 The model is generated and checked in; no code generation runs in the Maven build. The source is
 the [opc-ua-gds-model](https://github.com/kevinherron/opc-ua-gds-model) repository at commit
-`efa229d` ("Regenerate model from GDS NodeSet2 1.05.07"), produced by the GDS generators in
-[opc-ua-codegen2](https://github.com/kevinherron/opc-ua-codegen2) from GDS NodeSet2 1.05.07 on a
-1.05.07 base, the same base as Milo's namespace 0 model. Every file is copied with its package
+`800aeae`, produced by the GDS generators in
+[opc-ua-codegen2](https://github.com/kevinherron/opc-ua-codegen2) at commit `4027daa` from GDS
+NodeSet2 1.05.07 on a 1.05.07 base, the same base as Milo's namespace 0 model. Every file is copied with its package
 rewritten and the Eclipse Milo license header prepended; nothing else changes.
 
 | Source package (`opc-ua-gds-model`)          | Milo package                                          | Module            |
@@ -258,7 +262,7 @@ rewritten and the Eclipse Milo license header prepended; nothing else changes.
 | `com.digitalpetri.opcua.gds`                 | `org.eclipse.milo.opcua.stack.core.gds`               | `stack-core`      |
 | `com.digitalpetri.opcua.gds.types`           | `org.eclipse.milo.opcua.stack.core.gds.types`         | `stack-core`      |
 | `com.digitalpetri.opcua.gds` (`BinaryDataTypeDictionaryInitializer` only) | `org.eclipse.milo.opcua.sdk.core.dtd.gds` | `dtd-core` |
-| `com.digitalpetri.opcua.gds.client`          | `org.eclipse.milo.opcua.sdk.client.gds`               | `sdk-client`      |
+| `com.digitalpetri.opcua.gds.client`          | `org.eclipse.milo.opcua.sdk.client.gds.model`               | `sdk-client`      |
 | `com.digitalpetri.opcua.gds.client.objects`  | `org.eclipse.milo.opcua.sdk.client.gds.model.objects` | `sdk-client`      |
 | `com.digitalpetri.opcua.gds.server`          | `org.eclipse.milo.opcua.sdk.server.gds`               | `sdk-server`      |
 | `com.digitalpetri.opcua.gds.server.objects`  | `org.eclipse.milo.opcua.sdk.server.gds.model.objects` | `sdk-server`      |
@@ -276,6 +280,10 @@ To pick up a new GDS NodeSet release:
    document.
 5. Diff the Milo packages against the source with the prefixes rewritten; only the header and
    import order may differ.
+
+Generated blocking property writers throw `UaException` carrying any non-Good operation status.
+Their asynchronous counterparts return the `StatusCode`. The namespace 0 model uses the same
+writer generator and follows the same contract.
 
 The GDS `DataTypeInitializer` and both `ObjectTypeInitializer`s take a `NamespaceTable` and must
 stay out of the namespace 0 startup path (`DefaultDataTypeManager.createAndInitialize` and the

--- a/opc-ua-sdk/dtd-core/src/main/java/org/eclipse/milo/opcua/sdk/core/dtd/gds/BinaryDataTypeDictionaryInitializer.java
+++ b/opc-ua-sdk/dtd-core/src/main/java/org/eclipse/milo/opcua/sdk/core/dtd/gds/BinaryDataTypeDictionaryInitializer.java
@@ -10,20 +10,51 @@
 
 package org.eclipse.milo.opcua.sdk.core.dtd.gds;
 
+import java.io.ByteArrayInputStream;
+import java.util.Base64;
 import org.eclipse.milo.opcua.sdk.core.dtd.BinaryDataTypeCodec;
 import org.eclipse.milo.opcua.sdk.core.dtd.BinaryDataTypeDictionary;
+import org.eclipse.milo.opcua.sdk.core.dtd.BsdParser;
 import org.eclipse.milo.opcua.sdk.core.dtd.DataTypeDictionaryInitializer;
 import org.eclipse.milo.opcua.stack.core.NamespaceTable;
 import org.eclipse.milo.opcua.stack.core.gds.types.ApplicationRecordDataType;
 import org.eclipse.milo.opcua.stack.core.types.DataTypeDictionary;
+import org.eclipse.milo.opcua.stack.core.types.DataTypeManager;
+import org.opcfoundation.opcua.binaryschema.TypeDictionary;
 
 public class BinaryDataTypeDictionaryInitializer extends DataTypeDictionaryInitializer {
+  @Override
+  public void initialize(NamespaceTable namespaceTable, DataTypeManager dataTypeManager) {
+    if (dataTypeManager.getTypeDictionary("http://opcfoundation.org/UA/GDS/") != null) {
+      return;
+    }
+    try {
+      TypeDictionary schema =
+          BsdParser.parse(
+              new ByteArrayInputStream(
+                  Base64.getDecoder()
+                      .decode(
+                          String.join(
+                              "",
+                              "PG9wYzpUeXBlRGljdGlvbmFyeQ0KICB4bWxuczpvcGM9Imh0dHA6Ly9vcGNmb3VuZGF0aW9uLm9yZy9CaW5hcnlTY2hlbWEvIg0KICB4bWxuczp4c2k9Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvWE1MU2NoZW1hLWluc3RhbmNlIg0KICB4bWxuczp1YT0iaHR0cDovL29wY2ZvdW5kYXRpb24ub3JnL1VBLyINCiAgeG1sbnM6dG5zPSJodHRwOi8vb3BjZm91bmRhdGlvbi5vcmcvVUEvR0RTLyINCiAgRGVmYXVsdEJ5dGVPcmRlcj0iTGl0dGxlRW5kaWFuIg0KICBUYXJnZXROYW1lc3BhY2U9Imh0dHA6Ly9vcGNmb3VuZGF0aW9uLm9yZy9VQS9HRFMvIg0KPg0KICA8b3BjOkltcG9ydCBOYW1lc3BhY2U9Imh0dHA6Ly9vcGNmb3VuZGF0aW9uLm9yZy9VQS8iIExvY2F0aW9uPSJPcGMuVWEuQmluYXJ5U2NoZW1hLmJzZCIvPg0KDQogIDxvcGM6U3RydWN0dXJlZFR5cGUgTmFtZT0iQXBwbGljYXRpb25SZWNvcmREYXRhVHlwZSIgQmFzZVR5cGU9InVhOkV4dGVuc2lvbk9iamVjdCI+DQogICAgPG9wYzpGaWVsZCBOYW1lPSJBcHBsaWNhdGlvbklkIiBUeXBlTmFtZT0idWE6Tm9kZUlkIiAvPg0KICAgIDxvcGM6RmllbGQgTmFtZT0iQXBwbGljYXRpb25VcmkiIFR5cGVOYW1lPSJvcGM6U3RyaW5nIiAvPg0KICAgIDxvcGM6RmllbGQgTmFtZT0iQXBwbGljYXRpb25UeXBlIiBUeXBlTmFtZT0idWE6QXBwbGljYXRpb25UeXBlIiAvPg0KICAgIDxvcGM6RmllbGQgTmFtZT0iTm9PZkFwcGxpY2F0aW9uTmFtZXMiIFR5cGVOYW1lPSJvcGM6SW50MzIiIC8+DQogICAgPG9wYzpGaWVsZCBOYW1lPSJBcHBsaWNhdGlvbk5hbWVzIiBUeXBlTmFtZT0idWE6TG9jYWxpemVkVGV4dCIgTGVuZ3RoRmllbGQ9Ik5vT2ZBcHBsaWNhdGlvbk5hbWVzIiAvPg0KICAgIDxvcGM6RmllbGQgTmFtZT0iUHJvZHVjdFVyaSIgVHlwZU5hbWU9Im9wYzpTdHJpbmciIC8+DQogICAgPG9wYzpGaWVsZCBOYW1lPSJOb09mRGlzY292ZXJ5VXJscyIgVHlwZU5hbWU9Im9wYzpJbnQzMiIgLz4NCiAgICA8b3BjOkZpZWxkIE5hbWU9IkRpc2NvdmVyeVVybHMiIFR5cGVOYW1lPSJvcGM6U3RyaW5nIiBMZW5ndGhGaWVsZD0iTm9PZkRpc2NvdmVyeVVybHMiIC8+DQogICAgPG9wYzpGaWVsZCBOYW1lPSJOb09mU2VydmVyQ2FwYWJpbGl0aWVzIiBUeXBlTmFtZT0ib3BjOkludDMyIiAvPg0KICAgIDxvcGM6RmllbGQgTmFtZT0iU2VydmVyQ2FwYWJpbGl0aWVzIiBUeXBlTmFtZT0ib3BjOlN0cmluZyIgTGVuZ3RoRmllbGQ9Ik5vT2ZTZXJ2ZXJDYXBhYmlsaXRpZXMiIC8+DQogIDwvb3BjOlN0cnVjdHVyZWRUeXBlPg0KDQo8L29wYzpUeXBlRGljdGlvbmFyeT4="))));
+      BinaryDataTypeDictionary dictionary = new BinaryDataTypeDictionary(schema);
+      initializeStructs(namespaceTable, dictionary);
+      dataTypeManager.registerTypeDictionary(dictionary);
+      for (DataTypeDictionary.Type type : dictionary.getTypes()) {
+        dataTypeManager.registerType(
+            type.getDataTypeId(), type.getCodec(), type.getEncodingId(), null, null);
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
   @Override
   protected void initializeStructs(
       NamespaceTable namespaceTable, DataTypeDictionary binaryDictionary) throws Exception {
     binaryDictionary.registerType(
         new BinaryDataTypeDictionary.BinaryType(
-            "1:ApplicationRecordDataType",
+            "ApplicationRecordDataType",
             ApplicationRecordDataType.TYPE_ID.toNodeIdOrThrow(namespaceTable),
             ApplicationRecordDataType.BINARY_ENCODING_ID.toNodeIdOrThrow(namespaceTable),
             BinaryDataTypeCodec.from(new ApplicationRecordDataType.Codec())));

--- a/opc-ua-sdk/dtd-core/src/main/java/org/eclipse/milo/opcua/sdk/core/dtd/gds/package-info.java
+++ b/opc-ua-sdk/dtd-core/src/main/java/org/eclipse/milo/opcua/sdk/core/dtd/gds/package-info.java
@@ -12,15 +12,16 @@
  * Legacy DataTypeDictionary registration for the OPC UA Global Discovery Server namespace.
  *
  * <p>{@link org.eclipse.milo.opcua.sdk.core.dtd.gds.BinaryDataTypeDictionaryInitializer} adds the
- * {@code ApplicationRecordDataType} entry to the OPC UA Binary type dictionary, for applications
- * that still exchange type information through OPC UA 1.03-style dictionaries instead of the
- * DataTypeDefinition attribute. Like the rest of {@code org.eclipse.milo.opcua.sdk.core.dtd} it is
- * deprecated for removal; new code should register the codec through {@link
- * org.eclipse.milo.opcua.stack.core.gds.DataTypeInitializer} instead.
+ * {@code ApplicationRecordDataType} entry to a dictionary for the GDS namespace, independently of
+ * standard dictionary initialization order, for applications that still exchange type information
+ * through OPC UA 1.03-style dictionaries instead of the DataTypeDefinition attribute. Like the rest
+ * of {@code org.eclipse.milo.opcua.sdk.core.dtd} it is deprecated for removal; new code should
+ * register the codec through {@link org.eclipse.milo.opcua.stack.core.gds.DataTypeInitializer}
+ * instead.
  *
  * <p>Generated code, copied from the {@code gds-model-core} module of <a
  * href="https://github.com/kevinherron/opc-ua-gds-model">opc-ua-gds-model</a> at commit {@code
- * efa229d}; see the regeneration notes in {@link org.eclipse.milo.opcua.stack.core.gds}.
+ * 800aeae}; see the regeneration notes in {@link org.eclipse.milo.opcua.stack.core.gds}.
  */
 @Deprecated(forRemoval = true, since = "1.2.0")
 package org.eclipse.milo.opcua.sdk.core.dtd.gds;

--- a/opc-ua-sdk/dtd-core/src/test/java/org/eclipse/milo/opcua/sdk/core/dtd/GdsDictionaryInitializationTest.java
+++ b/opc-ua-sdk/dtd-core/src/test/java/org/eclipse/milo/opcua/sdk/core/dtd/GdsDictionaryInitializationTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.milo.opcua.sdk.core.dtd;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.eclipse.milo.opcua.stack.core.NamespaceTable;
+import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
+import org.eclipse.milo.opcua.stack.core.gds.types.ApplicationRecordDataType;
+import org.eclipse.milo.opcua.stack.core.types.DataTypeManager;
+import org.eclipse.milo.opcua.stack.core.types.DefaultDataTypeManager;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.ApplicationType;
+import org.junit.jupiter.api.Test;
+
+class GdsDictionaryInitializationTest {
+  private static final String GDS_URI = "http://opcfoundation.org/UA/GDS/";
+
+  // Standard initialization must not hide the separate GDS namespace's legacy dictionary/codec.
+  @Test
+  void standardThenGdsRegistersIndependentDictionaryAndCodec() throws Exception {
+    verifyInitialization(true);
+  }
+
+  // GDS-first registration must not install a partial standard dictionary and block its codecs.
+  @Test
+  void gdsThenStandardRegistersIndependentDictionaryAndCodec() throws Exception {
+    verifyInitialization(false);
+  }
+
+  private void verifyInitialization(boolean standardFirst) throws Exception {
+    var namespaces = new NamespaceTable();
+    namespaces.add("urn:unrelated");
+    namespaces.add(GDS_URI);
+    var manager = new DefaultDataTypeManager();
+    var standard = new BinaryDataTypeDictionaryInitializer();
+    var gds = new org.eclipse.milo.opcua.sdk.core.dtd.gds.BinaryDataTypeDictionaryInitializer();
+    if (standardFirst) standard.initialize(namespaces, manager);
+    gds.initialize(namespaces, manager);
+    if (!standardFirst) standard.initialize(namespaces, manager);
+    // Repeated registration remains idempotent for both namespaces.
+    gds.initialize(namespaces, manager);
+    standard.initialize(namespaces, manager);
+
+    BinaryDataTypeDictionary dictionary =
+        (BinaryDataTypeDictionary) manager.getTypeDictionary(GDS_URI);
+    assertNotNull(dictionary, "GDS needs its own dictionary regardless of initialization order");
+    assertNotNull(dictionary.getType("ApplicationRecordDataType"));
+    assertNotNull(dictionary.getTypeDescription("ApplicationRecordDataType"));
+    assertNull(
+        manager
+            .getTypeDictionary("http://opcfoundation.org/UA/")
+            .getType("1:ApplicationRecordDataType"));
+    assertNotNull(
+        manager.getCodec(ApplicationRecordDataType.BINARY_ENCODING_ID.toNodeIdOrThrow(namespaces)));
+
+    var context =
+        new DefaultEncodingContext() {
+          @Override
+          public NamespaceTable getNamespaceTable() {
+            return namespaces;
+          }
+
+          @Override
+          public DataTypeManager getDataTypeManager() {
+            return manager;
+          }
+        };
+    var record =
+        new ApplicationRecordDataType(
+            new NodeId(2, "app"),
+            "urn:test:gds",
+            ApplicationType.Client,
+            new LocalizedText[] {LocalizedText.english("Test")},
+            "urn:test:product",
+            null,
+            null);
+    ExtensionObject encoded = ExtensionObject.encode(context, record);
+    assertEquals(record, encoded.decode(context));
+  }
+}

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/GdsEncodingContractsTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/GdsEncodingContractsTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.milo.opcua.sdk.client.gds;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ubyte;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.Signature;
+import java.util.concurrent.TimeUnit;
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
+import org.bouncycastle.openssl.jcajce.JceOpenSSLPKCS8DecryptorProviderBuilder;
+import org.bouncycastle.pkcs.PKCS8EncryptedPrivateKeyInfo;
+import org.eclipse.milo.opcua.sdk.client.gds.model.objects.AuthorizationServiceType;
+import org.eclipse.milo.opcua.sdk.client.gds.model.objects.AuthorizationServiceTypeNode;
+import org.eclipse.milo.opcua.sdk.core.AccessLevel;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableNode;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
+import org.eclipse.milo.opcua.stack.core.util.CertificateUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class GdsEncodingContractsTest extends AbstractGdsClientTest {
+
+  // Part12 §7.9.4 defines PEM/PFX and a password. Parse the returned format and prove its key
+  // belongs to the issued certificate, including password-protected requests.
+  @ParameterizedTest
+  @CsvSource({"PEM,''", "PEM,secret", "PFX,''", "PFX,secret"})
+  void newKeyPairUsesRequestedEncodingAndPassword(String format, String password) throws Exception {
+    NodeId application = registerTestApplication();
+    NodeId request =
+        gdsClient.startNewKeyPairRequest(
+            application, null, null, "CN=Test", new String[0], format, password);
+    var issued = gdsClient.finishRequest(application, request);
+    byte[] bytes = issued.privateKey().bytesOrEmpty();
+    PrivateKey key;
+    if (format.equals("PFX")) {
+      KeyStore pfx = KeyStore.getInstance("PKCS12");
+      pfx.load(new ByteArrayInputStream(bytes), password.toCharArray());
+      String alias = pfx.aliases().nextElement();
+      key = (PrivateKey) pfx.getKey(alias, password.toCharArray());
+      assertEquals(
+          CertificateUtil.decodeCertificate(issued.certificate().bytesOrEmpty()),
+          pfx.getCertificate(alias));
+      if (!password.isEmpty()) {
+        assertThrows(
+            java.io.IOException.class,
+            () ->
+                KeyStore.getInstance("PKCS12")
+                    .load(new ByteArrayInputStream(bytes), "wrong-password".toCharArray()));
+      }
+    } else {
+      try (var parser =
+          new PEMParser(new StringReader(new String(bytes, StandardCharsets.US_ASCII)))) {
+        Object parsed = parser.readObject();
+        PrivateKeyInfo info;
+        if (password.isEmpty()) {
+          info = assertInstanceOf(PrivateKeyInfo.class, parsed);
+        } else {
+          var encrypted = assertInstanceOf(PKCS8EncryptedPrivateKeyInfo.class, parsed);
+          info =
+              encrypted.decryptPrivateKeyInfo(
+                  new JceOpenSSLPKCS8DecryptorProviderBuilder()
+                      .setProvider(new BouncyCastleProvider())
+                      .build(password.toCharArray()));
+        }
+        key = new JcaPEMKeyConverter().getPrivateKey(info);
+      }
+    }
+    var certificate = CertificateUtil.decodeCertificate(issued.certificate().bytesOrEmpty());
+    Signature signature = Signature.getInstance("SHA256withRSA");
+    signature.initSign(key);
+    signature.update(new byte[] {1, 2, 3});
+    byte[] signed = signature.sign();
+    signature.initVerify(certificate);
+    signature.update(new byte[] {1, 2, 3});
+    assertTrue(signature.verify(signed), "returned key must match the issued certificate");
+  }
+
+  // A request for an unsupported format must fail at request creation, not silently return DER.
+  @Test
+  void unsupportedPrivateKeyFormatIsRejected() throws Exception {
+    NodeId application = registerTestApplication();
+    UaException error =
+        assertThrows(
+            UaException.class,
+            () ->
+                gdsClient.startNewKeyPairRequest(
+                    application, null, null, "CN=Test", new String[0], "unsupported", null));
+    assertEquals(StatusCodes.Bad_InvalidArgument, error.getStatusCode().value());
+  }
+
+  // A successful Write service can carry Bad_UserAccessDenied for its one operation. Generated
+  // blocking
+  // writers promise UaException for that outcome while async writers expose the exact StatusCode.
+  @Test
+  void generatedBlockingWriterReportsOperationFailureAndStillAcceptsGoodWrites() throws Exception {
+    NodeId id = newNodeId("ReadOnlyAuthorizationService");
+    UaVariableNode[] property = new UaVariableNode[1];
+    testNamespace.configure(
+        (context, nodes) -> {
+          UaObjectNode object =
+              UaObjectNode.builder(context)
+                  .setNodeId(id)
+                  .setBrowseName(newQualifiedName("AuthorizationService"))
+                  .setDisplayName(LocalizedText.english("AuthorizationService"))
+                  .build();
+          nodes.addNode(object);
+          object.setProperty(AuthorizationServiceType.SERVICE_URI, "urn:original");
+          property[0] =
+              (UaVariableNode)
+                  object.getPropertyNode(AuthorizationServiceType.SERVICE_URI).orElseThrow();
+          property[0].setAccessLevel(AccessLevel.toValue(AccessLevel.READ_ONLY));
+          property[0].setUserAccessLevel(AccessLevel.toValue(AccessLevel.READ_ONLY));
+        });
+    var node =
+        new AuthorizationServiceTypeNode(
+            client,
+            id,
+            NodeClass.Object,
+            newQualifiedName("AuthorizationService"),
+            LocalizedText.english("AuthorizationService"),
+            LocalizedText.NULL_VALUE,
+            uint(0),
+            uint(0),
+            null,
+            null,
+            null,
+            ubyte(0));
+    assertEquals("urn:original", node.readServiceUri());
+    assertEquals(
+        StatusCodes.Bad_UserAccessDenied,
+        node.writeServiceUriAsync("urn:rejected").get(10, TimeUnit.SECONDS).value());
+    UaException error = assertThrows(UaException.class, () -> node.writeServiceUri("urn:rejected"));
+    assertEquals(StatusCodes.Bad_UserAccessDenied, error.getStatusCode().value());
+    assertEquals("urn:original", node.readServiceUri());
+    property[0].setAccessLevel(AccessLevel.toValue(AccessLevel.READ_WRITE));
+    property[0].setUserAccessLevel(AccessLevel.toValue(AccessLevel.READ_WRITE));
+    node.writeServiceUri("urn:accepted");
+    assertEquals("urn:accepted", node.readServiceUri());
+  }
+}

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/GdsModulePathTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/GdsModulePathTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.milo.opcua.sdk.client.gds;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.module.Configuration;
+import java.lang.module.ModuleFinder;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.jar.Attributes;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class GdsModulePathTest {
+  @TempDir Path directory;
+
+  // Java's module resolver rejects split packages even though ordinary classpath calls work.
+  // Resolve the actual production classes from both required artifacts together.
+  @Test
+  void clientAndGdsArtifactsResolveTogetherAsAutomaticModules() throws Exception {
+    Path client = moduleJar(OpcUaClient.class, "org.eclipse.milo.opcua.sdk.client");
+    Path gds = moduleJar(GdsClient.class, "org.eclipse.milo.opcua.sdk.client.gds");
+    Configuration resolved =
+        ModuleLayer.boot()
+            .configuration()
+            .resolve(
+                ModuleFinder.of(client, gds),
+                ModuleFinder.of(),
+                Set.of(
+                    "org.eclipse.milo.opcua.sdk.client", "org.eclipse.milo.opcua.sdk.client.gds"));
+    assertEquals(2, resolved.modules().size());
+  }
+
+  private Path moduleJar(Class<?> representative, String moduleName) throws Exception {
+    Path source =
+        Path.of(representative.getProtectionDomain().getCodeSource().getLocation().toURI());
+    if (Files.isRegularFile(source)) {
+      return source;
+    }
+    // Maven may expose a reactor dependency's classes directory instead of its packaged JAR.
+    var manifest = new Manifest();
+    manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
+    manifest.getMainAttributes().putValue("Automatic-Module-Name", moduleName);
+    Path jar = directory.resolve(moduleName + ".jar");
+    try (var output = new JarOutputStream(Files.newOutputStream(jar), manifest);
+        var files = Files.walk(source)) {
+      for (Path file : files.filter(Files::isRegularFile).toList()) {
+        String name = source.relativize(file).toString().replace('\\', '/');
+        if (name.equals("META-INF/MANIFEST.MF")) continue;
+        output.putNextEntry(new JarEntry(name));
+        Files.copy(file, output);
+        output.closeEntry();
+      }
+    }
+    return jar;
+  }
+}

--- a/opc-ua-sdk/sdk-client-gds-testing/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/testing/FakeGdsNamespace.java
+++ b/opc-ua-sdk/sdk-client-gds-testing/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/testing/FakeGdsNamespace.java
@@ -15,8 +15,13 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
+import java.io.ByteArrayOutputStream;
+import java.io.StringWriter;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
+import java.security.KeyStore;
+import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.Date;
@@ -37,8 +42,14 @@ import org.bouncycastle.asn1.x509.GeneralName;
 import org.bouncycastle.asn1.x509.GeneralNames;
 import org.bouncycastle.cert.X509v3CertificateBuilder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.openssl.PKCS8Generator;
+import org.bouncycastle.openssl.jcajce.JcaPKCS8Generator;
+import org.bouncycastle.openssl.jcajce.JceOpenSSLPKCS8EncryptorBuilder;
+import org.bouncycastle.operator.OutputEncryptor;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
+import org.bouncycastle.util.io.pem.PemWriter;
 import org.eclipse.milo.opcua.sdk.client.gds.GdsClient;
 import org.eclipse.milo.opcua.sdk.core.AccessLevel;
 import org.eclipse.milo.opcua.sdk.core.Reference;
@@ -163,7 +174,11 @@ public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
   }
 
   private record SigningRequest(
-      NodeId applicationId, @Nullable PKCS10CertificationRequest csr, AtomicInteger polls) {}
+      NodeId applicationId,
+      @Nullable PKCS10CertificationRequest csr,
+      AtomicInteger polls,
+      @Nullable String privateKeyFormat,
+      @Nullable String privateKeyPassword) {}
 
   private final KeyPair caKeyPair;
   private final X509Certificate caCertificate;
@@ -853,7 +868,8 @@ public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
           }
 
           NodeId requestId = newNodeId("Requests/" + nextId.getAndIncrement());
-          requests.put(requestId, new SigningRequest(applicationId, csr, new AtomicInteger()));
+          requests.put(
+              requestId, new SigningRequest(applicationId, csr, new AtomicInteger(), null, null));
 
           return new Variant[] {Variant.ofNodeId(requestId)};
         });
@@ -879,8 +895,19 @@ public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
 
           requireApplication(applicationId);
 
+          String format = (String) inputs[5].value();
+          if (format == null || format.isEmpty()) {
+            format = "PEM";
+          }
+          if (!format.equals("PEM") && !format.equals("PFX")) {
+            throw new UaException(
+                StatusCodes.Bad_InvalidArgument, "unsupported PrivateKeyFormat: " + format);
+          }
+          String password = (String) inputs[6].value();
           NodeId requestId = newNodeId("Requests/" + nextId.getAndIncrement());
-          requests.put(requestId, new SigningRequest(applicationId, null, new AtomicInteger()));
+          requests.put(
+              requestId,
+              new SigningRequest(applicationId, null, new AtomicInteger(), format, password));
 
           return new Variant[] {Variant.ofNodeId(requestId)};
         });
@@ -937,7 +964,7 @@ public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
                           List.of(),
                           List.of(),
                           "SHA256withRSA"));
-              privateKey = ByteString.of(keyPair.getPrivate().getEncoded());
+              privateKey = encodePrivateKey(request, keyPair.getPrivate(), certificate);
             }
 
             issued
@@ -1270,6 +1297,36 @@ public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
     }
 
     return Extensions.getInstance(attributes[0].getAttrValues().getObjectAt(0));
+  }
+
+  private ByteString encodePrivateKey(
+      SigningRequest request, PrivateKey key, X509Certificate certificate) throws Exception {
+    char[] password =
+        request.privateKeyPassword() != null
+            ? request.privateKeyPassword().toCharArray()
+            : new char[0];
+    if ("PFX".equals(request.privateKeyFormat())) {
+      KeyStore store = KeyStore.getInstance("PKCS12");
+      store.load(null, password);
+      store.setKeyEntry(
+          "application", key, password, new X509Certificate[] {certificate, caCertificate});
+      var output = new ByteArrayOutputStream();
+      store.store(output, password);
+      return ByteString.of(output.toByteArray());
+    }
+
+    OutputEncryptor encryptor =
+        password.length == 0
+            ? null
+            : new JceOpenSSLPKCS8EncryptorBuilder(PKCS8Generator.AES_256_CBC)
+                .setProvider(new BouncyCastleProvider())
+                .setPassword(password)
+                .build();
+    var output = new StringWriter();
+    try (var writer = new PemWriter(output)) {
+      writer.writeObject(new JcaPKCS8Generator(key, encryptor));
+    }
+    return ByteString.of(output.toString().getBytes(StandardCharsets.US_ASCII));
   }
 
   private X509Certificate sign(PKCS10CertificationRequest csr) throws Exception {

--- a/opc-ua-sdk/sdk-client-gds-testing/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/testing/package-info.java
+++ b/opc-ua-sdk/sdk-client-gds-testing/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/testing/package-info.java
@@ -14,7 +14,9 @@
  * <p>{@link org.eclipse.milo.opcua.sdk.client.gds.testing.FakeGdsNamespace} hosts an in-memory GDS
  * namespace on an {@link org.eclipse.milo.opcua.sdk.server.OpcUaServer}. Tests can control access,
  * registration, certificate issuance, and TrustList responses, then inspect recorded calls. The
- * fixture must be started before the server and shut down during test teardown.
+ * fixture returns requested PEM or PFX private keys and applies the supplied password. Pending
+ * requests retain their key format and password until issuance or reset. The fixture must be
+ * started before the server and shut down during test teardown.
  */
 @NullMarked
 package org.eclipse.milo.opcua.sdk.client.gds.testing;

--- a/opc-ua-sdk/sdk-client-gds/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/GdsClient.java
+++ b/opc-ua-sdk/sdk-client-gds/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/GdsClient.java
@@ -21,6 +21,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.client.gds.model.ObjectTypeInitializer;
+import org.eclipse.milo.opcua.sdk.client.gds.model.VariableTypeInitializer;
 import org.eclipse.milo.opcua.sdk.client.methods.UaMethodException;
 import org.eclipse.milo.opcua.stack.core.NamespaceTable;
 import org.eclipse.milo.opcua.stack.core.NodeIds;

--- a/opc-ua-sdk/sdk-client-gds/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/package-info.java
+++ b/opc-ua-sdk/sdk-client-gds/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/package-info.java
@@ -13,9 +13,9 @@
  * registration, certificate requests through the Pull Model, and trust list retrieval.
  *
  * <p>This package spans two modules. {@code milo-sdk-client} contributes the generated GDS model:
- * {@link org.eclipse.milo.opcua.sdk.client.gds.ObjectTypeInitializer}, {@link
- * org.eclipse.milo.opcua.sdk.client.gds.VariableTypeInitializer}, and the typed node classes in
- * {@code org.eclipse.milo.opcua.sdk.client.gds.model.objects}. {@code milo-sdk-client-gds}
+ * {@link org.eclipse.milo.opcua.sdk.client.gds.model.ObjectTypeInitializer}, {@link
+ * org.eclipse.milo.opcua.sdk.client.gds.model.VariableTypeInitializer}, and the typed node classes
+ * in {@code org.eclipse.milo.opcua.sdk.client.gds.model.objects}. {@code milo-sdk-client-gds}
  * contributes the hand-written layer described here, which an application opts into by adding that
  * module as a dependency.
  *

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/ObjectTypeInitializer.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/ObjectTypeInitializer.java
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-package org.eclipse.milo.opcua.sdk.client.gds;
+package org.eclipse.milo.opcua.sdk.client.gds.model;
 
 import org.eclipse.milo.opcua.sdk.client.ObjectTypeManager;
 import org.eclipse.milo.opcua.sdk.client.gds.model.objects.AccessTokenIssuedAuditEventTypeNode;

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/VariableTypeInitializer.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/VariableTypeInitializer.java
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-package org.eclipse.milo.opcua.sdk.client.gds;
+package org.eclipse.milo.opcua.sdk.client.gds.model;
 
 import org.eclipse.milo.opcua.sdk.client.VariableTypeManager;
 import org.eclipse.milo.opcua.stack.core.NamespaceTable;

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/AuthorizationServiceTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/AuthorizationServiceTypeNode.java
@@ -92,7 +92,10 @@ public class AuthorizationServiceTypeNode extends BaseObjectTypeNode
   @Override
   public void writeServiceUri(String value) throws UaException {
     try {
-      writeServiceUriAsync(value).get();
+      StatusCode statusCode = writeServiceUriAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -162,7 +165,10 @@ public class AuthorizationServiceTypeNode extends BaseObjectTypeNode
   @Override
   public void writeServiceCertificate(ByteString value) throws UaException {
     try {
-      writeServiceCertificateAsync(value).get();
+      StatusCode statusCode = writeServiceCertificateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -237,7 +243,10 @@ public class AuthorizationServiceTypeNode extends BaseObjectTypeNode
   @Override
   public void writeUserTokenPolicies(UserTokenPolicy[] value) throws UaException {
     try {
-      writeUserTokenPoliciesAsync(value).get();
+      StatusCode statusCode = writeUserTokenPoliciesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -313,7 +322,10 @@ public class AuthorizationServiceTypeNode extends BaseObjectTypeNode
   @Override
   public void writeSupportedRoles(String[] value) throws UaException {
     try {
-      writeSupportedRolesAsync(value).get();
+      StatusCode statusCode = writeSupportedRolesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/CertificateDeliveredAuditEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/CertificateDeliveredAuditEventTypeNode.java
@@ -89,7 +89,10 @@ public class CertificateDeliveredAuditEventTypeNode extends AuditUpdateMethodEve
   @Override
   public void writeCertificateGroup(NodeId value) throws UaException {
     try {
-      writeCertificateGroupAsync(value).get();
+      StatusCode statusCode = writeCertificateGroupAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -162,7 +165,10 @@ public class CertificateDeliveredAuditEventTypeNode extends AuditUpdateMethodEve
   @Override
   public void writeCertificateType(NodeId value) throws UaException {
     try {
-      writeCertificateTypeAsync(value).get();
+      StatusCode statusCode = writeCertificateTypeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/CertificateRequestedAuditEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/CertificateRequestedAuditEventTypeNode.java
@@ -89,7 +89,10 @@ public class CertificateRequestedAuditEventTypeNode extends AuditUpdateMethodEve
   @Override
   public void writeCertificateGroup(NodeId value) throws UaException {
     try {
-      writeCertificateGroupAsync(value).get();
+      StatusCode statusCode = writeCertificateGroupAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -162,7 +165,10 @@ public class CertificateRequestedAuditEventTypeNode extends AuditUpdateMethodEve
   @Override
   public void writeCertificateType(NodeId value) throws UaException {
     try {
-      writeCertificateTypeAsync(value).get();
+      StatusCode statusCode = writeCertificateTypeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/KeyCredentialServiceTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/KeyCredentialServiceTypeNode.java
@@ -89,7 +89,10 @@ public class KeyCredentialServiceTypeNode extends BaseObjectTypeNode
   @Override
   public void writeResourceUri(String value) throws UaException {
     try {
-      writeResourceUriAsync(value).get();
+      StatusCode statusCode = writeResourceUriAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -159,7 +162,10 @@ public class KeyCredentialServiceTypeNode extends BaseObjectTypeNode
   @Override
   public void writeProfileUris(String[] value) throws UaException {
     try {
-      writeProfileUrisAsync(value).get();
+      StatusCode statusCode = writeProfileUrisAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -229,7 +235,10 @@ public class KeyCredentialServiceTypeNode extends BaseObjectTypeNode
   @Override
   public void writeSecurityPolicyUris(String[] value) throws UaException {
     try {
-      writeSecurityPolicyUrisAsync(value).get();
+      StatusCode statusCode = writeSecurityPolicyUrisAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/package-info.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/package-info.java
@@ -24,20 +24,20 @@
  * <p>Instances of these classes are produced by {@link
  * org.eclipse.milo.opcua.sdk.client.AddressSpace} once the types are registered with the client's
  * {@link org.eclipse.milo.opcua.sdk.client.ObjectTypeManager} by {@link
- * org.eclipse.milo.opcua.sdk.client.gds.ObjectTypeInitializer}. That initializer resolves the GDS
- * namespace index through the client's live {@link
+ * org.eclipse.milo.opcua.sdk.client.gds.model.ObjectTypeInitializer}. That initializer resolves the
+ * GDS namespace index through the client's live {@link
  * org.eclipse.milo.opcua.stack.core.NamespaceTable}, so it can only run against a connected client
  * and is not part of the namespace 0 startup path.
  *
  * <h2>Regeneration</h2>
  *
  * <p>Every class in this package, together with {@link
- * org.eclipse.milo.opcua.sdk.client.gds.ObjectTypeInitializer} and {@link
- * org.eclipse.milo.opcua.sdk.client.gds.VariableTypeInitializer}, is generated and must not be
- * edited by hand. The source is the {@code gds-model-client} module of <a
+ * org.eclipse.milo.opcua.sdk.client.gds.model.ObjectTypeInitializer} and {@link
+ * org.eclipse.milo.opcua.sdk.client.gds.model.VariableTypeInitializer}, is generated and must not
+ * be edited by hand. The source is the {@code gds-model-client} module of <a
  * href="https://github.com/kevinherron/opc-ua-gds-model">opc-ua-gds-model</a> at commit {@code
- * efa229d} (GDS NodeSet2 1.05.07), copied in with {@code com.digitalpetri.opcua.gds.client}
- * rewritten to {@code org.eclipse.milo.opcua.sdk.client.gds} and {@code
+ * 800aeae} (GDS NodeSet2 1.05.07), copied in with {@code com.digitalpetri.opcua.gds.client}
+ * rewritten to {@code org.eclipse.milo.opcua.sdk.client.gds.model} and {@code
  * com.digitalpetri.opcua.gds.client.objects} rewritten to this package. See {@code
  * docs/features/gds-client.md} for the procedure.
  */

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/package-info.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/**
+ * Client type registration for the OPC UA Global Discovery Server information model.
+ *
+ * <p>The initializers register the generated classes in {@link
+ * org.eclipse.milo.opcua.sdk.client.gds.model.objects} after the client knows the GDS namespace
+ * index. Applications normally enter through {@code GdsClient.create} in the separate {@code
+ * milo-sdk-client-gds} module. These model classes belong to {@code milo-sdk-client}; the higher
+ * level module owns the parent {@code org.eclipse.milo.opcua.sdk.client.gds} package.
+ *
+ * <p>Generated initializers follow the package mapping in {@code docs/features/gds-client.md}.
+ */
+package org.eclipse.milo.opcua.sdk.client.gds.model;

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AcknowledgeableConditionTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AcknowledgeableConditionTypeNode.java
@@ -88,7 +88,10 @@ public class AcknowledgeableConditionTypeNode extends ConditionTypeNode
   @Override
   public void writeEnabledState(LocalizedText value) throws UaException {
     try {
-      writeEnabledStateAsync(value).get();
+      StatusCode statusCode = writeEnabledStateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -158,7 +161,10 @@ public class AcknowledgeableConditionTypeNode extends ConditionTypeNode
   @Override
   public void writeAckedState(LocalizedText value) throws UaException {
     try {
-      writeAckedStateAsync(value).get();
+      StatusCode statusCode = writeAckedStateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -228,7 +234,10 @@ public class AcknowledgeableConditionTypeNode extends ConditionTypeNode
   @Override
   public void writeConfirmedState(LocalizedText value) throws UaException {
     try {
-      writeConfirmedStateAsync(value).get();
+      StatusCode statusCode = writeConfirmedStateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AggregateConfigurationTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AggregateConfigurationTypeNode.java
@@ -88,7 +88,10 @@ public class AggregateConfigurationTypeNode extends BaseObjectTypeNode
   @Override
   public void writeTreatUncertainAsBad(Boolean value) throws UaException {
     try {
-      writeTreatUncertainAsBadAsync(value).get();
+      StatusCode statusCode = writeTreatUncertainAsBadAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -161,7 +164,10 @@ public class AggregateConfigurationTypeNode extends BaseObjectTypeNode
   @Override
   public void writePercentDataBad(UByte value) throws UaException {
     try {
-      writePercentDataBadAsync(value).get();
+      StatusCode statusCode = writePercentDataBadAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -231,7 +237,10 @@ public class AggregateConfigurationTypeNode extends BaseObjectTypeNode
   @Override
   public void writePercentDataGood(UByte value) throws UaException {
     try {
-      writePercentDataGoodAsync(value).get();
+      StatusCode statusCode = writePercentDataGoodAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -301,7 +310,10 @@ public class AggregateConfigurationTypeNode extends BaseObjectTypeNode
   @Override
   public void writeUseSlopedExtrapolation(Boolean value) throws UaException {
     try {
-      writeUseSlopedExtrapolationAsync(value).get();
+      StatusCode statusCode = writeUseSlopedExtrapolationAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AlarmConditionTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AlarmConditionTypeNode.java
@@ -92,7 +92,10 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   @Override
   public void writeInputNode(NodeId value) throws UaException {
     try {
-      writeInputNodeAsync(value).get();
+      StatusCode statusCode = writeInputNodeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -162,7 +165,10 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   @Override
   public void writeSuppressedOrShelved(Boolean value) throws UaException {
     try {
-      writeSuppressedOrShelvedAsync(value).get();
+      StatusCode statusCode = writeSuppressedOrShelvedAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -235,7 +241,10 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   @Override
   public void writeMaxTimeShelved(Double value) throws UaException {
     try {
-      writeMaxTimeShelvedAsync(value).get();
+      StatusCode statusCode = writeMaxTimeShelvedAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -305,7 +314,10 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   @Override
   public void writeAudibleEnabled(Boolean value) throws UaException {
     try {
-      writeAudibleEnabledAsync(value).get();
+      StatusCode statusCode = writeAudibleEnabledAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -375,7 +387,10 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   @Override
   public void writeOnDelay(Double value) throws UaException {
     try {
-      writeOnDelayAsync(value).get();
+      StatusCode statusCode = writeOnDelayAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -445,7 +460,10 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   @Override
   public void writeOffDelay(Double value) throws UaException {
     try {
-      writeOffDelayAsync(value).get();
+      StatusCode statusCode = writeOffDelayAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -515,7 +533,10 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   @Override
   public void writeReAlarmTime(Double value) throws UaException {
     try {
-      writeReAlarmTimeAsync(value).get();
+      StatusCode statusCode = writeReAlarmTimeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -585,7 +606,10 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   @Override
   public void writeEnabledState(LocalizedText value) throws UaException {
     try {
-      writeEnabledStateAsync(value).get();
+      StatusCode statusCode = writeEnabledStateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -655,7 +679,10 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   @Override
   public void writeActiveState(LocalizedText value) throws UaException {
     try {
-      writeActiveStateAsync(value).get();
+      StatusCode statusCode = writeActiveStateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -725,7 +752,10 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   @Override
   public void writeSuppressedState(LocalizedText value) throws UaException {
     try {
-      writeSuppressedStateAsync(value).get();
+      StatusCode statusCode = writeSuppressedStateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -795,7 +825,10 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   @Override
   public void writeOutOfServiceState(LocalizedText value) throws UaException {
     try {
-      writeOutOfServiceStateAsync(value).get();
+      StatusCode statusCode = writeOutOfServiceStateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -889,7 +922,10 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   @Override
   public void writeAudibleSound(ByteString value) throws UaException {
     try {
-      writeAudibleSoundAsync(value).get();
+      StatusCode statusCode = writeAudibleSoundAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -959,7 +995,10 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   @Override
   public void writeSilenceState(LocalizedText value) throws UaException {
     try {
-      writeSilenceStateAsync(value).get();
+      StatusCode statusCode = writeSilenceStateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -1029,7 +1068,10 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   @Override
   public void writeFirstInGroupFlag(Boolean value) throws UaException {
     try {
-      writeFirstInGroupFlagAsync(value).get();
+      StatusCode statusCode = writeFirstInGroupFlagAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -1122,7 +1164,10 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   @Override
   public void writeLatchedState(LocalizedText value) throws UaException {
     try {
-      writeLatchedStateAsync(value).get();
+      StatusCode statusCode = writeLatchedStateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -1192,7 +1237,10 @@ public class AlarmConditionTypeNode extends AcknowledgeableConditionTypeNode
   @Override
   public void writeReAlarmRepeatCount(Short value) throws UaException {
     try {
-      writeReAlarmRepeatCountAsync(value).get();
+      StatusCode statusCode = writeReAlarmRepeatCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AlarmMetricsTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AlarmMetricsTypeNode.java
@@ -89,7 +89,10 @@ public class AlarmMetricsTypeNode extends BaseObjectTypeNode implements AlarmMet
   @Override
   public void writeAlarmCount(UInteger value) throws UaException {
     try {
-      writeAlarmCountAsync(value).get();
+      StatusCode statusCode = writeAlarmCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -159,7 +162,10 @@ public class AlarmMetricsTypeNode extends BaseObjectTypeNode implements AlarmMet
   @Override
   public void writeStartTime(DateTime value) throws UaException {
     try {
-      writeStartTimeAsync(value).get();
+      StatusCode statusCode = writeStartTimeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -229,7 +235,10 @@ public class AlarmMetricsTypeNode extends BaseObjectTypeNode implements AlarmMet
   @Override
   public void writeMaximumActiveState(Double value) throws UaException {
     try {
-      writeMaximumActiveStateAsync(value).get();
+      StatusCode statusCode = writeMaximumActiveStateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -302,7 +311,10 @@ public class AlarmMetricsTypeNode extends BaseObjectTypeNode implements AlarmMet
   @Override
   public void writeMaximumUnAck(Double value) throws UaException {
     try {
-      writeMaximumUnAckAsync(value).get();
+      StatusCode statusCode = writeMaximumUnAckAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -372,7 +384,10 @@ public class AlarmMetricsTypeNode extends BaseObjectTypeNode implements AlarmMet
   @Override
   public void writeCurrentAlarmRate(Double value) throws UaException {
     try {
-      writeCurrentAlarmRateAsync(value).get();
+      StatusCode statusCode = writeCurrentAlarmRateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -445,7 +460,10 @@ public class AlarmMetricsTypeNode extends BaseObjectTypeNode implements AlarmMet
   @Override
   public void writeMaximumAlarmRate(Double value) throws UaException {
     try {
-      writeMaximumAlarmRateAsync(value).get();
+      StatusCode statusCode = writeMaximumAlarmRateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -518,7 +536,10 @@ public class AlarmMetricsTypeNode extends BaseObjectTypeNode implements AlarmMet
   @Override
   public void writeMaximumReAlarmCount(UInteger value) throws UaException {
     try {
-      writeMaximumReAlarmCountAsync(value).get();
+      StatusCode statusCode = writeMaximumReAlarmCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -591,7 +612,10 @@ public class AlarmMetricsTypeNode extends BaseObjectTypeNode implements AlarmMet
   @Override
   public void writeAverageAlarmRate(Double value) throws UaException {
     try {
-      writeAverageAlarmRateAsync(value).get();
+      StatusCode statusCode = writeAverageAlarmRateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AliasNameCategoryTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AliasNameCategoryTypeNode.java
@@ -87,7 +87,10 @@ public class AliasNameCategoryTypeNode extends FolderTypeNode implements AliasNa
   @Override
   public void writeLastChange(UInteger value) throws UaException {
     try {
-      writeLastChangeAsync(value).get();
+      StatusCode statusCode = writeLastChangeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AlternativeUnitTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AlternativeUnitTypeNode.java
@@ -90,7 +90,10 @@ public class AlternativeUnitTypeNode extends UnitTypeNode implements Alternative
   @Override
   public void writeLinearConversion(LinearConversionDataType value) throws UaException {
     try {
-      writeLinearConversionAsync(value).get();
+      StatusCode statusCode = writeLinearConversionAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -166,7 +169,10 @@ public class AlternativeUnitTypeNode extends UnitTypeNode implements Alternative
   @Override
   public void writeMathMlConversion(String value) throws UaException {
     try {
-      writeMathMlConversionAsync(value).get();
+      StatusCode statusCode = writeMathMlConversionAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -239,7 +245,10 @@ public class AlternativeUnitTypeNode extends UnitTypeNode implements Alternative
   @Override
   public void writeMathMlInverseConversion(String value) throws UaException {
     try {
-      writeMathMlInverseConversionAsync(value).get();
+      StatusCode statusCode = writeMathMlInverseConversionAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ApplicationConfigurationFileTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ApplicationConfigurationFileTypeNode.java
@@ -91,7 +91,10 @@ public class ApplicationConfigurationFileTypeNode extends ConfigurationFileTypeN
   @Override
   public void writeAvailableNetworks(String[] value) throws UaException {
     try {
-      writeAvailableNetworksAsync(value).get();
+      StatusCode statusCode = writeAvailableNetworksAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -164,7 +167,10 @@ public class ApplicationConfigurationFileTypeNode extends ConfigurationFileTypeN
   @Override
   public void writeAvailablePorts(String value) throws UaException {
     try {
-      writeAvailablePortsAsync(value).get();
+      StatusCode statusCode = writeAvailablePortsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -234,7 +240,10 @@ public class ApplicationConfigurationFileTypeNode extends ConfigurationFileTypeN
   @Override
   public void writeMaxEndpoints(UShort value) throws UaException {
     try {
-      writeMaxEndpointsAsync(value).get();
+      StatusCode statusCode = writeMaxEndpointsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -304,7 +313,10 @@ public class ApplicationConfigurationFileTypeNode extends ConfigurationFileTypeN
   @Override
   public void writeMaxCertificateGroups(UShort value) throws UaException {
     try {
-      writeMaxCertificateGroupsAsync(value).get();
+      StatusCode statusCode = writeMaxCertificateGroupsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -377,7 +389,10 @@ public class ApplicationConfigurationFileTypeNode extends ConfigurationFileTypeN
   @Override
   public void writeSecurityPolicyUris(String[] value) throws UaException {
     try {
-      writeSecurityPolicyUrisAsync(value).get();
+      StatusCode statusCode = writeSecurityPolicyUrisAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -452,7 +467,10 @@ public class ApplicationConfigurationFileTypeNode extends ConfigurationFileTypeN
   @Override
   public void writeUserTokenTypes(UserTokenPolicy[] value) throws UaException {
     try {
-      writeUserTokenTypesAsync(value).get();
+      StatusCode statusCode = writeUserTokenTypesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -524,7 +542,10 @@ public class ApplicationConfigurationFileTypeNode extends ConfigurationFileTypeN
   @Override
   public void writeCertificateTypes(NodeId[] value) throws UaException {
     try {
-      writeCertificateTypesAsync(value).get();
+      StatusCode statusCode = writeCertificateTypesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -597,7 +618,10 @@ public class ApplicationConfigurationFileTypeNode extends ConfigurationFileTypeN
   @Override
   public void writeCertificateGroupPurposes(NodeId[] value) throws UaException {
     try {
-      writeCertificateGroupPurposesAsync(value).get();
+      StatusCode statusCode = writeCertificateGroupPurposesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ApplicationConfigurationTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ApplicationConfigurationTypeNode.java
@@ -89,7 +89,10 @@ public class ApplicationConfigurationTypeNode extends ServerConfigurationTypeNod
   @Override
   public void writeApplicationUri(String value) throws UaException {
     try {
-      writeApplicationUriAsync(value).get();
+      StatusCode statusCode = writeApplicationUriAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -159,7 +162,10 @@ public class ApplicationConfigurationTypeNode extends ServerConfigurationTypeNod
   @Override
   public void writeProductUri(String value) throws UaException {
     try {
-      writeProductUriAsync(value).get();
+      StatusCode statusCode = writeProductUriAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -237,7 +243,10 @@ public class ApplicationConfigurationTypeNode extends ServerConfigurationTypeNod
   @Override
   public void writeApplicationType(ApplicationType value) throws UaException {
     try {
-      writeApplicationTypeAsync(value).get();
+      StatusCode statusCode = writeApplicationTypeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -315,7 +324,10 @@ public class ApplicationConfigurationTypeNode extends ServerConfigurationTypeNod
   @Override
   public void writeEnabled(Boolean value) throws UaException {
     try {
-      writeEnabledAsync(value).get();
+      StatusCode statusCode = writeEnabledAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -385,7 +397,10 @@ public class ApplicationConfigurationTypeNode extends ServerConfigurationTypeNod
   @Override
   public void writeIsNonUaApplication(Boolean value) throws UaException {
     try {
-      writeIsNonUaApplicationAsync(value).get();
+      StatusCode statusCode = writeIsNonUaApplicationAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditActivateSessionEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditActivateSessionEventTypeNode.java
@@ -172,7 +172,10 @@ public class AuditActivateSessionEventTypeNode extends AuditSessionEventTypeNode
   @Override
   public void writeUserIdentityToken(UserIdentityToken value) throws UaException {
     try {
-      writeUserIdentityTokenAsync(value).get();
+      StatusCode statusCode = writeUserIdentityTokenAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -248,7 +251,10 @@ public class AuditActivateSessionEventTypeNode extends AuditSessionEventTypeNode
   @Override
   public void writeSecureChannelId(String value) throws UaException {
     try {
-      writeSecureChannelIdAsync(value).get();
+      StatusCode statusCode = writeSecureChannelIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -318,7 +324,10 @@ public class AuditActivateSessionEventTypeNode extends AuditSessionEventTypeNode
   @Override
   public void writeCurrentRoleIds(NodeId[] value) throws UaException {
     try {
-      writeCurrentRoleIdsAsync(value).get();
+      StatusCode statusCode = writeCurrentRoleIdsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditAddNodesEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditAddNodesEventTypeNode.java
@@ -92,7 +92,10 @@ public class AuditAddNodesEventTypeNode extends AuditNodeManagementEventTypeNode
   @Override
   public void writeNodesToAdd(AddNodesItem[] value) throws UaException {
     try {
-      writeNodesToAddAsync(value).get();
+      StatusCode statusCode = writeNodesToAddAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditAddReferencesEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditAddReferencesEventTypeNode.java
@@ -92,7 +92,10 @@ public class AuditAddReferencesEventTypeNode extends AuditNodeManagementEventTyp
   @Override
   public void writeReferencesToAdd(AddReferencesItem[] value) throws UaException {
     try {
-      writeReferencesToAddAsync(value).get();
+      StatusCode statusCode = writeReferencesToAddAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditCancelEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditCancelEventTypeNode.java
@@ -88,7 +88,10 @@ public class AuditCancelEventTypeNode extends AuditSessionEventTypeNode
   @Override
   public void writeRequestHandle(UInteger value) throws UaException {
     try {
-      writeRequestHandleAsync(value).get();
+      StatusCode statusCode = writeRequestHandleAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditCertificateDataMismatchEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditCertificateDataMismatchEventTypeNode.java
@@ -88,7 +88,10 @@ public class AuditCertificateDataMismatchEventTypeNode extends AuditCertificateE
   @Override
   public void writeInvalidHostname(String value) throws UaException {
     try {
-      writeInvalidHostnameAsync(value).get();
+      StatusCode statusCode = writeInvalidHostnameAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -158,7 +161,10 @@ public class AuditCertificateDataMismatchEventTypeNode extends AuditCertificateE
   @Override
   public void writeInvalidUri(String value) throws UaException {
     try {
-      writeInvalidUriAsync(value).get();
+      StatusCode statusCode = writeInvalidUriAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditCertificateEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditCertificateEventTypeNode.java
@@ -89,7 +89,10 @@ public class AuditCertificateEventTypeNode extends AuditSecurityEventTypeNode
   @Override
   public void writeCertificate(ByteString value) throws UaException {
     try {
-      writeCertificateAsync(value).get();
+      StatusCode statusCode = writeCertificateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditChannelEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditChannelEventTypeNode.java
@@ -88,7 +88,10 @@ public class AuditChannelEventTypeNode extends AuditSecurityEventTypeNode
   @Override
   public void writeSecureChannelId(String value) throws UaException {
     try {
-      writeSecureChannelIdAsync(value).get();
+      StatusCode statusCode = writeSecureChannelIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditClientEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditClientEventTypeNode.java
@@ -87,7 +87,10 @@ public class AuditClientEventTypeNode extends AuditEventTypeNode implements Audi
   @Override
   public void writeServerUri(String value) throws UaException {
     try {
-      writeServerUriAsync(value).get();
+      StatusCode statusCode = writeServerUriAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditClientUpdateMethodResultEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditClientUpdateMethodResultEventTypeNode.java
@@ -88,7 +88,10 @@ public class AuditClientUpdateMethodResultEventTypeNode extends AuditClientEvent
   @Override
   public void writeObjectId(ExpandedNodeId value) throws UaException {
     try {
-      writeObjectIdAsync(value).get();
+      StatusCode statusCode = writeObjectIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -158,7 +161,10 @@ public class AuditClientUpdateMethodResultEventTypeNode extends AuditClientEvent
   @Override
   public void writeMethodId(ExpandedNodeId value) throws UaException {
     try {
-      writeMethodIdAsync(value).get();
+      StatusCode statusCode = writeMethodIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -228,7 +234,10 @@ public class AuditClientUpdateMethodResultEventTypeNode extends AuditClientEvent
   @Override
   public void writeStatusCodeId(StatusCode value) throws UaException {
     try {
-      writeStatusCodeIdAsync(value).get();
+      StatusCode statusCode = writeStatusCodeIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -298,7 +307,10 @@ public class AuditClientUpdateMethodResultEventTypeNode extends AuditClientEvent
   @Override
   public void writeInputArguments(Object[] value) throws UaException {
     try {
-      writeInputArgumentsAsync(value).get();
+      StatusCode statusCode = writeInputArgumentsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -368,7 +380,10 @@ public class AuditClientUpdateMethodResultEventTypeNode extends AuditClientEvent
   @Override
   public void writeOutputArguments(Object[] value) throws UaException {
     try {
-      writeOutputArgumentsAsync(value).get();
+      StatusCode statusCode = writeOutputArgumentsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditConditionAcknowledgeEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditConditionAcknowledgeEventTypeNode.java
@@ -89,7 +89,10 @@ public class AuditConditionAcknowledgeEventTypeNode extends AuditConditionEventT
   @Override
   public void writeConditionEventId(ByteString value) throws UaException {
     try {
-      writeConditionEventIdAsync(value).get();
+      StatusCode statusCode = writeConditionEventIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -162,7 +165,10 @@ public class AuditConditionAcknowledgeEventTypeNode extends AuditConditionEventT
   @Override
   public void writeComment(LocalizedText value) throws UaException {
     try {
-      writeCommentAsync(value).get();
+      StatusCode statusCode = writeCommentAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditConditionCommentEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditConditionCommentEventTypeNode.java
@@ -89,7 +89,10 @@ public class AuditConditionCommentEventTypeNode extends AuditConditionEventTypeN
   @Override
   public void writeConditionEventId(ByteString value) throws UaException {
     try {
-      writeConditionEventIdAsync(value).get();
+      StatusCode statusCode = writeConditionEventIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -162,7 +165,10 @@ public class AuditConditionCommentEventTypeNode extends AuditConditionEventTypeN
   @Override
   public void writeComment(LocalizedText value) throws UaException {
     try {
-      writeCommentAsync(value).get();
+      StatusCode statusCode = writeCommentAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditConditionConfirmEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditConditionConfirmEventTypeNode.java
@@ -89,7 +89,10 @@ public class AuditConditionConfirmEventTypeNode extends AuditConditionEventTypeN
   @Override
   public void writeConditionEventId(ByteString value) throws UaException {
     try {
-      writeConditionEventIdAsync(value).get();
+      StatusCode statusCode = writeConditionEventIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -162,7 +165,10 @@ public class AuditConditionConfirmEventTypeNode extends AuditConditionEventTypeN
   @Override
   public void writeComment(LocalizedText value) throws UaException {
     try {
-      writeCommentAsync(value).get();
+      StatusCode statusCode = writeCommentAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditConditionRespondEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditConditionRespondEventTypeNode.java
@@ -88,7 +88,10 @@ public class AuditConditionRespondEventTypeNode extends AuditConditionEventTypeN
   @Override
   public void writeSelectedResponse(UInteger value) throws UaException {
     try {
-      writeSelectedResponseAsync(value).get();
+      StatusCode statusCode = writeSelectedResponseAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditConditionShelvingEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditConditionShelvingEventTypeNode.java
@@ -88,7 +88,10 @@ public class AuditConditionShelvingEventTypeNode extends AuditConditionEventType
   @Override
   public void writeShelvingTime(Double value) throws UaException {
     try {
-      writeShelvingTimeAsync(value).get();
+      StatusCode statusCode = writeShelvingTimeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditCreateSessionEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditCreateSessionEventTypeNode.java
@@ -89,7 +89,10 @@ public class AuditCreateSessionEventTypeNode extends AuditSessionEventTypeNode
   @Override
   public void writeSecureChannelId(String value) throws UaException {
     try {
-      writeSecureChannelIdAsync(value).get();
+      StatusCode statusCode = writeSecureChannelIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -159,7 +162,10 @@ public class AuditCreateSessionEventTypeNode extends AuditSessionEventTypeNode
   @Override
   public void writeClientCertificate(ByteString value) throws UaException {
     try {
-      writeClientCertificateAsync(value).get();
+      StatusCode statusCode = writeClientCertificateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -232,7 +238,10 @@ public class AuditCreateSessionEventTypeNode extends AuditSessionEventTypeNode
   @Override
   public void writeClientCertificateThumbprint(String value) throws UaException {
     try {
-      writeClientCertificateThumbprintAsync(value).get();
+      StatusCode statusCode = writeClientCertificateThumbprintAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -306,7 +315,10 @@ public class AuditCreateSessionEventTypeNode extends AuditSessionEventTypeNode
   @Override
   public void writeRevisedSessionTimeout(Double value) throws UaException {
     try {
-      writeRevisedSessionTimeoutAsync(value).get();
+      StatusCode statusCode = writeRevisedSessionTimeoutAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditDeleteNodesEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditDeleteNodesEventTypeNode.java
@@ -92,7 +92,10 @@ public class AuditDeleteNodesEventTypeNode extends AuditNodeManagementEventTypeN
   @Override
   public void writeNodesToDelete(DeleteNodesItem[] value) throws UaException {
     try {
-      writeNodesToDeleteAsync(value).get();
+      StatusCode statusCode = writeNodesToDeleteAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditDeleteReferencesEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditDeleteReferencesEventTypeNode.java
@@ -92,7 +92,10 @@ public class AuditDeleteReferencesEventTypeNode extends AuditNodeManagementEvent
   @Override
   public void writeReferencesToDelete(DeleteReferencesItem[] value) throws UaException {
     try {
-      writeReferencesToDeleteAsync(value).get();
+      StatusCode statusCode = writeReferencesToDeleteAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditEventTypeNode.java
@@ -88,7 +88,10 @@ public class AuditEventTypeNode extends BaseEventTypeNode implements AuditEventT
   @Override
   public void writeActionTimeStamp(DateTime value) throws UaException {
     try {
-      writeActionTimeStampAsync(value).get();
+      StatusCode statusCode = writeActionTimeStampAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -158,7 +161,10 @@ public class AuditEventTypeNode extends BaseEventTypeNode implements AuditEventT
   @Override
   public void writeStatus(Boolean value) throws UaException {
     try {
-      writeStatusAsync(value).get();
+      StatusCode statusCode = writeStatusAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -228,7 +234,10 @@ public class AuditEventTypeNode extends BaseEventTypeNode implements AuditEventT
   @Override
   public void writeServerId(String value) throws UaException {
     try {
-      writeServerIdAsync(value).get();
+      StatusCode statusCode = writeServerIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -298,7 +307,10 @@ public class AuditEventTypeNode extends BaseEventTypeNode implements AuditEventT
   @Override
   public void writeClientAuditEntryId(String value) throws UaException {
     try {
-      writeClientAuditEntryIdAsync(value).get();
+      StatusCode statusCode = writeClientAuditEntryIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -371,7 +383,10 @@ public class AuditEventTypeNode extends BaseEventTypeNode implements AuditEventT
   @Override
   public void writeClientUserId(String value) throws UaException {
     try {
-      writeClientUserIdAsync(value).get();
+      StatusCode statusCode = writeClientUserIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -441,7 +456,10 @@ public class AuditEventTypeNode extends BaseEventTypeNode implements AuditEventT
   @Override
   public void writeClientApplicationUri(String value) throws UaException {
     try {
-      writeClientApplicationUriAsync(value).get();
+      StatusCode statusCode = writeClientApplicationUriAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditHistoryAnnotationUpdateEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditHistoryAnnotationUpdateEventTypeNode.java
@@ -99,7 +99,10 @@ public class AuditHistoryAnnotationUpdateEventTypeNode extends AuditHistoryUpdat
   @Override
   public void writePerformInsertReplace(PerformUpdateType value) throws UaException {
     try {
-      writePerformInsertReplaceAsync(value).get();
+      StatusCode statusCode = writePerformInsertReplaceAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -183,7 +186,10 @@ public class AuditHistoryAnnotationUpdateEventTypeNode extends AuditHistoryUpdat
   @Override
   public void writeNewValues(Annotation[] value) throws UaException {
     try {
-      writeNewValuesAsync(value).get();
+      StatusCode statusCode = writeNewValuesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -257,7 +263,10 @@ public class AuditHistoryAnnotationUpdateEventTypeNode extends AuditHistoryUpdat
   @Override
   public void writeOldValues(Annotation[] value) throws UaException {
     try {
-      writeOldValuesAsync(value).get();
+      StatusCode statusCode = writeOldValuesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditHistoryAtTimeDeleteEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditHistoryAtTimeDeleteEventTypeNode.java
@@ -89,7 +89,10 @@ public class AuditHistoryAtTimeDeleteEventTypeNode extends AuditHistoryDeleteEve
   @Override
   public void writeReqTimes(DateTime[] value) throws UaException {
     try {
-      writeReqTimesAsync(value).get();
+      StatusCode statusCode = writeReqTimesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -159,7 +162,10 @@ public class AuditHistoryAtTimeDeleteEventTypeNode extends AuditHistoryDeleteEve
   @Override
   public void writeOldValues(DataValue[] value) throws UaException {
     try {
-      writeOldValuesAsync(value).get();
+      StatusCode statusCode = writeOldValuesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditHistoryBulkInsertEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditHistoryBulkInsertEventTypeNode.java
@@ -89,7 +89,10 @@ public class AuditHistoryBulkInsertEventTypeNode extends AuditEventTypeNode
   @Override
   public void writeUpdatedNode(NodeId value) throws UaException {
     try {
-      writeUpdatedNodeAsync(value).get();
+      StatusCode statusCode = writeUpdatedNodeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -159,7 +162,10 @@ public class AuditHistoryBulkInsertEventTypeNode extends AuditEventTypeNode
   @Override
   public void writeStartTime(DateTime value) throws UaException {
     try {
-      writeStartTimeAsync(value).get();
+      StatusCode statusCode = writeStartTimeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -229,7 +235,10 @@ public class AuditHistoryBulkInsertEventTypeNode extends AuditEventTypeNode
   @Override
   public void writeEndTime(DateTime value) throws UaException {
     try {
-      writeEndTimeAsync(value).get();
+      StatusCode statusCode = writeEndTimeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditHistoryDeleteEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditHistoryDeleteEventTypeNode.java
@@ -88,7 +88,10 @@ public class AuditHistoryDeleteEventTypeNode extends AuditHistoryUpdateEventType
   @Override
   public void writeUpdatedNode(NodeId value) throws UaException {
     try {
-      writeUpdatedNodeAsync(value).get();
+      StatusCode statusCode = writeUpdatedNodeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditHistoryEventDeleteEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditHistoryEventDeleteEventTypeNode.java
@@ -91,7 +91,10 @@ public class AuditHistoryEventDeleteEventTypeNode extends AuditHistoryDeleteEven
   @Override
   public void writeEventIds(ByteString[] value) throws UaException {
     try {
-      writeEventIdsAsync(value).get();
+      StatusCode statusCode = writeEventIdsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -162,7 +165,10 @@ public class AuditHistoryEventDeleteEventTypeNode extends AuditHistoryDeleteEven
   @Override
   public void writeOldValues(HistoryEventFieldList value) throws UaException {
     try {
-      writeOldValuesAsync(value).get();
+      StatusCode statusCode = writeOldValuesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditHistoryEventUpdateEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditHistoryEventUpdateEventTypeNode.java
@@ -92,7 +92,10 @@ public class AuditHistoryEventUpdateEventTypeNode extends AuditHistoryUpdateEven
   @Override
   public void writeUpdatedNode(NodeId value) throws UaException {
     try {
-      writeUpdatedNodeAsync(value).get();
+      StatusCode statusCode = writeUpdatedNodeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -170,7 +173,10 @@ public class AuditHistoryEventUpdateEventTypeNode extends AuditHistoryUpdateEven
   @Override
   public void writePerformInsertReplace(PerformUpdateType value) throws UaException {
     try {
-      writePerformInsertReplaceAsync(value).get();
+      StatusCode statusCode = writePerformInsertReplaceAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -253,7 +259,10 @@ public class AuditHistoryEventUpdateEventTypeNode extends AuditHistoryUpdateEven
   @Override
   public void writeFilter(EventFilter value) throws UaException {
     try {
-      writeFilterAsync(value).get();
+      StatusCode statusCode = writeFilterAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -326,7 +335,10 @@ public class AuditHistoryEventUpdateEventTypeNode extends AuditHistoryUpdateEven
   @Override
   public void writeNewValues(HistoryEventFieldList[] value) throws UaException {
     try {
-      writeNewValuesAsync(value).get();
+      StatusCode statusCode = writeNewValuesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -400,7 +412,10 @@ public class AuditHistoryEventUpdateEventTypeNode extends AuditHistoryUpdateEven
   @Override
   public void writeOldValues(HistoryEventFieldList[] value) throws UaException {
     try {
-      writeOldValuesAsync(value).get();
+      StatusCode statusCode = writeOldValuesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditHistoryRawModifyDeleteEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditHistoryRawModifyDeleteEventTypeNode.java
@@ -89,7 +89,10 @@ public class AuditHistoryRawModifyDeleteEventTypeNode extends AuditHistoryDelete
   @Override
   public void writeIsDeleteModified(Boolean value) throws UaException {
     try {
-      writeIsDeleteModifiedAsync(value).get();
+      StatusCode statusCode = writeIsDeleteModifiedAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -162,7 +165,10 @@ public class AuditHistoryRawModifyDeleteEventTypeNode extends AuditHistoryDelete
   @Override
   public void writeStartTime(DateTime value) throws UaException {
     try {
-      writeStartTimeAsync(value).get();
+      StatusCode statusCode = writeStartTimeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -232,7 +238,10 @@ public class AuditHistoryRawModifyDeleteEventTypeNode extends AuditHistoryDelete
   @Override
   public void writeEndTime(DateTime value) throws UaException {
     try {
-      writeEndTimeAsync(value).get();
+      StatusCode statusCode = writeEndTimeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -302,7 +311,10 @@ public class AuditHistoryRawModifyDeleteEventTypeNode extends AuditHistoryDelete
   @Override
   public void writeOldValues(DataValue[] value) throws UaException {
     try {
-      writeOldValuesAsync(value).get();
+      StatusCode statusCode = writeOldValuesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditHistoryUpdateEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditHistoryUpdateEventTypeNode.java
@@ -88,7 +88,10 @@ public class AuditHistoryUpdateEventTypeNode extends AuditUpdateEventTypeNode
   @Override
   public void writeParameterDataTypeId(NodeId value) throws UaException {
     try {
-      writeParameterDataTypeIdAsync(value).get();
+      StatusCode statusCode = writeParameterDataTypeIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditHistoryValueUpdateEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditHistoryValueUpdateEventTypeNode.java
@@ -89,7 +89,10 @@ public class AuditHistoryValueUpdateEventTypeNode extends AuditHistoryUpdateEven
   @Override
   public void writeUpdatedNode(NodeId value) throws UaException {
     try {
-      writeUpdatedNodeAsync(value).get();
+      StatusCode statusCode = writeUpdatedNodeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -167,7 +170,10 @@ public class AuditHistoryValueUpdateEventTypeNode extends AuditHistoryUpdateEven
   @Override
   public void writePerformInsertReplace(PerformUpdateType value) throws UaException {
     try {
-      writePerformInsertReplaceAsync(value).get();
+      StatusCode statusCode = writePerformInsertReplaceAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -249,7 +255,10 @@ public class AuditHistoryValueUpdateEventTypeNode extends AuditHistoryUpdateEven
   @Override
   public void writeNewValues(DataValue[] value) throws UaException {
     try {
-      writeNewValuesAsync(value).get();
+      StatusCode statusCode = writeNewValuesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -319,7 +328,10 @@ public class AuditHistoryValueUpdateEventTypeNode extends AuditHistoryUpdateEven
   @Override
   public void writeOldValues(DataValue[] value) throws UaException {
     try {
-      writeOldValuesAsync(value).get();
+      StatusCode statusCode = writeOldValuesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditOpenSecureChannelEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditOpenSecureChannelEventTypeNode.java
@@ -91,7 +91,10 @@ public class AuditOpenSecureChannelEventTypeNode extends AuditChannelEventTypeNo
   @Override
   public void writeClientCertificate(ByteString value) throws UaException {
     try {
-      writeClientCertificateAsync(value).get();
+      StatusCode statusCode = writeClientCertificateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -164,7 +167,10 @@ public class AuditOpenSecureChannelEventTypeNode extends AuditChannelEventTypeNo
   @Override
   public void writeClientCertificateThumbprint(String value) throws UaException {
     try {
-      writeClientCertificateThumbprintAsync(value).get();
+      StatusCode statusCode = writeClientCertificateThumbprintAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -246,7 +252,10 @@ public class AuditOpenSecureChannelEventTypeNode extends AuditChannelEventTypeNo
   @Override
   public void writeRequestType(SecurityTokenRequestType value) throws UaException {
     try {
-      writeRequestTypeAsync(value).get();
+      StatusCode statusCode = writeRequestTypeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -324,7 +333,10 @@ public class AuditOpenSecureChannelEventTypeNode extends AuditChannelEventTypeNo
   @Override
   public void writeSecurityPolicyUri(String value) throws UaException {
     try {
-      writeSecurityPolicyUriAsync(value).get();
+      StatusCode statusCode = writeSecurityPolicyUriAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -405,7 +417,10 @@ public class AuditOpenSecureChannelEventTypeNode extends AuditChannelEventTypeNo
   @Override
   public void writeSecurityMode(MessageSecurityMode value) throws UaException {
     try {
-      writeSecurityModeAsync(value).get();
+      StatusCode statusCode = writeSecurityModeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -483,7 +498,10 @@ public class AuditOpenSecureChannelEventTypeNode extends AuditChannelEventTypeNo
   @Override
   public void writeRequestedLifetime(Double value) throws UaException {
     try {
-      writeRequestedLifetimeAsync(value).get();
+      StatusCode statusCode = writeRequestedLifetimeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -556,7 +574,10 @@ public class AuditOpenSecureChannelEventTypeNode extends AuditChannelEventTypeNo
   @Override
   public void writeCertificateErrorEventId(ByteString value) throws UaException {
     try {
-      writeCertificateErrorEventIdAsync(value).get();
+      StatusCode statusCode = writeCertificateErrorEventIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditProgramTransitionEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditProgramTransitionEventTypeNode.java
@@ -88,7 +88,10 @@ public class AuditProgramTransitionEventTypeNode extends AuditUpdateStateEventTy
   @Override
   public void writeTransitionNumber(UInteger value) throws UaException {
     try {
-      writeTransitionNumberAsync(value).get();
+      StatusCode statusCode = writeTransitionNumberAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditSecurityEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditSecurityEventTypeNode.java
@@ -88,7 +88,10 @@ public class AuditSecurityEventTypeNode extends AuditEventTypeNode
   @Override
   public void writeStatusCodeId(StatusCode value) throws UaException {
     try {
-      writeStatusCodeIdAsync(value).get();
+      StatusCode statusCode = writeStatusCodeIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditSessionEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditSessionEventTypeNode.java
@@ -88,7 +88,10 @@ public class AuditSessionEventTypeNode extends AuditSecurityEventTypeNode
   @Override
   public void writeSessionId(NodeId value) throws UaException {
     try {
-      writeSessionIdAsync(value).get();
+      StatusCode statusCode = writeSessionIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditUpdateMethodEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditUpdateMethodEventTypeNode.java
@@ -88,7 +88,10 @@ public class AuditUpdateMethodEventTypeNode extends AuditEventTypeNode
   @Override
   public void writeMethodId(NodeId value) throws UaException {
     try {
-      writeMethodIdAsync(value).get();
+      StatusCode statusCode = writeMethodIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -158,7 +161,10 @@ public class AuditUpdateMethodEventTypeNode extends AuditEventTypeNode
   @Override
   public void writeStatusCodeId(StatusCode value) throws UaException {
     try {
-      writeStatusCodeIdAsync(value).get();
+      StatusCode statusCode = writeStatusCodeIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -228,7 +234,10 @@ public class AuditUpdateMethodEventTypeNode extends AuditEventTypeNode
   @Override
   public void writeInputArguments(Object[] value) throws UaException {
     try {
-      writeInputArgumentsAsync(value).get();
+      StatusCode statusCode = writeInputArgumentsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -298,7 +307,10 @@ public class AuditUpdateMethodEventTypeNode extends AuditEventTypeNode
   @Override
   public void writeOutputArguments(Object[] value) throws UaException {
     try {
-      writeOutputArgumentsAsync(value).get();
+      StatusCode statusCode = writeOutputArgumentsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditUpdateStateEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditUpdateStateEventTypeNode.java
@@ -88,7 +88,10 @@ public class AuditUpdateStateEventTypeNode extends AuditUpdateMethodEventTypeNod
   @Override
   public void writeOldStateId(Object value) throws UaException {
     try {
-      writeOldStateIdAsync(value).get();
+      StatusCode statusCode = writeOldStateIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -158,7 +161,10 @@ public class AuditUpdateStateEventTypeNode extends AuditUpdateMethodEventTypeNod
   @Override
   public void writeNewStateId(Object value) throws UaException {
     try {
-      writeNewStateIdAsync(value).get();
+      StatusCode statusCode = writeNewStateIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditUrlMismatchEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditUrlMismatchEventTypeNode.java
@@ -88,7 +88,10 @@ public class AuditUrlMismatchEventTypeNode extends AuditCreateSessionEventTypeNo
   @Override
   public void writeEndpointUrl(String value) throws UaException {
     try {
-      writeEndpointUrlAsync(value).get();
+      StatusCode statusCode = writeEndpointUrlAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditWriteUpdateEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuditWriteUpdateEventTypeNode.java
@@ -88,7 +88,10 @@ public class AuditWriteUpdateEventTypeNode extends AuditUpdateEventTypeNode
   @Override
   public void writeAttributeId(UInteger value) throws UaException {
     try {
-      writeAttributeIdAsync(value).get();
+      StatusCode statusCode = writeAttributeIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -158,7 +161,10 @@ public class AuditWriteUpdateEventTypeNode extends AuditUpdateEventTypeNode
   @Override
   public void writeIndexRange(String value) throws UaException {
     try {
-      writeIndexRangeAsync(value).get();
+      StatusCode statusCode = writeIndexRangeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -228,7 +234,10 @@ public class AuditWriteUpdateEventTypeNode extends AuditUpdateEventTypeNode
   @Override
   public void writeOldValue(Object value) throws UaException {
     try {
-      writeOldValueAsync(value).get();
+      StatusCode statusCode = writeOldValueAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -298,7 +307,10 @@ public class AuditWriteUpdateEventTypeNode extends AuditUpdateEventTypeNode
   @Override
   public void writeNewValue(Object value) throws UaException {
     try {
-      writeNewValueAsync(value).get();
+      StatusCode statusCode = writeNewValueAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuthorizationServiceConfigurationTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/AuthorizationServiceConfigurationTypeNode.java
@@ -89,7 +89,10 @@ public class AuthorizationServiceConfigurationTypeNode extends BaseObjectTypeNod
   @Override
   public void writeServiceUri(String value) throws UaException {
     try {
-      writeServiceUriAsync(value).get();
+      StatusCode statusCode = writeServiceUriAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -159,7 +162,10 @@ public class AuthorizationServiceConfigurationTypeNode extends BaseObjectTypeNod
   @Override
   public void writeServiceCertificate(ByteString value) throws UaException {
     try {
-      writeServiceCertificateAsync(value).get();
+      StatusCode statusCode = writeServiceCertificateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -232,7 +238,10 @@ public class AuthorizationServiceConfigurationTypeNode extends BaseObjectTypeNod
   @Override
   public void writeIssuerEndpointUrl(String value) throws UaException {
     try {
-      writeIssuerEndpointUrlAsync(value).get();
+      StatusCode statusCode = writeIssuerEndpointUrlAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/BaseEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/BaseEventTypeNode.java
@@ -92,7 +92,10 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   @Override
   public void writeEventId(ByteString value) throws UaException {
     try {
-      writeEventIdAsync(value).get();
+      StatusCode statusCode = writeEventIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -162,7 +165,10 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   @Override
   public void writeEventType(NodeId value) throws UaException {
     try {
-      writeEventTypeAsync(value).get();
+      StatusCode statusCode = writeEventTypeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -232,7 +238,10 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   @Override
   public void writeSourceNode(NodeId value) throws UaException {
     try {
-      writeSourceNodeAsync(value).get();
+      StatusCode statusCode = writeSourceNodeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -302,7 +311,10 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   @Override
   public void writeSourceName(String value) throws UaException {
     try {
-      writeSourceNameAsync(value).get();
+      StatusCode statusCode = writeSourceNameAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -372,7 +384,10 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   @Override
   public void writeTime(DateTime value) throws UaException {
     try {
-      writeTimeAsync(value).get();
+      StatusCode statusCode = writeTimeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -442,7 +457,10 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   @Override
   public void writeReceiveTime(DateTime value) throws UaException {
     try {
-      writeReceiveTimeAsync(value).get();
+      StatusCode statusCode = writeReceiveTimeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -513,7 +531,10 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   @Override
   public void writeLocalTime(TimeZoneDataType value) throws UaException {
     try {
-      writeLocalTimeAsync(value).get();
+      StatusCode statusCode = writeLocalTimeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -584,7 +605,10 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   @Override
   public void writeMessage(LocalizedText value) throws UaException {
     try {
-      writeMessageAsync(value).get();
+      StatusCode statusCode = writeMessageAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -654,7 +678,10 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   @Override
   public void writeSeverity(UShort value) throws UaException {
     try {
-      writeSeverityAsync(value).get();
+      StatusCode statusCode = writeSeverityAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -724,7 +751,10 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   @Override
   public void writeConditionClassId(NodeId value) throws UaException {
     try {
-      writeConditionClassIdAsync(value).get();
+      StatusCode statusCode = writeConditionClassIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -797,7 +827,10 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   @Override
   public void writeConditionClassName(LocalizedText value) throws UaException {
     try {
-      writeConditionClassNameAsync(value).get();
+      StatusCode statusCode = writeConditionClassNameAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -871,7 +904,10 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   @Override
   public void writeConditionSubClassId(NodeId[] value) throws UaException {
     try {
-      writeConditionSubClassIdAsync(value).get();
+      StatusCode statusCode = writeConditionSubClassIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -944,7 +980,10 @@ public class BaseEventTypeNode extends BaseObjectTypeNode implements BaseEventTy
   @Override
   public void writeConditionSubClassName(LocalizedText[] value) throws UaException {
     try {
-      writeConditionSubClassNameAsync(value).get();
+      StatusCode statusCode = writeConditionSubClassNameAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/BaseLogEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/BaseLogEventTypeNode.java
@@ -89,7 +89,10 @@ public class BaseLogEventTypeNode extends BaseEventTypeNode implements BaseLogEv
   @Override
   public void writeConditionClassId(NodeId value) throws UaException {
     try {
-      writeConditionClassIdAsync(value).get();
+      StatusCode statusCode = writeConditionClassIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -162,7 +165,10 @@ public class BaseLogEventTypeNode extends BaseEventTypeNode implements BaseLogEv
   @Override
   public void writeConditionClassName(LocalizedText value) throws UaException {
     try {
-      writeConditionClassNameAsync(value).get();
+      StatusCode statusCode = writeConditionClassNameAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -236,7 +242,10 @@ public class BaseLogEventTypeNode extends BaseEventTypeNode implements BaseLogEv
   @Override
   public void writeErrorCode(StatusCode value) throws UaException {
     try {
-      writeErrorCodeAsync(value).get();
+      StatusCode statusCode = writeErrorCodeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -306,7 +315,10 @@ public class BaseLogEventTypeNode extends BaseEventTypeNode implements BaseLogEv
   @Override
   public void writeErrorCodeNode(NodeId value) throws UaException {
     try {
-      writeErrorCodeNodeAsync(value).get();
+      StatusCode statusCode = writeErrorCodeNodeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -377,7 +389,10 @@ public class BaseLogEventTypeNode extends BaseEventTypeNode implements BaseLogEv
   @Override
   public void writeTraceContext(TraceContextDataType value) throws UaException {
     try {
-      writeTraceContextAsync(value).get();
+      StatusCode statusCode = writeTraceContextAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/BrokerConnectionTransportTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/BrokerConnectionTransportTypeNode.java
@@ -88,7 +88,10 @@ public class BrokerConnectionTransportTypeNode extends ConnectionTransportTypeNo
   @Override
   public void writeResourceUri(String value) throws UaException {
     try {
-      writeResourceUriAsync(value).get();
+      StatusCode statusCode = writeResourceUriAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -158,7 +161,10 @@ public class BrokerConnectionTransportTypeNode extends ConnectionTransportTypeNo
   @Override
   public void writeAuthenticationProfileUri(String value) throws UaException {
     try {
-      writeAuthenticationProfileUriAsync(value).get();
+      StatusCode statusCode = writeAuthenticationProfileUriAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/BrokerDataSetReaderTransportTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/BrokerDataSetReaderTransportTypeNode.java
@@ -89,7 +89,10 @@ public class BrokerDataSetReaderTransportTypeNode extends DataSetReaderTransport
   @Override
   public void writeQueueName(String value) throws UaException {
     try {
-      writeQueueNameAsync(value).get();
+      StatusCode statusCode = writeQueueNameAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -159,7 +162,10 @@ public class BrokerDataSetReaderTransportTypeNode extends DataSetReaderTransport
   @Override
   public void writeResourceUri(String value) throws UaException {
     try {
-      writeResourceUriAsync(value).get();
+      StatusCode statusCode = writeResourceUriAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -229,7 +235,10 @@ public class BrokerDataSetReaderTransportTypeNode extends DataSetReaderTransport
   @Override
   public void writeAuthenticationProfileUri(String value) throws UaException {
     try {
-      writeAuthenticationProfileUriAsync(value).get();
+      StatusCode statusCode = writeAuthenticationProfileUriAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -396,7 +405,10 @@ public class BrokerDataSetReaderTransportTypeNode extends DataSetReaderTransport
   @Override
   public void writeMetaDataQueueName(String value) throws UaException {
     try {
-      writeMetaDataQueueNameAsync(value).get();
+      StatusCode statusCode = writeMetaDataQueueNameAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/BrokerDataSetWriterTransportTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/BrokerDataSetWriterTransportTypeNode.java
@@ -89,7 +89,10 @@ public class BrokerDataSetWriterTransportTypeNode extends DataSetWriterTransport
   @Override
   public void writeQueueName(String value) throws UaException {
     try {
-      writeQueueNameAsync(value).get();
+      StatusCode statusCode = writeQueueNameAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -159,7 +162,10 @@ public class BrokerDataSetWriterTransportTypeNode extends DataSetWriterTransport
   @Override
   public void writeMetaDataQueueName(String value) throws UaException {
     try {
-      writeMetaDataQueueNameAsync(value).get();
+      StatusCode statusCode = writeMetaDataQueueNameAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -232,7 +238,10 @@ public class BrokerDataSetWriterTransportTypeNode extends DataSetWriterTransport
   @Override
   public void writeResourceUri(String value) throws UaException {
     try {
-      writeResourceUriAsync(value).get();
+      StatusCode statusCode = writeResourceUriAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -302,7 +311,10 @@ public class BrokerDataSetWriterTransportTypeNode extends DataSetWriterTransport
   @Override
   public void writeAuthenticationProfileUri(String value) throws UaException {
     try {
-      writeAuthenticationProfileUriAsync(value).get();
+      StatusCode statusCode = writeAuthenticationProfileUriAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -469,7 +481,10 @@ public class BrokerDataSetWriterTransportTypeNode extends DataSetWriterTransport
   @Override
   public void writeMetaDataUpdateTime(Double value) throws UaException {
     try {
-      writeMetaDataUpdateTimeAsync(value).get();
+      StatusCode statusCode = writeMetaDataUpdateTimeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/BrokerWriterGroupTransportTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/BrokerWriterGroupTransportTypeNode.java
@@ -89,7 +89,10 @@ public class BrokerWriterGroupTransportTypeNode extends WriterGroupTransportType
   @Override
   public void writeQueueName(String value) throws UaException {
     try {
-      writeQueueNameAsync(value).get();
+      StatusCode statusCode = writeQueueNameAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -159,7 +162,10 @@ public class BrokerWriterGroupTransportTypeNode extends WriterGroupTransportType
   @Override
   public void writeResourceUri(String value) throws UaException {
     try {
-      writeResourceUriAsync(value).get();
+      StatusCode statusCode = writeResourceUriAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -229,7 +235,10 @@ public class BrokerWriterGroupTransportTypeNode extends WriterGroupTransportType
   @Override
   public void writeAuthenticationProfileUri(String value) throws UaException {
     try {
-      writeAuthenticationProfileUriAsync(value).get();
+      StatusCode statusCode = writeAuthenticationProfileUriAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/CertificateExpirationAlarmTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/CertificateExpirationAlarmTypeNode.java
@@ -90,7 +90,10 @@ public class CertificateExpirationAlarmTypeNode extends SystemOffNormalAlarmType
   @Override
   public void writeExpirationDate(DateTime value) throws UaException {
     try {
-      writeExpirationDateAsync(value).get();
+      StatusCode statusCode = writeExpirationDateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -160,7 +163,10 @@ public class CertificateExpirationAlarmTypeNode extends SystemOffNormalAlarmType
   @Override
   public void writeExpirationLimit(Double value) throws UaException {
     try {
-      writeExpirationLimitAsync(value).get();
+      StatusCode statusCode = writeExpirationLimitAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -230,7 +236,10 @@ public class CertificateExpirationAlarmTypeNode extends SystemOffNormalAlarmType
   @Override
   public void writeCertificateType(NodeId value) throws UaException {
     try {
-      writeCertificateTypeAsync(value).get();
+      StatusCode statusCode = writeCertificateTypeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -300,7 +309,10 @@ public class CertificateExpirationAlarmTypeNode extends SystemOffNormalAlarmType
   @Override
   public void writeCertificate(ByteString value) throws UaException {
     try {
-      writeCertificateAsync(value).get();
+      StatusCode statusCode = writeCertificateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/CertificateGroupTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/CertificateGroupTypeNode.java
@@ -87,7 +87,10 @@ public class CertificateGroupTypeNode extends BaseObjectTypeNode implements Cert
   @Override
   public void writeCertificateTypes(NodeId[] value) throws UaException {
     try {
-      writeCertificateTypesAsync(value).get();
+      StatusCode statusCode = writeCertificateTypesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -160,7 +163,10 @@ public class CertificateGroupTypeNode extends BaseObjectTypeNode implements Cert
   @Override
   public void writePurpose(NodeId value) throws UaException {
     try {
-      writePurposeAsync(value).get();
+      StatusCode statusCode = writePurposeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/CertificateUpdatedAuditEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/CertificateUpdatedAuditEventTypeNode.java
@@ -88,7 +88,10 @@ public class CertificateUpdatedAuditEventTypeNode extends AuditUpdateMethodEvent
   @Override
   public void writeCertificateGroup(NodeId value) throws UaException {
     try {
-      writeCertificateGroupAsync(value).get();
+      StatusCode statusCode = writeCertificateGroupAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -161,7 +164,10 @@ public class CertificateUpdatedAuditEventTypeNode extends AuditUpdateMethodEvent
   @Override
   public void writeCertificateType(NodeId value) throws UaException {
     try {
-      writeCertificateTypeAsync(value).get();
+      StatusCode statusCode = writeCertificateTypeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ConditionTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ConditionTypeNode.java
@@ -90,7 +90,10 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   @Override
   public void writeConditionClassId(NodeId value) throws UaException {
     try {
-      writeConditionClassIdAsync(value).get();
+      StatusCode statusCode = writeConditionClassIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -163,7 +166,10 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   @Override
   public void writeConditionClassName(LocalizedText value) throws UaException {
     try {
-      writeConditionClassNameAsync(value).get();
+      StatusCode statusCode = writeConditionClassNameAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -237,7 +243,10 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   @Override
   public void writeConditionSubClassId(NodeId[] value) throws UaException {
     try {
-      writeConditionSubClassIdAsync(value).get();
+      StatusCode statusCode = writeConditionSubClassIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -310,7 +319,10 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   @Override
   public void writeConditionSubClassName(LocalizedText[] value) throws UaException {
     try {
-      writeConditionSubClassNameAsync(value).get();
+      StatusCode statusCode = writeConditionSubClassNameAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -384,7 +396,10 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   @Override
   public void writeConditionName(String value) throws UaException {
     try {
-      writeConditionNameAsync(value).get();
+      StatusCode statusCode = writeConditionNameAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -454,7 +469,10 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   @Override
   public void writeBranchId(NodeId value) throws UaException {
     try {
-      writeBranchIdAsync(value).get();
+      StatusCode statusCode = writeBranchIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -524,7 +542,10 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   @Override
   public void writeRetain(Boolean value) throws UaException {
     try {
-      writeRetainAsync(value).get();
+      StatusCode statusCode = writeRetainAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -594,7 +615,10 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   @Override
   public void writeSupportsFilteredRetain(Boolean value) throws UaException {
     try {
-      writeSupportsFilteredRetainAsync(value).get();
+      StatusCode statusCode = writeSupportsFilteredRetainAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -668,7 +692,10 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   @Override
   public void writeClientUserId(String value) throws UaException {
     try {
-      writeClientUserIdAsync(value).get();
+      StatusCode statusCode = writeClientUserIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -738,7 +765,10 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   @Override
   public void writeEnabledState(LocalizedText value) throws UaException {
     try {
-      writeEnabledStateAsync(value).get();
+      StatusCode statusCode = writeEnabledStateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -808,7 +838,10 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   @Override
   public void writeQuality(StatusCode value) throws UaException {
     try {
-      writeQualityAsync(value).get();
+      StatusCode statusCode = writeQualityAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -878,7 +911,10 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   @Override
   public void writeLastSeverity(UShort value) throws UaException {
     try {
-      writeLastSeverityAsync(value).get();
+      StatusCode statusCode = writeLastSeverityAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -948,7 +984,10 @@ public class ConditionTypeNode extends BaseEventTypeNode implements ConditionTyp
   @Override
   public void writeComment(LocalizedText value) throws UaException {
     try {
-      writeCommentAsync(value).get();
+      StatusCode statusCode = writeCommentAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ConfigurationFileTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ConfigurationFileTypeNode.java
@@ -88,7 +88,10 @@ public class ConfigurationFileTypeNode extends FileTypeNode implements Configura
   @Override
   public void writeLastUpdateTime(DateTime value) throws UaException {
     try {
-      writeLastUpdateTimeAsync(value).get();
+      StatusCode statusCode = writeLastUpdateTimeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -158,7 +161,10 @@ public class ConfigurationFileTypeNode extends FileTypeNode implements Configura
   @Override
   public void writeCurrentVersion(UInteger value) throws UaException {
     try {
-      writeCurrentVersionAsync(value).get();
+      StatusCode statusCode = writeCurrentVersionAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -228,7 +234,10 @@ public class ConfigurationFileTypeNode extends FileTypeNode implements Configura
   @Override
   public void writeActivityTimeout(Double value) throws UaException {
     try {
-      writeActivityTimeoutAsync(value).get();
+      StatusCode statusCode = writeActivityTimeoutAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -298,7 +307,10 @@ public class ConfigurationFileTypeNode extends FileTypeNode implements Configura
   @Override
   public void writeSupportedDataType(NodeId value) throws UaException {
     try {
-      writeSupportedDataTypeAsync(value).get();
+      StatusCode statusCode = writeSupportedDataTypeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ConfigurationUpdatedAuditEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ConfigurationUpdatedAuditEventTypeNode.java
@@ -88,7 +88,10 @@ public class ConfigurationUpdatedAuditEventTypeNode extends AuditEventTypeNode
   @Override
   public void writeOldVersion(UInteger value) throws UaException {
     try {
-      writeOldVersionAsync(value).get();
+      StatusCode statusCode = writeOldVersionAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -158,7 +161,10 @@ public class ConfigurationUpdatedAuditEventTypeNode extends AuditEventTypeNode
   @Override
   public void writeNewVersion(UInteger value) throws UaException {
     try {
-      writeNewVersionAsync(value).get();
+      StatusCode statusCode = writeNewVersionAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/DataSetReaderTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/DataSetReaderTypeNode.java
@@ -94,7 +94,10 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   @Override
   public void writePublisherId(Object value) throws UaException {
     try {
-      writePublisherIdAsync(value).get();
+      StatusCode statusCode = writePublisherIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -164,7 +167,10 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   @Override
   public void writeWriterGroupId(UShort value) throws UaException {
     try {
-      writeWriterGroupIdAsync(value).get();
+      StatusCode statusCode = writeWriterGroupIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -234,7 +240,10 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   @Override
   public void writeDataSetWriterId(UShort value) throws UaException {
     try {
-      writeDataSetWriterIdAsync(value).get();
+      StatusCode statusCode = writeDataSetWriterIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -305,7 +314,10 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   @Override
   public void writeDataSetMetaData(DataSetMetaDataType value) throws UaException {
     try {
-      writeDataSetMetaDataAsync(value).get();
+      StatusCode statusCode = writeDataSetMetaDataAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -378,7 +390,10 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   @Override
   public void writeDataSetFieldContentMask(DataSetFieldContentMask value) throws UaException {
     try {
-      writeDataSetFieldContentMaskAsync(value).get();
+      StatusCode statusCode = writeDataSetFieldContentMaskAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -452,7 +467,10 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   @Override
   public void writeMessageReceiveTimeout(Double value) throws UaException {
     try {
-      writeMessageReceiveTimeoutAsync(value).get();
+      StatusCode statusCode = writeMessageReceiveTimeoutAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -526,7 +544,10 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   @Override
   public void writeKeyFrameCount(UInteger value) throws UaException {
     try {
-      writeKeyFrameCountAsync(value).get();
+      StatusCode statusCode = writeKeyFrameCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -596,7 +617,10 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   @Override
   public void writeHeaderLayoutUri(String value) throws UaException {
     try {
-      writeHeaderLayoutUriAsync(value).get();
+      StatusCode statusCode = writeHeaderLayoutUriAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -674,7 +698,10 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   @Override
   public void writeSecurityMode(MessageSecurityMode value) throws UaException {
     try {
-      writeSecurityModeAsync(value).get();
+      StatusCode statusCode = writeSecurityModeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -752,7 +779,10 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   @Override
   public void writeSecurityGroupId(String value) throws UaException {
     try {
-      writeSecurityGroupIdAsync(value).get();
+      StatusCode statusCode = writeSecurityGroupIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -824,7 +854,10 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   @Override
   public void writeSecurityKeyServices(EndpointDescription[] value) throws UaException {
     try {
-      writeSecurityKeyServicesAsync(value).get();
+      StatusCode statusCode = writeSecurityKeyServicesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -902,7 +935,10 @@ public class DataSetReaderTypeNode extends BaseObjectTypeNode implements DataSet
   @Override
   public void writeDataSetReaderProperties(KeyValuePair[] value) throws UaException {
     try {
-      writeDataSetReaderPropertiesAsync(value).get();
+      StatusCode statusCode = writeDataSetReaderPropertiesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/DataSetWriterTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/DataSetWriterTypeNode.java
@@ -91,7 +91,10 @@ public class DataSetWriterTypeNode extends BaseObjectTypeNode implements DataSet
   @Override
   public void writeDataSetWriterId(UShort value) throws UaException {
     try {
-      writeDataSetWriterIdAsync(value).get();
+      StatusCode statusCode = writeDataSetWriterIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -161,7 +164,10 @@ public class DataSetWriterTypeNode extends BaseObjectTypeNode implements DataSet
   @Override
   public void writeDataSetFieldContentMask(DataSetFieldContentMask value) throws UaException {
     try {
-      writeDataSetFieldContentMaskAsync(value).get();
+      StatusCode statusCode = writeDataSetFieldContentMaskAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -235,7 +241,10 @@ public class DataSetWriterTypeNode extends BaseObjectTypeNode implements DataSet
   @Override
   public void writeKeyFrameCount(UInteger value) throws UaException {
     try {
-      writeKeyFrameCountAsync(value).get();
+      StatusCode statusCode = writeKeyFrameCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -307,7 +316,10 @@ public class DataSetWriterTypeNode extends BaseObjectTypeNode implements DataSet
   @Override
   public void writeDataSetWriterProperties(KeyValuePair[] value) throws UaException {
     try {
-      writeDataSetWriterPropertiesAsync(value).get();
+      StatusCode statusCode = writeDataSetWriterPropertiesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/DatagramConnectionTransportTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/DatagramConnectionTransportTypeNode.java
@@ -90,7 +90,10 @@ public class DatagramConnectionTransportTypeNode extends ConnectionTransportType
   @Override
   public void writeDiscoveryAnnounceRate(UInteger value) throws UaException {
     try {
-      writeDiscoveryAnnounceRateAsync(value).get();
+      StatusCode statusCode = writeDiscoveryAnnounceRateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -164,7 +167,10 @@ public class DatagramConnectionTransportTypeNode extends ConnectionTransportType
   @Override
   public void writeDiscoveryMaxMessageSize(UInteger value) throws UaException {
     try {
-      writeDiscoveryMaxMessageSizeAsync(value).get();
+      StatusCode statusCode = writeDiscoveryMaxMessageSizeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -238,7 +244,10 @@ public class DatagramConnectionTransportTypeNode extends ConnectionTransportType
   @Override
   public void writeQosCategory(String value) throws UaException {
     try {
-      writeQosCategoryAsync(value).get();
+      StatusCode statusCode = writeQosCategoryAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -310,7 +319,10 @@ public class DatagramConnectionTransportTypeNode extends ConnectionTransportType
   @Override
   public void writeDatagramQos(QosDataType[] value) throws UaException {
     try {
-      writeDatagramQosAsync(value).get();
+      StatusCode statusCode = writeDatagramQosAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/DatagramDataSetReaderTransportTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/DatagramDataSetReaderTransportTypeNode.java
@@ -90,7 +90,10 @@ public class DatagramDataSetReaderTransportTypeNode extends DataSetReaderTranspo
   @Override
   public void writeQosCategory(String value) throws UaException {
     try {
-      writeQosCategoryAsync(value).get();
+      StatusCode statusCode = writeQosCategoryAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -162,7 +165,10 @@ public class DatagramDataSetReaderTransportTypeNode extends DataSetReaderTranspo
   @Override
   public void writeDatagramQos(ReceiveQosDataType[] value) throws UaException {
     try {
-      writeDatagramQosAsync(value).get();
+      StatusCode statusCode = writeDatagramQosAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -234,7 +240,10 @@ public class DatagramDataSetReaderTransportTypeNode extends DataSetReaderTranspo
   @Override
   public void writeTopic(String value) throws UaException {
     try {
-      writeTopicAsync(value).get();
+      StatusCode statusCode = writeTopicAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/DatagramWriterGroupTransportTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/DatagramWriterGroupTransportTypeNode.java
@@ -90,7 +90,10 @@ public class DatagramWriterGroupTransportTypeNode extends WriterGroupTransportTy
   @Override
   public void writeMessageRepeatCount(UByte value) throws UaException {
     try {
-      writeMessageRepeatCountAsync(value).get();
+      StatusCode statusCode = writeMessageRepeatCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -163,7 +166,10 @@ public class DatagramWriterGroupTransportTypeNode extends WriterGroupTransportTy
   @Override
   public void writeMessageRepeatDelay(Double value) throws UaException {
     try {
-      writeMessageRepeatDelayAsync(value).get();
+      StatusCode statusCode = writeMessageRepeatDelayAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -236,7 +242,10 @@ public class DatagramWriterGroupTransportTypeNode extends WriterGroupTransportTy
   @Override
   public void writeQosCategory(String value) throws UaException {
     try {
-      writeQosCategoryAsync(value).get();
+      StatusCode statusCode = writeQosCategoryAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -308,7 +317,10 @@ public class DatagramWriterGroupTransportTypeNode extends WriterGroupTransportTy
   @Override
   public void writeDatagramQos(TransmitQosDataType[] value) throws UaException {
     try {
-      writeDatagramQosAsync(value).get();
+      StatusCode statusCode = writeDatagramQosAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -380,7 +392,10 @@ public class DatagramWriterGroupTransportTypeNode extends WriterGroupTransportTy
   @Override
   public void writeDiscoveryAnnounceRate(UInteger value) throws UaException {
     try {
-      writeDiscoveryAnnounceRateAsync(value).get();
+      StatusCode statusCode = writeDiscoveryAnnounceRateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -454,7 +469,10 @@ public class DatagramWriterGroupTransportTypeNode extends WriterGroupTransportTy
   @Override
   public void writeTopic(String value) throws UaException {
     try {
-      writeTopicAsync(value).get();
+      StatusCode statusCode = writeTopicAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/DialogConditionTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/DialogConditionTypeNode.java
@@ -88,7 +88,10 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
   @Override
   public void writePrompt(LocalizedText value) throws UaException {
     try {
-      writePromptAsync(value).get();
+      StatusCode statusCode = writePromptAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -158,7 +161,10 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
   @Override
   public void writeResponseOptionSet(LocalizedText[] value) throws UaException {
     try {
-      writeResponseOptionSetAsync(value).get();
+      StatusCode statusCode = writeResponseOptionSetAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -232,7 +238,10 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
   @Override
   public void writeDefaultResponse(Integer value) throws UaException {
     try {
-      writeDefaultResponseAsync(value).get();
+      StatusCode statusCode = writeDefaultResponseAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -302,7 +311,10 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
   @Override
   public void writeOkResponse(Integer value) throws UaException {
     try {
-      writeOkResponseAsync(value).get();
+      StatusCode statusCode = writeOkResponseAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -372,7 +384,10 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
   @Override
   public void writeCancelResponse(Integer value) throws UaException {
     try {
-      writeCancelResponseAsync(value).get();
+      StatusCode statusCode = writeCancelResponseAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -442,7 +457,10 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
   @Override
   public void writeLastResponse(Integer value) throws UaException {
     try {
-      writeLastResponseAsync(value).get();
+      StatusCode statusCode = writeLastResponseAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -512,7 +530,10 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
   @Override
   public void writeEnabledState(LocalizedText value) throws UaException {
     try {
-      writeEnabledStateAsync(value).get();
+      StatusCode statusCode = writeEnabledStateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -582,7 +603,10 @@ public class DialogConditionTypeNode extends ConditionTypeNode implements Dialog
   @Override
   public void writeDialogState(LocalizedText value) throws UaException {
     try {
-      writeDialogStateAsync(value).get();
+      StatusCode statusCode = writeDialogStateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/DiscrepancyAlarmTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/DiscrepancyAlarmTypeNode.java
@@ -88,7 +88,10 @@ public class DiscrepancyAlarmTypeNode extends AlarmConditionTypeNode
   @Override
   public void writeTargetValueNode(NodeId value) throws UaException {
     try {
-      writeTargetValueNodeAsync(value).get();
+      StatusCode statusCode = writeTargetValueNodeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -158,7 +161,10 @@ public class DiscrepancyAlarmTypeNode extends AlarmConditionTypeNode
   @Override
   public void writeExpectedTime(Double value) throws UaException {
     try {
-      writeExpectedTimeAsync(value).get();
+      StatusCode statusCode = writeExpectedTimeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -228,7 +234,10 @@ public class DiscrepancyAlarmTypeNode extends AlarmConditionTypeNode
   @Override
   public void writeTolerance(Double value) throws UaException {
     try {
-      writeToleranceAsync(value).get();
+      StatusCode statusCode = writeToleranceAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ExclusiveDeviationAlarmTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ExclusiveDeviationAlarmTypeNode.java
@@ -88,7 +88,10 @@ public class ExclusiveDeviationAlarmTypeNode extends ExclusiveLimitAlarmTypeNode
   @Override
   public void writeSetpointNode(NodeId value) throws UaException {
     try {
-      writeSetpointNodeAsync(value).get();
+      StatusCode statusCode = writeSetpointNodeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -158,7 +161,10 @@ public class ExclusiveDeviationAlarmTypeNode extends ExclusiveLimitAlarmTypeNode
   @Override
   public void writeBaseSetpointNode(NodeId value) throws UaException {
     try {
-      writeBaseSetpointNodeAsync(value).get();
+      StatusCode statusCode = writeBaseSetpointNodeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ExclusiveLimitAlarmTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ExclusiveLimitAlarmTypeNode.java
@@ -88,7 +88,10 @@ public class ExclusiveLimitAlarmTypeNode extends LimitAlarmTypeNode
   @Override
   public void writeActiveState(LocalizedText value) throws UaException {
     try {
-      writeActiveStateAsync(value).get();
+      StatusCode statusCode = writeActiveStateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ExclusiveRateOfChangeAlarmTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ExclusiveRateOfChangeAlarmTypeNode.java
@@ -91,7 +91,10 @@ public class ExclusiveRateOfChangeAlarmTypeNode extends ExclusiveLimitAlarmTypeN
   @Override
   public void writeEngineeringUnits(EUInformation value) throws UaException {
     try {
-      writeEngineeringUnitsAsync(value).get();
+      StatusCode statusCode = writeEngineeringUnitsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/FileTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/FileTypeNode.java
@@ -90,7 +90,10 @@ public class FileTypeNode extends BaseObjectTypeNode implements FileType {
   @Override
   public void writeSize(ULong value) throws UaException {
     try {
-      writeSizeAsync(value).get();
+      StatusCode statusCode = writeSizeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -160,7 +163,10 @@ public class FileTypeNode extends BaseObjectTypeNode implements FileType {
   @Override
   public void writeWritable(Boolean value) throws UaException {
     try {
-      writeWritableAsync(value).get();
+      StatusCode statusCode = writeWritableAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -230,7 +236,10 @@ public class FileTypeNode extends BaseObjectTypeNode implements FileType {
   @Override
   public void writeUserWritable(Boolean value) throws UaException {
     try {
-      writeUserWritableAsync(value).get();
+      StatusCode statusCode = writeUserWritableAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -300,7 +309,10 @@ public class FileTypeNode extends BaseObjectTypeNode implements FileType {
   @Override
   public void writeOpenCount(UShort value) throws UaException {
     try {
-      writeOpenCountAsync(value).get();
+      StatusCode statusCode = writeOpenCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -370,7 +382,10 @@ public class FileTypeNode extends BaseObjectTypeNode implements FileType {
   @Override
   public void writeMimeType(String value) throws UaException {
     try {
-      writeMimeTypeAsync(value).get();
+      StatusCode statusCode = writeMimeTypeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -440,7 +455,10 @@ public class FileTypeNode extends BaseObjectTypeNode implements FileType {
   @Override
   public void writeMaxByteStringLength(UInteger value) throws UaException {
     try {
-      writeMaxByteStringLengthAsync(value).get();
+      StatusCode statusCode = writeMaxByteStringLengthAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -513,7 +531,10 @@ public class FileTypeNode extends BaseObjectTypeNode implements FileType {
   @Override
   public void writeLastModifiedTime(DateTime value) throws UaException {
     try {
-      writeLastModifiedTimeAsync(value).get();
+      StatusCode statusCode = writeLastModifiedTimeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/FiniteStateMachineTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/FiniteStateMachineTypeNode.java
@@ -90,7 +90,10 @@ public class FiniteStateMachineTypeNode extends StateMachineTypeNode
   @Override
   public void writeCurrentState(LocalizedText value) throws UaException {
     try {
-      writeCurrentStateAsync(value).get();
+      StatusCode statusCode = writeCurrentStateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -160,7 +163,10 @@ public class FiniteStateMachineTypeNode extends StateMachineTypeNode
   @Override
   public void writeLastTransition(LocalizedText value) throws UaException {
     try {
-      writeLastTransitionAsync(value).get();
+      StatusCode statusCode = writeLastTransitionAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -231,7 +237,10 @@ public class FiniteStateMachineTypeNode extends StateMachineTypeNode
   @Override
   public void writeAvailableStates(NodeId[] value) throws UaException {
     try {
-      writeAvailableStatesAsync(value).get();
+      StatusCode statusCode = writeAvailableStatesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -301,7 +310,10 @@ public class FiniteStateMachineTypeNode extends StateMachineTypeNode
   @Override
   public void writeAvailableTransitions(NodeId[] value) throws UaException {
     try {
-      writeAvailableTransitionsAsync(value).get();
+      StatusCode statusCode = writeAvailableTransitionsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/GeneralModelChangeEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/GeneralModelChangeEventTypeNode.java
@@ -92,7 +92,10 @@ public class GeneralModelChangeEventTypeNode extends BaseModelChangeEventTypeNod
   @Override
   public void writeChanges(ModelChangeStructureDataType[] value) throws UaException {
     try {
-      writeChangesAsync(value).get();
+      StatusCode statusCode = writeChangesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/HistoricalDataConfigurationTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/HistoricalDataConfigurationTypeNode.java
@@ -90,7 +90,10 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   @Override
   public void writeStepped(Boolean value) throws UaException {
     try {
-      writeSteppedAsync(value).get();
+      StatusCode statusCode = writeSteppedAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -160,7 +163,10 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   @Override
   public void writeDefinition(String value) throws UaException {
     try {
-      writeDefinitionAsync(value).get();
+      StatusCode statusCode = writeDefinitionAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -230,7 +236,10 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   @Override
   public void writeMaxTimeInterval(Double value) throws UaException {
     try {
-      writeMaxTimeIntervalAsync(value).get();
+      StatusCode statusCode = writeMaxTimeIntervalAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -300,7 +309,10 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   @Override
   public void writeMinTimeInterval(Double value) throws UaException {
     try {
-      writeMinTimeIntervalAsync(value).get();
+      StatusCode statusCode = writeMinTimeIntervalAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -370,7 +382,10 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   @Override
   public void writeExceptionDeviation(Double value) throws UaException {
     try {
-      writeExceptionDeviationAsync(value).get();
+      StatusCode statusCode = writeExceptionDeviationAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -451,7 +466,10 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   @Override
   public void writeExceptionDeviationFormat(ExceptionDeviationFormat value) throws UaException {
     try {
-      writeExceptionDeviationFormatAsync(value).get();
+      StatusCode statusCode = writeExceptionDeviationFormatAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -533,7 +551,10 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   @Override
   public void writeStartOfArchive(DateTime value) throws UaException {
     try {
-      writeStartOfArchiveAsync(value).get();
+      StatusCode statusCode = writeStartOfArchiveAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -603,7 +624,10 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   @Override
   public void writeStartOfOnlineArchive(DateTime value) throws UaException {
     try {
-      writeStartOfOnlineArchiveAsync(value).get();
+      StatusCode statusCode = writeStartOfOnlineArchiveAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -677,7 +701,10 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   @Override
   public void writeServerTimestampSupported(Boolean value) throws UaException {
     try {
-      writeServerTimestampSupportedAsync(value).get();
+      StatusCode statusCode = writeServerTimestampSupportedAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -751,7 +778,10 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   @Override
   public void writeMaxTimeStoredValues(Double value) throws UaException {
     try {
-      writeMaxTimeStoredValuesAsync(value).get();
+      StatusCode statusCode = writeMaxTimeStoredValuesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -824,7 +854,10 @@ public class HistoricalDataConfigurationTypeNode extends BaseObjectTypeNode
   @Override
   public void writeMaxCountStoredValues(UInteger value) throws UaException {
     try {
-      writeMaxCountStoredValuesAsync(value).get();
+      StatusCode statusCode = writeMaxCountStoredValuesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/HistoricalEventConfigurationTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/HistoricalEventConfigurationTypeNode.java
@@ -91,7 +91,10 @@ public class HistoricalEventConfigurationTypeNode extends BaseObjectTypeNode
   @Override
   public void writeStartOfArchive(DateTime value) throws UaException {
     try {
-      writeStartOfArchiveAsync(value).get();
+      StatusCode statusCode = writeStartOfArchiveAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -161,7 +164,10 @@ public class HistoricalEventConfigurationTypeNode extends BaseObjectTypeNode
   @Override
   public void writeStartOfOnlineArchive(DateTime value) throws UaException {
     try {
-      writeStartOfOnlineArchiveAsync(value).get();
+      StatusCode statusCode = writeStartOfOnlineArchiveAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -237,7 +243,10 @@ public class HistoricalEventConfigurationTypeNode extends BaseObjectTypeNode
   @Override
   public void writeSortByEventFields(SimpleAttributeOperand[] value) throws UaException {
     try {
-      writeSortByEventFieldsAsync(value).get();
+      StatusCode statusCode = writeSortByEventFieldsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/HistoricalExternalEventSourceTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/HistoricalExternalEventSourceTypeNode.java
@@ -92,7 +92,10 @@ public class HistoricalExternalEventSourceTypeNode extends BaseObjectTypeNode
   @Override
   public void writeServer(String value) throws UaException {
     try {
-      writeServerAsync(value).get();
+      StatusCode statusCode = writeServerAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -162,7 +165,10 @@ public class HistoricalExternalEventSourceTypeNode extends BaseObjectTypeNode
   @Override
   public void writeEndpointUrl(String value) throws UaException {
     try {
-      writeEndpointUrlAsync(value).get();
+      StatusCode statusCode = writeEndpointUrlAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -240,7 +246,10 @@ public class HistoricalExternalEventSourceTypeNode extends BaseObjectTypeNode
   @Override
   public void writeSecurityMode(MessageSecurityMode value) throws UaException {
     try {
-      writeSecurityModeAsync(value).get();
+      StatusCode statusCode = writeSecurityModeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -318,7 +327,10 @@ public class HistoricalExternalEventSourceTypeNode extends BaseObjectTypeNode
   @Override
   public void writeSecurityPolicyUri(String value) throws UaException {
     try {
-      writeSecurityPolicyUriAsync(value).get();
+      StatusCode statusCode = writeSecurityPolicyUriAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -392,7 +404,10 @@ public class HistoricalExternalEventSourceTypeNode extends BaseObjectTypeNode
   @Override
   public void writeIdentityTokenPolicy(UserTokenPolicy value) throws UaException {
     try {
-      writeIdentityTokenPolicyAsync(value).get();
+      StatusCode statusCode = writeIdentityTokenPolicyAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -468,7 +483,10 @@ public class HistoricalExternalEventSourceTypeNode extends BaseObjectTypeNode
   @Override
   public void writeTransportProfileUri(String value) throws UaException {
     try {
-      writeTransportProfileUriAsync(value).get();
+      StatusCode statusCode = writeTransportProfileUriAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -542,7 +560,10 @@ public class HistoricalExternalEventSourceTypeNode extends BaseObjectTypeNode
   @Override
   public void writeHistoricalEventFilter(EventFilter value) throws UaException {
     try {
-      writeHistoricalEventFilterAsync(value).get();
+      StatusCode statusCode = writeHistoricalEventFilterAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/HistoryServerCapabilitiesTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/HistoryServerCapabilitiesTypeNode.java
@@ -88,7 +88,10 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeAccessHistoryDataCapability(Boolean value) throws UaException {
     try {
-      writeAccessHistoryDataCapabilityAsync(value).get();
+      StatusCode statusCode = writeAccessHistoryDataCapabilityAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -162,7 +165,10 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeAccessHistoryEventsCapability(Boolean value) throws UaException {
     try {
-      writeAccessHistoryEventsCapabilityAsync(value).get();
+      StatusCode statusCode = writeAccessHistoryEventsCapabilityAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -236,7 +242,10 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeMaxReturnDataValues(UInteger value) throws UaException {
     try {
-      writeMaxReturnDataValuesAsync(value).get();
+      StatusCode statusCode = writeMaxReturnDataValuesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -309,7 +318,10 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeMaxReturnEventValues(UInteger value) throws UaException {
     try {
-      writeMaxReturnEventValuesAsync(value).get();
+      StatusCode statusCode = writeMaxReturnEventValuesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -383,7 +395,10 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeInsertDataCapability(Boolean value) throws UaException {
     try {
-      writeInsertDataCapabilityAsync(value).get();
+      StatusCode statusCode = writeInsertDataCapabilityAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -457,7 +472,10 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeReplaceDataCapability(Boolean value) throws UaException {
     try {
-      writeReplaceDataCapabilityAsync(value).get();
+      StatusCode statusCode = writeReplaceDataCapabilityAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -531,7 +549,10 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeUpdateDataCapability(Boolean value) throws UaException {
     try {
-      writeUpdateDataCapabilityAsync(value).get();
+      StatusCode statusCode = writeUpdateDataCapabilityAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -605,7 +626,10 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeDeleteRawCapability(Boolean value) throws UaException {
     try {
-      writeDeleteRawCapabilityAsync(value).get();
+      StatusCode statusCode = writeDeleteRawCapabilityAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -678,7 +702,10 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeDeleteAtTimeCapability(Boolean value) throws UaException {
     try {
-      writeDeleteAtTimeCapabilityAsync(value).get();
+      StatusCode statusCode = writeDeleteAtTimeCapabilityAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -752,7 +779,10 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeInsertEventCapability(Boolean value) throws UaException {
     try {
-      writeInsertEventCapabilityAsync(value).get();
+      StatusCode statusCode = writeInsertEventCapabilityAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -826,7 +856,10 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeReplaceEventCapability(Boolean value) throws UaException {
     try {
-      writeReplaceEventCapabilityAsync(value).get();
+      StatusCode statusCode = writeReplaceEventCapabilityAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -900,7 +933,10 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeUpdateEventCapability(Boolean value) throws UaException {
     try {
-      writeUpdateEventCapabilityAsync(value).get();
+      StatusCode statusCode = writeUpdateEventCapabilityAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -974,7 +1010,10 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeDeleteEventCapability(Boolean value) throws UaException {
     try {
-      writeDeleteEventCapabilityAsync(value).get();
+      StatusCode statusCode = writeDeleteEventCapabilityAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -1048,7 +1087,10 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeInsertAnnotationCapability(Boolean value) throws UaException {
     try {
-      writeInsertAnnotationCapabilityAsync(value).get();
+      StatusCode statusCode = writeInsertAnnotationCapabilityAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -1122,7 +1164,10 @@ public class HistoryServerCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeServerTimestampSupported(Boolean value) throws UaException {
     try {
-      writeServerTimestampSupportedAsync(value).get();
+      StatusCode statusCode = writeServerTimestampSupportedAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IBaseEthernetCapabilitiesTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IBaseEthernetCapabilitiesTypeNode.java
@@ -88,7 +88,10 @@ public class IBaseEthernetCapabilitiesTypeNode extends BaseInterfaceTypeNode
   @Override
   public void writeVlanTagCapable(Boolean value) throws UaException {
     try {
-      writeVlanTagCapableAsync(value).get();
+      StatusCode statusCode = writeVlanTagCapableAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IIeeeAutoNegotiationStatusTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IIeeeAutoNegotiationStatusTypeNode.java
@@ -97,7 +97,10 @@ public class IIeeeAutoNegotiationStatusTypeNode extends BaseInterfaceTypeNode
   @Override
   public void writeNegotiationStatus(NegotiationStatus value) throws UaException {
     try {
-      writeNegotiationStatusAsync(value).get();
+      StatusCode statusCode = writeNegotiationStatusAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IIeeeBaseEthernetPortTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IIeeeBaseEthernetPortTypeNode.java
@@ -92,7 +92,10 @@ public class IIeeeBaseEthernetPortTypeNode extends BaseInterfaceTypeNode
   @Override
   public void writeSpeed(ULong value) throws UaException {
     try {
-      writeSpeedAsync(value).get();
+      StatusCode statusCode = writeSpeedAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -170,7 +173,10 @@ public class IIeeeBaseEthernetPortTypeNode extends BaseInterfaceTypeNode
   @Override
   public void writeDuplex(Duplex value) throws UaException {
     try {
-      writeDuplexAsync(value).get();
+      StatusCode statusCode = writeDuplexAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -248,7 +254,10 @@ public class IIeeeBaseEthernetPortTypeNode extends BaseInterfaceTypeNode
   @Override
   public void writeMaxFrameLength(UShort value) throws UaException {
     try {
-      writeMaxFrameLengthAsync(value).get();
+      StatusCode statusCode = writeMaxFrameLengthAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IIeeeBaseTsnStatusStreamTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IIeeeBaseTsnStatusStreamTypeNode.java
@@ -99,7 +99,10 @@ public class IIeeeBaseTsnStatusStreamTypeNode extends BaseInterfaceTypeNode
   @Override
   public void writeTalkerStatus(TsnTalkerStatus value) throws UaException {
     try {
-      writeTalkerStatusAsync(value).get();
+      StatusCode statusCode = writeTalkerStatusAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -185,7 +188,10 @@ public class IIeeeBaseTsnStatusStreamTypeNode extends BaseInterfaceTypeNode
   @Override
   public void writeListenerStatus(TsnListenerStatus value) throws UaException {
     try {
-      writeListenerStatusAsync(value).get();
+      StatusCode statusCode = writeListenerStatusAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -271,7 +277,10 @@ public class IIeeeBaseTsnStatusStreamTypeNode extends BaseInterfaceTypeNode
   @Override
   public void writeFailureCode(TsnFailureCode value) throws UaException {
     try {
-      writeFailureCodeAsync(value).get();
+      StatusCode statusCode = writeFailureCodeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -349,7 +358,10 @@ public class IIeeeBaseTsnStatusStreamTypeNode extends BaseInterfaceTypeNode
   @Override
   public void writeFailureSystemIdentifier(Object value) throws UaException {
     try {
-      writeFailureSystemIdentifierAsync(value).get();
+      StatusCode statusCode = writeFailureSystemIdentifierAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IIeeeBaseTsnStreamTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IIeeeBaseTsnStreamTypeNode.java
@@ -89,7 +89,10 @@ public class IIeeeBaseTsnStreamTypeNode extends BaseInterfaceTypeNode
   @Override
   public void writeStreamId(UByte[] value) throws UaException {
     try {
-      writeStreamIdAsync(value).get();
+      StatusCode statusCode = writeStreamIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -159,7 +162,10 @@ public class IIeeeBaseTsnStreamTypeNode extends BaseInterfaceTypeNode
   @Override
   public void writeStreamName(String value) throws UaException {
     try {
-      writeStreamNameAsync(value).get();
+      StatusCode statusCode = writeStreamNameAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -237,7 +243,10 @@ public class IIeeeBaseTsnStreamTypeNode extends BaseInterfaceTypeNode
   @Override
   public void writeState(TsnStreamState value) throws UaException {
     try {
-      writeStateAsync(value).get();
+      StatusCode statusCode = writeStateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -315,7 +324,10 @@ public class IIeeeBaseTsnStreamTypeNode extends BaseInterfaceTypeNode
   @Override
   public void writeAccumulatedLatency(UInteger value) throws UaException {
     try {
-      writeAccumulatedLatencyAsync(value).get();
+      StatusCode statusCode = writeAccumulatedLatencyAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -388,7 +400,10 @@ public class IIeeeBaseTsnStreamTypeNode extends BaseInterfaceTypeNode
   @Override
   public void writeSrClassId(UByte value) throws UaException {
     try {
-      writeSrClassIdAsync(value).get();
+      StatusCode statusCode = writeSrClassIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IIeeeBaseTsnTrafficSpecificationTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IIeeeBaseTsnTrafficSpecificationTypeNode.java
@@ -91,7 +91,10 @@ public class IIeeeBaseTsnTrafficSpecificationTypeNode extends BaseInterfaceTypeN
   @Override
   public void writeMaxIntervalFrames(UShort value) throws UaException {
     try {
-      writeMaxIntervalFramesAsync(value).get();
+      StatusCode statusCode = writeMaxIntervalFramesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -164,7 +167,10 @@ public class IIeeeBaseTsnTrafficSpecificationTypeNode extends BaseInterfaceTypeN
   @Override
   public void writeMaxFrameSize(UInteger value) throws UaException {
     try {
-      writeMaxFrameSizeAsync(value).get();
+      StatusCode statusCode = writeMaxFrameSizeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -235,7 +241,10 @@ public class IIeeeBaseTsnTrafficSpecificationTypeNode extends BaseInterfaceTypeN
   @Override
   public void writeInterval(UnsignedRationalNumber value) throws UaException {
     try {
-      writeIntervalAsync(value).get();
+      StatusCode statusCode = writeIntervalAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IIeeeTsnInterfaceConfigurationListenerTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IIeeeTsnInterfaceConfigurationListenerTypeNode.java
@@ -89,7 +89,10 @@ public class IIeeeTsnInterfaceConfigurationListenerTypeNode
   @Override
   public void writeReceiveOffset(UInteger value) throws UaException {
     try {
-      writeReceiveOffsetAsync(value).get();
+      StatusCode statusCode = writeReceiveOffsetAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IIeeeTsnInterfaceConfigurationTalkerTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IIeeeTsnInterfaceConfigurationTalkerTypeNode.java
@@ -89,7 +89,10 @@ public class IIeeeTsnInterfaceConfigurationTalkerTypeNode
   @Override
   public void writeTimeAwareOffset(UInteger value) throws UaException {
     try {
-      writeTimeAwareOffsetAsync(value).get();
+      StatusCode statusCode = writeTimeAwareOffsetAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IIeeeTsnInterfaceConfigurationTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IIeeeTsnInterfaceConfigurationTypeNode.java
@@ -88,7 +88,10 @@ public class IIeeeTsnInterfaceConfigurationTypeNode extends BaseInterfaceTypeNod
   @Override
   public void writeMacAddress(String value) throws UaException {
     try {
-      writeMacAddressAsync(value).get();
+      StatusCode statusCode = writeMacAddressAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -158,7 +161,10 @@ public class IIeeeTsnInterfaceConfigurationTypeNode extends BaseInterfaceTypeNod
   @Override
   public void writeInterfaceName(String value) throws UaException {
     try {
-      writeInterfaceNameAsync(value).get();
+      StatusCode statusCode = writeInterfaceNameAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IIeeeTsnMacAddressTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IIeeeTsnMacAddressTypeNode.java
@@ -88,7 +88,10 @@ public class IIeeeTsnMacAddressTypeNode extends BaseInterfaceTypeNode
   @Override
   public void writeDestinationAddress(UByte[] value) throws UaException {
     try {
-      writeDestinationAddressAsync(value).get();
+      StatusCode statusCode = writeDestinationAddressAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -161,7 +164,10 @@ public class IIeeeTsnMacAddressTypeNode extends BaseInterfaceTypeNode
   @Override
   public void writeSourceAddress(UByte[] value) throws UaException {
     try {
-      writeSourceAddressAsync(value).get();
+      StatusCode statusCode = writeSourceAddressAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IIeeeTsnVlanTagTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IIeeeTsnVlanTagTypeNode.java
@@ -88,7 +88,10 @@ public class IIeeeTsnVlanTagTypeNode extends BaseInterfaceTypeNode implements II
   @Override
   public void writeVlanId(UShort value) throws UaException {
     try {
-      writeVlanIdAsync(value).get();
+      StatusCode statusCode = writeVlanIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -158,7 +161,10 @@ public class IIeeeTsnVlanTagTypeNode extends BaseInterfaceTypeNode implements II
   @Override
   public void writePriorityCodePoint(UByte value) throws UaException {
     try {
-      writePriorityCodePointAsync(value).get();
+      StatusCode statusCode = writePriorityCodePointAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IIetfBaseNetworkInterfaceTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IIetfBaseNetworkInterfaceTypeNode.java
@@ -100,7 +100,10 @@ public class IIetfBaseNetworkInterfaceTypeNode extends BaseInterfaceTypeNode
   @Override
   public void writeAdminStatus(InterfaceAdminStatus value) throws UaException {
     try {
-      writeAdminStatusAsync(value).get();
+      StatusCode statusCode = writeAdminStatusAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -186,7 +189,10 @@ public class IIetfBaseNetworkInterfaceTypeNode extends BaseInterfaceTypeNode
   @Override
   public void writeOperStatus(InterfaceOperStatus value) throws UaException {
     try {
-      writeOperStatusAsync(value).get();
+      StatusCode statusCode = writeOperStatusAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -264,7 +270,10 @@ public class IIetfBaseNetworkInterfaceTypeNode extends BaseInterfaceTypeNode
   @Override
   public void writePhysAddress(String value) throws UaException {
     try {
-      writePhysAddressAsync(value).get();
+      StatusCode statusCode = writePhysAddressAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -334,7 +343,10 @@ public class IIetfBaseNetworkInterfaceTypeNode extends BaseInterfaceTypeNode
   @Override
   public void writeSpeed(ULong value) throws UaException {
     try {
-      writeSpeedAsync(value).get();
+      StatusCode statusCode = writeSpeedAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IOrderedObjectTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IOrderedObjectTypeNode.java
@@ -87,7 +87,10 @@ public class IOrderedObjectTypeNode extends BaseInterfaceTypeNode implements IOr
   @Override
   public void writeNumberInList(Variant value) throws UaException {
     try {
-      writeNumberInListAsync(value).get();
+      StatusCode statusCode = writeNumberInListAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IPriorityMappingEntryTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IPriorityMappingEntryTypeNode.java
@@ -88,7 +88,10 @@ public class IPriorityMappingEntryTypeNode extends BaseInterfaceTypeNode
   @Override
   public void writeMappingUri(String value) throws UaException {
     try {
-      writeMappingUriAsync(value).get();
+      StatusCode statusCode = writeMappingUriAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -158,7 +161,10 @@ public class IPriorityMappingEntryTypeNode extends BaseInterfaceTypeNode
   @Override
   public void writePriorityLabel(String value) throws UaException {
     try {
-      writePriorityLabelAsync(value).get();
+      StatusCode statusCode = writePriorityLabelAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -228,7 +234,10 @@ public class IPriorityMappingEntryTypeNode extends BaseInterfaceTypeNode
   @Override
   public void writePriorityValuePcp(UByte value) throws UaException {
     try {
-      writePriorityValuePcpAsync(value).get();
+      StatusCode statusCode = writePriorityValuePcpAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -301,7 +310,10 @@ public class IPriorityMappingEntryTypeNode extends BaseInterfaceTypeNode
   @Override
   public void writePriorityValueDscp(UInteger value) throws UaException {
     try {
-      writePriorityValueDscpAsync(value).get();
+      StatusCode statusCode = writePriorityValueDscpAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ISrClassTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ISrClassTypeNode.java
@@ -88,7 +88,10 @@ public class ISrClassTypeNode extends BaseInterfaceTypeNode implements ISrClassT
   @Override
   public void writeId(UByte value) throws UaException {
     try {
-      writeIdAsync(value).get();
+      StatusCode statusCode = writeIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -157,7 +160,10 @@ public class ISrClassTypeNode extends BaseInterfaceTypeNode implements ISrClassT
   @Override
   public void writePriority(UByte value) throws UaException {
     try {
-      writePriorityAsync(value).get();
+      StatusCode statusCode = writePriorityAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -227,7 +233,10 @@ public class ISrClassTypeNode extends BaseInterfaceTypeNode implements ISrClassT
   @Override
   public void writeVid(UShort value) throws UaException {
     try {
-      writeVidAsync(value).get();
+      StatusCode statusCode = writeVidAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IVlanIdTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IVlanIdTypeNode.java
@@ -88,7 +88,10 @@ public class IVlanIdTypeNode extends BaseInterfaceTypeNode implements IVlanIdTyp
   @Override
   public void writeVlanId(UShort value) throws UaException {
     try {
-      writeVlanIdAsync(value).get();
+      StatusCode statusCode = writeVlanIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IetfBaseNetworkInterfaceTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/IetfBaseNetworkInterfaceTypeNode.java
@@ -100,7 +100,10 @@ public class IetfBaseNetworkInterfaceTypeNode extends BaseObjectTypeNode
   @Override
   public void writeAdminStatus(InterfaceAdminStatus value) throws UaException {
     try {
-      writeAdminStatusAsync(value).get();
+      StatusCode statusCode = writeAdminStatusAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -186,7 +189,10 @@ public class IetfBaseNetworkInterfaceTypeNode extends BaseObjectTypeNode
   @Override
   public void writeOperStatus(InterfaceOperStatus value) throws UaException {
     try {
-      writeOperStatusAsync(value).get();
+      StatusCode statusCode = writeOperStatusAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -264,7 +270,10 @@ public class IetfBaseNetworkInterfaceTypeNode extends BaseObjectTypeNode
   @Override
   public void writePhysAddress(String value) throws UaException {
     try {
-      writePhysAddressAsync(value).get();
+      StatusCode statusCode = writePhysAddressAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -334,7 +343,10 @@ public class IetfBaseNetworkInterfaceTypeNode extends BaseObjectTypeNode
   @Override
   public void writeSpeed(ULong value) throws UaException {
     try {
-      writeSpeedAsync(value).get();
+      StatusCode statusCode = writeSpeedAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/KeyCredentialAuditEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/KeyCredentialAuditEventTypeNode.java
@@ -88,7 +88,10 @@ public class KeyCredentialAuditEventTypeNode extends AuditUpdateMethodEventTypeN
   @Override
   public void writeResourceUri(String value) throws UaException {
     try {
-      writeResourceUriAsync(value).get();
+      StatusCode statusCode = writeResourceUriAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/KeyCredentialConfigurationTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/KeyCredentialConfigurationTypeNode.java
@@ -88,7 +88,10 @@ public class KeyCredentialConfigurationTypeNode extends BaseObjectTypeNode
   @Override
   public void writeResourceUri(String value) throws UaException {
     try {
-      writeResourceUriAsync(value).get();
+      StatusCode statusCode = writeResourceUriAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -158,7 +161,10 @@ public class KeyCredentialConfigurationTypeNode extends BaseObjectTypeNode
   @Override
   public void writeProfileUri(String value) throws UaException {
     try {
-      writeProfileUriAsync(value).get();
+      StatusCode statusCode = writeProfileUriAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -228,7 +234,10 @@ public class KeyCredentialConfigurationTypeNode extends BaseObjectTypeNode
   @Override
   public void writeEndpointUrls(String[] value) throws UaException {
     try {
-      writeEndpointUrlsAsync(value).get();
+      StatusCode statusCode = writeEndpointUrlsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -298,7 +307,10 @@ public class KeyCredentialConfigurationTypeNode extends BaseObjectTypeNode
   @Override
   public void writeCredentialId(String value) throws UaException {
     try {
-      writeCredentialIdAsync(value).get();
+      StatusCode statusCode = writeCredentialIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -368,7 +380,10 @@ public class KeyCredentialConfigurationTypeNode extends BaseObjectTypeNode
   @Override
   public void writeServiceStatus(StatusCode value) throws UaException {
     try {
-      writeServiceStatusAsync(value).get();
+      StatusCode statusCode = writeServiceStatusAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/KeyCredentialDeletedAuditEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/KeyCredentialDeletedAuditEventTypeNode.java
@@ -88,7 +88,10 @@ public class KeyCredentialDeletedAuditEventTypeNode extends KeyCredentialAuditEv
   @Override
   public void writeResourceUri(String value) throws UaException {
     try {
-      writeResourceUriAsync(value).get();
+      StatusCode statusCode = writeResourceUriAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/LimitAlarmTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/LimitAlarmTypeNode.java
@@ -88,7 +88,10 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   @Override
   public void writeHighHighLimit(Double value) throws UaException {
     try {
-      writeHighHighLimitAsync(value).get();
+      StatusCode statusCode = writeHighHighLimitAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -158,7 +161,10 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   @Override
   public void writeHighLimit(Double value) throws UaException {
     try {
-      writeHighLimitAsync(value).get();
+      StatusCode statusCode = writeHighLimitAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -228,7 +234,10 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   @Override
   public void writeLowLimit(Double value) throws UaException {
     try {
-      writeLowLimitAsync(value).get();
+      StatusCode statusCode = writeLowLimitAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -298,7 +307,10 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   @Override
   public void writeLowLowLimit(Double value) throws UaException {
     try {
-      writeLowLowLimitAsync(value).get();
+      StatusCode statusCode = writeLowLowLimitAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -368,7 +380,10 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   @Override
   public void writeBaseHighHighLimit(Double value) throws UaException {
     try {
-      writeBaseHighHighLimitAsync(value).get();
+      StatusCode statusCode = writeBaseHighHighLimitAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -441,7 +456,10 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   @Override
   public void writeBaseHighLimit(Double value) throws UaException {
     try {
-      writeBaseHighLimitAsync(value).get();
+      StatusCode statusCode = writeBaseHighLimitAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -511,7 +529,10 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   @Override
   public void writeBaseLowLimit(Double value) throws UaException {
     try {
-      writeBaseLowLimitAsync(value).get();
+      StatusCode statusCode = writeBaseLowLimitAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -581,7 +602,10 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   @Override
   public void writeBaseLowLowLimit(Double value) throws UaException {
     try {
-      writeBaseLowLowLimitAsync(value).get();
+      StatusCode statusCode = writeBaseLowLowLimitAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -651,7 +675,10 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   @Override
   public void writeSeverityHighHigh(UShort value) throws UaException {
     try {
-      writeSeverityHighHighAsync(value).get();
+      StatusCode statusCode = writeSeverityHighHighAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -724,7 +751,10 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   @Override
   public void writeSeverityHigh(UShort value) throws UaException {
     try {
-      writeSeverityHighAsync(value).get();
+      StatusCode statusCode = writeSeverityHighAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -794,7 +824,10 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   @Override
   public void writeSeverityLow(UShort value) throws UaException {
     try {
-      writeSeverityLowAsync(value).get();
+      StatusCode statusCode = writeSeverityLowAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -864,7 +897,10 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   @Override
   public void writeSeverityLowLow(UShort value) throws UaException {
     try {
-      writeSeverityLowLowAsync(value).get();
+      StatusCode statusCode = writeSeverityLowLowAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -934,7 +970,10 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   @Override
   public void writeHighHighDeadband(Double value) throws UaException {
     try {
-      writeHighHighDeadbandAsync(value).get();
+      StatusCode statusCode = writeHighHighDeadbandAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -1007,7 +1046,10 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   @Override
   public void writeHighDeadband(Double value) throws UaException {
     try {
-      writeHighDeadbandAsync(value).get();
+      StatusCode statusCode = writeHighDeadbandAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -1077,7 +1119,10 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   @Override
   public void writeLowDeadband(Double value) throws UaException {
     try {
-      writeLowDeadbandAsync(value).get();
+      StatusCode statusCode = writeLowDeadbandAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -1147,7 +1192,10 @@ public class LimitAlarmTypeNode extends AlarmConditionTypeNode implements LimitA
   @Override
   public void writeLowLowDeadband(Double value) throws UaException {
     try {
-      writeLowLowDeadbandAsync(value).get();
+      StatusCode statusCode = writeLowLowDeadbandAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/LldpLocalSystemTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/LldpLocalSystemTypeNode.java
@@ -97,7 +97,10 @@ public class LldpLocalSystemTypeNode extends BaseObjectTypeNode implements LldpL
   @Override
   public void writeChassisIdSubtype(ChassisIdSubtype value) throws UaException {
     try {
-      writeChassisIdSubtypeAsync(value).get();
+      StatusCode statusCode = writeChassisIdSubtypeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -179,7 +182,10 @@ public class LldpLocalSystemTypeNode extends BaseObjectTypeNode implements LldpL
   @Override
   public void writeChassisId(String value) throws UaException {
     try {
-      writeChassisIdAsync(value).get();
+      StatusCode statusCode = writeChassisIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -249,7 +255,10 @@ public class LldpLocalSystemTypeNode extends BaseObjectTypeNode implements LldpL
   @Override
   public void writeSystemName(String value) throws UaException {
     try {
-      writeSystemNameAsync(value).get();
+      StatusCode statusCode = writeSystemNameAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -319,7 +328,10 @@ public class LldpLocalSystemTypeNode extends BaseObjectTypeNode implements LldpL
   @Override
   public void writeSystemDescription(String value) throws UaException {
     try {
-      writeSystemDescriptionAsync(value).get();
+      StatusCode statusCode = writeSystemDescriptionAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -392,7 +404,10 @@ public class LldpLocalSystemTypeNode extends BaseObjectTypeNode implements LldpL
   @Override
   public void writeSystemCapabilitiesSupported(LldpSystemCapabilitiesMap value) throws UaException {
     try {
-      writeSystemCapabilitiesSupportedAsync(value).get();
+      StatusCode statusCode = writeSystemCapabilitiesSupportedAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -467,7 +482,10 @@ public class LldpLocalSystemTypeNode extends BaseObjectTypeNode implements LldpL
   @Override
   public void writeSystemCapabilitiesEnabled(LldpSystemCapabilitiesMap value) throws UaException {
     try {
-      writeSystemCapabilitiesEnabledAsync(value).get();
+      StatusCode statusCode = writeSystemCapabilitiesEnabledAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/LldpPortInformationTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/LldpPortInformationTypeNode.java
@@ -91,7 +91,10 @@ public class LldpPortInformationTypeNode extends BaseObjectTypeNode
   @Override
   public void writeIetfBaseNetworkInterfaceName(String value) throws UaException {
     try {
-      writeIetfBaseNetworkInterfaceNameAsync(value).get();
+      StatusCode statusCode = writeIetfBaseNetworkInterfaceNameAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -165,7 +168,10 @@ public class LldpPortInformationTypeNode extends BaseObjectTypeNode
   @Override
   public void writeDestMacAddress(UByte[] value) throws UaException {
     try {
-      writeDestMacAddressAsync(value).get();
+      StatusCode statusCode = writeDestMacAddressAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -243,7 +249,10 @@ public class LldpPortInformationTypeNode extends BaseObjectTypeNode
   @Override
   public void writePortIdSubtype(PortIdSubtype value) throws UaException {
     try {
-      writePortIdSubtypeAsync(value).get();
+      StatusCode statusCode = writePortIdSubtypeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -321,7 +330,10 @@ public class LldpPortInformationTypeNode extends BaseObjectTypeNode
   @Override
   public void writePortId(String value) throws UaException {
     try {
-      writePortIdAsync(value).get();
+      StatusCode statusCode = writePortIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -391,7 +403,10 @@ public class LldpPortInformationTypeNode extends BaseObjectTypeNode
   @Override
   public void writePortDescription(String value) throws UaException {
     try {
-      writePortDescriptionAsync(value).get();
+      StatusCode statusCode = writePortDescriptionAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/LldpRemoteStatisticsTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/LldpRemoteStatisticsTypeNode.java
@@ -88,7 +88,10 @@ public class LldpRemoteStatisticsTypeNode extends BaseObjectTypeNode
   @Override
   public void writeLastChangeTime(UInteger value) throws UaException {
     try {
-      writeLastChangeTimeAsync(value).get();
+      StatusCode statusCode = writeLastChangeTimeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -158,7 +161,10 @@ public class LldpRemoteStatisticsTypeNode extends BaseObjectTypeNode
   @Override
   public void writeRemoteInserts(UInteger value) throws UaException {
     try {
-      writeRemoteInsertsAsync(value).get();
+      StatusCode statusCode = writeRemoteInsertsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -228,7 +234,10 @@ public class LldpRemoteStatisticsTypeNode extends BaseObjectTypeNode
   @Override
   public void writeRemoteDeletes(UInteger value) throws UaException {
     try {
-      writeRemoteDeletesAsync(value).get();
+      StatusCode statusCode = writeRemoteDeletesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -298,7 +307,10 @@ public class LldpRemoteStatisticsTypeNode extends BaseObjectTypeNode
   @Override
   public void writeRemoteDrops(UInteger value) throws UaException {
     try {
-      writeRemoteDropsAsync(value).get();
+      StatusCode statusCode = writeRemoteDropsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -368,7 +380,10 @@ public class LldpRemoteStatisticsTypeNode extends BaseObjectTypeNode
   @Override
   public void writeRemoteAgeouts(UInteger value) throws UaException {
     try {
-      writeRemoteAgeoutsAsync(value).get();
+      StatusCode statusCode = writeRemoteAgeoutsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/LldpRemoteSystemTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/LldpRemoteSystemTypeNode.java
@@ -93,7 +93,10 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   @Override
   public void writeTimeMark(UInteger value) throws UaException {
     try {
-      writeTimeMarkAsync(value).get();
+      StatusCode statusCode = writeTimeMarkAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -163,7 +166,10 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   @Override
   public void writeRemoteIndex(UInteger value) throws UaException {
     try {
-      writeRemoteIndexAsync(value).get();
+      StatusCode statusCode = writeRemoteIndexAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -241,7 +247,10 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   @Override
   public void writeChassisIdSubtype(ChassisIdSubtype value) throws UaException {
     try {
-      writeChassisIdSubtypeAsync(value).get();
+      StatusCode statusCode = writeChassisIdSubtypeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -323,7 +332,10 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   @Override
   public void writeChassisId(String value) throws UaException {
     try {
-      writeChassisIdAsync(value).get();
+      StatusCode statusCode = writeChassisIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -401,7 +413,10 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   @Override
   public void writePortIdSubtype(PortIdSubtype value) throws UaException {
     try {
-      writePortIdSubtypeAsync(value).get();
+      StatusCode statusCode = writePortIdSubtypeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -479,7 +494,10 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   @Override
   public void writePortId(String value) throws UaException {
     try {
-      writePortIdAsync(value).get();
+      StatusCode statusCode = writePortIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -549,7 +567,10 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   @Override
   public void writePortDescription(String value) throws UaException {
     try {
-      writePortDescriptionAsync(value).get();
+      StatusCode statusCode = writePortDescriptionAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -619,7 +640,10 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   @Override
   public void writeSystemName(String value) throws UaException {
     try {
-      writeSystemNameAsync(value).get();
+      StatusCode statusCode = writeSystemNameAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -689,7 +713,10 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   @Override
   public void writeSystemDescription(String value) throws UaException {
     try {
-      writeSystemDescriptionAsync(value).get();
+      StatusCode statusCode = writeSystemDescriptionAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -762,7 +789,10 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   @Override
   public void writeSystemCapabilitiesSupported(LldpSystemCapabilitiesMap value) throws UaException {
     try {
-      writeSystemCapabilitiesSupportedAsync(value).get();
+      StatusCode statusCode = writeSystemCapabilitiesSupportedAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -838,7 +868,10 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   @Override
   public void writeSystemCapabilitiesEnabled(LldpSystemCapabilitiesMap value) throws UaException {
     try {
-      writeSystemCapabilitiesEnabledAsync(value).get();
+      StatusCode statusCode = writeSystemCapabilitiesEnabledAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -914,7 +947,10 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   @Override
   public void writeRemoteChanges(Boolean value) throws UaException {
     try {
-      writeRemoteChangesAsync(value).get();
+      StatusCode statusCode = writeRemoteChangesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -984,7 +1020,10 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   @Override
   public void writeRemoteTooManyNeighbors(Boolean value) throws UaException {
     try {
-      writeRemoteTooManyNeighborsAsync(value).get();
+      StatusCode statusCode = writeRemoteTooManyNeighborsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -1061,7 +1100,10 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   @Override
   public void writeManagementAddress(LldpManagementAddressType[] value) throws UaException {
     try {
-      writeManagementAddressAsync(value).get();
+      StatusCode statusCode = writeManagementAddressAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -1139,7 +1181,10 @@ public class LldpRemoteSystemTypeNode extends BaseObjectTypeNode implements Lldp
   @Override
   public void writeRemoteUnknownTlv(LldpTlvType[] value) throws UaException {
     try {
-      writeRemoteUnknownTlvAsync(value).get();
+      StatusCode statusCode = writeRemoteUnknownTlvAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/LogObjectTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/LogObjectTypeNode.java
@@ -88,7 +88,10 @@ public class LogObjectTypeNode extends BaseObjectTypeNode implements LogObjectTy
   @Override
   public void writeMaxRecords(UInteger value) throws UaException {
     try {
-      writeMaxRecordsAsync(value).get();
+      StatusCode statusCode = writeMaxRecordsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -158,7 +161,10 @@ public class LogObjectTypeNode extends BaseObjectTypeNode implements LogObjectTy
   @Override
   public void writeMaxStorageDuration(Double value) throws UaException {
     try {
-      writeMaxStorageDurationAsync(value).get();
+      StatusCode statusCode = writeMaxStorageDurationAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -231,7 +237,10 @@ public class LogObjectTypeNode extends BaseObjectTypeNode implements LogObjectTy
   @Override
   public void writeMinimumSeverity(UShort value) throws UaException {
     try {
-      writeMinimumSeverityAsync(value).get();
+      StatusCode statusCode = writeMinimumSeverityAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/NamespaceMetadataTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/NamespaceMetadataTypeNode.java
@@ -90,7 +90,10 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   @Override
   public void writeNamespaceUri(String value) throws UaException {
     try {
-      writeNamespaceUriAsync(value).get();
+      StatusCode statusCode = writeNamespaceUriAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -160,7 +163,10 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   @Override
   public void writeNamespaceVersion(String value) throws UaException {
     try {
-      writeNamespaceVersionAsync(value).get();
+      StatusCode statusCode = writeNamespaceVersionAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -233,7 +239,10 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   @Override
   public void writeNamespacePublicationDate(DateTime value) throws UaException {
     try {
-      writeNamespacePublicationDateAsync(value).get();
+      StatusCode statusCode = writeNamespacePublicationDateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -307,7 +316,10 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   @Override
   public void writeIsNamespaceSubset(Boolean value) throws UaException {
     try {
-      writeIsNamespaceSubsetAsync(value).get();
+      StatusCode statusCode = writeIsNamespaceSubsetAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -393,7 +405,10 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   @Override
   public void writeStaticNodeIdTypes(IdType[] value) throws UaException {
     try {
-      writeStaticNodeIdTypesAsync(value).get();
+      StatusCode statusCode = writeStaticNodeIdTypesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -481,7 +496,10 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   @Override
   public void writeStaticNumericNodeIdRange(String[] value) throws UaException {
     try {
-      writeStaticNumericNodeIdRangeAsync(value).get();
+      StatusCode statusCode = writeStaticNumericNodeIdRangeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -555,7 +573,10 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   @Override
   public void writeStaticStringNodeIdPattern(String value) throws UaException {
     try {
-      writeStaticStringNodeIdPatternAsync(value).get();
+      StatusCode statusCode = writeStaticStringNodeIdPatternAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -631,7 +652,10 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   @Override
   public void writeDefaultRolePermissions(RolePermissionType[] value) throws UaException {
     try {
-      writeDefaultRolePermissionsAsync(value).get();
+      StatusCode statusCode = writeDefaultRolePermissionsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -709,7 +733,10 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   @Override
   public void writeDefaultUserRolePermissions(RolePermissionType[] value) throws UaException {
     try {
-      writeDefaultUserRolePermissionsAsync(value).get();
+      StatusCode statusCode = writeDefaultUserRolePermissionsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -785,7 +812,10 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   @Override
   public void writeDefaultAccessRestrictions(AccessRestrictionType value) throws UaException {
     try {
-      writeDefaultAccessRestrictionsAsync(value).get();
+      StatusCode statusCode = writeDefaultAccessRestrictionsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -859,7 +889,10 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   @Override
   public void writeConfigurationVersion(UInteger value) throws UaException {
     try {
-      writeConfigurationVersionAsync(value).get();
+      StatusCode statusCode = writeConfigurationVersionAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -933,7 +966,10 @@ public class NamespaceMetadataTypeNode extends BaseObjectTypeNode implements Nam
   @Override
   public void writeModelVersion(String value) throws UaException {
     try {
-      writeModelVersionAsync(value).get();
+      StatusCode statusCode = writeModelVersionAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/NetworkAddressTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/NetworkAddressTypeNode.java
@@ -87,7 +87,10 @@ public class NetworkAddressTypeNode extends BaseObjectTypeNode implements Networ
   @Override
   public void writeNetworkInterface(String value) throws UaException {
     try {
-      writeNetworkInterfaceAsync(value).get();
+      StatusCode statusCode = writeNetworkInterfaceAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/NetworkAddressUrlTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/NetworkAddressUrlTypeNode.java
@@ -88,7 +88,10 @@ public class NetworkAddressUrlTypeNode extends NetworkAddressTypeNode
   @Override
   public void writeUrl(String value) throws UaException {
     try {
-      writeUrlAsync(value).get();
+      StatusCode statusCode = writeUrlAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/NonExclusiveDeviationAlarmTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/NonExclusiveDeviationAlarmTypeNode.java
@@ -88,7 +88,10 @@ public class NonExclusiveDeviationAlarmTypeNode extends NonExclusiveLimitAlarmTy
   @Override
   public void writeSetpointNode(NodeId value) throws UaException {
     try {
-      writeSetpointNodeAsync(value).get();
+      StatusCode statusCode = writeSetpointNodeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -158,7 +161,10 @@ public class NonExclusiveDeviationAlarmTypeNode extends NonExclusiveLimitAlarmTy
   @Override
   public void writeBaseSetpointNode(NodeId value) throws UaException {
     try {
-      writeBaseSetpointNodeAsync(value).get();
+      StatusCode statusCode = writeBaseSetpointNodeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/NonExclusiveLimitAlarmTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/NonExclusiveLimitAlarmTypeNode.java
@@ -88,7 +88,10 @@ public class NonExclusiveLimitAlarmTypeNode extends LimitAlarmTypeNode
   @Override
   public void writeActiveState(LocalizedText value) throws UaException {
     try {
-      writeActiveStateAsync(value).get();
+      StatusCode statusCode = writeActiveStateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -158,7 +161,10 @@ public class NonExclusiveLimitAlarmTypeNode extends LimitAlarmTypeNode
   @Override
   public void writeHighHighState(LocalizedText value) throws UaException {
     try {
-      writeHighHighStateAsync(value).get();
+      StatusCode statusCode = writeHighHighStateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -228,7 +234,10 @@ public class NonExclusiveLimitAlarmTypeNode extends LimitAlarmTypeNode
   @Override
   public void writeHighState(LocalizedText value) throws UaException {
     try {
-      writeHighStateAsync(value).get();
+      StatusCode statusCode = writeHighStateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -298,7 +307,10 @@ public class NonExclusiveLimitAlarmTypeNode extends LimitAlarmTypeNode
   @Override
   public void writeLowState(LocalizedText value) throws UaException {
     try {
-      writeLowStateAsync(value).get();
+      StatusCode statusCode = writeLowStateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -368,7 +380,10 @@ public class NonExclusiveLimitAlarmTypeNode extends LimitAlarmTypeNode
   @Override
   public void writeLowLowState(LocalizedText value) throws UaException {
     try {
-      writeLowLowStateAsync(value).get();
+      StatusCode statusCode = writeLowLowStateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/NonExclusiveRateOfChangeAlarmTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/NonExclusiveRateOfChangeAlarmTypeNode.java
@@ -91,7 +91,10 @@ public class NonExclusiveRateOfChangeAlarmTypeNode extends NonExclusiveLimitAlar
   @Override
   public void writeEngineeringUnits(EUInformation value) throws UaException {
     try {
-      writeEngineeringUnitsAsync(value).get();
+      StatusCode statusCode = writeEngineeringUnitsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/NonTransparentBackupRedundancyTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/NonTransparentBackupRedundancyTypeNode.java
@@ -93,7 +93,10 @@ public class NonTransparentBackupRedundancyTypeNode extends NonTransparentRedund
   @Override
   public void writeRedundantServerArray(RedundantServerDataType[] value) throws UaException {
     try {
-      writeRedundantServerArrayAsync(value).get();
+      StatusCode statusCode = writeRedundantServerArrayAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -177,7 +180,10 @@ public class NonTransparentBackupRedundancyTypeNode extends NonTransparentRedund
   @Override
   public void writeMode(RedundantServerMode value) throws UaException {
     try {
-      writeModeAsync(value).get();
+      StatusCode statusCode = writeModeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/NonTransparentNetworkRedundancyTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/NonTransparentNetworkRedundancyTypeNode.java
@@ -92,7 +92,10 @@ public class NonTransparentNetworkRedundancyTypeNode extends NonTransparentRedun
   @Override
   public void writeServerNetworkGroups(NetworkGroupDataType[] value) throws UaException {
     try {
-      writeServerNetworkGroupsAsync(value).get();
+      StatusCode statusCode = writeServerNetworkGroupsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/NonTransparentRedundancyTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/NonTransparentRedundancyTypeNode.java
@@ -88,7 +88,10 @@ public class NonTransparentRedundancyTypeNode extends ServerRedundancyTypeNode
   @Override
   public void writeServerUriArray(String[] value) throws UaException {
     try {
-      writeServerUriArrayAsync(value).get();
+      StatusCode statusCode = writeServerUriArrayAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/OffNormalAlarmTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/OffNormalAlarmTypeNode.java
@@ -87,7 +87,10 @@ public class OffNormalAlarmTypeNode extends DiscreteAlarmTypeNode implements Off
   @Override
   public void writeNormalState(NodeId value) throws UaException {
     try {
-      writeNormalStateAsync(value).get();
+      StatusCode statusCode = writeNormalStateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/OperationLimitsTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/OperationLimitsTypeNode.java
@@ -87,7 +87,10 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   @Override
   public void writeMaxNodesPerRead(UInteger value) throws UaException {
     try {
-      writeMaxNodesPerReadAsync(value).get();
+      StatusCode statusCode = writeMaxNodesPerReadAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -157,7 +160,10 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   @Override
   public void writeMaxNodesPerHistoryReadData(UInteger value) throws UaException {
     try {
-      writeMaxNodesPerHistoryReadDataAsync(value).get();
+      StatusCode statusCode = writeMaxNodesPerHistoryReadDataAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -231,7 +237,10 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   @Override
   public void writeMaxNodesPerHistoryReadEvents(UInteger value) throws UaException {
     try {
-      writeMaxNodesPerHistoryReadEventsAsync(value).get();
+      StatusCode statusCode = writeMaxNodesPerHistoryReadEventsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -305,7 +314,10 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   @Override
   public void writeMaxNodesPerWrite(UInteger value) throws UaException {
     try {
-      writeMaxNodesPerWriteAsync(value).get();
+      StatusCode statusCode = writeMaxNodesPerWriteAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -378,7 +390,10 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   @Override
   public void writeMaxNodesPerHistoryUpdateData(UInteger value) throws UaException {
     try {
-      writeMaxNodesPerHistoryUpdateDataAsync(value).get();
+      StatusCode statusCode = writeMaxNodesPerHistoryUpdateDataAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -452,7 +467,10 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   @Override
   public void writeMaxNodesPerHistoryUpdateEvents(UInteger value) throws UaException {
     try {
-      writeMaxNodesPerHistoryUpdateEventsAsync(value).get();
+      StatusCode statusCode = writeMaxNodesPerHistoryUpdateEventsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -527,7 +545,10 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   @Override
   public void writeMaxNodesPerMethodCall(UInteger value) throws UaException {
     try {
-      writeMaxNodesPerMethodCallAsync(value).get();
+      StatusCode statusCode = writeMaxNodesPerMethodCallAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -601,7 +622,10 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   @Override
   public void writeMaxNodesPerBrowse(UInteger value) throws UaException {
     try {
-      writeMaxNodesPerBrowseAsync(value).get();
+      StatusCode statusCode = writeMaxNodesPerBrowseAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -674,7 +698,10 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   @Override
   public void writeMaxNodesPerRegisterNodes(UInteger value) throws UaException {
     try {
-      writeMaxNodesPerRegisterNodesAsync(value).get();
+      StatusCode statusCode = writeMaxNodesPerRegisterNodesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -748,7 +775,10 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   @Override
   public void writeMaxNodesPerTranslateBrowsePathsToNodeIds(UInteger value) throws UaException {
     try {
-      writeMaxNodesPerTranslateBrowsePathsToNodeIdsAsync(value).get();
+      StatusCode statusCode = writeMaxNodesPerTranslateBrowsePathsToNodeIdsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -823,7 +853,10 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   @Override
   public void writeMaxNodesPerNodeManagement(UInteger value) throws UaException {
     try {
-      writeMaxNodesPerNodeManagementAsync(value).get();
+      StatusCode statusCode = writeMaxNodesPerNodeManagementAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -897,7 +930,10 @@ public class OperationLimitsTypeNode extends FolderTypeNode implements Operation
   @Override
   public void writeMaxMonitoredItemsPerCall(UInteger value) throws UaException {
     try {
-      writeMaxMonitoredItemsPerCallAsync(value).get();
+      StatusCode statusCode = writeMaxMonitoredItemsPerCallAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/OrderedListTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/OrderedListTypeNode.java
@@ -87,7 +87,10 @@ public class OrderedListTypeNode extends BaseObjectTypeNode implements OrderedLi
   @Override
   public void writeNodeVersion(String value) throws UaException {
     try {
-      writeNodeVersionAsync(value).get();
+      StatusCode statusCode = writeNodeVersionAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PriorityMappingTableTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PriorityMappingTableTypeNode.java
@@ -92,7 +92,10 @@ public class PriorityMappingTableTypeNode extends BaseObjectTypeNode
   @Override
   public void writePriorityMapppingEntries(PriorityMappingEntryType[] value) throws UaException {
     try {
-      writePriorityMapppingEntriesAsync(value).get();
+      StatusCode statusCode = writePriorityMapppingEntriesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ProgramStateMachineTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ProgramStateMachineTypeNode.java
@@ -93,7 +93,10 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   @Override
   public void writeCreatable(Boolean value) throws UaException {
     try {
-      writeCreatableAsync(value).get();
+      StatusCode statusCode = writeCreatableAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -163,7 +166,10 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   @Override
   public void writeDeletable(Boolean value) throws UaException {
     try {
-      writeDeletableAsync(value).get();
+      StatusCode statusCode = writeDeletableAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -233,7 +239,10 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   @Override
   public void writeAutoDelete(Boolean value) throws UaException {
     try {
-      writeAutoDeleteAsync(value).get();
+      StatusCode statusCode = writeAutoDeleteAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -303,7 +312,10 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   @Override
   public void writeRecycleCount(Integer value) throws UaException {
     try {
-      writeRecycleCountAsync(value).get();
+      StatusCode statusCode = writeRecycleCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -373,7 +385,10 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   @Override
   public void writeInstanceCount(UInteger value) throws UaException {
     try {
-      writeInstanceCountAsync(value).get();
+      StatusCode statusCode = writeInstanceCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -443,7 +458,10 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   @Override
   public void writeMaxInstanceCount(UInteger value) throws UaException {
     try {
-      writeMaxInstanceCountAsync(value).get();
+      StatusCode statusCode = writeMaxInstanceCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -516,7 +534,10 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   @Override
   public void writeMaxRecycleCount(UInteger value) throws UaException {
     try {
-      writeMaxRecycleCountAsync(value).get();
+      StatusCode statusCode = writeMaxRecycleCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -586,7 +607,10 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   @Override
   public void writeCurrentState(LocalizedText value) throws UaException {
     try {
-      writeCurrentStateAsync(value).get();
+      StatusCode statusCode = writeCurrentStateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -656,7 +680,10 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   @Override
   public void writeLastTransition(LocalizedText value) throws UaException {
     try {
-      writeLastTransitionAsync(value).get();
+      StatusCode statusCode = writeLastTransitionAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -728,7 +755,10 @@ public class ProgramStateMachineTypeNode extends FiniteStateMachineTypeNode
   @Override
   public void writeProgramDiagnostic(ProgramDiagnostic2DataType value) throws UaException {
     try {
-      writeProgramDiagnosticAsync(value).get();
+      StatusCode statusCode = writeProgramDiagnosticAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ProgramTransitionAuditEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ProgramTransitionAuditEventTypeNode.java
@@ -88,7 +88,10 @@ public class ProgramTransitionAuditEventTypeNode extends AuditUpdateStateEventTy
   @Override
   public void writeTransition(LocalizedText value) throws UaException {
     try {
-      writeTransitionAsync(value).get();
+      StatusCode statusCode = writeTransitionAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ProgramTransitionEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ProgramTransitionEventTypeNode.java
@@ -88,7 +88,10 @@ public class ProgramTransitionEventTypeNode extends TransitionEventTypeNode
   @Override
   public void writeIntermediateResult(Object value) throws UaException {
     try {
-      writeIntermediateResultAsync(value).get();
+      StatusCode statusCode = writeIntermediateResultAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ProgressEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ProgressEventTypeNode.java
@@ -88,7 +88,10 @@ public class ProgressEventTypeNode extends BaseEventTypeNode implements Progress
   @Override
   public void writeContext(Object value) throws UaException {
     try {
-      writeContextAsync(value).get();
+      StatusCode statusCode = writeContextAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -158,7 +161,10 @@ public class ProgressEventTypeNode extends BaseEventTypeNode implements Progress
   @Override
   public void writeProgress(UShort value) throws UaException {
     try {
-      writeProgressAsync(value).get();
+      StatusCode statusCode = writeProgressAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ProvisionableDeviceTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ProvisionableDeviceTypeNode.java
@@ -88,7 +88,10 @@ public class ProvisionableDeviceTypeNode extends BaseObjectTypeNode
   @Override
   public void writeIsSingleton(Boolean value) throws UaException {
     try {
-      writeIsSingletonAsync(value).get();
+      StatusCode statusCode = writeIsSingletonAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubCapabilitiesTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubCapabilitiesTypeNode.java
@@ -88,7 +88,10 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeMaxPubSubConnections(UInteger value) throws UaException {
     try {
-      writeMaxPubSubConnectionsAsync(value).get();
+      StatusCode statusCode = writeMaxPubSubConnectionsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -162,7 +165,10 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeMaxWriterGroups(UInteger value) throws UaException {
     try {
-      writeMaxWriterGroupsAsync(value).get();
+      StatusCode statusCode = writeMaxWriterGroupsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -232,7 +238,10 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeMaxReaderGroups(UInteger value) throws UaException {
     try {
-      writeMaxReaderGroupsAsync(value).get();
+      StatusCode statusCode = writeMaxReaderGroupsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -302,7 +311,10 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeMaxDataSetWriters(UInteger value) throws UaException {
     try {
-      writeMaxDataSetWritersAsync(value).get();
+      StatusCode statusCode = writeMaxDataSetWritersAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -375,7 +387,10 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeMaxDataSetReaders(UInteger value) throws UaException {
     try {
-      writeMaxDataSetReadersAsync(value).get();
+      StatusCode statusCode = writeMaxDataSetReadersAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -448,7 +463,10 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeMaxFieldsPerDataSet(UInteger value) throws UaException {
     try {
-      writeMaxFieldsPerDataSetAsync(value).get();
+      StatusCode statusCode = writeMaxFieldsPerDataSetAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -521,7 +539,10 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeMaxDataSetWritersPerGroup(UInteger value) throws UaException {
     try {
-      writeMaxDataSetWritersPerGroupAsync(value).get();
+      StatusCode statusCode = writeMaxDataSetWritersPerGroupAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -595,7 +616,10 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeMaxSecurityGroups(UInteger value) throws UaException {
     try {
-      writeMaxSecurityGroupsAsync(value).get();
+      StatusCode statusCode = writeMaxSecurityGroupsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -668,7 +692,10 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeMaxPushTargets(UInteger value) throws UaException {
     try {
-      writeMaxPushTargetsAsync(value).get();
+      StatusCode statusCode = writeMaxPushTargetsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -738,7 +765,10 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeMaxPublishedDataSets(UInteger value) throws UaException {
     try {
-      writeMaxPublishedDataSetsAsync(value).get();
+      StatusCode statusCode = writeMaxPublishedDataSetsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -812,7 +842,10 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeMaxStandaloneSubscribedDataSets(UInteger value) throws UaException {
     try {
-      writeMaxStandaloneSubscribedDataSetsAsync(value).get();
+      StatusCode statusCode = writeMaxStandaloneSubscribedDataSetsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -887,7 +920,10 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeMaxNetworkMessageSizeDatagram(UInteger value) throws UaException {
     try {
-      writeMaxNetworkMessageSizeDatagramAsync(value).get();
+      StatusCode statusCode = writeMaxNetworkMessageSizeDatagramAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -961,7 +997,10 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeMaxNetworkMessageSizeBroker(UInteger value) throws UaException {
     try {
-      writeMaxNetworkMessageSizeBrokerAsync(value).get();
+      StatusCode statusCode = writeMaxNetworkMessageSizeBrokerAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -1035,7 +1074,10 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeSupportSecurityKeyPull(Boolean value) throws UaException {
     try {
-      writeSupportSecurityKeyPullAsync(value).get();
+      StatusCode statusCode = writeSupportSecurityKeyPullAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -1109,7 +1151,10 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeSupportSecurityKeyPush(Boolean value) throws UaException {
     try {
-      writeSupportSecurityKeyPushAsync(value).get();
+      StatusCode statusCode = writeSupportSecurityKeyPushAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -1183,7 +1228,10 @@ public class PubSubCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeSupportSecurityKeyServer(Boolean value) throws UaException {
     try {
-      writeSupportSecurityKeyServerAsync(value).get();
+      StatusCode statusCode = writeSupportSecurityKeyServerAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubCommunicationFailureEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubCommunicationFailureEventTypeNode.java
@@ -88,7 +88,10 @@ public class PubSubCommunicationFailureEventTypeNode extends PubSubStatusEventTy
   @Override
   public void writeError(StatusCode value) throws UaException {
     try {
-      writeErrorAsync(value).get();
+      StatusCode statusCode = writeErrorAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubConnectionTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubConnectionTypeNode.java
@@ -90,7 +90,10 @@ public class PubSubConnectionTypeNode extends BaseObjectTypeNode implements PubS
   @Override
   public void writePublisherId(Object value) throws UaException {
     try {
-      writePublisherIdAsync(value).get();
+      StatusCode statusCode = writePublisherIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -162,7 +165,10 @@ public class PubSubConnectionTypeNode extends BaseObjectTypeNode implements PubS
   @Override
   public void writeConnectionProperties(KeyValuePair[] value) throws UaException {
     try {
-      writeConnectionPropertiesAsync(value).get();
+      StatusCode statusCode = writeConnectionPropertiesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -238,7 +244,10 @@ public class PubSubConnectionTypeNode extends BaseObjectTypeNode implements PubS
   @Override
   public void writeTransportProfileUri(String value) throws UaException {
     try {
-      writeTransportProfileUriAsync(value).get();
+      StatusCode statusCode = writeTransportProfileUriAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubDiagnosticsTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubDiagnosticsTypeNode.java
@@ -97,7 +97,10 @@ public class PubSubDiagnosticsTypeNode extends BaseObjectTypeNode implements Pub
   @Override
   public void writeDiagnosticsLevel(DiagnosticsLevel value) throws UaException {
     try {
-      writeDiagnosticsLevelAsync(value).get();
+      StatusCode statusCode = writeDiagnosticsLevelAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -179,7 +182,10 @@ public class PubSubDiagnosticsTypeNode extends BaseObjectTypeNode implements Pub
   @Override
   public void writeTotalInformation(UInteger value) throws UaException {
     try {
-      writeTotalInformationAsync(value).get();
+      StatusCode statusCode = writeTotalInformationAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -253,7 +259,10 @@ public class PubSubDiagnosticsTypeNode extends BaseObjectTypeNode implements Pub
   @Override
   public void writeTotalError(UInteger value) throws UaException {
     try {
-      writeTotalErrorAsync(value).get();
+      StatusCode statusCode = writeTotalErrorAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -323,7 +332,10 @@ public class PubSubDiagnosticsTypeNode extends BaseObjectTypeNode implements Pub
   @Override
   public void writeSubError(Boolean value) throws UaException {
     try {
-      writeSubErrorAsync(value).get();
+      StatusCode statusCode = writeSubErrorAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubGroupTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubGroupTypeNode.java
@@ -99,7 +99,10 @@ public class PubSubGroupTypeNode extends BaseObjectTypeNode implements PubSubGro
   @Override
   public void writeSecurityMode(MessageSecurityMode value) throws UaException {
     try {
-      writeSecurityModeAsync(value).get();
+      StatusCode statusCode = writeSecurityModeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -177,7 +180,10 @@ public class PubSubGroupTypeNode extends BaseObjectTypeNode implements PubSubGro
   @Override
   public void writeSecurityGroupId(String value) throws UaException {
     try {
-      writeSecurityGroupIdAsync(value).get();
+      StatusCode statusCode = writeSecurityGroupIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -249,7 +255,10 @@ public class PubSubGroupTypeNode extends BaseObjectTypeNode implements PubSubGro
   @Override
   public void writeSecurityKeyServices(EndpointDescription[] value) throws UaException {
     try {
-      writeSecurityKeyServicesAsync(value).get();
+      StatusCode statusCode = writeSecurityKeyServicesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -325,7 +334,10 @@ public class PubSubGroupTypeNode extends BaseObjectTypeNode implements PubSubGro
   @Override
   public void writeMaxNetworkMessageSize(UInteger value) throws UaException {
     try {
-      writeMaxNetworkMessageSizeAsync(value).get();
+      StatusCode statusCode = writeMaxNetworkMessageSizeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -401,7 +413,10 @@ public class PubSubGroupTypeNode extends BaseObjectTypeNode implements PubSubGro
   @Override
   public void writeGroupProperties(KeyValuePair[] value) throws UaException {
     try {
-      writeGroupPropertiesAsync(value).get();
+      StatusCode statusCode = writeGroupPropertiesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubKeyPushTargetTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubKeyPushTargetTypeNode.java
@@ -92,7 +92,10 @@ public class PubSubKeyPushTargetTypeNode extends BaseObjectTypeNode
   @Override
   public void writeApplicationUri(String value) throws UaException {
     try {
-      writeApplicationUriAsync(value).get();
+      StatusCode statusCode = writeApplicationUriAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -162,7 +165,10 @@ public class PubSubKeyPushTargetTypeNode extends BaseObjectTypeNode
   @Override
   public void writeEndpointUrl(String value) throws UaException {
     try {
-      writeEndpointUrlAsync(value).get();
+      StatusCode statusCode = writeEndpointUrlAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -232,7 +238,10 @@ public class PubSubKeyPushTargetTypeNode extends BaseObjectTypeNode
   @Override
   public void writeSecurityPolicyUri(String value) throws UaException {
     try {
-      writeSecurityPolicyUriAsync(value).get();
+      StatusCode statusCode = writeSecurityPolicyUriAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -306,7 +315,10 @@ public class PubSubKeyPushTargetTypeNode extends BaseObjectTypeNode
   @Override
   public void writeUserTokenType(UserTokenPolicy value) throws UaException {
     try {
-      writeUserTokenTypeAsync(value).get();
+      StatusCode statusCode = writeUserTokenTypeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -378,7 +390,10 @@ public class PubSubKeyPushTargetTypeNode extends BaseObjectTypeNode
   @Override
   public void writeRequestedKeyCount(UShort value) throws UaException {
     try {
-      writeRequestedKeyCountAsync(value).get();
+      StatusCode statusCode = writeRequestedKeyCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -451,7 +466,10 @@ public class PubSubKeyPushTargetTypeNode extends BaseObjectTypeNode
   @Override
   public void writeRetryInterval(Double value) throws UaException {
     try {
-      writeRetryIntervalAsync(value).get();
+      StatusCode statusCode = writeRetryIntervalAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -521,7 +539,10 @@ public class PubSubKeyPushTargetTypeNode extends BaseObjectTypeNode
   @Override
   public void writeLastPushExecutionTime(DateTime value) throws UaException {
     try {
-      writeLastPushExecutionTimeAsync(value).get();
+      StatusCode statusCode = writeLastPushExecutionTimeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -595,7 +616,10 @@ public class PubSubKeyPushTargetTypeNode extends BaseObjectTypeNode
   @Override
   public void writeLastPushErrorTime(DateTime value) throws UaException {
     try {
-      writeLastPushErrorTimeAsync(value).get();
+      StatusCode statusCode = writeLastPushErrorTimeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubStatusEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubStatusEventTypeNode.java
@@ -89,7 +89,10 @@ public class PubSubStatusEventTypeNode extends SystemEventTypeNode
   @Override
   public void writeConnectionId(NodeId value) throws UaException {
     try {
-      writeConnectionIdAsync(value).get();
+      StatusCode statusCode = writeConnectionIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -159,7 +162,10 @@ public class PubSubStatusEventTypeNode extends SystemEventTypeNode
   @Override
   public void writeGroupId(NodeId value) throws UaException {
     try {
-      writeGroupIdAsync(value).get();
+      StatusCode statusCode = writeGroupIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -237,7 +243,10 @@ public class PubSubStatusEventTypeNode extends SystemEventTypeNode
   @Override
   public void writeState(PubSubState value) throws UaException {
     try {
-      writeStateAsync(value).get();
+      StatusCode statusCode = writeStateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubStatusTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubStatusTypeNode.java
@@ -96,7 +96,10 @@ public class PubSubStatusTypeNode extends BaseObjectTypeNode implements PubSubSt
   @Override
   public void writeState(PubSubState value) throws UaException {
     try {
-      writeStateAsync(value).get();
+      StatusCode statusCode = writeStateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubTransportLimitsExceedEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PubSubTransportLimitsExceedEventTypeNode.java
@@ -88,7 +88,10 @@ public class PubSubTransportLimitsExceedEventTypeNode extends PubSubStatusEventT
   @Override
   public void writeActual(UInteger value) throws UaException {
     try {
-      writeActualAsync(value).get();
+      StatusCode statusCode = writeActualAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -158,7 +161,10 @@ public class PubSubTransportLimitsExceedEventTypeNode extends PubSubStatusEventT
   @Override
   public void writeMaximum(UInteger value) throws UaException {
     try {
-      writeMaximumAsync(value).get();
+      StatusCode statusCode = writeMaximumAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PublishSubscribeTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PublishSubscribeTypeNode.java
@@ -92,7 +92,10 @@ public class PublishSubscribeTypeNode extends PubSubKeyServiceTypeNode
   @Override
   public void writeSupportedTransportProfiles(String[] value) throws UaException {
     try {
-      writeSupportedTransportProfilesAsync(value).get();
+      StatusCode statusCode = writeSupportedTransportProfilesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -166,7 +169,10 @@ public class PublishSubscribeTypeNode extends PubSubKeyServiceTypeNode
   @Override
   public void writeDefaultDatagramPublisherId(ULong value) throws UaException {
     try {
-      writeDefaultDatagramPublisherIdAsync(value).get();
+      StatusCode statusCode = writeDefaultDatagramPublisherIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -240,7 +246,10 @@ public class PublishSubscribeTypeNode extends PubSubKeyServiceTypeNode
   @Override
   public void writeConfigurationVersion(UInteger value) throws UaException {
     try {
-      writeConfigurationVersionAsync(value).get();
+      StatusCode statusCode = writeConfigurationVersionAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -316,7 +325,10 @@ public class PublishSubscribeTypeNode extends PubSubKeyServiceTypeNode
   @Override
   public void writeDefaultSecurityKeyServices(EndpointDescription[] value) throws UaException {
     try {
-      writeDefaultSecurityKeyServicesAsync(value).get();
+      StatusCode statusCode = writeDefaultSecurityKeyServicesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -394,7 +406,10 @@ public class PublishSubscribeTypeNode extends PubSubKeyServiceTypeNode
   @Override
   public void writeConfigurationProperties(KeyValuePair[] value) throws UaException {
     try {
-      writeConfigurationPropertiesAsync(value).get();
+      StatusCode statusCode = writeConfigurationPropertiesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PublishedDataItemsTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PublishedDataItemsTypeNode.java
@@ -92,7 +92,10 @@ public class PublishedDataItemsTypeNode extends PublishedDataSetTypeNode
   @Override
   public void writePublishedData(PublishedVariableDataType[] value) throws UaException {
     try {
-      writePublishedDataAsync(value).get();
+      StatusCode statusCode = writePublishedDataAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PublishedDataSetTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PublishedDataSetTypeNode.java
@@ -92,7 +92,10 @@ public class PublishedDataSetTypeNode extends BaseObjectTypeNode implements Publ
   @Override
   public void writeConfigurationVersion(ConfigurationVersionDataType value) throws UaException {
     try {
-      writeConfigurationVersionAsync(value).get();
+      StatusCode statusCode = writeConfigurationVersionAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -169,7 +172,10 @@ public class PublishedDataSetTypeNode extends BaseObjectTypeNode implements Publ
   @Override
   public void writeDataSetMetaData(DataSetMetaDataType value) throws UaException {
     try {
-      writeDataSetMetaDataAsync(value).get();
+      StatusCode statusCode = writeDataSetMetaDataAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -242,7 +248,10 @@ public class PublishedDataSetTypeNode extends BaseObjectTypeNode implements Publ
   @Override
   public void writeDataSetClassId(UUID value) throws UaException {
     try {
-      writeDataSetClassIdAsync(value).get();
+      StatusCode statusCode = writeDataSetClassIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -312,7 +321,10 @@ public class PublishedDataSetTypeNode extends BaseObjectTypeNode implements Publ
   @Override
   public void writeCyclicDataSet(Boolean value) throws UaException {
     try {
-      writeCyclicDataSetAsync(value).get();
+      StatusCode statusCode = writeCyclicDataSetAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PublishedEventsTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/PublishedEventsTypeNode.java
@@ -91,7 +91,10 @@ public class PublishedEventsTypeNode extends PublishedDataSetTypeNode
   @Override
   public void writePubSubEventNotifier(NodeId value) throws UaException {
     try {
-      writePubSubEventNotifierAsync(value).get();
+      StatusCode statusCode = writePubSubEventNotifierAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -166,7 +169,10 @@ public class PublishedEventsTypeNode extends PublishedDataSetTypeNode
   @Override
   public void writeSelectedFields(SimpleAttributeOperand[] value) throws UaException {
     try {
-      writeSelectedFieldsAsync(value).get();
+      StatusCode statusCode = writeSelectedFieldsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -240,7 +246,10 @@ public class PublishedEventsTypeNode extends PublishedDataSetTypeNode
   @Override
   public void writeFilter(ContentFilter value) throws UaException {
     try {
-      writeFilterAsync(value).get();
+      StatusCode statusCode = writeFilterAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/QuantityTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/QuantityTypeNode.java
@@ -90,7 +90,10 @@ public class QuantityTypeNode extends BaseObjectTypeNode implements QuantityType
   @Override
   public void writeSymbol(LocalizedText value) throws UaException {
     try {
-      writeSymbolAsync(value).get();
+      StatusCode statusCode = writeSymbolAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -162,7 +165,10 @@ public class QuantityTypeNode extends BaseObjectTypeNode implements QuantityType
   @Override
   public void writeAnnotation(AnnotationDataType[] value) throws UaException {
     try {
-      writeAnnotationAsync(value).get();
+      StatusCode statusCode = writeAnnotationAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -234,7 +240,10 @@ public class QuantityTypeNode extends BaseObjectTypeNode implements QuantityType
   @Override
   public void writeConversionService(String value) throws UaException {
     try {
-      writeConversionServiceAsync(value).get();
+      StatusCode statusCode = writeConversionServiceAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -308,7 +317,10 @@ public class QuantityTypeNode extends BaseObjectTypeNode implements QuantityType
   @Override
   public void writeDimension(QuantityDimension value) throws UaException {
     try {
-      writeDimensionAsync(value).get();
+      StatusCode statusCode = writeDimensionAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/RoleTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/RoleTypeNode.java
@@ -92,7 +92,10 @@ public class RoleTypeNode extends BaseObjectTypeNode implements RoleType {
   @Override
   public void writeIdentities(IdentityMappingRuleType[] value) throws UaException {
     try {
-      writeIdentitiesAsync(value).get();
+      StatusCode statusCode = writeIdentitiesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -164,7 +167,10 @@ public class RoleTypeNode extends BaseObjectTypeNode implements RoleType {
   @Override
   public void writeApplicationsExclude(Boolean value) throws UaException {
     try {
-      writeApplicationsExcludeAsync(value).get();
+      StatusCode statusCode = writeApplicationsExcludeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -237,7 +243,10 @@ public class RoleTypeNode extends BaseObjectTypeNode implements RoleType {
   @Override
   public void writeApplications(String[] value) throws UaException {
     try {
-      writeApplicationsAsync(value).get();
+      StatusCode statusCode = writeApplicationsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -307,7 +316,10 @@ public class RoleTypeNode extends BaseObjectTypeNode implements RoleType {
   @Override
   public void writeEndpointsExclude(Boolean value) throws UaException {
     try {
-      writeEndpointsExcludeAsync(value).get();
+      StatusCode statusCode = writeEndpointsExcludeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -382,7 +394,10 @@ public class RoleTypeNode extends BaseObjectTypeNode implements RoleType {
   @Override
   public void writeEndpoints(EndpointType[] value) throws UaException {
     try {
-      writeEndpointsAsync(value).get();
+      StatusCode statusCode = writeEndpointsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -454,7 +469,10 @@ public class RoleTypeNode extends BaseObjectTypeNode implements RoleType {
   @Override
   public void writeCustomConfiguration(Boolean value) throws UaException {
     try {
-      writeCustomConfigurationAsync(value).get();
+      StatusCode statusCode = writeCustomConfigurationAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/SecurityGroupFolderTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/SecurityGroupFolderTypeNode.java
@@ -87,7 +87,10 @@ public class SecurityGroupFolderTypeNode extends FolderTypeNode implements Secur
   @Override
   public void writeSupportedSecurityPolicyUris(String[] value) throws UaException {
     try {
-      writeSupportedSecurityPolicyUrisAsync(value).get();
+      StatusCode statusCode = writeSupportedSecurityPolicyUrisAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/SecurityGroupTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/SecurityGroupTypeNode.java
@@ -87,7 +87,10 @@ public class SecurityGroupTypeNode extends BaseObjectTypeNode implements Securit
   @Override
   public void writeSecurityGroupId(String value) throws UaException {
     try {
-      writeSecurityGroupIdAsync(value).get();
+      StatusCode statusCode = writeSecurityGroupIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -157,7 +160,10 @@ public class SecurityGroupTypeNode extends BaseObjectTypeNode implements Securit
   @Override
   public void writeKeyLifetime(Double value) throws UaException {
     try {
-      writeKeyLifetimeAsync(value).get();
+      StatusCode statusCode = writeKeyLifetimeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -227,7 +233,10 @@ public class SecurityGroupTypeNode extends BaseObjectTypeNode implements Securit
   @Override
   public void writeSecurityPolicyUri(String value) throws UaException {
     try {
-      writeSecurityPolicyUriAsync(value).get();
+      StatusCode statusCode = writeSecurityPolicyUriAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -300,7 +309,10 @@ public class SecurityGroupTypeNode extends BaseObjectTypeNode implements Securit
   @Override
   public void writeMaxFutureKeyCount(UInteger value) throws UaException {
     try {
-      writeMaxFutureKeyCountAsync(value).get();
+      StatusCode statusCode = writeMaxFutureKeyCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -373,7 +385,10 @@ public class SecurityGroupTypeNode extends BaseObjectTypeNode implements Securit
   @Override
   public void writeMaxPastKeyCount(UInteger value) throws UaException {
     try {
-      writeMaxPastKeyCountAsync(value).get();
+      StatusCode statusCode = writeMaxPastKeyCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/SemanticChangeEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/SemanticChangeEventTypeNode.java
@@ -92,7 +92,10 @@ public class SemanticChangeEventTypeNode extends BaseEventTypeNode
   @Override
   public void writeChanges(SemanticChangeStructureDataType[] value) throws UaException {
     try {
-      writeChangesAsync(value).get();
+      StatusCode statusCode = writeChangesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/SerializationEntityTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/SerializationEntityTypeNode.java
@@ -93,7 +93,10 @@ public class SerializationEntityTypeNode extends BaseObjectTypeNode
   @Override
   public void writeIncludeReferenceTypes(NodeId[] value) throws UaException {
     try {
-      writeIncludeReferenceTypesAsync(value).get();
+      StatusCode statusCode = writeIncludeReferenceTypesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -167,7 +170,10 @@ public class SerializationEntityTypeNode extends BaseObjectTypeNode
   @Override
   public void writeExcludeReferenceTypes(NodeId[] value) throws UaException {
     try {
-      writeExcludeReferenceTypesAsync(value).get();
+      StatusCode statusCode = writeExcludeReferenceTypesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -241,7 +247,10 @@ public class SerializationEntityTypeNode extends BaseObjectTypeNode
   @Override
   public void writeSerializationDepth(UShort value) throws UaException {
     try {
-      writeSerializationDepthAsync(value).get();
+      StatusCode statusCode = writeSerializationDepthAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -314,7 +323,10 @@ public class SerializationEntityTypeNode extends BaseObjectTypeNode
   @Override
   public void writeConsiderSubElementSerializationProperties(Boolean value) throws UaException {
     try {
-      writeConsiderSubElementSerializationPropertiesAsync(value).get();
+      StatusCode statusCode = writeConsiderSubElementSerializationPropertiesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -391,7 +403,10 @@ public class SerializationEntityTypeNode extends BaseObjectTypeNode
   @Override
   public void writeCustomMetaDataProperties(KeyValuePair[] value) throws UaException {
     try {
-      writeCustomMetaDataPropertiesAsync(value).get();
+      StatusCode statusCode = writeCustomMetaDataPropertiesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -467,7 +482,10 @@ public class SerializationEntityTypeNode extends BaseObjectTypeNode
   @Override
   public void writeCustomMetaDataRef(NodeId value) throws UaException {
     try {
-      writeCustomMetaDataRefAsync(value).get();
+      StatusCode statusCode = writeCustomMetaDataRefAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -540,7 +558,10 @@ public class SerializationEntityTypeNode extends BaseObjectTypeNode
   @Override
   public void writeIncludeStatus(Boolean value) throws UaException {
     try {
-      writeIncludeStatusAsync(value).get();
+      StatusCode statusCode = writeIncludeStatusAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -610,7 +631,10 @@ public class SerializationEntityTypeNode extends BaseObjectTypeNode
   @Override
   public void writeIncludeSourceTimestamp(Boolean value) throws UaException {
     try {
-      writeIncludeSourceTimestampAsync(value).get();
+      StatusCode statusCode = writeIncludeSourceTimestampAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -684,7 +708,10 @@ public class SerializationEntityTypeNode extends BaseObjectTypeNode
   @Override
   public void writeIncludeDictionaryReference(Boolean value) throws UaException {
     try {
-      writeIncludeDictionaryReferenceAsync(value).get();
+      StatusCode statusCode = writeIncludeDictionaryReferenceAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -759,7 +786,10 @@ public class SerializationEntityTypeNode extends BaseObjectTypeNode
   @Override
   public void writeSerializedData(Structure value) throws UaException {
     try {
-      writeSerializedDataAsync(value).get();
+      StatusCode statusCode = writeSerializedDataAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ServerCapabilitiesTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ServerCapabilitiesTypeNode.java
@@ -91,7 +91,10 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeServerProfileArray(String[] value) throws UaException {
     try {
-      writeServerProfileArrayAsync(value).get();
+      StatusCode statusCode = writeServerProfileArrayAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -164,7 +167,10 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeLocaleIdArray(String[] value) throws UaException {
     try {
-      writeLocaleIdArrayAsync(value).get();
+      StatusCode statusCode = writeLocaleIdArrayAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -234,7 +240,10 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeMinSupportedSampleRate(Double value) throws UaException {
     try {
-      writeMinSupportedSampleRateAsync(value).get();
+      StatusCode statusCode = writeMinSupportedSampleRateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -308,7 +317,10 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeMaxBrowseContinuationPoints(UShort value) throws UaException {
     try {
-      writeMaxBrowseContinuationPointsAsync(value).get();
+      StatusCode statusCode = writeMaxBrowseContinuationPointsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -382,7 +394,10 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeMaxQueryContinuationPoints(UShort value) throws UaException {
     try {
-      writeMaxQueryContinuationPointsAsync(value).get();
+      StatusCode statusCode = writeMaxQueryContinuationPointsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -456,7 +471,10 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeMaxHistoryContinuationPoints(UShort value) throws UaException {
     try {
-      writeMaxHistoryContinuationPointsAsync(value).get();
+      StatusCode statusCode = writeMaxHistoryContinuationPointsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -530,7 +548,10 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeMaxLogObjectContinuationPoints(UShort value) throws UaException {
     try {
-      writeMaxLogObjectContinuationPointsAsync(value).get();
+      StatusCode statusCode = writeMaxLogObjectContinuationPointsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -607,7 +628,10 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeSoftwareCertificates(SignedSoftwareCertificate[] value) throws UaException {
     try {
-      writeSoftwareCertificatesAsync(value).get();
+      StatusCode statusCode = writeSoftwareCertificatesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -683,7 +707,10 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeMaxArrayLength(UInteger value) throws UaException {
     try {
-      writeMaxArrayLengthAsync(value).get();
+      StatusCode statusCode = writeMaxArrayLengthAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -753,7 +780,10 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeMaxStringLength(UInteger value) throws UaException {
     try {
-      writeMaxStringLengthAsync(value).get();
+      StatusCode statusCode = writeMaxStringLengthAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -823,7 +853,10 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeMaxByteStringLength(UInteger value) throws UaException {
     try {
-      writeMaxByteStringLengthAsync(value).get();
+      StatusCode statusCode = writeMaxByteStringLengthAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -896,7 +929,10 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeMaxSessions(UInteger value) throws UaException {
     try {
-      writeMaxSessionsAsync(value).get();
+      StatusCode statusCode = writeMaxSessionsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -966,7 +1002,10 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeMaxSubscriptions(UInteger value) throws UaException {
     try {
-      writeMaxSubscriptionsAsync(value).get();
+      StatusCode statusCode = writeMaxSubscriptionsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -1039,7 +1078,10 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeMaxMonitoredItems(UInteger value) throws UaException {
     try {
-      writeMaxMonitoredItemsAsync(value).get();
+      StatusCode statusCode = writeMaxMonitoredItemsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -1112,7 +1154,10 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeMaxSubscriptionsPerSession(UInteger value) throws UaException {
     try {
-      writeMaxSubscriptionsPerSessionAsync(value).get();
+      StatusCode statusCode = writeMaxSubscriptionsPerSessionAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -1186,7 +1231,10 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeMaxMonitoredItemsPerSubscription(UInteger value) throws UaException {
     try {
-      writeMaxMonitoredItemsPerSubscriptionAsync(value).get();
+      StatusCode statusCode = writeMaxMonitoredItemsPerSubscriptionAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -1261,7 +1309,10 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeMaxSelectClauseParameters(UInteger value) throws UaException {
     try {
-      writeMaxSelectClauseParametersAsync(value).get();
+      StatusCode statusCode = writeMaxSelectClauseParametersAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -1335,7 +1386,10 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeMaxWhereClauseParameters(UInteger value) throws UaException {
     try {
-      writeMaxWhereClauseParametersAsync(value).get();
+      StatusCode statusCode = writeMaxWhereClauseParametersAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -1409,7 +1463,10 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeMaxMonitoredItemsQueueSize(UInteger value) throws UaException {
     try {
-      writeMaxMonitoredItemsQueueSizeAsync(value).get();
+      StatusCode statusCode = writeMaxMonitoredItemsQueueSizeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -1483,7 +1540,10 @@ public class ServerCapabilitiesTypeNode extends BaseObjectTypeNode
   @Override
   public void writeConformanceUnits(QualifiedName[] value) throws UaException {
     try {
-      writeConformanceUnitsAsync(value).get();
+      StatusCode statusCode = writeConformanceUnitsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ServerConfigurationTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ServerConfigurationTypeNode.java
@@ -89,7 +89,10 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   @Override
   public void writeApplicationUri(String value) throws UaException {
     try {
-      writeApplicationUriAsync(value).get();
+      StatusCode statusCode = writeApplicationUriAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -159,7 +162,10 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   @Override
   public void writeProductUri(String value) throws UaException {
     try {
-      writeProductUriAsync(value).get();
+      StatusCode statusCode = writeProductUriAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -237,7 +243,10 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   @Override
   public void writeApplicationType(ApplicationType value) throws UaException {
     try {
-      writeApplicationTypeAsync(value).get();
+      StatusCode statusCode = writeApplicationTypeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -315,7 +324,10 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   @Override
   public void writeApplicationNames(LocalizedText[] value) throws UaException {
     try {
-      writeApplicationNamesAsync(value).get();
+      StatusCode statusCode = writeApplicationNamesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -389,7 +401,10 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   @Override
   public void writeServerCapabilities(String[] value) throws UaException {
     try {
-      writeServerCapabilitiesAsync(value).get();
+      StatusCode statusCode = writeServerCapabilitiesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -462,7 +477,10 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   @Override
   public void writeSupportedPrivateKeyFormats(String[] value) throws UaException {
     try {
-      writeSupportedPrivateKeyFormatsAsync(value).get();
+      StatusCode statusCode = writeSupportedPrivateKeyFormatsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -536,7 +554,10 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   @Override
   public void writeMaxTrustListSize(UInteger value) throws UaException {
     try {
-      writeMaxTrustListSizeAsync(value).get();
+      StatusCode statusCode = writeMaxTrustListSizeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -609,7 +630,10 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   @Override
   public void writeMulticastDnsEnabled(Boolean value) throws UaException {
     try {
-      writeMulticastDnsEnabledAsync(value).get();
+      StatusCode statusCode = writeMulticastDnsEnabledAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -682,7 +706,10 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   @Override
   public void writeHasSecureElement(Boolean value) throws UaException {
     try {
-      writeHasSecureElementAsync(value).get();
+      StatusCode statusCode = writeHasSecureElementAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -755,7 +782,10 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   @Override
   public void writeSupportsTransactions(Boolean value) throws UaException {
     try {
-      writeSupportsTransactionsAsync(value).get();
+      StatusCode statusCode = writeSupportsTransactionsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -829,7 +859,10 @@ public class ServerConfigurationTypeNode extends BaseObjectTypeNode
   @Override
   public void writeInApplicationSetup(Boolean value) throws UaException {
     try {
-      writeInApplicationSetupAsync(value).get();
+      StatusCode statusCode = writeInApplicationSetupAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ServerDiagnosticsTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ServerDiagnosticsTypeNode.java
@@ -94,7 +94,10 @@ public class ServerDiagnosticsTypeNode extends BaseObjectTypeNode implements Ser
   @Override
   public void writeEnabledFlag(Boolean value) throws UaException {
     try {
-      writeEnabledFlagAsync(value).get();
+      StatusCode statusCode = writeEnabledFlagAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ServerRedundancyTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ServerRedundancyTypeNode.java
@@ -98,7 +98,10 @@ public class ServerRedundancyTypeNode extends BaseObjectTypeNode implements Serv
   @Override
   public void writeRedundancySupport(RedundancySupport value) throws UaException {
     try {
-      writeRedundancySupportAsync(value).get();
+      StatusCode statusCode = writeRedundancySupportAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -182,7 +185,10 @@ public class ServerRedundancyTypeNode extends BaseObjectTypeNode implements Serv
   @Override
   public void writeRedundantServerArray(RedundantServerDataType[] value) throws UaException {
     try {
-      writeRedundantServerArrayAsync(value).get();
+      StatusCode statusCode = writeRedundantServerArrayAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ServerTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ServerTypeNode.java
@@ -92,7 +92,10 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
   @Override
   public void writeServerArray(String[] value) throws UaException {
     try {
-      writeServerArrayAsync(value).get();
+      StatusCode statusCode = writeServerArrayAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -162,7 +165,10 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
   @Override
   public void writeNamespaceArray(String[] value) throws UaException {
     try {
-      writeNamespaceArrayAsync(value).get();
+      StatusCode statusCode = writeNamespaceArrayAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -232,7 +238,10 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
   @Override
   public void writeUrisVersion(UInteger value) throws UaException {
     try {
-      writeUrisVersionAsync(value).get();
+      StatusCode statusCode = writeUrisVersionAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -302,7 +311,10 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
   @Override
   public void writeServiceLevel(UByte value) throws UaException {
     try {
-      writeServiceLevelAsync(value).get();
+      StatusCode statusCode = writeServiceLevelAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -372,7 +384,10 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
   @Override
   public void writeAuditing(Boolean value) throws UaException {
     try {
-      writeAuditingAsync(value).get();
+      StatusCode statusCode = writeAuditingAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -442,7 +457,10 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
   @Override
   public void writeEstimatedReturnTime(DateTime value) throws UaException {
     try {
-      writeEstimatedReturnTimeAsync(value).get();
+      StatusCode statusCode = writeEstimatedReturnTimeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -516,7 +534,10 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
   @Override
   public void writeLocalTime(TimeZoneDataType value) throws UaException {
     try {
-      writeLocalTimeAsync(value).get();
+      StatusCode statusCode = writeLocalTimeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -588,7 +609,10 @@ public class ServerTypeNode extends BaseObjectTypeNode implements ServerType {
   @Override
   public void writeServerStatus(ServerStatusDataType value) throws UaException {
     try {
-      writeServerStatusAsync(value).get();
+      StatusCode statusCode = writeServerStatusAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ServerUnitTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ServerUnitTypeNode.java
@@ -96,7 +96,10 @@ public class ServerUnitTypeNode extends UnitTypeNode implements ServerUnitType {
   @Override
   public void writeConversionLimit(ConversionLimitEnum value) throws UaException {
     try {
-      writeConversionLimitAsync(value).get();
+      StatusCode statusCode = writeConversionLimitAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/SessionDiagnosticsObjectTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/SessionDiagnosticsObjectTypeNode.java
@@ -95,7 +95,10 @@ public class SessionDiagnosticsObjectTypeNode extends BaseObjectTypeNode
   @Override
   public void writeCurrentRoleIds(NodeId[] value) throws UaException {
     try {
-      writeCurrentRoleIdsAsync(value).get();
+      StatusCode statusCode = writeCurrentRoleIdsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -166,7 +169,10 @@ public class SessionDiagnosticsObjectTypeNode extends BaseObjectTypeNode
   @Override
   public void writeSessionDiagnostics(SessionDiagnosticsDataType value) throws UaException {
     try {
-      writeSessionDiagnosticsAsync(value).get();
+      StatusCode statusCode = writeSessionDiagnosticsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/SessionsDiagnosticsSummaryTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/SessionsDiagnosticsSummaryTypeNode.java
@@ -94,7 +94,10 @@ public class SessionsDiagnosticsSummaryTypeNode extends BaseObjectTypeNode
   @Override
   public void writeSessionDiagnosticsArray(SessionDiagnosticsDataType[] value) throws UaException {
     try {
-      writeSessionDiagnosticsArrayAsync(value).get();
+      StatusCode statusCode = writeSessionDiagnosticsArrayAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ShelvedStateMachineTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/ShelvedStateMachineTypeNode.java
@@ -88,7 +88,10 @@ public class ShelvedStateMachineTypeNode extends FiniteStateMachineTypeNode
   @Override
   public void writeUnshelveTime(Double value) throws UaException {
     try {
-      writeUnshelveTimeAsync(value).get();
+      StatusCode statusCode = writeUnshelveTimeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/StandaloneSubscribedDataSetTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/StandaloneSubscribedDataSetTypeNode.java
@@ -91,7 +91,10 @@ public class StandaloneSubscribedDataSetTypeNode extends BaseObjectTypeNode
   @Override
   public void writeDataSetMetaData(DataSetMetaDataType value) throws UaException {
     try {
-      writeDataSetMetaDataAsync(value).get();
+      StatusCode statusCode = writeDataSetMetaDataAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -164,7 +167,10 @@ public class StandaloneSubscribedDataSetTypeNode extends BaseObjectTypeNode
   @Override
   public void writeIsConnected(Boolean value) throws UaException {
     try {
-      writeIsConnectedAsync(value).get();
+      StatusCode statusCode = writeIsConnectedAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/StateMachineTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/StateMachineTypeNode.java
@@ -88,7 +88,10 @@ public class StateMachineTypeNode extends BaseObjectTypeNode implements StateMac
   @Override
   public void writeCurrentState(LocalizedText value) throws UaException {
     try {
-      writeCurrentStateAsync(value).get();
+      StatusCode statusCode = writeCurrentStateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -158,7 +161,10 @@ public class StateMachineTypeNode extends BaseObjectTypeNode implements StateMac
   @Override
   public void writeLastTransition(LocalizedText value) throws UaException {
     try {
-      writeLastTransitionAsync(value).get();
+      StatusCode statusCode = writeLastTransitionAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/StateTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/StateTypeNode.java
@@ -87,7 +87,10 @@ public class StateTypeNode extends BaseObjectTypeNode implements StateType {
   @Override
   public void writeStateNumber(UInteger value) throws UaException {
     try {
-      writeStateNumberAsync(value).get();
+      StatusCode statusCode = writeStateNumberAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/SyntaxReferenceEntryTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/SyntaxReferenceEntryTypeNode.java
@@ -88,7 +88,10 @@ public class SyntaxReferenceEntryTypeNode extends DictionaryEntryTypeNode
   @Override
   public void writeCommonName(String value) throws UaException {
     try {
-      writeCommonNameAsync(value).get();
+      StatusCode statusCode = writeCommonNameAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/SystemStatusChangeEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/SystemStatusChangeEventTypeNode.java
@@ -97,7 +97,10 @@ public class SystemStatusChangeEventTypeNode extends SystemEventTypeNode
   @Override
   public void writeSystemState(ServerState value) throws UaException {
     try {
-      writeSystemStateAsync(value).get();
+      StatusCode statusCode = writeSystemStateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/TargetVariablesTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/TargetVariablesTypeNode.java
@@ -92,7 +92,10 @@ public class TargetVariablesTypeNode extends SubscribedDataSetTypeNode
   @Override
   public void writeTargetVariables(FieldTargetDataType[] value) throws UaException {
     try {
-      writeTargetVariablesAsync(value).get();
+      StatusCode statusCode = writeTargetVariablesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/TemporaryFileTransferTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/TemporaryFileTransferTypeNode.java
@@ -88,7 +88,10 @@ public class TemporaryFileTransferTypeNode extends BaseObjectTypeNode
   @Override
   public void writeClientProcessingTimeout(Double value) throws UaException {
     try {
-      writeClientProcessingTimeoutAsync(value).get();
+      StatusCode statusCode = writeClientProcessingTimeoutAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/TransactionDiagnosticsTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/TransactionDiagnosticsTypeNode.java
@@ -91,7 +91,10 @@ public class TransactionDiagnosticsTypeNode extends BaseObjectTypeNode
   @Override
   public void writeStartTime(DateTime value) throws UaException {
     try {
-      writeStartTimeAsync(value).get();
+      StatusCode statusCode = writeStartTimeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -161,7 +164,10 @@ public class TransactionDiagnosticsTypeNode extends BaseObjectTypeNode
   @Override
   public void writeEndTime(DateTime value) throws UaException {
     try {
-      writeEndTimeAsync(value).get();
+      StatusCode statusCode = writeEndTimeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -231,7 +237,10 @@ public class TransactionDiagnosticsTypeNode extends BaseObjectTypeNode
   @Override
   public void writeResult(StatusCode value) throws UaException {
     try {
-      writeResultAsync(value).get();
+      StatusCode statusCode = writeResultAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -301,7 +310,10 @@ public class TransactionDiagnosticsTypeNode extends BaseObjectTypeNode
   @Override
   public void writeAffectedTrustLists(NodeId[] value) throws UaException {
     try {
-      writeAffectedTrustListsAsync(value).get();
+      StatusCode statusCode = writeAffectedTrustListsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -374,7 +386,10 @@ public class TransactionDiagnosticsTypeNode extends BaseObjectTypeNode
   @Override
   public void writeAffectedCertificateGroups(NodeId[] value) throws UaException {
     try {
-      writeAffectedCertificateGroupsAsync(value).get();
+      StatusCode statusCode = writeAffectedCertificateGroupsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -450,7 +465,10 @@ public class TransactionDiagnosticsTypeNode extends BaseObjectTypeNode
   @Override
   public void writeErrors(TransactionErrorType[] value) throws UaException {
     try {
-      writeErrorsAsync(value).get();
+      StatusCode statusCode = writeErrorsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/TransitionEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/TransitionEventTypeNode.java
@@ -88,7 +88,10 @@ public class TransitionEventTypeNode extends BaseEventTypeNode implements Transi
   @Override
   public void writeTransition(LocalizedText value) throws UaException {
     try {
-      writeTransitionAsync(value).get();
+      StatusCode statusCode = writeTransitionAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -158,7 +161,10 @@ public class TransitionEventTypeNode extends BaseEventTypeNode implements Transi
   @Override
   public void writeFromState(LocalizedText value) throws UaException {
     try {
-      writeFromStateAsync(value).get();
+      StatusCode statusCode = writeFromStateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -228,7 +234,10 @@ public class TransitionEventTypeNode extends BaseEventTypeNode implements Transi
   @Override
   public void writeToState(LocalizedText value) throws UaException {
     try {
-      writeToStateAsync(value).get();
+      StatusCode statusCode = writeToStateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/TransitionTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/TransitionTypeNode.java
@@ -87,7 +87,10 @@ public class TransitionTypeNode extends BaseObjectTypeNode implements Transition
   @Override
   public void writeTransitionNumber(UInteger value) throws UaException {
     try {
-      writeTransitionNumberAsync(value).get();
+      StatusCode statusCode = writeTransitionNumberAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/TransparentRedundancyTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/TransparentRedundancyTypeNode.java
@@ -92,7 +92,10 @@ public class TransparentRedundancyTypeNode extends ServerRedundancyTypeNode
   @Override
   public void writeRedundantServerArray(RedundantServerDataType[] value) throws UaException {
     try {
-      writeRedundantServerArrayAsync(value).get();
+      StatusCode statusCode = writeRedundantServerArrayAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -168,7 +171,10 @@ public class TransparentRedundancyTypeNode extends ServerRedundancyTypeNode
   @Override
   public void writeCurrentServerId(String value) throws UaException {
     try {
-      writeCurrentServerIdAsync(value).get();
+      StatusCode statusCode = writeCurrentServerIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/TrustListOutOfDateAlarmTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/TrustListOutOfDateAlarmTypeNode.java
@@ -89,7 +89,10 @@ public class TrustListOutOfDateAlarmTypeNode extends SystemOffNormalAlarmTypeNod
   @Override
   public void writeTrustListId(NodeId value) throws UaException {
     try {
-      writeTrustListIdAsync(value).get();
+      StatusCode statusCode = writeTrustListIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -159,7 +162,10 @@ public class TrustListOutOfDateAlarmTypeNode extends SystemOffNormalAlarmTypeNod
   @Override
   public void writeLastUpdateTime(DateTime value) throws UaException {
     try {
-      writeLastUpdateTimeAsync(value).get();
+      StatusCode statusCode = writeLastUpdateTimeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -229,7 +235,10 @@ public class TrustListOutOfDateAlarmTypeNode extends SystemOffNormalAlarmTypeNod
   @Override
   public void writeUpdateFrequency(Double value) throws UaException {
     try {
-      writeUpdateFrequencyAsync(value).get();
+      StatusCode statusCode = writeUpdateFrequencyAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/TrustListTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/TrustListTypeNode.java
@@ -89,7 +89,10 @@ public class TrustListTypeNode extends FileTypeNode implements TrustListType {
   @Override
   public void writeLastUpdateTime(DateTime value) throws UaException {
     try {
-      writeLastUpdateTimeAsync(value).get();
+      StatusCode statusCode = writeLastUpdateTimeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -159,7 +162,10 @@ public class TrustListTypeNode extends FileTypeNode implements TrustListType {
   @Override
   public void writeUpdateFrequency(Double value) throws UaException {
     try {
-      writeUpdateFrequencyAsync(value).get();
+      StatusCode statusCode = writeUpdateFrequencyAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -229,7 +235,10 @@ public class TrustListTypeNode extends FileTypeNode implements TrustListType {
   @Override
   public void writeActivityTimeout(Double value) throws UaException {
     try {
-      writeActivityTimeoutAsync(value).get();
+      StatusCode statusCode = writeActivityTimeoutAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -299,7 +308,10 @@ public class TrustListTypeNode extends FileTypeNode implements TrustListType {
   @Override
   public void writeDefaultValidationOptions(TrustListValidationOptions value) throws UaException {
     try {
-      writeDefaultValidationOptionsAsync(value).get();
+      StatusCode statusCode = writeDefaultValidationOptionsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/TrustListUpdatedAuditEventTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/TrustListUpdatedAuditEventTypeNode.java
@@ -88,7 +88,10 @@ public class TrustListUpdatedAuditEventTypeNode extends AuditUpdateMethodEventTy
   @Override
   public void writeTrustListId(NodeId value) throws UaException {
     try {
-      writeTrustListIdAsync(value).get();
+      StatusCode statusCode = writeTrustListIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/UadpDataSetReaderMessageTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/UadpDataSetReaderMessageTypeNode.java
@@ -92,7 +92,10 @@ public class UadpDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
   @Override
   public void writeGroupVersion(UInteger value) throws UaException {
     try {
-      writeGroupVersionAsync(value).get();
+      StatusCode statusCode = writeGroupVersionAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -162,7 +165,10 @@ public class UadpDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
   @Override
   public void writeNetworkMessageNumber(UShort value) throws UaException {
     try {
-      writeNetworkMessageNumberAsync(value).get();
+      StatusCode statusCode = writeNetworkMessageNumberAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -235,7 +241,10 @@ public class UadpDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
   @Override
   public void writeDataSetOffset(UShort value) throws UaException {
     try {
-      writeDataSetOffsetAsync(value).get();
+      StatusCode statusCode = writeDataSetOffsetAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -305,7 +314,10 @@ public class UadpDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
   @Override
   public void writeDataSetClassId(UUID value) throws UaException {
     try {
-      writeDataSetClassIdAsync(value).get();
+      StatusCode statusCode = writeDataSetClassIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -527,7 +539,10 @@ public class UadpDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
   @Override
   public void writePublishingInterval(Double value) throws UaException {
     try {
-      writePublishingIntervalAsync(value).get();
+      StatusCode statusCode = writePublishingIntervalAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -600,7 +615,10 @@ public class UadpDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
   @Override
   public void writeProcessingOffset(Double value) throws UaException {
     try {
-      writeProcessingOffsetAsync(value).get();
+      StatusCode statusCode = writeProcessingOffsetAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -673,7 +691,10 @@ public class UadpDataSetReaderMessageTypeNode extends DataSetReaderMessageTypeNo
   @Override
   public void writeReceiveOffset(Double value) throws UaException {
     try {
-      writeReceiveOffsetAsync(value).get();
+      StatusCode statusCode = writeReceiveOffsetAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/UadpDataSetWriterMessageTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/UadpDataSetWriterMessageTypeNode.java
@@ -166,7 +166,10 @@ public class UadpDataSetWriterMessageTypeNode extends DataSetWriterMessageTypeNo
   @Override
   public void writeConfiguredSize(UShort value) throws UaException {
     try {
-      writeConfiguredSizeAsync(value).get();
+      StatusCode statusCode = writeConfiguredSizeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -236,7 +239,10 @@ public class UadpDataSetWriterMessageTypeNode extends DataSetWriterMessageTypeNo
   @Override
   public void writeNetworkMessageNumber(UShort value) throws UaException {
     try {
-      writeNetworkMessageNumberAsync(value).get();
+      StatusCode statusCode = writeNetworkMessageNumberAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -309,7 +315,10 @@ public class UadpDataSetWriterMessageTypeNode extends DataSetWriterMessageTypeNo
   @Override
   public void writeDataSetOffset(UShort value) throws UaException {
     try {
-      writeDataSetOffsetAsync(value).get();
+      StatusCode statusCode = writeDataSetOffsetAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/UadpWriterGroupMessageTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/UadpWriterGroupMessageTypeNode.java
@@ -90,7 +90,10 @@ public class UadpWriterGroupMessageTypeNode extends WriterGroupMessageTypeNode
   @Override
   public void writeGroupVersion(UInteger value) throws UaException {
     try {
-      writeGroupVersionAsync(value).get();
+      StatusCode statusCode = writeGroupVersionAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -168,7 +171,10 @@ public class UadpWriterGroupMessageTypeNode extends WriterGroupMessageTypeNode
   @Override
   public void writeDataSetOrdering(DataSetOrderingType value) throws UaException {
     try {
-      writeDataSetOrderingAsync(value).get();
+      StatusCode statusCode = writeDataSetOrderingAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -323,7 +329,10 @@ public class UadpWriterGroupMessageTypeNode extends WriterGroupMessageTypeNode
   @Override
   public void writeSamplingOffset(Double value) throws UaException {
     try {
-      writeSamplingOffsetAsync(value).get();
+      StatusCode statusCode = writeSamplingOffsetAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -393,7 +402,10 @@ public class UadpWriterGroupMessageTypeNode extends WriterGroupMessageTypeNode
   @Override
   public void writePublishingOffset(Double[] value) throws UaException {
     try {
-      writePublishingOffsetAsync(value).get();
+      StatusCode statusCode = writePublishingOffsetAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/UnitTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/UnitTypeNode.java
@@ -87,7 +87,10 @@ public class UnitTypeNode extends BaseObjectTypeNode implements UnitType {
   @Override
   public void writeSymbol(LocalizedText value) throws UaException {
     try {
-      writeSymbolAsync(value).get();
+      StatusCode statusCode = writeSymbolAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -157,7 +160,10 @@ public class UnitTypeNode extends BaseObjectTypeNode implements UnitType {
   @Override
   public void writeUnitSystem(String value) throws UaException {
     try {
-      writeUnitSystemAsync(value).get();
+      StatusCode statusCode = writeUnitSystemAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -227,7 +233,10 @@ public class UnitTypeNode extends BaseObjectTypeNode implements UnitType {
   @Override
   public void writeDiscipline(String value) throws UaException {
     try {
-      writeDisciplineAsync(value).get();
+      StatusCode statusCode = writeDisciplineAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/UserManagementTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/UserManagementTypeNode.java
@@ -93,7 +93,10 @@ public class UserManagementTypeNode extends BaseObjectTypeNode implements UserMa
   @Override
   public void writeUsers(UserManagementDataType[] value) throws UaException {
     try {
-      writeUsersAsync(value).get();
+      StatusCode statusCode = writeUsersAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -166,7 +169,10 @@ public class UserManagementTypeNode extends BaseObjectTypeNode implements UserMa
   @Override
   public void writePasswordLength(Range value) throws UaException {
     try {
-      writePasswordLengthAsync(value).get();
+      StatusCode statusCode = writePasswordLengthAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -238,7 +244,10 @@ public class UserManagementTypeNode extends BaseObjectTypeNode implements UserMa
   @Override
   public void writePasswordOptions(PasswordOptionsMask value) throws UaException {
     try {
-      writePasswordOptionsAsync(value).get();
+      StatusCode statusCode = writePasswordOptionsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -309,7 +318,10 @@ public class UserManagementTypeNode extends BaseObjectTypeNode implements UserMa
   @Override
   public void writePasswordRestrictions(LocalizedText value) throws UaException {
     try {
-      writePasswordRestrictionsAsync(value).get();
+      StatusCode statusCode = writePasswordRestrictionsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/WriterGroupTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/WriterGroupTypeNode.java
@@ -88,7 +88,10 @@ public class WriterGroupTypeNode extends PubSubGroupTypeNode implements WriterGr
   @Override
   public void writeWriterGroupId(UShort value) throws UaException {
     try {
-      writeWriterGroupIdAsync(value).get();
+      StatusCode statusCode = writeWriterGroupIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -158,7 +161,10 @@ public class WriterGroupTypeNode extends PubSubGroupTypeNode implements WriterGr
   @Override
   public void writePublishingInterval(Double value) throws UaException {
     try {
-      writePublishingIntervalAsync(value).get();
+      StatusCode statusCode = writePublishingIntervalAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -231,7 +237,10 @@ public class WriterGroupTypeNode extends PubSubGroupTypeNode implements WriterGr
   @Override
   public void writeKeepAliveTime(Double value) throws UaException {
     try {
-      writeKeepAliveTimeAsync(value).get();
+      StatusCode statusCode = writeKeepAliveTimeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -301,7 +310,10 @@ public class WriterGroupTypeNode extends PubSubGroupTypeNode implements WriterGr
   @Override
   public void writePriority(UByte value) throws UaException {
     try {
-      writePriorityAsync(value).get();
+      StatusCode statusCode = writePriorityAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -371,7 +383,10 @@ public class WriterGroupTypeNode extends PubSubGroupTypeNode implements WriterGr
   @Override
   public void writeLocaleIds(String[] value) throws UaException {
     try {
-      writeLocaleIdsAsync(value).get();
+      StatusCode statusCode = writeLocaleIdsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -441,7 +456,10 @@ public class WriterGroupTypeNode extends PubSubGroupTypeNode implements WriterGr
   @Override
   public void writeHeaderLayoutUri(String value) throws UaException {
     try {
-      writeHeaderLayoutUriAsync(value).get();
+      StatusCode statusCode = writeHeaderLayoutUriAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/package-info.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/objects/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/**
+ * Generated client node interfaces and implementations for namespace-zero ObjectTypes.
+ *
+ * <p>AddressSpace constructs these typed nodes after resolving their type definition. Attribute
+ * accessors expose local snapshots; explicit read and write methods communicate with the server.
+ * Asynchronous property writers return the operation StatusCode. Their blocking counterparts throw
+ * UaException for a non-Good operation result, independently of whether the Write service completed
+ * normally.
+ *
+ * <p>The classes are generated from the standard NodeSet by opc-ua-codegen2. Change the generator
+ * and regenerate the affected model classes when modifying their shared accessors.
+ */
+package org.eclipse.milo.opcua.sdk.client.model.objects;

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/AlarmRateVariableTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/AlarmRateVariableTypeNode.java
@@ -105,7 +105,10 @@ public class AlarmRateVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeRate(UShort value) throws UaException {
     try {
-      writeRateAsync(value).get();
+      StatusCode statusCode = writeRateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/AlarmStateVariableTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/AlarmStateVariableTypeNode.java
@@ -107,7 +107,10 @@ public class AlarmStateVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeHighestActiveSeverity(UShort value) throws UaException {
     try {
-      writeHighestActiveSeverityAsync(value).get();
+      StatusCode statusCode = writeHighestActiveSeverityAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -181,7 +184,10 @@ public class AlarmStateVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeHighestUnackSeverity(UShort value) throws UaException {
     try {
-      writeHighestUnackSeverityAsync(value).get();
+      StatusCode statusCode = writeHighestUnackSeverityAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -254,7 +260,10 @@ public class AlarmStateVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeActiveCount(UInteger value) throws UaException {
     try {
-      writeActiveCountAsync(value).get();
+      StatusCode statusCode = writeActiveCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -324,7 +333,10 @@ public class AlarmStateVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeUnacknowledgedCount(UInteger value) throws UaException {
     try {
-      writeUnacknowledgedCountAsync(value).get();
+      StatusCode statusCode = writeUnacknowledgedCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -397,7 +409,10 @@ public class AlarmStateVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeUnconfirmedCount(UInteger value) throws UaException {
     try {
-      writeUnconfirmedCountAsync(value).get();
+      StatusCode statusCode = writeUnconfirmedCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -471,7 +486,10 @@ public class AlarmStateVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeFilter(ContentFilter value) throws UaException {
     try {
-      writeFilterAsync(value).get();
+      StatusCode statusCode = writeFilterAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/AnalogItemTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/AnalogItemTypeNode.java
@@ -106,7 +106,10 @@ public class AnalogItemTypeNode extends BaseAnalogTypeNode implements AnalogItem
   @Override
   public void writeEuRange(Range value) throws UaException {
     try {
-      writeEuRangeAsync(value).get();
+      StatusCode statusCode = writeEuRangeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/AnalogNumberItemTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/AnalogNumberItemTypeNode.java
@@ -106,7 +106,10 @@ public class AnalogNumberItemTypeNode extends AnalogItemTypeNode implements Anal
   @Override
   public void writeEuNumberRange(NumberRange value) throws UaException {
     try {
-      writeEuNumberRangeAsync(value).get();
+      StatusCode statusCode = writeEuNumberRangeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/AnalogNumberUnitRangeTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/AnalogNumberUnitRangeTypeNode.java
@@ -107,7 +107,10 @@ public class AnalogNumberUnitRangeTypeNode extends AnalogUnitRangeTypeNode
   @Override
   public void writeEuNumberRange(NumberRange value) throws UaException {
     try {
-      writeEuNumberRangeAsync(value).get();
+      StatusCode statusCode = writeEuNumberRangeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/AnalogUnitRangeTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/AnalogUnitRangeTypeNode.java
@@ -106,7 +106,10 @@ public class AnalogUnitRangeTypeNode extends AnalogItemTypeNode implements Analo
   @Override
   public void writeEngineeringUnits(EUInformation value) throws UaException {
     try {
-      writeEngineeringUnitsAsync(value).get();
+      StatusCode statusCode = writeEngineeringUnitsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/AnalogUnitTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/AnalogUnitTypeNode.java
@@ -106,7 +106,10 @@ public class AnalogUnitTypeNode extends BaseAnalogTypeNode implements AnalogUnit
   @Override
   public void writeEngineeringUnits(EUInformation value) throws UaException {
     try {
-      writeEngineeringUnitsAsync(value).get();
+      StatusCode statusCode = writeEngineeringUnitsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ArrayItemTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ArrayItemTypeNode.java
@@ -108,7 +108,10 @@ public class ArrayItemTypeNode extends DataItemTypeNode implements ArrayItemType
   @Override
   public void writeInstrumentRange(Range value) throws UaException {
     try {
-      writeInstrumentRangeAsync(value).get();
+      StatusCode statusCode = writeInstrumentRangeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -181,7 +184,10 @@ public class ArrayItemTypeNode extends DataItemTypeNode implements ArrayItemType
   @Override
   public void writeEuRange(Range value) throws UaException {
     try {
-      writeEuRangeAsync(value).get();
+      StatusCode statusCode = writeEuRangeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -253,7 +259,10 @@ public class ArrayItemTypeNode extends DataItemTypeNode implements ArrayItemType
   @Override
   public void writeEngineeringUnits(EUInformation value) throws UaException {
     try {
-      writeEngineeringUnitsAsync(value).get();
+      StatusCode statusCode = writeEngineeringUnitsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -328,7 +337,10 @@ public class ArrayItemTypeNode extends DataItemTypeNode implements ArrayItemType
   @Override
   public void writeTitle(LocalizedText value) throws UaException {
     try {
-      writeTitleAsync(value).get();
+      StatusCode statusCode = writeTitleAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -406,7 +418,10 @@ public class ArrayItemTypeNode extends DataItemTypeNode implements ArrayItemType
   @Override
   public void writeAxisScaleType(AxisScaleEnumeration value) throws UaException {
     try {
-      writeAxisScaleTypeAsync(value).get();
+      StatusCode statusCode = writeAxisScaleTypeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/AudioVariableTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/AudioVariableTypeNode.java
@@ -103,7 +103,10 @@ public class AudioVariableTypeNode extends BaseDataVariableTypeNode implements A
   @Override
   public void writeListId(String value) throws UaException {
     try {
-      writeListIdAsync(value).get();
+      StatusCode statusCode = writeListIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -173,7 +176,10 @@ public class AudioVariableTypeNode extends BaseDataVariableTypeNode implements A
   @Override
   public void writeAgencyId(String value) throws UaException {
     try {
-      writeAgencyIdAsync(value).get();
+      StatusCode statusCode = writeAgencyIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -243,7 +249,10 @@ public class AudioVariableTypeNode extends BaseDataVariableTypeNode implements A
   @Override
   public void writeVersionId(String value) throws UaException {
     try {
-      writeVersionIdAsync(value).get();
+      StatusCode statusCode = writeVersionIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/BaseAnalogTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/BaseAnalogTypeNode.java
@@ -108,7 +108,10 @@ public class BaseAnalogTypeNode extends DataItemTypeNode implements BaseAnalogTy
   @Override
   public void writeInstrumentRange(Range value) throws UaException {
     try {
-      writeInstrumentRangeAsync(value).get();
+      StatusCode statusCode = writeInstrumentRangeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -181,7 +184,10 @@ public class BaseAnalogTypeNode extends DataItemTypeNode implements BaseAnalogTy
   @Override
   public void writeInstrumentNumberRange(NumberRange value) throws UaException {
     try {
-      writeInstrumentNumberRangeAsync(value).get();
+      StatusCode statusCode = writeInstrumentNumberRangeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -258,7 +264,10 @@ public class BaseAnalogTypeNode extends DataItemTypeNode implements BaseAnalogTy
   @Override
   public void writeEuRange(Range value) throws UaException {
     try {
-      writeEuRangeAsync(value).get();
+      StatusCode statusCode = writeEuRangeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -330,7 +339,10 @@ public class BaseAnalogTypeNode extends DataItemTypeNode implements BaseAnalogTy
   @Override
   public void writeEuNumberRange(NumberRange value) throws UaException {
     try {
-      writeEuNumberRangeAsync(value).get();
+      StatusCode statusCode = writeEuNumberRangeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -403,7 +415,10 @@ public class BaseAnalogTypeNode extends DataItemTypeNode implements BaseAnalogTy
   @Override
   public void writeEngineeringUnits(EUInformation value) throws UaException {
     try {
-      writeEngineeringUnitsAsync(value).get();
+      StatusCode statusCode = writeEngineeringUnitsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/BitFieldTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/BitFieldTypeNode.java
@@ -107,7 +107,10 @@ public class BitFieldTypeNode extends BaseDataVariableTypeNode implements BitFie
   @Override
   public void writeBitFieldsDefinitions(BitFieldDefinition[] value) throws UaException {
     try {
-      writeBitFieldsDefinitionsAsync(value).get();
+      StatusCode statusCode = writeBitFieldsDefinitionsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/BuildInfoTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/BuildInfoTypeNode.java
@@ -104,7 +104,10 @@ public class BuildInfoTypeNode extends BaseDataVariableTypeNode implements Build
   @Override
   public void writeProductUri(String value) throws UaException {
     try {
-      writeProductUriAsync(value).get();
+      StatusCode statusCode = writeProductUriAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -174,7 +177,10 @@ public class BuildInfoTypeNode extends BaseDataVariableTypeNode implements Build
   @Override
   public void writeManufacturerName(String value) throws UaException {
     try {
-      writeManufacturerNameAsync(value).get();
+      StatusCode statusCode = writeManufacturerNameAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -247,7 +253,10 @@ public class BuildInfoTypeNode extends BaseDataVariableTypeNode implements Build
   @Override
   public void writeProductName(String value) throws UaException {
     try {
-      writeProductNameAsync(value).get();
+      StatusCode statusCode = writeProductNameAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -317,7 +326,10 @@ public class BuildInfoTypeNode extends BaseDataVariableTypeNode implements Build
   @Override
   public void writeSoftwareVersion(String value) throws UaException {
     try {
-      writeSoftwareVersionAsync(value).get();
+      StatusCode statusCode = writeSoftwareVersionAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -387,7 +399,10 @@ public class BuildInfoTypeNode extends BaseDataVariableTypeNode implements Build
   @Override
   public void writeBuildNumber(String value) throws UaException {
     try {
-      writeBuildNumberAsync(value).get();
+      StatusCode statusCode = writeBuildNumberAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -457,7 +472,10 @@ public class BuildInfoTypeNode extends BaseDataVariableTypeNode implements Build
   @Override
   public void writeBuildDate(DateTime value) throws UaException {
     try {
-      writeBuildDateAsync(value).get();
+      StatusCode statusCode = writeBuildDateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/CartesianCoordinatesTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/CartesianCoordinatesTypeNode.java
@@ -107,7 +107,10 @@ public class CartesianCoordinatesTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeLengthUnit(EUInformation value) throws UaException {
     try {
-      writeLengthUnitAsync(value).get();
+      StatusCode statusCode = writeLengthUnitAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ConditionVariableTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ConditionVariableTypeNode.java
@@ -105,7 +105,10 @@ public class ConditionVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeSourceTimestamp(DateTime value) throws UaException {
     try {
-      writeSourceTimestampAsync(value).get();
+      StatusCode statusCode = writeSourceTimestampAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/CubeItemTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/CubeItemTypeNode.java
@@ -106,7 +106,10 @@ public class CubeItemTypeNode extends ArrayItemTypeNode implements CubeItemType 
   @Override
   public void writeXAxisDefinition(AxisInformation value) throws UaException {
     try {
-      writeXAxisDefinitionAsync(value).get();
+      StatusCode statusCode = writeXAxisDefinitionAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -179,7 +182,10 @@ public class CubeItemTypeNode extends ArrayItemTypeNode implements CubeItemType 
   @Override
   public void writeYAxisDefinition(AxisInformation value) throws UaException {
     try {
-      writeYAxisDefinitionAsync(value).get();
+      StatusCode statusCode = writeYAxisDefinitionAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -252,7 +258,10 @@ public class CubeItemTypeNode extends ArrayItemTypeNode implements CubeItemType 
   @Override
   public void writeZAxisDefinition(AxisInformation value) throws UaException {
     try {
-      writeZAxisDefinitionAsync(value).get();
+      StatusCode statusCode = writeZAxisDefinitionAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/DataItemTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/DataItemTypeNode.java
@@ -103,7 +103,10 @@ public class DataItemTypeNode extends BaseDataVariableTypeNode implements DataIt
   @Override
   public void writeDefinition(String value) throws UaException {
     try {
-      writeDefinitionAsync(value).get();
+      StatusCode statusCode = writeDefinitionAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -173,7 +176,10 @@ public class DataItemTypeNode extends BaseDataVariableTypeNode implements DataIt
   @Override
   public void writeValuePrecision(Double value) throws UaException {
     try {
-      writeValuePrecisionAsync(value).get();
+      StatusCode statusCode = writeValuePrecisionAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/DataTypeDescriptionTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/DataTypeDescriptionTypeNode.java
@@ -105,7 +105,10 @@ public class DataTypeDescriptionTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeDataTypeVersion(String value) throws UaException {
     try {
-      writeDataTypeVersionAsync(value).get();
+      StatusCode statusCode = writeDataTypeVersionAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -175,7 +178,10 @@ public class DataTypeDescriptionTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeDictionaryFragment(ByteString value) throws UaException {
     try {
-      writeDictionaryFragmentAsync(value).get();
+      StatusCode statusCode = writeDictionaryFragmentAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/DataTypeDictionaryTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/DataTypeDictionaryTypeNode.java
@@ -104,7 +104,10 @@ public class DataTypeDictionaryTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeDataTypeVersion(String value) throws UaException {
     try {
-      writeDataTypeVersionAsync(value).get();
+      StatusCode statusCode = writeDataTypeVersionAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -174,7 +177,10 @@ public class DataTypeDictionaryTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeNamespaceUri(String value) throws UaException {
     try {
-      writeNamespaceUriAsync(value).get();
+      StatusCode statusCode = writeNamespaceUriAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -244,7 +250,10 @@ public class DataTypeDictionaryTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeDeprecated(Boolean value) throws UaException {
     try {
-      writeDeprecatedAsync(value).get();
+      StatusCode statusCode = writeDeprecatedAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ExpressionGuardVariableTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ExpressionGuardVariableTypeNode.java
@@ -107,7 +107,10 @@ public class ExpressionGuardVariableTypeNode extends GuardVariableTypeNode
   @Override
   public void writeExpression(ContentFilter value) throws UaException {
     try {
-      writeExpressionAsync(value).get();
+      StatusCode statusCode = writeExpressionAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/FiniteStateVariableTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/FiniteStateVariableTypeNode.java
@@ -104,7 +104,10 @@ public class FiniteStateVariableTypeNode extends StateVariableTypeNode
   @Override
   public void writeId(NodeId value) throws UaException {
     try {
-      writeIdAsync(value).get();
+      StatusCode statusCode = writeIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/FiniteTransitionVariableTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/FiniteTransitionVariableTypeNode.java
@@ -104,7 +104,10 @@ public class FiniteTransitionVariableTypeNode extends TransitionVariableTypeNode
   @Override
   public void writeId(NodeId value) throws UaException {
     try {
-      writeIdAsync(value).get();
+      StatusCode statusCode = writeIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/FrameTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/FrameTypeNode.java
@@ -106,7 +106,10 @@ public class FrameTypeNode extends BaseDataVariableTypeNode implements FrameType
   @Override
   public void writeConstant(Boolean value) throws UaException {
     try {
-      writeConstantAsync(value).get();
+      StatusCode statusCode = writeConstantAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -176,7 +179,10 @@ public class FrameTypeNode extends BaseDataVariableTypeNode implements FrameType
   @Override
   public void writeFixedBase(Boolean value) throws UaException {
     try {
-      writeFixedBaseAsync(value).get();
+      StatusCode statusCode = writeFixedBaseAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -247,7 +253,10 @@ public class FrameTypeNode extends BaseDataVariableTypeNode implements FrameType
   @Override
   public void writeCartesianCoordinates(CartesianCoordinates value) throws UaException {
     try {
-      writeCartesianCoordinatesAsync(value).get();
+      StatusCode statusCode = writeCartesianCoordinatesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -325,7 +334,10 @@ public class FrameTypeNode extends BaseDataVariableTypeNode implements FrameType
   @Override
   public void writeOrientation(Orientation value) throws UaException {
     try {
-      writeOrientationAsync(value).get();
+      StatusCode statusCode = writeOrientationAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -397,7 +409,10 @@ public class FrameTypeNode extends BaseDataVariableTypeNode implements FrameType
   @Override
   public void writeBaseFrame(NodeId value) throws UaException {
     try {
-      writeBaseFrameAsync(value).get();
+      StatusCode statusCode = writeBaseFrameAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ImageItemTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ImageItemTypeNode.java
@@ -106,7 +106,10 @@ public class ImageItemTypeNode extends ArrayItemTypeNode implements ImageItemTyp
   @Override
   public void writeXAxisDefinition(AxisInformation value) throws UaException {
     try {
-      writeXAxisDefinitionAsync(value).get();
+      StatusCode statusCode = writeXAxisDefinitionAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -179,7 +182,10 @@ public class ImageItemTypeNode extends ArrayItemTypeNode implements ImageItemTyp
   @Override
   public void writeYAxisDefinition(AxisInformation value) throws UaException {
     try {
-      writeYAxisDefinitionAsync(value).get();
+      StatusCode statusCode = writeYAxisDefinitionAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/MultiStateDictionaryEntryDiscreteBaseTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/MultiStateDictionaryEntryDiscreteBaseTypeNode.java
@@ -104,7 +104,10 @@ public class MultiStateDictionaryEntryDiscreteBaseTypeNode extends MultiStateVal
   @Override
   public void writeEnumDictionaryEntries(Object value) throws UaException {
     try {
-      writeEnumDictionaryEntriesAsync(value).get();
+      StatusCode statusCode = writeEnumDictionaryEntriesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -178,7 +181,10 @@ public class MultiStateDictionaryEntryDiscreteBaseTypeNode extends MultiStateVal
   @Override
   public void writeValueAsDictionaryEntries(NodeId[] value) throws UaException {
     try {
-      writeValueAsDictionaryEntriesAsync(value).get();
+      StatusCode statusCode = writeValueAsDictionaryEntriesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/MultiStateDictionaryEntryDiscreteTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/MultiStateDictionaryEntryDiscreteTypeNode.java
@@ -105,7 +105,10 @@ public class MultiStateDictionaryEntryDiscreteTypeNode
   @Override
   public void writeValueAsDictionaryEntries(NodeId[] value) throws UaException {
     try {
-      writeValueAsDictionaryEntriesAsync(value).get();
+      StatusCode statusCode = writeValueAsDictionaryEntriesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/MultiStateDiscreteTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/MultiStateDiscreteTypeNode.java
@@ -104,7 +104,10 @@ public class MultiStateDiscreteTypeNode extends DiscreteItemTypeNode
   @Override
   public void writeEnumStrings(LocalizedText[] value) throws UaException {
     try {
-      writeEnumStringsAsync(value).get();
+      StatusCode statusCode = writeEnumStringsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/MultiStateValueDiscreteTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/MultiStateValueDiscreteTypeNode.java
@@ -108,7 +108,10 @@ public class MultiStateValueDiscreteTypeNode extends DiscreteItemTypeNode
   @Override
   public void writeEnumValues(EnumValueType[] value) throws UaException {
     try {
-      writeEnumValuesAsync(value).get();
+      StatusCode statusCode = writeEnumValuesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -180,7 +183,10 @@ public class MultiStateValueDiscreteTypeNode extends DiscreteItemTypeNode
   @Override
   public void writeValueAsText(LocalizedText value) throws UaException {
     try {
-      writeValueAsTextAsync(value).get();
+      StatusCode statusCode = writeValueAsTextAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/NDimensionArrayItemTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/NDimensionArrayItemTypeNode.java
@@ -108,7 +108,10 @@ public class NDimensionArrayItemTypeNode extends ArrayItemTypeNode
   @Override
   public void writeAxisDefinition(AxisInformation[] value) throws UaException {
     try {
-      writeAxisDefinitionAsync(value).get();
+      StatusCode statusCode = writeAxisDefinitionAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/OptionSetTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/OptionSetTypeNode.java
@@ -103,7 +103,10 @@ public class OptionSetTypeNode extends BaseDataVariableTypeNode implements Optio
   @Override
   public void writeOptionSetValues(LocalizedText[] value) throws UaException {
     try {
-      writeOptionSetValuesAsync(value).get();
+      StatusCode statusCode = writeOptionSetValuesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -173,7 +176,10 @@ public class OptionSetTypeNode extends BaseDataVariableTypeNode implements Optio
   @Override
   public void writeBitMask(Boolean[] value) throws UaException {
     try {
-      writeBitMaskAsync(value).get();
+      StatusCode statusCode = writeBitMaskAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/OrientationTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/OrientationTypeNode.java
@@ -106,7 +106,10 @@ public class OrientationTypeNode extends BaseDataVariableTypeNode implements Ori
   @Override
   public void writeAngleUnit(EUInformation value) throws UaException {
     try {
-      writeAngleUnitAsync(value).get();
+      StatusCode statusCode = writeAngleUnitAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ProgramDiagnostic2TypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ProgramDiagnostic2TypeNode.java
@@ -107,7 +107,10 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeLastTransitionTime(DateTime value) throws UaException {
     try {
-      writeLastTransitionTimeAsync(value).get();
+      StatusCode statusCode = writeLastTransitionTimeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -180,7 +183,10 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeCreateSessionId(NodeId value) throws UaException {
     try {
-      writeCreateSessionIdAsync(value).get();
+      StatusCode statusCode = writeCreateSessionIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -250,7 +256,10 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeCreateClientName(String value) throws UaException {
     try {
-      writeCreateClientNameAsync(value).get();
+      StatusCode statusCode = writeCreateClientNameAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -323,7 +332,10 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeInvocationCreationTime(DateTime value) throws UaException {
     try {
-      writeInvocationCreationTimeAsync(value).get();
+      StatusCode statusCode = writeInvocationCreationTimeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -398,7 +410,10 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeLastMethodCall(String value) throws UaException {
     try {
-      writeLastMethodCallAsync(value).get();
+      StatusCode statusCode = writeLastMethodCallAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -468,7 +483,10 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeLastMethodSessionId(NodeId value) throws UaException {
     try {
-      writeLastMethodSessionIdAsync(value).get();
+      StatusCode statusCode = writeLastMethodSessionIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -543,7 +561,10 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeLastMethodInputArguments(Argument[] value) throws UaException {
     try {
-      writeLastMethodInputArgumentsAsync(value).get();
+      StatusCode statusCode = writeLastMethodInputArgumentsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -622,7 +643,10 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeLastMethodOutputArguments(Argument[] value) throws UaException {
     try {
-      writeLastMethodOutputArgumentsAsync(value).get();
+      StatusCode statusCode = writeLastMethodOutputArgumentsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -699,7 +723,10 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeLastMethodInputValues(Object[] value) throws UaException {
     try {
-      writeLastMethodInputValuesAsync(value).get();
+      StatusCode statusCode = writeLastMethodInputValuesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -773,7 +800,10 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeLastMethodOutputValues(Object[] value) throws UaException {
     try {
-      writeLastMethodOutputValuesAsync(value).get();
+      StatusCode statusCode = writeLastMethodOutputValuesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -848,7 +878,10 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeLastMethodCallTime(DateTime value) throws UaException {
     try {
-      writeLastMethodCallTimeAsync(value).get();
+      StatusCode statusCode = writeLastMethodCallTimeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -921,7 +954,10 @@ public class ProgramDiagnostic2TypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeLastMethodReturnStatus(StatusCode value) throws UaException {
     try {
-      writeLastMethodReturnStatusAsync(value).get();
+      StatusCode statusCode = writeLastMethodReturnStatusAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ProgramDiagnosticTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ProgramDiagnosticTypeNode.java
@@ -107,7 +107,10 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeCreateSessionId(NodeId value) throws UaException {
     try {
-      writeCreateSessionIdAsync(value).get();
+      StatusCode statusCode = writeCreateSessionIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -177,7 +180,10 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeCreateClientName(String value) throws UaException {
     try {
-      writeCreateClientNameAsync(value).get();
+      StatusCode statusCode = writeCreateClientNameAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -250,7 +256,10 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeInvocationCreationTime(DateTime value) throws UaException {
     try {
-      writeInvocationCreationTimeAsync(value).get();
+      StatusCode statusCode = writeInvocationCreationTimeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -324,7 +333,10 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeLastTransitionTime(DateTime value) throws UaException {
     try {
-      writeLastTransitionTimeAsync(value).get();
+      StatusCode statusCode = writeLastTransitionTimeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -397,7 +409,10 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeLastMethodCall(String value) throws UaException {
     try {
-      writeLastMethodCallAsync(value).get();
+      StatusCode statusCode = writeLastMethodCallAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -467,7 +482,10 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeLastMethodSessionId(NodeId value) throws UaException {
     try {
-      writeLastMethodSessionIdAsync(value).get();
+      StatusCode statusCode = writeLastMethodSessionIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -540,7 +558,10 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeLastMethodInputArguments(Object[] value) throws UaException {
     try {
-      writeLastMethodInputArgumentsAsync(value).get();
+      StatusCode statusCode = writeLastMethodInputArgumentsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -614,7 +635,10 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeLastMethodOutputArguments(Object[] value) throws UaException {
     try {
-      writeLastMethodOutputArgumentsAsync(value).get();
+      StatusCode statusCode = writeLastMethodOutputArgumentsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -688,7 +712,10 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeLastMethodCallTime(DateTime value) throws UaException {
     try {
-      writeLastMethodCallTimeAsync(value).get();
+      StatusCode statusCode = writeLastMethodCallTimeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -762,7 +789,10 @@ public class ProgramDiagnosticTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeLastMethodReturnStatus(StatusResult value) throws UaException {
     try {
-      writeLastMethodReturnStatusAsync(value).get();
+      StatusCode statusCode = writeLastMethodReturnStatusAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/PubSubDiagnosticsCounterTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/PubSubDiagnosticsCounterTypeNode.java
@@ -107,7 +107,10 @@ public class PubSubDiagnosticsCounterTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeActive(Boolean value) throws UaException {
     try {
-      writeActiveAsync(value).get();
+      StatusCode statusCode = writeActiveAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -185,7 +188,10 @@ public class PubSubDiagnosticsCounterTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeClassification(PubSubDiagnosticsCounterClassification value) throws UaException {
     try {
-      writeClassificationAsync(value).get();
+      StatusCode statusCode = writeClassificationAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -273,7 +279,10 @@ public class PubSubDiagnosticsCounterTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeDiagnosticsLevel(DiagnosticsLevel value) throws UaException {
     try {
-      writeDiagnosticsLevelAsync(value).get();
+      StatusCode statusCode = writeDiagnosticsLevelAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -355,7 +364,10 @@ public class PubSubDiagnosticsCounterTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeTimeFirstChange(DateTime value) throws UaException {
     try {
-      writeTimeFirstChangeAsync(value).get();
+      StatusCode statusCode = writeTimeFirstChangeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/RationalNumberTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/RationalNumberTypeNode.java
@@ -103,7 +103,10 @@ public class RationalNumberTypeNode extends BaseDataVariableTypeNode implements 
   @Override
   public void writeNumerator(Integer value) throws UaException {
     try {
-      writeNumeratorAsync(value).get();
+      StatusCode statusCode = writeNumeratorAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -173,7 +176,10 @@ public class RationalNumberTypeNode extends BaseDataVariableTypeNode implements 
   @Override
   public void writeDenominator(UInteger value) throws UaException {
     try {
-      writeDenominatorAsync(value).get();
+      StatusCode statusCode = writeDenominatorAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ReferenceDescriptionVariableTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ReferenceDescriptionVariableTypeNode.java
@@ -108,7 +108,10 @@ public class ReferenceDescriptionVariableTypeNode extends BaseDataVariableTypeNo
   @Override
   public void writeReferenceRefinement(ReferenceListEntryDataType[] value) throws UaException {
     try {
-      writeReferenceRefinementAsync(value).get();
+      StatusCode statusCode = writeReferenceRefinementAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/SamplingIntervalDiagnosticsTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/SamplingIntervalDiagnosticsTypeNode.java
@@ -104,7 +104,10 @@ public class SamplingIntervalDiagnosticsTypeNode extends BaseDataVariableTypeNod
   @Override
   public void writeSamplingInterval(Double value) throws UaException {
     try {
-      writeSamplingIntervalAsync(value).get();
+      StatusCode statusCode = writeSamplingIntervalAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -177,7 +180,10 @@ public class SamplingIntervalDiagnosticsTypeNode extends BaseDataVariableTypeNod
   @Override
   public void writeSampledMonitoredItemsCount(UInteger value) throws UaException {
     try {
-      writeSampledMonitoredItemsCountAsync(value).get();
+      StatusCode statusCode = writeSampledMonitoredItemsCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -252,7 +258,10 @@ public class SamplingIntervalDiagnosticsTypeNode extends BaseDataVariableTypeNod
   @Override
   public void writeMaxSampledMonitoredItemsCount(UInteger value) throws UaException {
     try {
-      writeMaxSampledMonitoredItemsCountAsync(value).get();
+      StatusCode statusCode = writeMaxSampledMonitoredItemsCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -327,7 +336,10 @@ public class SamplingIntervalDiagnosticsTypeNode extends BaseDataVariableTypeNod
   @Override
   public void writeDisabledMonitoredItemsSamplingCount(UInteger value) throws UaException {
     try {
-      writeDisabledMonitoredItemsSamplingCountAsync(value).get();
+      StatusCode statusCode = writeDisabledMonitoredItemsSamplingCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/SelectionListTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/SelectionListTypeNode.java
@@ -103,7 +103,10 @@ public class SelectionListTypeNode extends BaseDataVariableTypeNode implements S
   @Override
   public void writeSelections(Object[] value) throws UaException {
     try {
-      writeSelectionsAsync(value).get();
+      StatusCode statusCode = writeSelectionsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -173,7 +176,10 @@ public class SelectionListTypeNode extends BaseDataVariableTypeNode implements S
   @Override
   public void writeSelectionDescriptions(LocalizedText[] value) throws UaException {
     try {
-      writeSelectionDescriptionsAsync(value).get();
+      StatusCode statusCode = writeSelectionDescriptionsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -247,7 +253,10 @@ public class SelectionListTypeNode extends BaseDataVariableTypeNode implements S
   @Override
   public void writeRestrictToList(Boolean value) throws UaException {
     try {
-      writeRestrictToListAsync(value).get();
+      StatusCode statusCode = writeRestrictToListAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ServerDiagnosticsSummaryTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ServerDiagnosticsSummaryTypeNode.java
@@ -104,7 +104,10 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeServerViewCount(UInteger value) throws UaException {
     try {
-      writeServerViewCountAsync(value).get();
+      StatusCode statusCode = writeServerViewCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -174,7 +177,10 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeCurrentSessionCount(UInteger value) throws UaException {
     try {
-      writeCurrentSessionCountAsync(value).get();
+      StatusCode statusCode = writeCurrentSessionCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -247,7 +253,10 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeCumulatedSessionCount(UInteger value) throws UaException {
     try {
-      writeCumulatedSessionCountAsync(value).get();
+      StatusCode statusCode = writeCumulatedSessionCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -321,7 +330,10 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeSecurityRejectedSessionCount(UInteger value) throws UaException {
     try {
-      writeSecurityRejectedSessionCountAsync(value).get();
+      StatusCode statusCode = writeSecurityRejectedSessionCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -396,7 +408,10 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeRejectedSessionCount(UInteger value) throws UaException {
     try {
-      writeRejectedSessionCountAsync(value).get();
+      StatusCode statusCode = writeRejectedSessionCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -470,7 +485,10 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeSessionTimeoutCount(UInteger value) throws UaException {
     try {
-      writeSessionTimeoutCountAsync(value).get();
+      StatusCode statusCode = writeSessionTimeoutCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -543,7 +561,10 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeSessionAbortCount(UInteger value) throws UaException {
     try {
-      writeSessionAbortCountAsync(value).get();
+      StatusCode statusCode = writeSessionAbortCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -616,7 +637,10 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writePublishingIntervalCount(UInteger value) throws UaException {
     try {
-      writePublishingIntervalCountAsync(value).get();
+      StatusCode statusCode = writePublishingIntervalCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -691,7 +715,10 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeCurrentSubscriptionCount(UInteger value) throws UaException {
     try {
-      writeCurrentSubscriptionCountAsync(value).get();
+      StatusCode statusCode = writeCurrentSubscriptionCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -766,7 +793,10 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeCumulatedSubscriptionCount(UInteger value) throws UaException {
     try {
-      writeCumulatedSubscriptionCountAsync(value).get();
+      StatusCode statusCode = writeCumulatedSubscriptionCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -841,7 +871,10 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeSecurityRejectedRequestsCount(UInteger value) throws UaException {
     try {
-      writeSecurityRejectedRequestsCountAsync(value).get();
+      StatusCode statusCode = writeSecurityRejectedRequestsCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -916,7 +949,10 @@ public class ServerDiagnosticsSummaryTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeRejectedRequestsCount(UInteger value) throws UaException {
     try {
-      writeRejectedRequestsCountAsync(value).get();
+      StatusCode statusCode = writeRejectedRequestsCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ServerStatusTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ServerStatusTypeNode.java
@@ -107,7 +107,10 @@ public class ServerStatusTypeNode extends BaseDataVariableTypeNode implements Se
   @Override
   public void writeStartTime(DateTime value) throws UaException {
     try {
-      writeStartTimeAsync(value).get();
+      StatusCode statusCode = writeStartTimeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -177,7 +180,10 @@ public class ServerStatusTypeNode extends BaseDataVariableTypeNode implements Se
   @Override
   public void writeCurrentTime(DateTime value) throws UaException {
     try {
-      writeCurrentTimeAsync(value).get();
+      StatusCode statusCode = writeCurrentTimeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -255,7 +261,10 @@ public class ServerStatusTypeNode extends BaseDataVariableTypeNode implements Se
   @Override
   public void writeState(ServerState value) throws UaException {
     try {
-      writeStateAsync(value).get();
+      StatusCode statusCode = writeStateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -334,7 +343,10 @@ public class ServerStatusTypeNode extends BaseDataVariableTypeNode implements Se
   @Override
   public void writeBuildInfo(BuildInfo value) throws UaException {
     try {
-      writeBuildInfoAsync(value).get();
+      StatusCode statusCode = writeBuildInfoAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -405,7 +417,10 @@ public class ServerStatusTypeNode extends BaseDataVariableTypeNode implements Se
   @Override
   public void writeSecondsTillShutdown(UInteger value) throws UaException {
     try {
-      writeSecondsTillShutdownAsync(value).get();
+      StatusCode statusCode = writeSecondsTillShutdownAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -478,7 +493,10 @@ public class ServerStatusTypeNode extends BaseDataVariableTypeNode implements Se
   @Override
   public void writeShutdownReason(LocalizedText value) throws UaException {
     try {
-      writeShutdownReasonAsync(value).get();
+      StatusCode statusCode = writeShutdownReasonAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/SessionDiagnosticsArrayTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/SessionDiagnosticsArrayTypeNode.java
@@ -107,7 +107,10 @@ public class SessionDiagnosticsArrayTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeSessionDiagnostics(SessionDiagnosticsDataType value) throws UaException {
     try {
-      writeSessionDiagnosticsAsync(value).get();
+      StatusCode statusCode = writeSessionDiagnosticsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/SessionDiagnosticsVariableTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/SessionDiagnosticsVariableTypeNode.java
@@ -108,7 +108,10 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeSessionId(NodeId value) throws UaException {
     try {
-      writeSessionIdAsync(value).get();
+      StatusCode statusCode = writeSessionIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -178,7 +181,10 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeSessionName(String value) throws UaException {
     try {
-      writeSessionNameAsync(value).get();
+      StatusCode statusCode = writeSessionNameAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -249,7 +255,10 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeClientDescription(ApplicationDescription value) throws UaException {
     try {
-      writeClientDescriptionAsync(value).get();
+      StatusCode statusCode = writeClientDescriptionAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -325,7 +334,10 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeServerUri(String value) throws UaException {
     try {
-      writeServerUriAsync(value).get();
+      StatusCode statusCode = writeServerUriAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -395,7 +407,10 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeEndpointUrl(String value) throws UaException {
     try {
-      writeEndpointUrlAsync(value).get();
+      StatusCode statusCode = writeEndpointUrlAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -465,7 +480,10 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeLocaleIds(String[] value) throws UaException {
     try {
-      writeLocaleIdsAsync(value).get();
+      StatusCode statusCode = writeLocaleIdsAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -535,7 +553,10 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeActualSessionTimeout(Double value) throws UaException {
     try {
-      writeActualSessionTimeoutAsync(value).get();
+      StatusCode statusCode = writeActualSessionTimeoutAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -608,7 +629,10 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeMaxResponseMessageSize(UInteger value) throws UaException {
     try {
-      writeMaxResponseMessageSizeAsync(value).get();
+      StatusCode statusCode = writeMaxResponseMessageSizeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -683,7 +707,10 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeClientConnectionTime(DateTime value) throws UaException {
     try {
-      writeClientConnectionTimeAsync(value).get();
+      StatusCode statusCode = writeClientConnectionTimeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -757,7 +784,10 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeClientLastContactTime(DateTime value) throws UaException {
     try {
-      writeClientLastContactTimeAsync(value).get();
+      StatusCode statusCode = writeClientLastContactTimeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -831,7 +861,10 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeCurrentSubscriptionsCount(UInteger value) throws UaException {
     try {
-      writeCurrentSubscriptionsCountAsync(value).get();
+      StatusCode statusCode = writeCurrentSubscriptionsCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -906,7 +939,10 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeCurrentMonitoredItemsCount(UInteger value) throws UaException {
     try {
-      writeCurrentMonitoredItemsCountAsync(value).get();
+      StatusCode statusCode = writeCurrentMonitoredItemsCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -981,7 +1017,10 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeCurrentPublishRequestsInQueue(UInteger value) throws UaException {
     try {
-      writeCurrentPublishRequestsInQueueAsync(value).get();
+      StatusCode statusCode = writeCurrentPublishRequestsInQueueAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -1057,7 +1096,10 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeTotalRequestCount(ServiceCounterDataType value) throws UaException {
     try {
-      writeTotalRequestCountAsync(value).get();
+      StatusCode statusCode = writeTotalRequestCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -1133,7 +1175,10 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeUnauthorizedRequestCount(UInteger value) throws UaException {
     try {
-      writeUnauthorizedRequestCountAsync(value).get();
+      StatusCode statusCode = writeUnauthorizedRequestCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -1209,7 +1254,10 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeReadCount(ServiceCounterDataType value) throws UaException {
     try {
-      writeReadCountAsync(value).get();
+      StatusCode statusCode = writeReadCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -1281,7 +1329,10 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeHistoryReadCount(ServiceCounterDataType value) throws UaException {
     try {
-      writeHistoryReadCountAsync(value).get();
+      StatusCode statusCode = writeHistoryReadCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -1358,7 +1409,10 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeWriteCount(ServiceCounterDataType value) throws UaException {
     try {
-      writeWriteCountAsync(value).get();
+      StatusCode statusCode = writeWriteCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -1430,7 +1484,10 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeHistoryUpdateCount(ServiceCounterDataType value) throws UaException {
     try {
-      writeHistoryUpdateCountAsync(value).get();
+      StatusCode statusCode = writeHistoryUpdateCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -1507,7 +1564,10 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeCallCount(ServiceCounterDataType value) throws UaException {
     try {
-      writeCallCountAsync(value).get();
+      StatusCode statusCode = writeCallCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -1579,7 +1639,10 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeCreateMonitoredItemsCount(ServiceCounterDataType value) throws UaException {
     try {
-      writeCreateMonitoredItemsCountAsync(value).get();
+      StatusCode statusCode = writeCreateMonitoredItemsCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -1657,7 +1720,10 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeModifyMonitoredItemsCount(ServiceCounterDataType value) throws UaException {
     try {
-      writeModifyMonitoredItemsCountAsync(value).get();
+      StatusCode statusCode = writeModifyMonitoredItemsCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -1735,7 +1801,10 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeSetMonitoringModeCount(ServiceCounterDataType value) throws UaException {
     try {
-      writeSetMonitoringModeCountAsync(value).get();
+      StatusCode statusCode = writeSetMonitoringModeCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -1813,7 +1882,10 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeSetTriggeringCount(ServiceCounterDataType value) throws UaException {
     try {
-      writeSetTriggeringCountAsync(value).get();
+      StatusCode statusCode = writeSetTriggeringCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -1890,7 +1962,10 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeDeleteMonitoredItemsCount(ServiceCounterDataType value) throws UaException {
     try {
-      writeDeleteMonitoredItemsCountAsync(value).get();
+      StatusCode statusCode = writeDeleteMonitoredItemsCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -1968,7 +2043,10 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeCreateSubscriptionCount(ServiceCounterDataType value) throws UaException {
     try {
-      writeCreateSubscriptionCountAsync(value).get();
+      StatusCode statusCode = writeCreateSubscriptionCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -2046,7 +2124,10 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeModifySubscriptionCount(ServiceCounterDataType value) throws UaException {
     try {
-      writeModifySubscriptionCountAsync(value).get();
+      StatusCode statusCode = writeModifySubscriptionCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -2124,7 +2205,10 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeSetPublishingModeCount(ServiceCounterDataType value) throws UaException {
     try {
-      writeSetPublishingModeCountAsync(value).get();
+      StatusCode statusCode = writeSetPublishingModeCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -2202,7 +2286,10 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writePublishCount(ServiceCounterDataType value) throws UaException {
     try {
-      writePublishCountAsync(value).get();
+      StatusCode statusCode = writePublishCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -2275,7 +2362,10 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeRepublishCount(ServiceCounterDataType value) throws UaException {
     try {
-      writeRepublishCountAsync(value).get();
+      StatusCode statusCode = writeRepublishCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -2349,7 +2439,10 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeTransferSubscriptionsCount(ServiceCounterDataType value) throws UaException {
     try {
-      writeTransferSubscriptionsCountAsync(value).get();
+      StatusCode statusCode = writeTransferSubscriptionsCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -2427,7 +2520,10 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeDeleteSubscriptionsCount(ServiceCounterDataType value) throws UaException {
     try {
-      writeDeleteSubscriptionsCountAsync(value).get();
+      StatusCode statusCode = writeDeleteSubscriptionsCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -2505,7 +2601,10 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeAddNodesCount(ServiceCounterDataType value) throws UaException {
     try {
-      writeAddNodesCountAsync(value).get();
+      StatusCode statusCode = writeAddNodesCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -2579,7 +2678,10 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeAddReferencesCount(ServiceCounterDataType value) throws UaException {
     try {
-      writeAddReferencesCountAsync(value).get();
+      StatusCode statusCode = writeAddReferencesCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -2656,7 +2758,10 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeDeleteNodesCount(ServiceCounterDataType value) throws UaException {
     try {
-      writeDeleteNodesCountAsync(value).get();
+      StatusCode statusCode = writeDeleteNodesCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -2733,7 +2838,10 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeDeleteReferencesCount(ServiceCounterDataType value) throws UaException {
     try {
-      writeDeleteReferencesCountAsync(value).get();
+      StatusCode statusCode = writeDeleteReferencesCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -2810,7 +2918,10 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeBrowseCount(ServiceCounterDataType value) throws UaException {
     try {
-      writeBrowseCountAsync(value).get();
+      StatusCode statusCode = writeBrowseCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -2883,7 +2994,10 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeBrowseNextCount(ServiceCounterDataType value) throws UaException {
     try {
-      writeBrowseNextCountAsync(value).get();
+      StatusCode statusCode = writeBrowseNextCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -3039,7 +3153,10 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeQueryFirstCount(ServiceCounterDataType value) throws UaException {
     try {
-      writeQueryFirstCountAsync(value).get();
+      StatusCode statusCode = writeQueryFirstCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -3113,7 +3230,10 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeQueryNextCount(ServiceCounterDataType value) throws UaException {
     try {
-      writeQueryNextCountAsync(value).get();
+      StatusCode statusCode = writeQueryNextCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -3187,7 +3307,10 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeRegisterNodesCount(ServiceCounterDataType value) throws UaException {
     try {
-      writeRegisterNodesCountAsync(value).get();
+      StatusCode statusCode = writeRegisterNodesCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -3264,7 +3387,10 @@ public class SessionDiagnosticsVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeUnregisterNodesCount(ServiceCounterDataType value) throws UaException {
     try {
-      writeUnregisterNodesCountAsync(value).get();
+      StatusCode statusCode = writeUnregisterNodesCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/SessionSecurityDiagnosticsTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/SessionSecurityDiagnosticsTypeNode.java
@@ -106,7 +106,10 @@ public class SessionSecurityDiagnosticsTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeSessionId(NodeId value) throws UaException {
     try {
-      writeSessionIdAsync(value).get();
+      StatusCode statusCode = writeSessionIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -176,7 +179,10 @@ public class SessionSecurityDiagnosticsTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeClientUserIdOfSession(String value) throws UaException {
     try {
-      writeClientUserIdOfSessionAsync(value).get();
+      StatusCode statusCode = writeClientUserIdOfSessionAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -250,7 +256,10 @@ public class SessionSecurityDiagnosticsTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeClientUserIdHistory(String[] value) throws UaException {
     try {
-      writeClientUserIdHistoryAsync(value).get();
+      StatusCode statusCode = writeClientUserIdHistoryAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -323,7 +332,10 @@ public class SessionSecurityDiagnosticsTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeAuthenticationMechanism(String value) throws UaException {
     try {
-      writeAuthenticationMechanismAsync(value).get();
+      StatusCode statusCode = writeAuthenticationMechanismAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -398,7 +410,10 @@ public class SessionSecurityDiagnosticsTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeEncoding(String value) throws UaException {
     try {
-      writeEncodingAsync(value).get();
+      StatusCode statusCode = writeEncodingAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -468,7 +483,10 @@ public class SessionSecurityDiagnosticsTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeTransportProtocol(String value) throws UaException {
     try {
-      writeTransportProtocolAsync(value).get();
+      StatusCode statusCode = writeTransportProtocolAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -549,7 +567,10 @@ public class SessionSecurityDiagnosticsTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeSecurityMode(MessageSecurityMode value) throws UaException {
     try {
-      writeSecurityModeAsync(value).get();
+      StatusCode statusCode = writeSecurityModeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -627,7 +648,10 @@ public class SessionSecurityDiagnosticsTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeSecurityPolicyUri(String value) throws UaException {
     try {
-      writeSecurityPolicyUriAsync(value).get();
+      StatusCode statusCode = writeSecurityPolicyUriAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -700,7 +724,10 @@ public class SessionSecurityDiagnosticsTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeClientCertificate(ByteString value) throws UaException {
     try {
-      writeClientCertificateAsync(value).get();
+      StatusCode statusCode = writeClientCertificateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/StateVariableTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/StateVariableTypeNode.java
@@ -103,7 +103,10 @@ public class StateVariableTypeNode extends BaseDataVariableTypeNode implements S
   @Override
   public void writeId(Object value) throws UaException {
     try {
-      writeIdAsync(value).get();
+      StatusCode statusCode = writeIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -172,7 +175,10 @@ public class StateVariableTypeNode extends BaseDataVariableTypeNode implements S
   @Override
   public void writeName(QualifiedName value) throws UaException {
     try {
-      writeNameAsync(value).get();
+      StatusCode statusCode = writeNameAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -242,7 +248,10 @@ public class StateVariableTypeNode extends BaseDataVariableTypeNode implements S
   @Override
   public void writeNumber(UInteger value) throws UaException {
     try {
-      writeNumberAsync(value).get();
+      StatusCode statusCode = writeNumberAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -312,7 +321,10 @@ public class StateVariableTypeNode extends BaseDataVariableTypeNode implements S
   @Override
   public void writeEffectiveDisplayName(LocalizedText value) throws UaException {
     try {
-      writeEffectiveDisplayNameAsync(value).get();
+      StatusCode statusCode = writeEffectiveDisplayNameAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/SubscriptionDiagnosticsTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/SubscriptionDiagnosticsTypeNode.java
@@ -104,7 +104,10 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeSessionId(NodeId value) throws UaException {
     try {
-      writeSessionIdAsync(value).get();
+      StatusCode statusCode = writeSessionIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -174,7 +177,10 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeSubscriptionId(UInteger value) throws UaException {
     try {
-      writeSubscriptionIdAsync(value).get();
+      StatusCode statusCode = writeSubscriptionIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -244,7 +250,10 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writePriority(UByte value) throws UaException {
     try {
-      writePriorityAsync(value).get();
+      StatusCode statusCode = writePriorityAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -314,7 +323,10 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writePublishingInterval(Double value) throws UaException {
     try {
-      writePublishingIntervalAsync(value).get();
+      StatusCode statusCode = writePublishingIntervalAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -387,7 +399,10 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeMaxKeepAliveCount(UInteger value) throws UaException {
     try {
-      writeMaxKeepAliveCountAsync(value).get();
+      StatusCode statusCode = writeMaxKeepAliveCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -460,7 +475,10 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeMaxLifetimeCount(UInteger value) throws UaException {
     try {
-      writeMaxLifetimeCountAsync(value).get();
+      StatusCode statusCode = writeMaxLifetimeCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -533,7 +551,10 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeMaxNotificationsPerPublish(UInteger value) throws UaException {
     try {
-      writeMaxNotificationsPerPublishAsync(value).get();
+      StatusCode statusCode = writeMaxNotificationsPerPublishAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -608,7 +629,10 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writePublishingEnabled(Boolean value) throws UaException {
     try {
-      writePublishingEnabledAsync(value).get();
+      StatusCode statusCode = writePublishingEnabledAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -681,7 +705,10 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeModifyCount(UInteger value) throws UaException {
     try {
-      writeModifyCountAsync(value).get();
+      StatusCode statusCode = writeModifyCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -751,7 +778,10 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeEnableCount(UInteger value) throws UaException {
     try {
-      writeEnableCountAsync(value).get();
+      StatusCode statusCode = writeEnableCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -821,7 +851,10 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeDisableCount(UInteger value) throws UaException {
     try {
-      writeDisableCountAsync(value).get();
+      StatusCode statusCode = writeDisableCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -891,7 +924,10 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeRepublishRequestCount(UInteger value) throws UaException {
     try {
-      writeRepublishRequestCountAsync(value).get();
+      StatusCode statusCode = writeRepublishRequestCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -965,7 +1001,10 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeRepublishMessageRequestCount(UInteger value) throws UaException {
     try {
-      writeRepublishMessageRequestCountAsync(value).get();
+      StatusCode statusCode = writeRepublishMessageRequestCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -1040,7 +1079,10 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeRepublishMessageCount(UInteger value) throws UaException {
     try {
-      writeRepublishMessageCountAsync(value).get();
+      StatusCode statusCode = writeRepublishMessageCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -1114,7 +1156,10 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeTransferRequestCount(UInteger value) throws UaException {
     try {
-      writeTransferRequestCountAsync(value).get();
+      StatusCode statusCode = writeTransferRequestCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -1188,7 +1233,10 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeTransferredToAltClientCount(UInteger value) throws UaException {
     try {
-      writeTransferredToAltClientCountAsync(value).get();
+      StatusCode statusCode = writeTransferredToAltClientCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -1263,7 +1311,10 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeTransferredToSameClientCount(UInteger value) throws UaException {
     try {
-      writeTransferredToSameClientCountAsync(value).get();
+      StatusCode statusCode = writeTransferredToSameClientCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -1338,7 +1389,10 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writePublishRequestCount(UInteger value) throws UaException {
     try {
-      writePublishRequestCountAsync(value).get();
+      StatusCode statusCode = writePublishRequestCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -1411,7 +1465,10 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeDataChangeNotificationsCount(UInteger value) throws UaException {
     try {
-      writeDataChangeNotificationsCountAsync(value).get();
+      StatusCode statusCode = writeDataChangeNotificationsCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -1486,7 +1543,10 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeEventNotificationsCount(UInteger value) throws UaException {
     try {
-      writeEventNotificationsCountAsync(value).get();
+      StatusCode statusCode = writeEventNotificationsCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -1561,7 +1621,10 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeNotificationsCount(UInteger value) throws UaException {
     try {
-      writeNotificationsCountAsync(value).get();
+      StatusCode statusCode = writeNotificationsCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -1634,7 +1697,10 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeLatePublishRequestCount(UInteger value) throws UaException {
     try {
-      writeLatePublishRequestCountAsync(value).get();
+      StatusCode statusCode = writeLatePublishRequestCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -1709,7 +1775,10 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeCurrentKeepAliveCount(UInteger value) throws UaException {
     try {
-      writeCurrentKeepAliveCountAsync(value).get();
+      StatusCode statusCode = writeCurrentKeepAliveCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -1783,7 +1852,10 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeCurrentLifetimeCount(UInteger value) throws UaException {
     try {
-      writeCurrentLifetimeCountAsync(value).get();
+      StatusCode statusCode = writeCurrentLifetimeCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -1857,7 +1929,10 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeUnacknowledgedMessageCount(UInteger value) throws UaException {
     try {
-      writeUnacknowledgedMessageCountAsync(value).get();
+      StatusCode statusCode = writeUnacknowledgedMessageCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -1932,7 +2007,10 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeDiscardedMessageCount(UInteger value) throws UaException {
     try {
-      writeDiscardedMessageCountAsync(value).get();
+      StatusCode statusCode = writeDiscardedMessageCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -2006,7 +2084,10 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeMonitoredItemCount(UInteger value) throws UaException {
     try {
-      writeMonitoredItemCountAsync(value).get();
+      StatusCode statusCode = writeMonitoredItemCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -2079,7 +2160,10 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeDisabledMonitoredItemCount(UInteger value) throws UaException {
     try {
-      writeDisabledMonitoredItemCountAsync(value).get();
+      StatusCode statusCode = writeDisabledMonitoredItemCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -2154,7 +2238,10 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeMonitoringQueueOverflowCount(UInteger value) throws UaException {
     try {
-      writeMonitoringQueueOverflowCountAsync(value).get();
+      StatusCode statusCode = writeMonitoringQueueOverflowCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -2229,7 +2316,10 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeNextSequenceNumber(UInteger value) throws UaException {
     try {
-      writeNextSequenceNumberAsync(value).get();
+      StatusCode statusCode = writeNextSequenceNumberAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -2302,7 +2392,10 @@ public class SubscriptionDiagnosticsTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeEventQueueOverflowCount(UInteger value) throws UaException {
     try {
-      writeEventQueueOverflowCountAsync(value).get();
+      StatusCode statusCode = writeEventQueueOverflowCountAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ThreeDCartesianCoordinatesTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ThreeDCartesianCoordinatesTypeNode.java
@@ -104,7 +104,10 @@ public class ThreeDCartesianCoordinatesTypeNode extends CartesianCoordinatesType
   @Override
   public void writeX(Double value) throws UaException {
     try {
-      writeXAsync(value).get();
+      StatusCode statusCode = writeXAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -173,7 +176,10 @@ public class ThreeDCartesianCoordinatesTypeNode extends CartesianCoordinatesType
   @Override
   public void writeY(Double value) throws UaException {
     try {
-      writeYAsync(value).get();
+      StatusCode statusCode = writeYAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -242,7 +248,10 @@ public class ThreeDCartesianCoordinatesTypeNode extends CartesianCoordinatesType
   @Override
   public void writeZ(Double value) throws UaException {
     try {
-      writeZAsync(value).get();
+      StatusCode statusCode = writeZAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ThreeDFrameTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ThreeDFrameTypeNode.java
@@ -107,7 +107,10 @@ public class ThreeDFrameTypeNode extends FrameTypeNode implements ThreeDFrameTyp
   @Override
   public void writeCartesianCoordinates(ThreeDCartesianCoordinates value) throws UaException {
     try {
-      writeCartesianCoordinatesAsync(value).get();
+      StatusCode statusCode = writeCartesianCoordinatesAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -185,7 +188,10 @@ public class ThreeDFrameTypeNode extends FrameTypeNode implements ThreeDFrameTyp
   @Override
   public void writeOrientation(ThreeDOrientation value) throws UaException {
     try {
-      writeOrientationAsync(value).get();
+      StatusCode statusCode = writeOrientationAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ThreeDOrientationTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ThreeDOrientationTypeNode.java
@@ -104,7 +104,10 @@ public class ThreeDOrientationTypeNode extends OrientationTypeNode
   @Override
   public void writeA(Double value) throws UaException {
     try {
-      writeAAsync(value).get();
+      StatusCode statusCode = writeAAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -173,7 +176,10 @@ public class ThreeDOrientationTypeNode extends OrientationTypeNode
   @Override
   public void writeB(Double value) throws UaException {
     try {
-      writeBAsync(value).get();
+      StatusCode statusCode = writeBAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -242,7 +248,10 @@ public class ThreeDOrientationTypeNode extends OrientationTypeNode
   @Override
   public void writeC(Double value) throws UaException {
     try {
-      writeCAsync(value).get();
+      StatusCode statusCode = writeCAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ThreeDVectorTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/ThreeDVectorTypeNode.java
@@ -103,7 +103,10 @@ public class ThreeDVectorTypeNode extends VectorTypeNode implements ThreeDVector
   @Override
   public void writeX(Double value) throws UaException {
     try {
-      writeXAsync(value).get();
+      StatusCode statusCode = writeXAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -172,7 +175,10 @@ public class ThreeDVectorTypeNode extends VectorTypeNode implements ThreeDVector
   @Override
   public void writeY(Double value) throws UaException {
     try {
-      writeYAsync(value).get();
+      StatusCode statusCode = writeYAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -241,7 +247,10 @@ public class ThreeDVectorTypeNode extends VectorTypeNode implements ThreeDVector
   @Override
   public void writeZ(Double value) throws UaException {
     try {
-      writeZAsync(value).get();
+      StatusCode statusCode = writeZAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/TransitionVariableTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/TransitionVariableTypeNode.java
@@ -105,7 +105,10 @@ public class TransitionVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeId(Object value) throws UaException {
     try {
-      writeIdAsync(value).get();
+      StatusCode statusCode = writeIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -174,7 +177,10 @@ public class TransitionVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeName(QualifiedName value) throws UaException {
     try {
-      writeNameAsync(value).get();
+      StatusCode statusCode = writeNameAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -244,7 +250,10 @@ public class TransitionVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeNumber(UInteger value) throws UaException {
     try {
-      writeNumberAsync(value).get();
+      StatusCode statusCode = writeNumberAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -314,7 +323,10 @@ public class TransitionVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeTransitionTime(DateTime value) throws UaException {
     try {
-      writeTransitionTimeAsync(value).get();
+      StatusCode statusCode = writeTransitionTimeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -384,7 +396,10 @@ public class TransitionVariableTypeNode extends BaseDataVariableTypeNode
   @Override
   public void writeEffectiveTransitionTime(DateTime value) throws UaException {
     try {
-      writeEffectiveTransitionTimeAsync(value).get();
+      StatusCode statusCode = writeEffectiveTransitionTimeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/TwoStateDiscreteTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/TwoStateDiscreteTypeNode.java
@@ -103,7 +103,10 @@ public class TwoStateDiscreteTypeNode extends DiscreteItemTypeNode implements Tw
   @Override
   public void writeFalseState(LocalizedText value) throws UaException {
     try {
-      writeFalseStateAsync(value).get();
+      StatusCode statusCode = writeFalseStateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -173,7 +176,10 @@ public class TwoStateDiscreteTypeNode extends DiscreteItemTypeNode implements Tw
   @Override
   public void writeTrueState(LocalizedText value) throws UaException {
     try {
-      writeTrueStateAsync(value).get();
+      StatusCode statusCode = writeTrueStateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/TwoStateVariableTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/TwoStateVariableTypeNode.java
@@ -105,7 +105,10 @@ public class TwoStateVariableTypeNode extends StateVariableTypeNode
   @Override
   public void writeId(Boolean value) throws UaException {
     try {
-      writeIdAsync(value).get();
+      StatusCode statusCode = writeIdAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -174,7 +177,10 @@ public class TwoStateVariableTypeNode extends StateVariableTypeNode
   @Override
   public void writeTransitionTime(DateTime value) throws UaException {
     try {
-      writeTransitionTimeAsync(value).get();
+      StatusCode statusCode = writeTransitionTimeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -244,7 +250,10 @@ public class TwoStateVariableTypeNode extends StateVariableTypeNode
   @Override
   public void writeEffectiveTransitionTime(DateTime value) throws UaException {
     try {
-      writeEffectiveTransitionTimeAsync(value).get();
+      StatusCode statusCode = writeEffectiveTransitionTimeAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -318,7 +327,10 @@ public class TwoStateVariableTypeNode extends StateVariableTypeNode
   @Override
   public void writeTrueState(LocalizedText value) throws UaException {
     try {
-      writeTrueStateAsync(value).get();
+      StatusCode statusCode = writeTrueStateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {
@@ -388,7 +400,10 @@ public class TwoStateVariableTypeNode extends StateVariableTypeNode
   @Override
   public void writeFalseState(LocalizedText value) throws UaException {
     try {
-      writeFalseStateAsync(value).get();
+      StatusCode statusCode = writeFalseStateAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/VectorTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/VectorTypeNode.java
@@ -106,7 +106,10 @@ public class VectorTypeNode extends BaseDataVariableTypeNode implements VectorTy
   @Override
   public void writeVectorUnit(EUInformation value) throws UaException {
     try {
-      writeVectorUnitAsync(value).get();
+      StatusCode statusCode = writeVectorUnitAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/XYArrayItemTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/XYArrayItemTypeNode.java
@@ -106,7 +106,10 @@ public class XYArrayItemTypeNode extends ArrayItemTypeNode implements XYArrayIte
   @Override
   public void writeXAxisDefinition(AxisInformation value) throws UaException {
     try {
-      writeXAxisDefinitionAsync(value).get();
+      StatusCode statusCode = writeXAxisDefinitionAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/YArrayItemTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/YArrayItemTypeNode.java
@@ -106,7 +106,10 @@ public class YArrayItemTypeNode extends ArrayItemTypeNode implements YArrayItemT
   @Override
   public void writeXAxisDefinition(AxisInformation value) throws UaException {
     try {
-      writeXAxisDefinitionAsync(value).get();
+      StatusCode statusCode = writeXAxisDefinitionAsync(value).get();
+      if (statusCode != null && !statusCode.isGood()) {
+        throw new UaException(statusCode);
+      }
     } catch (ExecutionException e) {
       throw new UaException(e.getCause());
     } catch (InterruptedException e) {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/package-info.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/model/variables/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/**
+ * Generated client node interfaces and implementations for namespace-zero VariableTypes.
+ *
+ * <p>AddressSpace constructs these typed nodes after resolving their type definition. Attribute
+ * accessors expose local snapshots; explicit read and write methods communicate with the server.
+ * Asynchronous property writers return the operation StatusCode. Their blocking counterparts throw
+ * UaException for a non-Good operation result, independently of whether the Write service completed
+ * normally.
+ *
+ * <p>The classes are generated from the standard NodeSet by opc-ua-codegen2. Change the generator
+ * and regenerate the affected model classes when modifying their shared accessors.
+ */
+package org.eclipse.milo.opcua.sdk.client.model.variables;

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/package-info.java
@@ -32,7 +32,7 @@
  * <p>Every class in this package and its {@code model.objects} subpackage is generated and must not
  * be edited by hand. The source is the {@code gds-model-server} module of <a
  * href="https://github.com/kevinherron/opc-ua-gds-model">opc-ua-gds-model</a> at commit {@code
- * efa229d} (GDS NodeSet2 1.05.07), copied in with {@code com.digitalpetri.opcua.gds.server}
+ * 800aeae} (GDS NodeSet2 1.05.07), copied in with {@code com.digitalpetri.opcua.gds.server}
  * rewritten to this package and {@code com.digitalpetri.opcua.gds.server.objects} rewritten to
  * {@code org.eclipse.milo.opcua.sdk.server.gds.model.objects}. See {@code
  * docs/features/gds-client.md} for the procedure.

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/gds/package-info.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/gds/package-info.java
@@ -34,7 +34,7 @@
  * <p>Every class in this package and in {@code org.eclipse.milo.opcua.stack.core.gds.types} is
  * generated and must not be edited by hand. The source is the {@code gds-model-core} module of <a
  * href="https://github.com/kevinherron/opc-ua-gds-model">opc-ua-gds-model</a> at commit {@code
- * efa229d} (GDS NodeSet2 1.05.07 on a 1.05.07 base model), copied in with the package prefix {@code
+ * 800aeae} (GDS NodeSet2 1.05.07 on a 1.05.07 base model), copied in with the package prefix {@code
  * com.digitalpetri.opcua.gds} rewritten to {@code org.eclipse.milo.opcua.stack.core.gds} and the
  * Eclipse Milo license header prepended. To pick up a newer NodeSet, regenerate in that repository
  * first, then recopy; the procedure is documented in {@code docs/features/gds-client.md}.


### PR DESCRIPTION
This PR fixes GDS module compatibility, dictionary initialization, generated Write error handling, and test-server private-key formats.

## Java module package overlap

Using `milo-sdk-client` and `milo-sdk-client-gds` together on the module path fails because both jars contain `org.eclipse.milo.opcua.sdk.client.gds`. The generated type initializers now live in `org.eclipse.milo.opcua.sdk.client.gds.model`, with registration and documentation updated to match.

## Legacy dictionary registration

Initializing the standard dictionary first skips GDS registration; initializing GDS first puts its entries in the standard dictionary. The regenerated adapter now registers an independent GDS dictionary with unqualified type names. Initialization order is a Milo registration contract.

## Blocking property Write results

Generated blocking writers discard rejected operation statuses and return successfully. The regenerated GDS and namespace-zero writers now throw `UaException` carrying any non-Good result, matching Milo's existing blocking API. OPC UA defines per-operation results; the Java exception mapping is Milo's contract. [Part 4 §5.11.4.2](https://reference.opcfoundation.org/specs/OPC-10000-4/5.11.4.2)

## Test-fixture private key formats

`FakeGdsNamespace` returns raw DER for a PEM request and ignores format/password arguments. It now returns actual PKCS#8 PEM or PKCS#12 PFX, applies the requested password, and rejects unsupported formats. PFX includes the issued certificate and its issuer.

Part 12 §7.9.4 says, "All CertificateManager implementations shall support "PEM" and "PFX"." It also says, "If PFX is used the packet shall include the Certificate and the PrivateKey." [StartNewKeyPairRequest](https://reference.opcfoundation.org/specs/OPC-10000-12/7.9.4)

## Verification

All nine new regression cases fail on the original code at the intended assertions. They resolve the actual modules, initialize both dictionary orders and round-trip a GDS ExtensionObject, parse requested key formats and verify their keys, and exercise rejected and successful Writes through a client/server connection.

The complete selected GDS and TrustList suites passed, including all nine new regressions, with zero failures, errors, or skips. Formatting and full clean compile passed. The [generator changes](https://github.com/kevinherron/opc-ua-codegen2/pull/1) passed both emitted-code runtime regressions, both BACnet generation checks, formatting, and full clean compile. The [regenerated GDS source model](https://github.com/kevinherron/opc-ua-gds-model/pull/1) passed formatting, full clean compile, and verify.
