### PR TITLE
Fix alias deletion, shutdown ordering, and change versions

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/aliases/AliasLifecycleConsistencyTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/aliases/AliasLifecycleConsistencyTest.java
@@ -1,0 +1,400 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.aliases;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
+import org.eclipse.milo.opcua.sdk.core.Reference;
+import org.eclipse.milo.opcua.sdk.server.Session;
+import org.eclipse.milo.opcua.sdk.server.UaNodeManager;
+import org.eclipse.milo.opcua.sdk.server.model.objects.AliasNameCategoryType;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
+import org.eclipse.milo.opcua.sdk.test.AbstractClientServerTest;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.structured.CallMethodRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.CallMethodResult;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class AliasLifecycleConsistencyTest extends AbstractClientServerTest {
+
+  private final AtomicInteger sequence = new AtomicInteger();
+  private final List<Reference> externalReferences = new ArrayList<>();
+  private UaNodeManager nodeManager;
+  private Set<NodeId> originalNodes;
+  private TestVersionStore store;
+  private AliasManager manager;
+  private String prefix;
+
+  @BeforeEach
+  void prepareFixture() {
+    testNamespace.configure((context, nodes) -> nodeManager = nodes);
+    originalNodes = Set.copyOf(nodeManager.getNodeIds());
+    prefix = "AliasConsistency" + sequence.incrementAndGet();
+    store = new TestVersionStore();
+    manager =
+        new AliasManager(
+            server,
+            AliasManagerConfig.builder()
+                .nodeNamespaceIndex(testNamespace.getNamespaceIndex())
+                .versionStore(store)
+                .configurationEnabled(true)
+                .authorizationPolicy(
+                    new AliasAuthorizationPolicy() {
+                      @Override
+                      public boolean checkFind(@Nullable Session session, NodeId categoryId) {
+                        return true;
+                      }
+
+                      @Override
+                      public boolean checkMutate(@Nullable Session session, NodeId categoryId) {
+                        return true;
+                      }
+                    })
+                .build());
+  }
+
+  @AfterEach
+  void cleanFixture() {
+    store.failOn = null;
+    manager.shutdown();
+    externalReferences.forEach(
+        reference -> nodeManager.removeReferences(reference, server.getNamespaceTable()));
+    externalReferences.clear();
+    nodeManager.getNodes().stream()
+        .filter(node -> !originalNodes.contains(node.getNodeId()))
+        .forEach(UaNode::delete);
+  }
+
+  // AliasFor may be stored by either endpoint's registered manager. Successful public/wire
+  // deletion must remove both directions there, or the next lookup still returns the target.
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void deletingTargetRemovesReferencesOwnedByAnotherManager(boolean wire) throws Exception {
+    manager.startup();
+    NodeId first = newNodeId("TestInt32");
+    NodeId second = newNodeId("TestAnalogValue");
+    NodeId aliasId = manager.addAlias(NodeIds.Aliases, prefix, List.of(target(first)));
+    Reference external =
+        new Reference(second, NodeIds.AliasFor, aliasId.expanded(), Reference.Direction.INVERSE);
+    managed(second).addReference(external);
+    externalReferences.add(external);
+    manager.touch(NodeIds.Aliases);
+    assertEquals(Set.of(first, second), targets(NodeIds.Aliases, prefix));
+
+    if (wire) {
+      assertArrayEquals(
+          new StatusCode[] {StatusCode.GOOD}, deleteOverWire(NodeIds.Aliases, prefix, second));
+    } else {
+      manager.deleteAlias(NodeIds.Aliases, prefix, List.of(target(second)));
+    }
+
+    assertEquals(Set.of(first), targets(NodeIds.Aliases, prefix));
+    assertFalse(
+        nodeManager.getReferences(second).contains(external),
+        "inverse reference must also be removed");
+  }
+
+  // A child's parent reference was created after its parent journal. Parent removal must detach
+  // the surviving child so reuse of the parent's NodeId cannot silently reconnect its contents.
+  @Test
+  void removingParentDetachesSurvivingChildBeforeParentNodeIdReuse() throws Exception {
+    manager.startup();
+    AliasCategoryConfig parent = category("Parent", NodeIds.Aliases);
+    AliasCategoryConfig child = category("Child", parent.categoryNodeId());
+    manager.addCategory(parent);
+    manager.addCategory(child);
+    NodeId aliasId =
+        manager.addAlias(child.categoryNodeId(), prefix, List.of(target(newNodeId("TestInt32"))));
+    manager.removeCategory(parent.categoryNodeId());
+
+    assertTrue(server.getAddressSpaceManager().getManagedNode(child.categoryNodeId()).isPresent());
+    assertTrue(server.getAddressSpaceManager().getManagedNode(aliasId).isPresent());
+    assertFalse(
+        server
+            .getAddressSpaceManager()
+            .getManagedReferences(child.categoryNodeId(), Reference.ORGANIZED_BY_PREDICATE)
+            .stream()
+            .anyMatch(
+                reference ->
+                    reference.getTargetNodeId().equals(parent.categoryNodeId().expanded())));
+    manager.addCategory(parent);
+    assertTrue(manager.findAlias(parent.categoryNodeId(), prefix, null).isEmpty());
+    assertEquals(Set.of(newNodeId("TestInt32")), targets(child.categoryNodeId(), prefix));
+  }
+
+  // Part 17 §6.3.5 requires all-or-none deletion per entry. A later same-name alias can introduce
+  // an additional affected category whose version save fails; earlier aliases must remain intact.
+  @Test
+  void failedVersionSaveLeavesEveryAliasInOneWireDeletionEntryUntouched() throws Exception {
+    manager.startup();
+    NodeId category = category("Category", NodeIds.Aliases).categoryNodeId();
+    NodeId other = category("Other", NodeIds.Aliases).categoryNodeId();
+    manager.addCategory(category("Category", NodeIds.Aliases));
+    manager.addCategory(category("Other", NodeIds.Aliases));
+    NodeId targetId = newNodeId("TestInt32");
+    NodeId first = manager.addAlias(category, prefix, List.of(target(targetId)));
+    NodeId second = manager.addAlias(other, prefix, List.of(target(targetId)));
+    managed(second)
+        .addReference(
+            new Reference(
+                second, NodeIds.Organizes, category.expanded(), Reference.Direction.INVERSE));
+    manager.touch(category);
+    assertEquals(2, manager.findAlias(category, prefix, null).size());
+    store.failOn = other.expanded(server.getNamespaceTable());
+
+    assertArrayEquals(
+        new StatusCode[] {StatusCode.of(StatusCodes.Bad_InternalError)},
+        deleteOverWire(category, prefix, targetId));
+
+    assertTrue(
+        server.getAddressSpaceManager().getManagedNode(first).isPresent(),
+        "first alias must survive later save failure");
+    assertTrue(server.getAddressSpaceManager().getManagedNode(second).isPresent());
+    assertEquals(2, manager.findAlias(category, prefix, null).size());
+    assertEquals(Set.of(targetId), targets(other, prefix));
+  }
+
+  // Pausing just before the mutation lock models a caller that passed its running check while
+  // shutdown wins the lock. Every public mutator must reject after shutdown and avoid persistence.
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "addCategory",
+        "adoptCategory",
+        "removeCategory",
+        "addAlias",
+        "deleteAlias",
+        "touch"
+      })
+  void publicMutationRechecksLifecycleAfterWaitingForLock(String operation) throws Exception {
+    manager.startup();
+    AliasCategoryConfig category = category("Category", NodeIds.Aliases);
+    manager.addCategory(category);
+    manager.addAlias(NodeIds.Aliases, prefix, List.of(target(newNodeId("TestInt32"))));
+    Executable mutation =
+        switch (operation) {
+          case "addCategory" -> () -> manager.addCategory(category("New", NodeIds.Aliases));
+          case "adoptCategory" -> () -> manager.adoptCategory(category.categoryNodeId());
+          case "removeCategory" -> () -> manager.removeCategory(category.categoryNodeId());
+          case "addAlias" ->
+              () ->
+                  manager.addAlias(
+                      NodeIds.Aliases,
+                      prefix + "AfterShutdown",
+                      List.of(target(newNodeId("TestInt32"))));
+          case "deleteAlias" -> () -> manager.deleteAlias(NodeIds.Aliases, prefix, null);
+          case "touch" -> () -> manager.touch(NodeIds.Aliases);
+          default -> throw new AssertionError(operation);
+        };
+    var gate = new PausingLock();
+    Field field = AliasManager.class.getDeclaredField("lock");
+    field.setAccessible(true);
+    field.set(manager, gate);
+    var executor = Executors.newSingleThreadExecutor();
+    try {
+      var result =
+          executor.submit(
+              () -> {
+                gate.pausedThread = Thread.currentThread();
+                try {
+                  mutation.execute();
+                  return null;
+                } catch (Throwable e) {
+                  return e;
+                }
+              });
+      gate.entered.get(10, TimeUnit.SECONDS);
+      manager.shutdown();
+      int savesAfterShutdown = store.saves.get();
+      gate.resume.complete(null);
+
+      assertInstanceOf(IllegalStateException.class, result.get(10, TimeUnit.SECONDS));
+      assertEquals(
+          savesAfterShutdown, store.saves.get(), "shutdown must fence later version writes");
+      assertTrue(
+          server.getAddressSpaceManager().getManagedNode(newNodeId(prefix + "New")).isEmpty());
+    } finally {
+      gate.resume.complete(null);
+      executor.shutdownNow();
+      assertTrue(executor.awaitTermination(10, TimeUnit.SECONDS));
+    }
+  }
+
+  // A stored version ahead of wall time makes NodeId reuse deterministic without a timing race.
+  // Both deleting stores and stores that retain entries must preserve the live manager's sequence.
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void recreatedCategoryAdvancesBeyondItsPreviousContents(boolean deleteStoredEntry)
+      throws Exception {
+    AliasCategoryConfig category = category("Versioned", NodeIds.Aliases);
+    store.deleteEntries = deleteStoredEntry;
+    store.entries.put(
+        category.categoryNodeId().expanded(server.getNamespaceTable()),
+        UInteger.valueOf(4_000_000_000L));
+    manager.startup();
+    manager.addCategory(category);
+    manager.addAlias(
+        category.categoryNodeId(), prefix + "Old", List.of(target(newNodeId("TestInt32"))));
+    long before = lastChange(category.categoryNodeId());
+    manager.removeCategory(category.categoryNodeId());
+    manager.addCategory(category);
+    manager.addAlias(
+        category.categoryNodeId(), prefix + "New", List.of(target(newNodeId("TestAnalogValue"))));
+
+    assertTrue(
+        lastChange(category.categoryNodeId()) > before,
+        "different category contents require a new version");
+    assertTrue(manager.findAlias(category.categoryNodeId(), prefix + "Old", null).isEmpty());
+    assertEquals(
+        Set.of(newNodeId("TestAnalogValue")), targets(category.categoryNodeId(), prefix + "New"));
+  }
+
+  private AliasCategoryConfig category(String suffix, NodeId parent) {
+    return new AliasCategoryConfig(
+        newNodeId(prefix + suffix),
+        parent,
+        newQualifiedName(prefix + suffix),
+        nodeManager,
+        name -> newNodeId(prefix + suffix + "/" + name),
+        true,
+        false,
+        true);
+  }
+
+  private AliasTarget target(NodeId id) {
+    return new AliasTarget(id.expanded(), null, NodeIds.AliasFor);
+  }
+
+  private UaNode managed(NodeId id) {
+    return server.getAddressSpaceManager().getManagedNode(id).orElseThrow();
+  }
+
+  private Set<NodeId> targets(NodeId category, String name) throws UaException {
+    return manager.findAlias(category, name, null).stream()
+        .flatMap(alias -> Arrays.stream(alias.getReferencedNodes()))
+        .map(id -> id.toNodeId(server.getNamespaceTable()).orElseThrow())
+        .collect(Collectors.toSet());
+  }
+
+  private long lastChange(NodeId categoryId) {
+    return ((UInteger)
+            managed(categoryId)
+                .getPropertyNode(AliasNameCategoryType.LAST_CHANGE)
+                .orElseThrow()
+                .getValue()
+                .value()
+                .value())
+        .longValue();
+  }
+
+  private StatusCode[] deleteOverWire(NodeId category, String name, NodeId target)
+      throws UaException {
+    NodeId method =
+        server
+            .getAddressSpaceManager()
+            .getManagedReferences(category, Reference.HAS_COMPONENT_PREDICATE)
+            .stream()
+            .map(
+                reference ->
+                    reference.getTargetNodeId().toNodeId(server.getNamespaceTable()).orElseThrow())
+            .filter(id -> "DeleteAliasesFromCategory".equals(managed(id).getBrowseName().name()))
+            .findFirst()
+            .orElseThrow();
+    CallMethodResult result =
+        client.call(
+                List.of(
+                    new CallMethodRequest(
+                        category,
+                        method,
+                        new Variant[] {
+                          new Variant(new String[] {name}),
+                          new Variant(new ExpandedNodeId[] {target.expanded()})
+                        })))
+            .getResults()[0];
+    assertEquals(StatusCode.GOOD, result.getStatusCode());
+    return (StatusCode[]) result.getOutputArguments()[0].value();
+  }
+
+  private static final class PausingLock extends ReentrantLock {
+    private volatile Thread pausedThread;
+    private final CompletableFuture<Void> entered = new CompletableFuture<>();
+    private final CompletableFuture<Void> resume = new CompletableFuture<>();
+
+    @Override
+    public void lock() {
+      if (Thread.currentThread() == pausedThread) {
+        entered.complete(null);
+        try {
+          resume.get(10, TimeUnit.SECONDS);
+        } catch (Exception e) {
+          throw new AssertionError(e);
+        }
+      }
+      super.lock();
+    }
+  }
+
+  private static final class TestVersionStore implements AliasVersionStore {
+    private final Map<ExpandedNodeId, UInteger> entries = new ConcurrentHashMap<>();
+    private final AtomicInteger saves = new AtomicInteger();
+    private volatile ExpandedNodeId failOn;
+    private boolean deleteEntries;
+
+    @Override
+    public Map<ExpandedNodeId, UInteger> load() {
+      return Map.copyOf(entries);
+    }
+
+    @Override
+    public void save(ExpandedNodeId categoryId, UInteger value) throws UaException {
+      if (categoryId.equals(failOn)) {
+        throw new UaException(StatusCodes.Bad_ResourceUnavailable, "controlled save failure");
+      }
+      entries.put(categoryId, value);
+      saves.incrementAndGet();
+    }
+
+    @Override
+    public void delete(ExpandedNodeId categoryId) {
+      if (deleteEntries) entries.remove(categoryId);
+    }
+  }
+}

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/aliases/AliasLifecycleConsistencyTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/aliases/AliasLifecycleConsistencyTest.java
@@ -34,11 +34,13 @@ import org.eclipse.milo.opcua.sdk.server.Session;
 import org.eclipse.milo.opcua.sdk.server.UaNodeManager;
 import org.eclipse.milo.opcua.sdk.server.model.objects.AliasNameCategoryType;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectNode;
 import org.eclipse.milo.opcua.sdk.test.AbstractClientServerTest;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
