### PR TITLE
Fix Condition event consistency and shelving Method ownership

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/conditions/ConditionDispatchLifecycleTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/conditions/ConditionDispatchLifecycleTest.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.conditions;
+
+import static java.util.Objects.requireNonNull;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.eclipse.milo.opcua.sdk.server.EventListener;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.sdk.server.Session;
+import org.eclipse.milo.opcua.sdk.server.events.EventContentFilter;
+import org.eclipse.milo.opcua.sdk.server.events.FilterContext;
+import org.eclipse.milo.opcua.sdk.server.methods.MethodInvocationHandler;
+import org.eclipse.milo.opcua.sdk.server.model.objects.AlarmConditionTypeNode;
+import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaMethodNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.instantiation.InstantiationRequest;
+import org.eclipse.milo.opcua.sdk.server.nodes.instantiation.MethodInstantiation;
+import org.eclipse.milo.opcua.sdk.test.AbstractClientServerTest;
+import org.eclipse.milo.opcua.stack.core.AttributeId;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.structured.CallMethodRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.CallMethodResult;
+import org.eclipse.milo.opcua.stack.core.types.structured.SimpleAttributeOperand;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Real event selection, refresh copying, and wire dispatch across Condition lifecycle boundaries.
+ */
+class ConditionDispatchLifecycleTest extends AbstractClientServerTest {
+
+  @Test
+  void expiredRestoreCannotChangeAnEventDuringFieldSelection() throws Exception {
+    AlarmCondition alarm = restoredExpiredAlarm("event");
+    List<Variant[]> events = new ArrayList<>();
+    EventListener listener =
+        event -> {
+          if (event.getNodeId().equals(alarm.getConditionId())) {
+            events.add(select(event));
+          }
+        };
+    server.getEventNotifier().register(listener);
+    try {
+      alarm.setSeverity(ushort(701));
+      assertFalse(events.isEmpty());
+      for (Variant[] fields : events) {
+        assertEquals(fields[0], fields[4], "one event must have one EventId");
+        assertEquals(fields[1], fields[5], "shelving state must be stable during selection");
+        assertEquals(Boolean.FALSE, fields[1].getValue());
+        assertEquals("Unshelved", ((LocalizedText) fields[2].getValue()).text());
+      }
+    } finally {
+      server.getEventNotifier().unregister(listener);
+    }
+  }
+
+  @Test
+  void refreshResolvesExpiredRestoreBeforeCopyingFields() throws Exception {
+    AlarmCondition alarm = restoredExpiredAlarm("refresh");
+    List<ConditionEventSnapshot> snapshots = alarm.createRefreshSnapshots();
+    try {
+      assertEquals(1, snapshots.size());
+      Variant[] fields = select(snapshots.get(0).getEventNode());
+      assertEquals(Boolean.FALSE, fields[1].getValue());
+      assertEquals("Unshelved", ((LocalizedText) fields[2].getValue()).text());
+      assertEquals(0.0, fields[3].getValue());
+      assertEquals(alarm.currentBranch().getLastEventId(), fields[0].getValue());
+    } finally {
+      snapshots.forEach(ConditionEventSnapshot::delete);
+    }
+  }
+
+  @Test
+  void unregisterRetiresCopiedAcknowledgementAndShelvingHandlers() throws Exception {
+    AlarmCondition alarm = newAlarm("retired");
+    alarm.setActive(true);
+    ByteString eventId = alarm.currentBranch().getLastEventId();
+    UaMethodNode acknowledge = requireNonNull(alarm.getNode().getAcknowledgeMethodNode());
+    var shelving = requireNonNull(alarm.getShelvingState());
+    UaMethodNode timedShelve = requireNonNull(shelving.getTimedShelveMethodNode());
+
+    server.getConditionManager().unregister(alarm);
+
+    assertEquals(
+        StatusCodes.Bad_NotImplemented,
+        call(
+                alarm.getConditionId(),
+                acknowledge.getNodeId(),
+                new Variant(eventId),
+                new Variant(LocalizedText.NULL_VALUE))
+            .getStatusCode()
+            .value());
+    assertEquals(
+        StatusCodes.Bad_NotImplemented,
+        call(shelving.getNodeId(), timedShelve.getNodeId(), new Variant(30_000.0))
+            .getStatusCode()
+            .value());
+    assertFalse(alarm.isAcked());
+    assertEquals("Unshelved", shelving.getCurrentState().text());
+    assertFalse(requireNonNull(alarm.getShelvingRuntime()).hasExpiryTimerForTesting());
+  }
+
+  @Test
+  void unregisterPreservesAnApplicationReplacementHandler() throws Exception {
+    AlarmCondition alarm = newAlarm("application-handler");
+    UaMethodNode method = requireNonNull(alarm.getNode().getAcknowledgeMethodNode());
+    MethodInvocationHandler replacement = MethodInvocationHandler.NODE_ID_UNKNOWN;
+    method.setInvocationHandler(replacement);
+
+    server.getConditionManager().unregister(alarm);
+
+    assertSame(replacement, method.getInvocationHandler());
+  }
+
+  @Test
+  void replacingBehaviorPreservesTheNewWrappersHandlers() throws Exception {
+    AlarmCondition original = newAlarm("replacement");
+    AlarmCondition replacement = AlarmCondition.attach(original.getNode());
+    server.getConditionManager().register(replacement);
+    replacement.setActive(true);
+    UaMethodNode acknowledge = requireNonNull(replacement.getNode().getAcknowledgeMethodNode());
+
+    CallMethodResult result =
+        call(
+            replacement.getConditionId(),
+            acknowledge.getNodeId(),
+            new Variant(replacement.currentBranch().getLastEventId()),
+            new Variant(LocalizedText.NULL_VALUE));
+
+    assertTrue(result.getStatusCode().isGood());
+    assertTrue(replacement.isAcked());
+  }
+
+  @Test
+  void sharedShelvingMethodResolvesItsNestedObjectWithoutChangingTheTypeHandler() throws Exception {
+    AlarmConditionTypeNode node =
+        server
+            .getNodeInstantiator()
+            .instantiate(
+                InstantiationRequest.of(AlarmConditionTypeNode.class, NodeIds.AlarmConditionType)
+                    .nodeId(newNodeId("shared"))
+                    .browseName(newQualifiedName("shared"))
+                    .target(testNamespace.getNodeManager())
+                    .methodInstantiation(MethodInstantiation.SHARE)
+                    .includeOptionals(
+                        d ->
+                            Set.of("ShelvingState", "LastTransition")
+                                .contains(d.browseName().name()))
+                    .build())
+            .root();
+    node.setEventType(NodeIds.AlarmConditionType);
+    node.setSeverity(ushort(700));
+    AlarmCondition alarm = AlarmCondition.attach(node);
+    server.getConditionManager().register(alarm);
+    alarm.setActive(true);
+    var shelving = requireNonNull(alarm.getShelvingState());
+    UaMethodNode method = requireNonNull(shelving.getTimedShelveMethodNode());
+    MethodInvocationHandler typeHandler = method.getInvocationHandler();
+
+    CallMethodResult result = call(shelving.getNodeId(), method.getNodeId(), new Variant(30_000.0));
+
+    assertTrue(result.getStatusCode().isGood(), () -> result.getStatusCode().toString());
+    assertEquals("TimedShelved", shelving.getCurrentState().text());
+    assertSame(typeHandler, method.getInvocationHandler());
+    CallMethodResult unshelve =
+        call(alarm.getConditionId(), requireNonNull(shelving.getUnshelveMethodNode()).getNodeId());
+    assertTrue(unshelve.getStatusCode().isGood(), () -> unshelve.getStatusCode().toString());
+    assertEquals("Unshelved", shelving.getCurrentState().text());
+    assertSame(typeHandler, method.getInvocationHandler());
+  }
+
+  private AlarmCondition newAlarm(String name) throws Exception {
+    AlarmCondition alarm =
+        AlarmCondition.create(
+            testNamespace.getNodeContext(),
+            b ->
+                b.nodeId(newNodeId(name))
+                    .browseName(newQualifiedName(name))
+                    .severity(ushort(700))
+                    .withShelving(Duration.ofMinutes(5)));
+    server.getConditionManager().register(alarm);
+    return alarm;
+  }
+
+  private AlarmCondition restoredExpiredAlarm(String name) throws Exception {
+    AlarmCondition alarm = newAlarm(name);
+    ByteString eventId = ByteString.of(new byte[] {1, 2, 3, 4});
+    DateTime eventTime = DateTime.now();
+    alarm.restoreSnapshot(
+        new ConditionSnapshot(
+            true,
+            ushort(700),
+            ushort(700),
+            null,
+            null,
+            null,
+            new ConditionSnapshot.ShelvingSnapshot(
+                ShelvedState.TIMED_SHELVED, new DateTime(Instant.now().minusSeconds(1))),
+            List.of(
+                new ConditionSnapshot.BranchSnapshot(
+                    NodeId.NULL_VALUE,
+                    false,
+                    null,
+                    true,
+                    Set.of(),
+                    null,
+                    true,
+                    eventId,
+                    eventTime,
+                    List.of(
+                        new ConditionSnapshot.AcceptedEventId(
+                            eventId, false, false, true, true))))));
+    return alarm;
+  }
+
+  private Variant[] select(BaseEventTypeNode event) {
+    FilterContext context =
+        new FilterContext() {
+          @Override
+          public OpcUaServer getServer() {
+            return server;
+          }
+
+          @Override
+          public Optional<Session> getSession() {
+            return Optional.empty();
+          }
+        };
+    return EventContentFilter.select(
+        context,
+        new SimpleAttributeOperand[] {
+          field("EventId"), field("SuppressedOrShelved"), field("ShelvingState", "CurrentState"),
+          field("ShelvingState", "UnshelveTime"), field("EventId"), field("SuppressedOrShelved")
+        },
+        event);
+  }
+
+  private static SimpleAttributeOperand field(String... path) {
+    return new SimpleAttributeOperand(
+        NodeIds.AlarmConditionType,
+        Arrays.stream(path).map(name -> new QualifiedName(0, name)).toArray(QualifiedName[]::new),
+        AttributeId.Value.uid(),
+        null);
+  }
+
+  private CallMethodResult call(NodeId objectId, NodeId methodId, Variant... inputs)
+      throws Exception {
+    return requireNonNull(
+        client.call(List.of(new CallMethodRequest(objectId, methodId, inputs))).getResults())[0];
+  }
+}

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/conditions/ConditionDispatchLifecycleTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/conditions/ConditionDispatchLifecycleTest.java
@@ -159,26 +159,7 @@ class ConditionDispatchLifecycleTest extends AbstractClientServerTest {
 
   @Test
   void sharedShelvingMethodResolvesItsNestedObjectWithoutChangingTheTypeHandler() throws Exception {
-    AlarmConditionTypeNode node =
-        server
-            .getNodeInstantiator()
-            .instantiate(
-                InstantiationRequest.of(AlarmConditionTypeNode.class, NodeIds.AlarmConditionType)
-                    .nodeId(newNodeId("shared"))
-                    .browseName(newQualifiedName("shared"))
-                    .target(testNamespace.getNodeManager())
-                    .methodInstantiation(MethodInstantiation.SHARE)
-                    .includeOptionals(
-                        d ->
-                            Set.of("ShelvingState", "LastTransition")
-                                .contains(d.browseName().name()))
-                    .build())
-            .root();
-    node.setEventType(NodeIds.AlarmConditionType);
-    node.setSeverity(ushort(700));
-    AlarmCondition alarm = AlarmCondition.attach(node);
-    server.getConditionManager().register(alarm);
-    alarm.setActive(true);
+    AlarmCondition alarm = newSharedAlarm("shared");
     var shelving = requireNonNull(alarm.getShelvingState());
     UaMethodNode method = requireNonNull(shelving.getTimedShelveMethodNode());
     MethodInvocationHandler typeHandler = method.getInvocationHandler();
@@ -193,6 +174,50 @@ class ConditionDispatchLifecycleTest extends AbstractClientServerTest {
     assertTrue(unshelve.getStatusCode().isGood(), () -> unshelve.getStatusCode().toString());
     assertEquals("Unshelved", shelving.getCurrentState().text());
     assertSame(typeHandler, method.getInvocationHandler());
+  }
+
+  // The nested state machine exposes shelving Methods only. An otherwise valid Acknowledge
+  // call must use the ConditionId and must not mutate the alarm through ShelvingState.
+  @Test
+  void nestedShelvingObjectCannotInvokeAnAlarmMethod() throws Exception {
+    AlarmCondition alarm = newSharedAlarm("shared-method-owner");
+    var shelving = requireNonNull(alarm.getShelvingState());
+    UaMethodNode acknowledge = requireNonNull(alarm.getNode().getAcknowledgeMethodNode());
+    Variant[] inputs = {
+      new Variant(alarm.currentBranch().getLastEventId()), new Variant(LocalizedText.NULL_VALUE)
+    };
+
+    CallMethodResult rejected = call(shelving.getNodeId(), acknowledge.getNodeId(), inputs);
+
+    assertEquals(StatusCodes.Bad_MethodInvalid, rejected.getStatusCode().value());
+    assertFalse(alarm.isAcked());
+    CallMethodResult accepted = call(alarm.getConditionId(), acknowledge.getNodeId(), inputs);
+    assertTrue(accepted.getStatusCode().isGood(), () -> accepted.getStatusCode().toString());
+    assertTrue(alarm.isAcked());
+  }
+
+  private AlarmCondition newSharedAlarm(String name) throws Exception {
+    AlarmConditionTypeNode node =
+        server
+            .getNodeInstantiator()
+            .instantiate(
+                InstantiationRequest.of(AlarmConditionTypeNode.class, NodeIds.AlarmConditionType)
+                    .nodeId(newNodeId(name))
+                    .browseName(newQualifiedName(name))
+                    .target(testNamespace.getNodeManager())
+                    .methodInstantiation(MethodInstantiation.SHARE)
+                    .includeOptionals(
+                        d ->
+                            Set.of("ShelvingState", "LastTransition")
+                                .contains(d.browseName().name()))
+                    .build())
+            .root();
+    node.setEventType(NodeIds.AlarmConditionType);
+    node.setSeverity(ushort(700));
+    AlarmCondition alarm = AlarmCondition.attach(node);
+    server.getConditionManager().register(alarm);
+    alarm.setActive(true);
+    return alarm;
   }
 
   private AlarmCondition newAlarm(String name) throws Exception {

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/AlarmCondition.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/AlarmCondition.java
@@ -224,6 +224,11 @@ public class AlarmCondition extends AcknowledgeableCondition {
   }
 
   @Override
+  void prepareEventState() {
+    applyShelvingExpiryIfDue();
+  }
+
+  @Override
   Optional<UaMethodNode> findMethodNode(NodeId methodId) {
     return shelvingRuntime != null ? shelvingRuntime.findMethodNode(methodId) : Optional.empty();
   }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/Condition.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/Condition.java
@@ -1042,7 +1042,8 @@ public class Condition {
   }
 
   /**
-   * Find a Method exposed through ConditionId dispatch but owned by a nested state machine.
+   * Find a Method owned by a nested state machine and also exposed through ConditionId dispatch.
+   * The manager uses this lookup to restrict calls targeting the nested ObjectId to its Methods.
    * Subclasses override for the nested methods they support.
    */
   Optional<UaMethodNode> findMethodNode(NodeId methodId) {

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/Condition.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/Condition.java
@@ -104,6 +104,11 @@ public class Condition {
   private final Set<FilterRegistration> filterRegistrations = ConcurrentHashMap.newKeySet();
   private final Map<NodeId, MethodInvocationHandler> sharedMethodHandlers =
       new ConcurrentHashMap<>();
+  private final Map<UaMethodNode, MethodInvocationHandler> ownedMethodHandlers =
+      new ConcurrentHashMap<>();
+
+  /** Suppresses lazy read-side transitions while one event's fields are selected or copied. */
+  private int eventFieldReadDepth;
 
   private volatile ConditionMethodInterceptor interceptor = NOOP_INTERCEPTOR;
 
@@ -584,6 +589,7 @@ public class Condition {
   protected void withStateChange(String message, StateMutation mutation) {
     lock.lock();
     try {
+      prepareEventState();
       DateTime now = DateTime.now();
 
       boolean wasRetained = trunk.isRetained();
@@ -651,6 +657,7 @@ public class Condition {
   List<ConditionEventSnapshot> createRefreshSnapshots() throws UaException {
     lock.lock();
     try {
+      prepareEventState();
       if (!trunk.isRetained()) {
         return List.of();
       }
@@ -671,7 +678,12 @@ public class Condition {
       // The replayed EventId is now client-visible: a later restore may not invalidate it.
       live = true;
 
-      return List.of(ConditionEventSnapshot.create(server, node, trunk));
+      eventFieldReadDepth++;
+      try {
+        return List.of(ConditionEventSnapshot.create(server, node, trunk));
+      } finally {
+        eventFieldReadDepth--;
+      }
     } finally {
       lock.unlock();
     }
@@ -834,7 +846,20 @@ public class Condition {
 
     trunk.recordEvent(eventId, time);
 
-    server.getEventNotifier().fire(node);
+    eventFieldReadDepth++;
+    try {
+      server.getEventNotifier().fire(node);
+    } finally {
+      eventFieldReadDepth--;
+    }
+  }
+
+  /** Resolve deferred runtime transitions before assigning or exposing an event identity. */
+  void prepareEventState() {}
+
+  /** Whether the calling thread is selecting or copying one event under this Condition's lock. */
+  final boolean isReadingEventFields() {
+    return lock.isHeldByCurrentThread() && eventFieldReadDepth > 0;
   }
 
   void handleEnable(InvocationContext context) throws UaException {
@@ -1001,6 +1026,7 @@ public class Condition {
 
     if (discovered.exclusivelyOwned()) {
       method.setInvocationHandler(invocationHandler);
+      ownedMethodHandlers.put(method, invocationHandler);
     } else if (method.getInvocationHandler() == MethodInvocationHandler.NOT_IMPLEMENTED) {
       sharedMethodHandlers.put(method.getNodeId(), invocationHandler);
     }
@@ -1029,6 +1055,11 @@ public class Condition {
 
   /** Release runtime resources when this Condition is unregistered or the server shuts down. */
   void shutdown() {
+    ownedMethodHandlers.forEach(
+        (method, handler) ->
+            method.compareAndSetInvocationHandler(
+                handler, MethodInvocationHandler.NOT_IMPLEMENTED));
+    ownedMethodHandlers.clear();
     for (FilterRegistration registration : filterRegistrations) {
       registration.node().getFilterChain().remove(registration.filter());
     }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/DefaultConditionManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/DefaultConditionManager.java
@@ -23,7 +23,9 @@ import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
 import org.eclipse.milo.opcua.sdk.server.Session;
 import org.eclipse.milo.opcua.sdk.server.events.EventNotifierScope;
 import org.eclipse.milo.opcua.sdk.server.items.MonitoredEventItem;
+import org.eclipse.milo.opcua.sdk.server.methods.MethodInvocationHandler;
 import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaMethodNode;
 import org.eclipse.milo.opcua.sdk.server.subscriptions.Subscription;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
@@ -102,6 +104,51 @@ public class DefaultConditionManager implements ConditionManager {
   @Override
   public Optional<Condition> findCondition(NodeId conditionId) {
     return Optional.ofNullable(conditions.get(conditionId));
+  }
+
+  @Override
+  public Optional<MethodInvocationHandler> findMethodInvocationHandler(
+      NodeId objectId, NodeId methodId) {
+    return findMethodOwner(objectId)
+        .flatMap(condition -> condition.findMethodInvocationHandler(methodId));
+  }
+
+  @Override
+  public Optional<UaMethodNode> findMethodNode(NodeId objectId, NodeId methodId) {
+    return findMethodOwner(objectId).flatMap(condition -> condition.findMethodNode(methodId));
+  }
+
+  private Optional<Condition> findMethodOwner(NodeId objectId) {
+    Condition direct = conditions.get(objectId);
+    if (direct != null) {
+      return Optional.of(direct);
+    }
+
+    // A ShelvingState ObjectId names a nested state machine, while its behavior belongs to the
+    // registered AlarmCondition. Follow only its actual parent edge and verify that ownership.
+    return server
+        .getAddressSpaceManager()
+        .getManagedNode(objectId)
+        .flatMap(
+            node ->
+                node.getReferences().stream()
+                    .filter(
+                        reference ->
+                            !reference.isForward()
+                                && reference.getReferenceTypeId().equals(NodeIds.HasComponent))
+                    .map(
+                        reference ->
+                            reference
+                                .getTargetNodeId()
+                                .toNodeId(server.getNamespaceTable())
+                                .map(conditions::get)
+                                .orElse(null))
+                    .filter(
+                        condition ->
+                            condition instanceof AlarmCondition alarm
+                                && alarm.getShelvingState() != null
+                                && alarm.getShelvingState().getNodeId().equals(objectId))
+                    .findFirst());
   }
 
   @Override

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/DefaultConditionManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/DefaultConditionManager.java
@@ -25,6 +25,7 @@ import org.eclipse.milo.opcua.sdk.server.events.EventNotifierScope;
 import org.eclipse.milo.opcua.sdk.server.items.MonitoredEventItem;
 import org.eclipse.milo.opcua.sdk.server.methods.MethodInvocationHandler;
 import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
+import org.eclipse.milo.opcua.sdk.server.model.objects.ShelvedStateMachineTypeNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaMethodNode;
 import org.eclipse.milo.opcua.sdk.server.subscriptions.Subscription;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
@@ -109,26 +110,29 @@ public class DefaultConditionManager implements ConditionManager {
   @Override
   public Optional<MethodInvocationHandler> findMethodInvocationHandler(
       NodeId objectId, NodeId methodId) {
-    return findMethodOwner(objectId)
+    return findMethodOwner(objectId, methodId)
         .flatMap(condition -> condition.findMethodInvocationHandler(methodId));
   }
 
   @Override
   public Optional<UaMethodNode> findMethodNode(NodeId objectId, NodeId methodId) {
-    return findMethodOwner(objectId).flatMap(condition -> condition.findMethodNode(methodId));
+    return findMethodOwner(objectId, methodId)
+        .flatMap(condition -> condition.findMethodNode(methodId));
   }
 
-  private Optional<Condition> findMethodOwner(NodeId objectId) {
+  private Optional<Condition> findMethodOwner(NodeId objectId, NodeId methodId) {
     Condition direct = conditions.get(objectId);
     if (direct != null) {
       return Optional.of(direct);
     }
 
     // A ShelvingState ObjectId names a nested state machine, while its behavior belongs to the
-    // registered AlarmCondition. Follow only its actual parent edge and verify that ownership.
+    // registered AlarmCondition. Verify its parent ownership and restrict this route to Methods
+    // actually exposed by the nested state machine.
     return server
         .getAddressSpaceManager()
         .getManagedNode(objectId)
+        .filter(ShelvedStateMachineTypeNode.class::isInstance)
         .flatMap(
             node ->
                 node.getReferences().stream()
@@ -147,7 +151,8 @@ public class DefaultConditionManager implements ConditionManager {
                         condition ->
                             condition instanceof AlarmCondition alarm
                                 && alarm.getShelvingState() != null
-                                && alarm.getShelvingState().getNodeId().equals(objectId))
+                                && alarm.getShelvingState().getNodeId().equals(objectId)
+                                && alarm.findMethodNode(methodId).isPresent())
                     .findFirst());
   }
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/ShelvingRuntime.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/ShelvingRuntime.java
@@ -78,6 +78,7 @@ final class ShelvingRuntime {
 
   // Guarded by the owning Condition's lock.
   private long shelveGeneration = 0;
+  private boolean transitionInProgress;
   private @Nullable ScheduledFuture<?> expiryTimer;
   private boolean expiryTimerSuppressed = false;
   private boolean shutdown = false;
@@ -360,6 +361,7 @@ final class ShelvingRuntime {
     DateTime deadline = unshelveDeadline;
 
     if (!shutdown
+        && !transitionInProgress
         && state != ShelvedState.UNSHELVED
         && deadline != null
         && System.currentTimeMillis() >= deadline.getJavaTime()) {
@@ -370,9 +372,15 @@ final class ShelvingRuntime {
   private void shelveTransition(
       ShelvedState target, @Nullable Function<DateTime, DateTime> deadline) {
 
-    alarm.withStateChange(
-        target.stateName(),
-        now -> applyTransition(target, deadline != null ? deadline.apply(now) : null, now));
+    boolean previous = transitionInProgress;
+    transitionInProgress = true;
+    try {
+      alarm.withStateChange(
+          target.stateName(),
+          now -> applyTransition(target, deadline != null ? deadline.apply(now) : null, now));
+    } finally {
+      transitionInProgress = previous;
+    }
   }
 
   private void applyTransition(ShelvedState target, @Nullable DateTime deadline, DateTime time) {
@@ -584,10 +592,14 @@ final class ShelvingRuntime {
   }
 
   private double computeUnshelveTime() {
-    // A read is a shelving touch. Apply due expiry under the Condition lock before producing the
-    // value; event-field extraction may recursively read UnshelveTime, but by then the state is
-    // already Unshelved and this check is a no-op.
-    alarm.runLocked(this::applyExpiryIfDue);
+    // An ordinary read still supplies the lazy fallback. Event selection and refresh copying have
+    // already resolved expiry and must not change state if the deadline passes between fields.
+    alarm.runLocked(
+        () -> {
+          if (!alarm.isReadingEventFields()) {
+            applyExpiryIfDue();
+          }
+        });
 
     ReadSnapshot snapshot = readSnapshot;
     ShelvedState state = snapshot.state();

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/package-info.java
@@ -49,6 +49,16 @@
  * Condition through the ConditionManager, leaving the shared node and any application-installed
  * handler unchanged.
  *
+ * <p>The default manager resolves shared shelving Methods through either the ConditionId or the
+ * nested ShelvingState ObjectId. Unregistering retires handlers installed on copied Methods only
+ * while they still belong to that behavior, preserving later application or replacement handlers.
+ * Calls that already obtained a handler may finish against the retired behavior.
+ *
+ * <p>Deferred shelving expiry is resolved before event emission or refresh copying. Field reads
+ * within those operations cannot trigger another expiry transition, so one event retains one
+ * EventId and one shelving state. Ordinary UnshelveTime reads still apply the lazy expiry fallback
+ * when a timer prompt was lost or delayed.
+ *
  * <h2>Limit-alarm data flow</h2>
  *
  * <p>Limit-alarm behavior separates domain evaluation from Condition state application. The {@code

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/UaMethodNode.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/UaMethodNode.java
@@ -18,6 +18,7 @@ import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -44,7 +45,8 @@ import org.jspecify.annotations.Nullable;
 
 public class UaMethodNode extends UaNode implements MethodNode {
 
-  private volatile MethodInvocationHandler handler = MethodInvocationHandler.NOT_IMPLEMENTED;
+  private final AtomicReference<MethodInvocationHandler> handler =
+      new AtomicReference<>(MethodInvocationHandler.NOT_IMPLEMENTED);
 
   private Boolean executable;
   private Boolean userExecutable;
@@ -185,11 +187,26 @@ public class UaMethodNode extends UaNode implements MethodNode {
   }
 
   public MethodInvocationHandler getInvocationHandler() {
-    return handler;
+    return handler.get();
   }
 
   public void setInvocationHandler(MethodInvocationHandler handler) {
-    this.handler = handler;
+    this.handler.set(handler);
+  }
+
+  /**
+   * Replace the invocation handler only while the current handler is {@code expected} by identity.
+   *
+   * <p>Behavior owners can release their dispatch without removing a handler installed later by
+   * another owner or by the application.
+   *
+   * @param expected the handler owned by the caller.
+   * @param replacement the handler to install if ownership has not changed.
+   * @return whether the replacement was applied.
+   */
+  public boolean compareAndSetInvocationHandler(
+      MethodInvocationHandler expected, MethodInvocationHandler replacement) {
+    return handler.compareAndSet(expected, replacement);
   }
 
   /**

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/**
+ * Mutable server nodes used by generated information models and application address spaces.
+ *
+ * <p>A node owns its attributes and attribute filters; its NodeManager owns registration and
+ * reference storage. Generated model nodes add typed accessors over these primitives. Applications
+ * can extend the node classes or install filters and method handlers to provide runtime behavior.
+ *
+ * <p>Method handlers may belong to a separate lifecycle owner, such as a Condition wrapper. Such
+ * owners should release their handler with {@link
+ * org.eclipse.milo.opcua.sdk.server.nodes.UaMethodNode#compareAndSetInvocationHandler} so cleanup
+ * cannot remove a handler installed later. A call that already obtained the old handler may finish
+ * after replacement; changing the handler controls subsequent dispatch.
+ */
+package org.eclipse.milo.opcua.sdk.server.nodes;


### PR DESCRIPTION
This PR fixes three Condition lifecycle issues involving event consistency and shelving Method dispatch.

### Keep shelving state consistent within one event

Lazy shelving expiry could change a Condition's EventId and state while its fields were being selected for one notification or copied for refresh. Expiry now resolves before those operations, and field reads cannot trigger another shelving transition partway through them. Ordinary UnshelveTime reads retain their lazy-expiry fallback.

[Part 5 §6.4.2](https://reference.opcfoundation.org/specs/OPC-10000-5/6.4.2) defines the identity contract: "EventId is generated by the Server to uniquely identify a particular Event Notification." The fix keeps that identity and its shelving state consistent across the notification's fields.

### Retire Method handlers when a Condition is unregistered

Copied Method nodes could retain handlers belonging to a retired Condition behavior. Unregistering a Condition now removes handlers it installed only if it still owns them. Application handlers and handlers installed by a replacement behavior survive. Calls that already obtained a handler may finish against the retired behavior.

### Dispatch shared shelving methods through either supported ObjectId

Shared shelving methods previously failed to find their behavior through a nested ShelvingState ObjectId. Dispatch now resolves both that target and the ConditionId, while leaving the shared type Method's handler unchanged. The nested route accepts only Methods owned by the shelving state machine, so an Acknowledge call still requires the ConditionId.

[Part 9 §5.8.17.4](https://reference.opcfoundation.org/specs/OPC-10000-9/5.8.17.4) defines the Shelving object's NodeId as the normal call target and also requires that "all Servers shall also allow Clients to call the TimedShelve Method by specifying ConditionId as the ObjectId".

### Verification

Formatting, a full clean compile, and the selected Condition and event-handling suites passed with no failures, errors, or skips. Regressions exercise coherent event selection and refresh, wire calls after unregister, preserved replacement handlers, and both shelving call targets. The base implementation failed four of the first six new cases; the remaining two provide compatibility controls.

A further wire regression rejects Acknowledge through the nested ShelvingState ObjectId and then proves that the same Method and arguments succeed through the ConditionId. It failed before the dispatch ownership restriction and passes with the final implementation.