@@ -130,6 +132,95 @@ class AliasLifecycleConsistencyTest extends AbstractClientServerTest {
     assertFalse(
         nodeManager.getReferences(second).contains(external),
         "inverse reference must also be removed");
+  }
+
+  // Whole-alias deletion must remove cross-manager references before the deterministic alias
+  // NodeId is reused, or an old target silently becomes part of the replacement alias.
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void deletingWholeAliasDoesNotResurrectTargetsFromAnotherManager(boolean wire) throws Exception {
+    manager.startup();
+    NodeId first = newNodeId("TestInt32");
+    NodeId second = newNodeId("TestAnalogValue");
+    NodeId aliasId = manager.addAlias(NodeIds.Aliases, prefix, List.of(target(first)));
+    Reference external =
+        new Reference(second, NodeIds.AliasFor, aliasId.expanded(), Reference.Direction.INVERSE);
+    managed(second).addReference(external);
+    externalReferences.add(external);
+    manager.touch(NodeIds.Aliases);
+    assertEquals(Set.of(first, second), targets(NodeIds.Aliases, prefix));
+
+    if (wire) {
+      assertArrayEquals(
+          new StatusCode[] {StatusCode.GOOD}, deleteOverWire(NodeIds.Aliases, prefix, null));
+    } else {
+      manager.deleteAlias(NodeIds.Aliases, prefix, null);
+    }
+    assertTrue(server.getAddressSpaceManager().getManagedNode(aliasId).isEmpty());
+    NodeId replacement = manager.addAlias(NodeIds.Aliases, prefix, List.of(target(first)));
+    assertEquals(aliasId, replacement);
+    assertEquals(
+        Set.of(first), targets(NodeIds.Aliases, prefix), "deleted targets must not reappear");
+    assertTrue(nodeManager.getReferences(aliasId).isEmpty());
+    assertFalse(nodeManager.getReferences(second).contains(external));
+  }
+
+  // Removing the last target deletes the alias from every category, including Organizes links
+  // stored outside the alias's manager. Reuse must not reconnect the deleted membership.
+  @Test
+  void deletingTargetlessAliasRemovesExternalOrganizingReferences() throws Exception {
+    manager.startup();
+    NodeId first = newNodeId("TestInt32");
+    NodeId aliasId = manager.addAlias(NodeIds.Aliases, prefix, List.of(target(first)));
+    AliasCategoryConfig other = category("Other", NodeIds.Aliases);
+    manager.addCategory(other);
+    Reference external =
+        new Reference(
+            other.categoryNodeId(),
+            NodeIds.Organizes,
+            aliasId.expanded(),
+            Reference.Direction.FORWARD);
+    managed(other.categoryNodeId()).addReference(external);
+    externalReferences.add(external);
+    manager.touch(other.categoryNodeId());
+    assertEquals(Set.of(first), targets(other.categoryNodeId(), prefix));
+
+    manager.deleteAlias(NodeIds.Aliases, prefix, List.of(target(first)));
+    assertTrue(server.getAddressSpaceManager().getManagedNode(aliasId).isEmpty());
+    assertEquals(aliasId, manager.addAlias(NodeIds.Aliases, prefix, List.of(target(first))));
+    assertTrue(
+        targets(other.categoryNodeId(), prefix).isEmpty(), "deleted membership must not reappear");
+    assertFalse(nodeManager.getReferences(other.categoryNodeId()).contains(external));
+    assertTrue(nodeManager.getReferences(aliasId).isEmpty());
+  }
+
+  // UaNode.delete traverses owned HasChild links. Global reference cleanup must preserve that
+  // traversal so deleting an alias cannot strand a component in its own manager.
+  @Test
+  void deletingWholeAliasStillDeletesItsOwnedChildren() throws Exception {
+    manager.startup();
+    NodeId aliasId =
+        manager.addAlias(NodeIds.Aliases, prefix, List.of(target(newNodeId("TestInt32"))));
+    UaNode alias = managed(aliasId);
+    NodeId childId = newNodeId(prefix + "Component");
+    UaObjectNode child =
+        new UaObjectNode.UaObjectNodeBuilder(alias.getNodeContext())
+            .setNodeId(childId)
+            .setBrowseName(newQualifiedName(prefix + "Component"))
+            .setDisplayName(LocalizedText.english("component"))
+            .build();
+    alias.getNodeManager().addNode(child);
+    alias.addReference(
+        new Reference(
+            aliasId, NodeIds.HasComponent, childId.expanded(), Reference.Direction.FORWARD));
+    assertTrue(server.getAddressSpaceManager().getManagedNode(childId).isPresent());
+
+    manager.deleteAlias(NodeIds.Aliases, prefix, null);
+
+    assertTrue(server.getAddressSpaceManager().getManagedNode(aliasId).isEmpty());
+    assertTrue(
+        server.getAddressSpaceManager().getManagedNode(childId).isEmpty(),
+        "owned child deletion must still follow HasComponent");
   }
 
   // A child's parent reference was created after its parent journal. Parent removal must detach
@@ -325,7 +416,7 @@ class AliasLifecycleConsistencyTest extends AbstractClientServerTest {
         .longValue();
   }
 
-  private StatusCode[] deleteOverWire(NodeId category, String name, NodeId target)
+  private StatusCode[] deleteOverWire(NodeId category, String name, @Nullable NodeId target)
       throws UaException {
     NodeId method =
         server
@@ -346,7 +437,8 @@ class AliasLifecycleConsistencyTest extends AbstractClientServerTest {
                         method,
                         new Variant[] {
                           new Variant(new String[] {name}),
-                          new Variant(new ExpandedNodeId[] {target.expanded()})
+                          new Variant(
+                              new ExpandedNodeId[] {target == null ? null : target.expanded()})
                         })))
             .getResults()[0];
     assertEquals(StatusCode.GOOD, result.getStatusCode());

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/AddressSpaceManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/AddressSpaceManager.java
@@ -134,4 +134,18 @@ public class AddressSpaceManager extends AddressSpaceComposite {
         .flatMap(Collection::stream)
         .collect(Collectors.toList());
   }
+
+  /**
+   * Remove {@code reference} and its inverse from every registered {@link NodeManager}.
+   *
+   * <p>References may be stored by either endpoint's manager, or by another registered manager. Use
+   * this when removing an association collected through {@link #getManagedReferences(NodeId)}.
+   *
+   * @param reference the association to remove in both directions.
+   */
+  public void removeManagedReferences(Reference reference) {
+    for (NodeManager<UaNode> nodeManager : nodeManagers) {
+      nodeManager.removeReferences(reference, getServer().getNamespaceTable());
+    }
+  }
 }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/aliases/AliasManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/aliases/AliasManager.java
@@ -938,7 +938,7 @@ public final class AliasManager extends AbstractLifecycle {
           removeFromCategory(aliasNode, categoryId);
 
           if (getOrganizingCategories(aliasNodeId).isEmpty()) {
-            aliasNode.delete();
+            deleteAliasNode(aliasNode);
           }
         } finally {
           versionManager.publishPending();
@@ -1325,13 +1325,10 @@ public final class AliasManager extends AbstractLifecycle {
    * target that is not associated changes nothing and reports {@code Good}; §6.3.5 reserves {@code
    * Bad_NotFound} for an alias name the category does not contain.
    *
-   * <p>Validation happens before any mutation, and reference removal through the manager's own
-   * fragment cannot partially fail, so an entry ordinarily either fully applies or leaves its state
-   * untouched (§6.3.5: "If all targets for an AliasNames array entry cannot be deleted, then none
-   * of the targets are deleted"). Aliases living in an application {@link NodeManager} can throw
-   * unchecked mid-entry, however; such a failure is confined to its entry as {@code
-   * Bad_InternalError}, and any category whose new version was prepared before the mutation still
-   * gets its LastChange published.
+   * <p>Validation and category-version persistence happen before any mutation. Reference removal
+   * spans every registered {@link NodeManager}. A custom NodeManager can throw unchecked mid-entry;
+   * such a failure is confined to its entry as {@code Bad_InternalError}, and any category whose
+   * new version was prepared before the mutation still gets its LastChange published.
    */
   private StatusCode deleteAliasEntry(
       NodeId categoryId, @Nullable String aliasName, @Nullable ExpandedNodeId targetNode) {
@@ -1368,7 +1365,7 @@ public final class AliasManager extends AbstractLifecycle {
           removeFromCategory(aliasNode, categoryId);
 
           if (getOrganizingCategories(aliasNodeId).isEmpty()) {
-            aliasNode.delete();
+            deleteAliasNode(aliasNode);
           }
         }
 
@@ -1939,9 +1936,19 @@ public final class AliasManager extends AbstractLifecycle {
 
     versionManager.prepare(getOrganizingCategories(aliasNodeId));
 
-    aliasNode.delete();
+    deleteAliasNode(aliasNode);
 
     return true;
+  }
+
+  private void deleteAliasNode(UaNode aliasNode) {
+    var addressSpaceManager = server.getAddressSpaceManager();
+    List<Reference> references = addressSpaceManager.getManagedReferences(aliasNode.getNodeId());
+
+    // Preserve UaNode.delete's traversal of owned HasChild references before removing the
+    // snapshotted associations from every registered manager.
+    aliasNode.delete();
+    references.forEach(addressSpaceManager::removeManagedReferences);
   }
 
   /** The forward {@code AliasFor}-or-subtype References of an alias Node. */

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/aliases/AliasManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/aliases/AliasManager.java
@@ -15,6 +15,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -323,10 +324,10 @@ public final class AliasManager extends AbstractLifecycle {
    * @throws IllegalStateException if the manager is not running.
    */
   public AliasCategory addCategory(AliasCategoryConfig categoryConfig) throws UaException {
-    checkRunning();
-
     lock.lock();
     try {
+      checkRunning();
+
       String name = categoryConfig.browseName().getName();
       if (name == null || name.isEmpty()) {
         throw new UaException(
@@ -469,10 +470,10 @@ public final class AliasManager extends AbstractLifecycle {
    * @throws IllegalStateException if the manager is not running.
    */
   public AliasCategory adoptCategory(NodeId categoryId) throws UaException {
-    checkRunning();
-
     lock.lock();
     try {
+      checkRunning();
+
       if (categories.containsKey(categoryId)) {
         throw new UaException(
             StatusCodes.Bad_NodeIdExists,
@@ -584,15 +585,16 @@ public final class AliasManager extends AbstractLifecycle {
    * Stop managing a category: unbind its Method handlers and, if the category was created by {@link
    * #addCategory}, delete the Nodes and References that creation added.
    *
-   * <p>Alias Nodes added to the category after its creation are not deleted — their {@code
-   * Organizes} linkage to the category is removed so no References target the deleted NodeId, but
-   * the alias Nodes themselves survive. Delete them first with {@link #deleteAlias} if they should
-   * not outlive the category.
+   * <p>Alias Nodes and child categories added after the category's creation survive. Their {@code
+   * Organizes} linkage to the deleted category is removed so recreating its NodeId does not
+   * reconnect them. Delete aliases first with {@link #deleteAlias} if they should not outlive the
+   * category.
    *
    * <p>When the category Node is deleted, {@code LastChange} is bumped for its former ancestor
-   * categories (captured before deletion) and the category's own in-memory version entry is
-   * dropped. Removing an <em>adopted</em> category only unbinds handlers — the AddressSpace is
-   * unchanged, so no version is bumped.
+   * categories (captured before deletion). The category's version high-water mark is retained for
+   * the manager's lifetime so recreating its NodeId continues the sequence. Removing an
+   * <em>adopted</em> category only unbinds handlers — the AddressSpace is unchanged, so no version
+   * is bumped.
    *
    * @param categoryId the NodeId of the category to remove.
    * @throws UaException with {@code Bad_InvalidArgument} if {@code categoryId} is a standard
@@ -602,10 +604,10 @@ public final class AliasManager extends AbstractLifecycle {
    * @throws IllegalStateException if the manager is not running.
    */
   public void removeCategory(NodeId categoryId) throws UaException {
-    checkRunning();
-
     lock.lock();
     try {
+      checkRunning();
+
       if (STANDARD_CATEGORY_IDS.contains(categoryId)) {
         throw new UaException(
             StatusCodes.Bad_InvalidArgument,
@@ -640,16 +642,13 @@ public final class AliasManager extends AbstractLifecycle {
         }
 
         if (record.instantiationResult() != null) {
-          // Detach aliases organized after creation: deleteCreated removes only what the
-          // instantiation recorded, so their Organizes linkage would otherwise dangle on the
-          // alias side, pointing at the deleted category — and silently reattach if a category
-          // with the same NodeId were created later. The alias Nodes themselves survive, per
-          // this method's contract.
-          for (NodeId aliasNodeId : findOrganizedAliases(categoryId)) {
+          // A surviving member's linkage may have been added after this category's creation
+          // journal. Detach both aliases and child categories before deleting the parent.
+          for (NodeId memberId : findOrganizedMembers(categoryId)) {
             server
                 .getAddressSpaceManager()
-                .getManagedNode(aliasNodeId)
-                .ifPresent(aliasNode -> removeFromCategory(aliasNode, categoryId));
+                .getManagedNode(memberId)
+                .ifPresent(member -> removeFromCategory(member, categoryId));
           }
 
           record.instantiationResult().deleteCreated();
@@ -712,10 +711,10 @@ public final class AliasManager extends AbstractLifecycle {
   public NodeId addAlias(NodeId categoryId, String aliasName, List<AliasTarget> targets)
       throws UaException {
 
-    checkRunning();
-
     lock.lock();
     try {
+      checkRunning();
+
       CategoryRecord record = resolveCategoryRecord(categoryId);
 
       if (aliasName.isEmpty()) {
@@ -906,10 +905,10 @@ public final class AliasManager extends AbstractLifecycle {
   public void deleteAlias(NodeId categoryId, String aliasName, @Nullable List<AliasTarget> targets)
       throws UaException {
 
-    checkRunning();
-
     lock.lock();
     try {
+      checkRunning();
+
       resolveCategoryRecord(categoryId);
 
       NodeId aliasNodeId = findAliasInCategory(categoryId, aliasName);
@@ -994,7 +993,7 @@ public final class AliasManager extends AbstractLifecycle {
         versionManager.prepare(bumped);
 
         for (Reference reference : matching) {
-          aliasNode.removeReference(reference);
+          server.getAddressSpaceManager().removeManagedReferences(reference);
         }
 
         deleteIfTargetless(aliasNode);
@@ -1382,6 +1381,9 @@ public final class AliasManager extends AbstractLifecycle {
         return StatusCode.GOOD;
       }
 
+      var removals = new LinkedHashMap<UaNode, List<Reference>>();
+      var bumped = new LinkedHashSet<NodeId>();
+
       for (NodeId aliasNodeId : aliasNodeIds) {
         UaNode aliasNode = server.getAddressSpaceManager().getManagedNode(aliasNodeId).orElse(null);
         if (aliasNode == null) {
@@ -1393,24 +1395,23 @@ public final class AliasManager extends AbstractLifecycle {
         List<Reference> matching =
             findTargetReferences(aliasNodeId, targetNodeId, aliasTypes::isAliasForOrSubtype);
 
-        if (matching.isEmpty()) {
-          continue;
+        if (!matching.isEmpty()) {
+          removals.put(aliasNode, matching);
+          bumped.add(categoryId);
+          bumped.addAll(getOrganizingCategories(aliasNodeId));
         }
+      }
 
-        // A target change is observable from every category that organizes the alias, not just
-        // the one addressed, so all of them get a LastChange bump. Prepared BEFORE the mutation
-        // so a failed save fails the entry before this alias is touched, and the bumps publish
-        // even if a Reference removal throws partway through.
-        var bumped = new ArrayList<NodeId>();
-        bumped.add(categoryId);
-        bumped.addAll(getOrganizingCategories(aliasNodeId));
-        versionManager.prepare(bumped);
+      // One entry can affect several same-name aliases and their other organizing categories.
+      // Persist the entire union before the first deletion, so any save failure leaves every
+      // alias in this entry untouched.
+      versionManager.prepare(bumped);
 
-        for (Reference reference : matching) {
-          aliasNode.removeReference(reference);
+      for (var removal : removals.entrySet()) {
+        for (Reference reference : removal.getValue()) {
+          server.getAddressSpaceManager().removeManagedReferences(reference);
         }
-
-        deleteIfTargetless(aliasNode);
+        deleteIfTargetless(removal.getKey());
       }
 
       return StatusCode.GOOD;
@@ -1486,10 +1487,10 @@ public final class AliasManager extends AbstractLifecycle {
    * @throws IllegalStateException if the manager is not running.
    */
   public void touch(NodeId categoryId) throws UaException {
-    checkRunning();
-
     lock.lock();
     try {
+      checkRunning();
+
       versionManager.touch(categoryId);
     } finally {
       lock.unlock();
@@ -1825,8 +1826,8 @@ public final class AliasManager extends AbstractLifecycle {
         .orElse(null);
   }
 
-  /** Find every alias Object directly organized by {@code categoryId}, regardless of name. */
-  private List<NodeId> findOrganizedAliases(NodeId categoryId) {
+  /** Find alias Objects and child categories directly organized by {@code categoryId}. */
+  private List<NodeId> findOrganizedMembers(NodeId categoryId) {
     List<Reference> organizes =
         server
             .getAddressSpaceManager()
@@ -1837,7 +1838,9 @@ public final class AliasManager extends AbstractLifecycle {
       reference
           .getTargetNodeId()
           .toNodeId(server.getNamespaceTable())
-          .filter(aliasTypes::isAliasNameInstance)
+          .filter(
+              id ->
+                  aliasTypes.isAliasNameInstance(id) || aliasTypes.isAliasNameCategoryInstance(id))
           .ifPresent(found::add);
     }
     return found;
@@ -1978,28 +1981,16 @@ public final class AliasManager extends AbstractLifecycle {
     return categoryIds;
   }
 
-  /**
-   * Remove the Organizes linkage between {@code categoryId} and the alias, from both Nodes'
-   * NodeManagers — the linkage may have been stored by either side.
-   */
-  private void removeFromCategory(UaNode aliasNode, NodeId categoryId) {
-    NodeId aliasNodeId = aliasNode.getNodeId();
-
-    aliasNode.removeReference(
-        new Reference(
-            aliasNodeId, NodeIds.Organizes, categoryId.expanded(), Reference.Direction.INVERSE));
-
+  /** Remove both directions of a member's Organizes linkage from every registered manager. */
+  private void removeFromCategory(UaNode member, NodeId categoryId) {
     server
         .getAddressSpaceManager()
-        .getManagedNode(categoryId)
-        .ifPresent(
-            categoryNode ->
-                categoryNode.removeReference(
-                    new Reference(
-                        categoryId,
-                        NodeIds.Organizes,
-                        aliasNodeId.expanded(),
-                        Reference.Direction.FORWARD)));
+        .removeManagedReferences(
+            new Reference(
+                member.getNodeId(),
+                NodeIds.Organizes,
+                categoryId.expanded(),
+                Reference.Direction.INVERSE));
   }
 
   /**

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/aliases/AliasVersionManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/aliases/AliasVersionManager.java
@@ -50,7 +50,9 @@ import org.slf4j.LoggerFactory;
  * the prepared values to the {@code LastChange} Property Nodes, called from a {@code finally} so
  * values whose mutation partially applied are still published. Because no value becomes observable
  * before it is persisted, a restart can never re-produce an observed {@code LastChange} value for
- * different content — the failure mode that would leave Client caches undetectably stale.
+ * different content while its stored entry is retained. Removed categories keep their in-memory
+ * high-water mark for the manager's lifetime; retention across restarts depends on the store's
+ * deletion policy.
  *
  * <p>Store entries are keyed by namespace-URI-qualified {@link ExpandedNodeId}s (see {@link
  * AliasVersionStore}); this class converts to and from runtime NodeIds at the store boundary.
@@ -263,18 +265,18 @@ class AliasVersionManager {
   }
 
   /**
-   * Drop the version entry of a category that no longer exists, in memory and — best-effort — in
-   * the store.
+   * Remove pending publication and clean up the stored entry of a category that no longer exists,
+   * retaining its in-memory high-water mark for the manager's lifetime.
    *
    * <p>The store delete is cleanup, not correctness: a failure is logged and the removal proceeds,
    * and stores whose {@link AliasVersionStore#delete} is the default no-op simply keep the entry. A
-   * leftover entry is inert unless a category with the same NodeId is created again, in which case
-   * the monotonic version sequence resumes from the persisted value — which is the safe direction.
+   * retained entry also preserves the sequence across a manager restart. A store that deletes the
+   * entry gives up that restart guarantee for the removed category. Recreating the NodeId within
+   * this manager always resumes above the previous version, regardless of store deletion.
    *
    * @param categoryId the NodeId of the removed category.
    */
   void remove(NodeId categoryId) {
-    versions.remove(categoryId);
     pending.remove(categoryId);
 
     try {

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/aliases/AliasVersionStore.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/aliases/AliasVersionStore.java
@@ -71,8 +71,11 @@ public interface AliasVersionStore {
    * <p>Called when a manager-created category is removed, so durable stores do not accumulate
    * entries forever. Best-effort cleanup: a thrown exception is logged by the caller and the
    * removal proceeds — a leftover entry is inert unless a category with the same NodeId is created
-   * again, in which case the version sequence resumes from it, which is harmless. The default
-   * implementation does nothing, for stores that prefer to keep (or externally expire) old entries.
+   * again, in which case the version sequence resumes from it. Within the same manager lifetime, an
+   * in-memory high-water mark preserves the sequence even if the stored entry is deleted. Across
+   * manager restarts, preserving the sequence for reused NodeIds requires retaining their entries.
+   * The default implementation does nothing, for stores that prefer to keep (or externally expire)
+   * old entries.
    *
    * @param categoryId the namespace-URI-qualified ExpandedNodeId of the removed category.
    * @throws UaException if the entry cannot be removed.

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/aliases/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/aliases/package-info.java
@@ -48,7 +48,10 @@
  * and unregisters its fragment: Nodes the manager hosts there (materialized Methods, alias Nodes
  * created in standard or adopted categories) leave the AddressSpace with it, while category and
  * alias Nodes hosted in application NodeManagers remain in place. Applications register their own
- * categories and aliases through the manager's programmatic API after startup.
+ * categories and aliases through the manager's programmatic API after startup. Public and wire
+ * mutations check lifecycle state while holding the mutation lock, so a caller waiting for that
+ * lock cannot mutate after shutdown completes. Removing a manager-created category detaches its
+ * surviving aliases and child categories before deleting the category itself.
  *
  * <h2>Data flow</h2>
  *
@@ -59,11 +62,13 @@
  * trade-off is weak consistency under concurrent mutation — the same weak consistency Browse
  * already has — and that out-of-band AddressSpace edits do not bump {@code LastChange}; mutations
  * must flow through the manager (or be followed by an explicit {@code touch}) for version
- * correctness. Out-of-band edits carry one further caveat: References recorded in only one
- * direction (e.g. a category-side-only {@code Organizes} Reference loaded from a NodeSet without
- * its inverse) are still found by search, which follows the forward direction, but are invisible to
- * alias-side operations — organizing-category resolution during delete and ancestor discovery
- * during version propagation both walk inverse References and miss such linkage.
+ * correctness. Association removal covers every registered NodeManager that may store either
+ * direction, matching the scope of reference collection. Out-of-band edits carry one further
+ * caveat: References recorded in only one direction (e.g. a category-side-only {@code Organizes}
+ * Reference loaded from a NodeSet without its inverse) are still found by search, which follows the
+ * forward direction, but are invisible to alias-side operations — organizing-category resolution
+ * during delete and ancestor discovery during version propagation both walk inverse References and
+ * miss such linkage.
  *
  * <h2>Network mutation</h2>
  *
@@ -92,12 +97,15 @@
  * org.eclipse.milo.opcua.sdk.server.aliases.AliasVersionStore} <em>before</em> the mutation they
  * describe is applied or the value is published: a failed save aborts the operation (or fails the
  * entry) with {@code Bad_InternalError} and nothing changed, so no Client can ever observe an
- * unpersisted {@code LastChange} value — after a restart the sequence therefore never repeats an
- * observed value for different content, which would leave Client caches undetectably stale.
- * Likewise a failed load at startup fails startup, because silently reset versions would violate
- * the persistence contract undetectably. Categories whose {@code LastChange} Property does not
- * exist (it is Optional per category) still participate in propagation; only the Property write is
- * skipped.
+ * unpersisted {@code LastChange} value. A deletion entry prepares the union of categories affected
+ * by every matching alias before deleting any association, so a later category's save failure
+ * leaves the whole entry untouched. Likewise a failed load at startup fails startup, because
+ * silently reset versions would violate the persistence contract undetectably. Categories whose
+ * {@code LastChange} Property does not exist (it is Optional per category) still participate in
+ * propagation; only the Property write is skipped. Removed categories retain an in-memory version
+ * high-water mark for the manager's lifetime, so reusing a category NodeId cannot repeat a version
+ * for different contents. Across restarts, that guarantee for removed categories depends on the
+ * version store retaining their entries; the root category is never removed.
  */
 @NullMarked
 package org.eclipse.milo.opcua.sdk.server.aliases;

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/aliases/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/aliases/package-info.java
@@ -63,12 +63,14 @@
  * already has — and that out-of-band AddressSpace edits do not bump {@code LastChange}; mutations
  * must flow through the manager (or be followed by an explicit {@code touch}) for version
  * correctness. Association removal covers every registered NodeManager that may store either
- * direction, matching the scope of reference collection. Out-of-band edits carry one further
- * caveat: References recorded in only one direction (e.g. a category-side-only {@code Organizes}
- * Reference loaded from a NodeSet without its inverse) are still found by search, which follows the
- * forward direction, but are invisible to alias-side operations — organizing-category resolution
- * during delete and ancestor discovery during version propagation both walk inverse References and
- * miss such linkage.
+ * direction, matching the scope of reference collection. Whole-alias deletion preserves the owning
+ * manager's child-node traversal and removes the alias's collected References from all registered
+ * managers, so NodeId reuse cannot restore a deleted target or category membership. Out-of-band
+ * edits carry one further caveat: References recorded in only one direction (e.g. a
+ * category-side-only {@code Organizes} Reference loaded from a NodeSet without its inverse) are
+ * still found by search, which follows the forward direction, but are invisible to alias-side
+ * operations — organizing-category resolution during delete and ancestor discovery during version
+ * propagation both walk inverse References and miss such linkage.
  *
  * <h2>Network mutation</h2>
  *

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/package-info.java
@@ -46,6 +46,14 @@
  * participant shutdown therefore runs without external server visibility but before the standard
  * address space and event facilities are torn down.
  *
+ * <h2>Reference storage</h2>
+ *
+ * <p>{@link org.eclipse.milo.opcua.sdk.server.AddressSpaceManager} aggregates references from every
+ * registered NodeManager. Reference ownership is independent of node ownership: either endpoint's
+ * manager, or another registered manager, can store an association. Removing an association through
+ * the address-space manager removes both directions from all registered stores, matching the scope
+ * used for discovery.
+ *
  * <h2>Runtime boundaries</h2>
  *
  * <p>The SDK server package coordinates high-level server configuration and lifecycle. Certificate


### PR DESCRIPTION
This PR fixes five alias-management issues involving deletion, lifecycle ordering, and change-version tracking.

### Remove alias references across node managers

Deleting a target or a whole alias could report success while leaving references in another NodeManager. Recreating the same alias name could then restore a deleted target or category membership. Reference removal now covers every registered manager that can store the association. Whole-alias deletion preserves deletion of its owned children before removing the saved cross-manager references.

### Prepare all category versions before deleting an entry

A version-store failure could leave one deletion entry partly applied. Each entry now prepares the union of affected category versions before removing its first target.

[Part 17 §6.3.5](https://reference.opcfoundation.org/specs/OPC-10000-17/6.3.5) requires: "If all targets for an AliasNames array entry cannot be deleted, then none of the targets are deleted." Preparing versions first prevents a persistence failure from deleting only some aliases in that entry. Existing custom NodeManager failure behavior is unchanged.

### Detach surviving child categories

Removing a parent category could leave its surviving children attached to a deleted parent. Category removal now detaches surviving child categories as well as aliases.

### Reject mutations after shutdown begins

A caller could pass the lifecycle check, wait for the mutation lock, and then change the address space after shutdown. Public mutations now check lifecycle state while holding that lock.

### Preserve change versions when a category ID is reused

Recreating a category NodeId could reuse an observed LastChange for different contents. The manager now retains the category's version high-water mark across removal and recreation.

[Part 17 §6.3.1](https://reference.opcfoundation.org/specs/OPC-10000-17/6.3.1) states: "The LastChange shall be persisted." The reuse fix preserves Milo's version-store contract within the manager's lifetime. Preserving removed-category versions across manager restarts still requires the store to retain their entries.

### Verification

Formatting, a full clean compile, and the selected alias suites passed with no failures, errors, or skips. The original 12 regressions fail at their intended assertions without the fixes, including real wire deletion and deterministic shutdown interleavings.

Three additional regressions fail before the whole-alias cleanup correction and pass afterward: public and wire deletion followed by same-name recreation, and deletion with category membership stored in another manager. A fourth case confirms that owned-child deletion still works. The unchanged in-memory version-store tests passed in the earlier verification run.
