### PR TITLE
Preserve failed activation state and select compatible X509 policies

### DIFF
--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/identity/X509IdentityProvider.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/identity/X509IdentityProvider.java
@@ -19,13 +19,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
-import java.util.stream.Stream;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.security.CertificateCompatibility;
 import org.eclipse.milo.opcua.stack.core.security.ChannelBoundSignatureData;
 import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
 import org.eclipse.milo.opcua.stack.core.security.SecurityPolicyProfile;
-import org.eclipse.milo.opcua.stack.core.security.UserTokenSecurityPolicyRules;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.UserTokenType;
 import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
@@ -222,14 +221,38 @@ public class X509IdentityProvider implements IdentityProvider {
         inputs.clientNonce());
   }
 
-  private static UserTokenPolicy selectTokenPolicy(EndpointDescription endpoint) throws Exception {
+  private UserTokenPolicy selectTokenPolicy(EndpointDescription endpoint) throws UaException {
     UserTokenPolicy[] userIdentityTokens =
         requireNonNullElse(endpoint.getUserIdentityTokens(), new UserTokenPolicy[0]);
 
-    return Stream.of(userIdentityTokens)
-        .filter(t -> t.getTokenType() == UserTokenType.Certificate)
-        .findFirst()
-        .orElseThrow(() -> new Exception("no x509 certificate token policy found"));
+    if (certificateChain.isEmpty()) {
+      throw new UaException(StatusCodes.Bad_IdentityTokenInvalid, "no user certificate configured");
+    }
+
+    X509Certificate certificate = certificateChain.get(0);
+    UaException lastFailure = null;
+
+    for (UserTokenPolicy tokenPolicy : userIdentityTokens) {
+      if (tokenPolicy == null || tokenPolicy.getTokenType() != UserTokenType.Certificate) {
+        continue;
+      }
+
+      try {
+        SecurityPolicy securityPolicy = resolveSecurityPolicy(endpoint, tokenPolicy);
+        CertificateCompatibility.checkPublicKey(
+            securityPolicy.getProfile(), certificate.getPublicKey());
+        ChannelBoundSignatureData.checkUserTokenChannelCompatibility(
+            securityPolicy.getProfile(), SecurityPolicy.fromUri(endpoint.getSecurityPolicyUri()));
+        return tokenPolicy;
+      } catch (UaException e) {
+        lastFailure = e;
+      }
+    }
+
+    throw new UaException(
+        StatusCodes.Bad_IdentityTokenRejected,
+        "no compatible x509 certificate token policy found",
+        lastFailure);
   }
 
   private static SecurityPolicy resolveSecurityPolicy(
@@ -247,13 +270,7 @@ public class X509IdentityProvider implements IdentityProvider {
       throw new UaException(StatusCodes.Bad_SecurityPolicyRejected, t);
     }
 
-    // Part 4 (7.41): an explicitly specified certificate user-token policy must use the same
-    // public-key algorithm as the SecureChannel. The enhanced-secret/None rule does not apply to
-    // certificate tokens: they are signed, not encrypted, and an enhanced signature is supported on
-    // a None channel (the reduced Part 4 §6.1.8 Table 101 layout).
-    UserTokenSecurityPolicyRules.requireSamePublicKeyAlgorithmAsChannel(
-        endpoint, securityPolicy, explicitlySpecified);
-
+    // Part 4 (7.41) permits certificate-token policies to use a different key algorithm.
     return securityPolicy;
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/identity/X509IdentityProvider.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/identity/X509IdentityProvider.java
@@ -39,7 +39,8 @@ import org.jspecify.annotations.Nullable;
  * An {@link IdentityProvider} that authenticates with a certificate user-token policy.
  *
  * <p>The provider sends the configured certificate chain as the user identity token and signs the
- * server certificate plus nonce when the selected user-token security policy requires a signature.
+ * server certificate plus nonce with the selected signing policy. Certificate policies resolving to
+ * SecurityPolicy.None are skipped because they cannot prove possession of the private key.
  * Certificate-token policies do not use the enhanced username-secret additional-header exchange,
  * even when the certificate-token policy itself uses an ECC or RSA-DH security policy.
  */
@@ -239,6 +240,11 @@ public class X509IdentityProvider implements IdentityProvider {
 
       try {
         SecurityPolicy securityPolicy = resolveSecurityPolicy(endpoint, tokenPolicy);
+        if (securityPolicy == SecurityPolicy.None) {
+          throw new UaException(
+              StatusCodes.Bad_SecurityPolicyRejected,
+              "certificate user token requires a signing policy");
+        }
         CertificateCompatibility.checkPublicKey(
             securityPolicy.getProfile(), certificate.getPublicKey());
         ChannelBoundSignatureData.checkUserTokenChannelCompatibility(

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/identity/package-info.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/identity/package-info.java
@@ -18,8 +18,9 @@
  * several providers in order.
  *
  * <p>The X.509 provider tries advertised certificate-token policies in order and selects the first
- * compatible with both the user certificate's public key and the SecureChannel. Selection uses the
- * public key, including its curve, so it does not access a supplied private key until signing.
+ * signing policy compatible with both the user certificate's public key and the SecureChannel.
+ * Policies resolving to SecurityPolicy.None are skipped. Selection uses the public key, including
+ * its curve, so it does not access a supplied private key until signing.
  *
  * <h2>Session handoff</h2>
  *

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/identity/package-info.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/identity/package-info.java
@@ -17,6 +17,10 @@
  * providers: anonymous, username/password, X.509 certificate, or a composite provider that tries
  * several providers in order.
  *
+ * <p>The X.509 provider tries advertised certificate-token policies in order and selects the first
+ * compatible with both the user certificate's public key and the SecureChannel. Selection uses the
+ * public key, including its curve, so it does not access a supplied private key until signing.
+ *
  * <h2>Session handoff</h2>
  *
  * <p>Some user-token policies need data learned during CreateSession before the provider can build

--- a/opc-ua-sdk/sdk-client/src/test/java/org/eclipse/milo/opcua/sdk/client/identity/UserTokenSecurityPolicyRulesTest.java
+++ b/opc-ua-sdk/sdk-client/src/test/java/org/eclipse/milo/opcua/sdk/client/identity/UserTokenSecurityPolicyRulesTest.java
@@ -179,11 +179,11 @@ class UserTokenSecurityPolicyRulesTest {
                 endpoint, SecurityPolicy.ECC_nistP256_AesGcm));
   }
 
-  // ---- X509IdentityProvider wiring: the certificate provider applies the public-key-family rule,
-  // but not the enhanced-secret rule (its token is signed, not encrypted) ----
+  // Certificate policies must match the configured user certificate. Encrypted-secret policy
+  // restrictions do not apply to their signatures.
 
   @Test
-  void x509ProviderRejectsExplicitCrossFamilyCertificateTokenPolicy() throws Exception {
+  void x509ProviderRejectsPolicyIncompatibleWithItsCertificate() throws Exception {
     X509IdentityProvider provider = rsaX509Provider();
     EndpointDescription endpoint =
         endpointWithCertificateToken(
@@ -194,8 +194,8 @@ class UserTokenSecurityPolicyRulesTest {
     UaException ex =
         assertThrows(UaException.class, () -> provider.getUserTokenSecurityPolicy(endpoint));
 
-    assertEquals(StatusCodes.Bad_SecurityPolicyRejected, ex.getStatusCode().getValue());
-    assertTrue(ex.getMessage().contains("public-key algorithm"));
+    assertEquals(StatusCodes.Bad_IdentityTokenRejected, ex.getStatusCode().getValue());
+    assertTrue(ex.getMessage().contains("no compatible"));
   }
 
   // The enhanced-secret rule must NOT be applied to certificate tokens: an enhanced X509 signature
@@ -203,7 +203,13 @@ class UserTokenSecurityPolicyRulesTest {
   // rejected the way an enhanced username secret would be.
   @Test
   void x509ProviderAllowsEnhancedCertificateTokenPolicyOnNoneChannel() throws Exception {
-    X509IdentityProvider provider = rsaX509Provider();
+    KeyPair keys = SelfSignedCertificateGenerator.generateNistP256KeyPair();
+    X509Certificate certificate =
+        SelfSignedCertificateBuilder.forEccApplicationCertificate(keys)
+            .setCommonName("user")
+            .setApplicationUri("urn:test:user")
+            .build();
+    X509IdentityProvider provider = new X509IdentityProvider(certificate, keys.getPrivate());
     EndpointDescription endpoint =
         endpointWithCertificateToken(
             SecurityPolicy.None,

--- a/opc-ua-sdk/sdk-client/src/test/java/org/eclipse/milo/opcua/sdk/client/identity/X509PolicySelectionTest.java
+++ b/opc-ua-sdk/sdk-client/src/test/java/org/eclipse/milo/opcua/sdk/client/identity/X509PolicySelectionTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /** Policy advertisement order must not prevent a compatible certificate identity from signing. */
 class X509PolicySelectionTest {
@@ -74,6 +75,28 @@ class X509PolicySelectionTest {
             SecurityPolicy.None,
             policy("incompatible", incompatible),
             policy("compatible", compatible));
+    assertSignsWithCompatiblePolicy(endpoint);
+  }
+
+  // A certificate identity must prove possession of its private key. Both explicit None and
+  // inherited None are unusable even when advertised before a valid signing policy.
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void skipsCertificatePoliciesThatResolveToNone(boolean inherited) throws Exception {
+    assertSignsWithCompatiblePolicy(
+        endpoint(
+            SecurityPolicy.None,
+            new UserTokenPolicy(
+                "none",
+                UserTokenType.Certificate,
+                null,
+                null,
+                inherited ? null : SecurityPolicy.None.getUri()),
+            policy("compatible", SecurityPolicy.ECC_nistP256_AesGcm)));
+  }
+
+  private void assertSignsWithCompatiblePolicy(EndpointDescription endpoint) throws Exception {
+    SecurityPolicy compatible = SecurityPolicy.ECC_nistP256_AesGcm;
     AtomicInteger privateKeyReads = new AtomicInteger();
     X509IdentityProvider provider =
         new X509IdentityProvider(

--- a/opc-ua-sdk/sdk-client/src/test/java/org/eclipse/milo/opcua/sdk/client/identity/X509PolicySelectionTest.java
+++ b/opc-ua-sdk/sdk-client/src/test/java/org/eclipse/milo/opcua/sdk/client/identity/X509PolicySelectionTest.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.identity;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ubyte;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.security.KeyPair;
+import java.security.cert.X509Certificate;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.eclipse.milo.opcua.stack.core.security.ChannelBoundSignatureData;
+import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.ApplicationType;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.MessageSecurityMode;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.UserTokenType;
+import org.eclipse.milo.opcua.stack.core.types.structured.ApplicationDescription;
+import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
+import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
+import org.eclipse.milo.opcua.stack.core.util.NonceUtil;
+import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateBuilder;
+import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateGenerator;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+/** Policy advertisement order must not prevent a compatible certificate identity from signing. */
+class X509PolicySelectionTest {
+
+  private static KeyPair userKeys;
+  private static X509Certificate userCertificate;
+  private static ByteString serverCertificate;
+
+  @BeforeAll
+  static void createCertificates() throws Exception {
+    userKeys = SelfSignedCertificateGenerator.generateNistP256KeyPair();
+    userCertificate =
+        SelfSignedCertificateBuilder.forEccApplicationCertificate(userKeys)
+            .setCommonName("user")
+            .setApplicationUri("urn:test:user")
+            .build();
+    KeyPair serverKeys = SelfSignedCertificateGenerator.generateRsaKeyPair(2048);
+    serverCertificate =
+        ByteString.of(
+            SelfSignedCertificateBuilder.forRsaApplicationCertificate(serverKeys)
+                .setCommonName("server")
+                .setApplicationUri("urn:test:server")
+                .build()
+                .getEncoded());
+  }
+
+  /** Includes a different EC curve, since a shared key algorithm alone is insufficient. */
+  @ParameterizedTest
+  @EnumSource(
+      value = SecurityPolicy.class,
+      names = {"Basic256Sha256", "ECC_nistP384_AesGcm"})
+  void skipsIncompatiblePolicyAndProducesVerifiableSignature(SecurityPolicy incompatible)
+      throws Exception {
+    SecurityPolicy compatible = SecurityPolicy.ECC_nistP256_AesGcm;
+    EndpointDescription endpoint =
+        endpoint(
+            SecurityPolicy.None,
+            policy("incompatible", incompatible),
+            policy("compatible", compatible));
+    AtomicInteger privateKeyReads = new AtomicInteger();
+    X509IdentityProvider provider =
+        new X509IdentityProvider(
+            userCertificate,
+            () -> {
+              privateKeyReads.incrementAndGet();
+              return userKeys.getPrivate();
+            });
+
+    assertEquals(compatible, provider.getUserTokenSecurityPolicy(endpoint).orElseThrow());
+    assertTrue(provider.getEnhancedUserTokenSecurityPolicy(endpoint).isEmpty());
+    assertEquals(0, privateKeyReads.get(), "policy selection must not access the private key");
+
+    ByteString serverNonce = NonceUtil.generateNonce(32);
+    ByteString clientNonce = NonceUtil.generateNonce(32);
+    var inputs =
+        new ChannelSignatureInputs(
+            ByteString.NULL_VALUE,
+            clientNonce,
+            serverCertificate,
+            serverCertificate,
+            ByteString.NULL_VALUE);
+    SignedIdentityToken signed =
+        provider.getIdentityToken(
+            new IdentityProviderContext(endpoint, serverNonce, null, null, null, null, inputs));
+
+    assertEquals("compatible", signed.getToken().getPolicyId());
+    assertEquals(1, privateKeyReads.get());
+    byte[] signedData =
+        ChannelBoundSignatureData.userTokenSignatureData(
+            compatible.getProfile(),
+            false,
+            ByteString.NULL_VALUE,
+            serverNonce,
+            serverCertificate,
+            ByteString.NULL_VALUE,
+            ByteString.NULL_VALUE,
+            ByteString.NULL_VALUE,
+            clientNonce);
+    ChannelBoundSignatureData.verify(
+        compatible, userCertificate, signedData, signed.getSignature());
+  }
+
+  @Test
+  void certificatePolicyCanUseADifferentKeyAlgorithmFromTheChannel() throws Exception {
+    KeyPair rsaKeys = SelfSignedCertificateGenerator.generateRsaKeyPair(2048);
+    X509Certificate rsaCertificate =
+        SelfSignedCertificateBuilder.forRsaApplicationCertificate(rsaKeys)
+            .setCommonName("rsa-user")
+            .setApplicationUri("urn:test:rsa-user")
+            .build();
+    X509IdentityProvider provider = new X509IdentityProvider(rsaCertificate, rsaKeys.getPrivate());
+    EndpointDescription endpoint =
+        endpoint(
+            SecurityPolicy.ECC_nistP256_AesGcm,
+            policy("ecc", SecurityPolicy.ECC_nistP256_AesGcm),
+            policy("rsa", SecurityPolicy.Basic256Sha256));
+    ByteString nonce = NonceUtil.generateNonce(32);
+
+    assertEquals(
+        SecurityPolicy.Basic256Sha256, provider.getUserTokenSecurityPolicy(endpoint).orElseThrow());
+    SignedIdentityToken signed = provider.getIdentityToken(endpoint, nonce);
+    assertEquals("rsa", signed.getToken().getPolicyId());
+    ChannelBoundSignatureData.verify(
+        SecurityPolicy.Basic256Sha256,
+        rsaCertificate,
+        ChannelBoundSignatureData.legacyUserTokenSignatureData(serverCertificate, nonce),
+        signed.getSignature());
+  }
+
+  @Test
+  void failsSelectionWhenNoPolicyMatchesTheCertificate() {
+    X509IdentityProvider provider =
+        new X509IdentityProvider(userCertificate, userKeys.getPrivate());
+    assertThrows(
+        Exception.class,
+        () ->
+            provider.getUserTokenSecurityPolicy(
+                endpoint(SecurityPolicy.None, policy("rsa", SecurityPolicy.Basic256Sha256))));
+  }
+
+  @Test
+  void preservesAdvertisedOrderAmongCompatiblePolicies() throws Exception {
+    X509IdentityProvider provider =
+        new X509IdentityProvider(userCertificate, userKeys.getPrivate());
+    SecurityPolicy first = SecurityPolicy.ECC_nistP256_ChaChaPoly;
+    assertEquals(
+        first,
+        provider
+            .getUserTokenSecurityPolicy(
+                endpoint(
+                    SecurityPolicy.None,
+                    policy("first", first),
+                    policy("second", SecurityPolicy.ECC_nistP256_AesGcm)))
+            .orElseThrow());
+  }
+
+  @Test
+  void inheritsChannelPolicyWhenTokenPolicyOmitsItsUri() throws Exception {
+    X509IdentityProvider provider =
+        new X509IdentityProvider(userCertificate, userKeys.getPrivate());
+    SecurityPolicy channel = SecurityPolicy.ECC_nistP256_AesGcm;
+    assertEquals(
+        channel,
+        provider
+            .getUserTokenSecurityPolicy(
+                endpoint(
+                    channel,
+                    new UserTokenPolicy("inherited", UserTokenType.Certificate, null, null, null)))
+            .orElseThrow());
+  }
+
+  private static UserTokenPolicy policy(String id, SecurityPolicy policy) {
+    return new UserTokenPolicy(id, UserTokenType.Certificate, null, null, policy.getUri());
+  }
+
+  private static EndpointDescription endpoint(SecurityPolicy channel, UserTokenPolicy... policies) {
+    return new EndpointDescription(
+        "opc.tcp://localhost:4840/test",
+        new ApplicationDescription(
+            "urn:test:server",
+            "urn:test:product",
+            LocalizedText.english("test"),
+            ApplicationType.Server,
+            null,
+            null,
+            null),
+        serverCertificate,
+        channel == SecurityPolicy.None
+            ? MessageSecurityMode.None
+            : MessageSecurityMode.SignAndEncrypt,
+        channel.getUri(),
+        policies,
+        "http://opcfoundation.org/UA-Profile/Transport/uatcp-uasc-uabinary",
+        ubyte(0));
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/SessionManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/SessionManager.java
@@ -376,51 +376,57 @@ public class SessionManager {
             secureChannelId,
             securityConfiguration);
 
-    session.setLastNonce(serverNonce);
-    session.setClientNonce(clientNonce);
-    session.setClientAddress(context.clientAddress());
+    ExtensionObject additionalHeader;
+    boolean registered = false;
+    try {
+      session.setLastNonce(serverNonce);
+      session.setClientNonce(clientNonce);
+      session.setClientAddress(context.clientAddress());
 
-    ExtensionObject additionalHeader =
-        createSessionAdditionalHeader(request, securityConfiguration, session);
+      additionalHeader = createSessionAdditionalHeader(request, securityConfiguration, session);
 
-    // Enforce the session limit and register the new session atomically so that concurrent
-    // CreateSession requests cannot exceed the maximum. Done after validation so that a request
-    // which is going to fail never evicts another client's pending session.
-    synchronized (sessionLock) {
-      if (isShutdownRequested()) {
-        session.close(false);
-        throw new UaException(StatusCodes.Bad_Shutdown);
-      }
-
-      long maxSessionCount = server.getConfig().getLimits().getMaxSessions().longValue();
-      if (createdSessions.size() + activeSessions.size() >= maxSessionCount) {
-        // OPC UA Part 4, 5.7.2: at the session limit the Server shall close the oldest Session
-        // that has not yet been activated before rejecting a new request. Only if every existing
-        // Session has already been activated is Bad_TooManySessions returned.
-        Session oldestUnactivated =
-            createdSessions.values().stream()
-                .min(Comparator.comparingLong(s -> s.getConnectionTime().getUtcTime()))
-                .orElse(null);
-
-        if (oldestUnactivated == null) {
-          // Release the timeout task of the session we are not going to register. No lifecycle
-          // listener has been added yet, so this fires no session-closed notifications.
-          session.close(false);
-          throw new UaException(StatusCodes.Bad_TooManySessions);
+      // Enforce the session limit and register the new session atomically so that concurrent
+      // CreateSession requests cannot exceed the maximum. Done after validation so that a request
+      // which is going to fail never evicts another client's pending session.
+      synchronized (sessionLock) {
+        if (isShutdownRequested()) {
+          throw new UaException(StatusCodes.Bad_Shutdown);
         }
 
-        oldestUnactivated.close(false);
+        long maxSessionCount = server.getConfig().getLimits().getMaxSessions().longValue();
+        if (createdSessions.size() + activeSessions.size() >= maxSessionCount) {
+          // OPC UA Part 4, 5.7.2: at the session limit the Server shall close the oldest Session
+          // that has not yet been activated before rejecting a new request. Only if every existing
+          // Session has already been activated is Bad_TooManySessions returned.
+          Session oldestUnactivated =
+              createdSessions.values().stream()
+                  .min(Comparator.comparingLong(s -> s.getConnectionTime().getUtcTime()))
+                  .orElse(null);
+
+          if (oldestUnactivated == null) {
+            throw new UaException(StatusCodes.Bad_TooManySessions);
+          }
+
+          oldestUnactivated.close(false);
+        }
+
+        session.addLifecycleListener(
+            (s, remove) -> {
+              createdSessions.remove(authenticationToken);
+              activeSessions.remove(authenticationToken);
+
+              fireSessionClosed(s);
+            });
+
+        createdSessions.put(authenticationToken, session);
+        registered = true;
       }
 
-      session.addLifecycleListener(
-          (s, remove) -> {
-            createdSessions.remove(authenticationToken);
-            activeSessions.remove(authenticationToken);
-
-            fireSessionClosed(s);
-          });
-
-      createdSessions.put(authenticationToken, session);
+    } finally {
+      if (!registered) {
+        // The constructor schedules the timeout before response-header negotiation can fail.
+        session.close(false);
+      }
     }
 
     fireSessionCreated(session);
@@ -560,10 +566,13 @@ public class SessionManager {
         EccEncryptedSecret.createEphemeralKey(
             securityPolicy.getProfile(), signingKeyPair, ephemeralKeyPair);
 
+    ExtensionObject response =
+        EnhancedUserTokenAdditionalHeader.createResponse(
+            server.getStaticEncodingContext(), securityPolicy, ephemeralKey);
+
     session.setUserTokenEphemeralKeyPair(ephemeralKeyPair, ephemeralPublicKey);
 
-    return EnhancedUserTokenAdditionalHeader.createResponse(
-        server.getStaticEncodingContext(), securityPolicy, ephemeralKey);
+    return response;
   }
 
   private KeyPair selectUserTokenSigningKeyPair(
@@ -899,13 +908,13 @@ public class SessionManager {
 
           ByteString serverNonce = NonceUtil.generateNonce(32);
 
+          ExtensionObject additionalHeader =
+              activateSessionAdditionalHeader(request, securityConfiguration, session);
+
           session.setClientAddress(context.clientAddress());
           session.setIdentity(identity, identityToken);
           session.setLastNonce(serverNonce);
           session.setLocaleIds(request.getLocaleIds());
-
-          ExtensionObject additionalHeader =
-              activateSessionAdditionalHeader(request, securityConfiguration, session);
 
           return new ActivateSessionResponse(
               createResponseHeader(request, StatusCode.GOOD, additionalHeader),
@@ -959,6 +968,14 @@ public class SessionManager {
                     clientCertificateBytes, securityConfiguration.getClientCertificateBytes());
 
             if (sameIdentity && sameCertificate) {
+              StatusCode[] results = new StatusCode[clientSoftwareCertificates.length];
+              Arrays.fill(results, StatusCode.GOOD);
+
+              ByteString serverNonce = NonceUtil.generateNonce(32);
+
+              ExtensionObject additionalHeader =
+                  activateSessionAdditionalHeader(request, newSecurityConfiguration, session);
+
               session.setSecureChannelId(secureChannelId);
 
               logger.debug(
@@ -966,17 +983,9 @@ public class SessionManager {
                   session.getSessionId(),
                   secureChannelId);
 
-              StatusCode[] results = new StatusCode[clientSoftwareCertificates.length];
-              Arrays.fill(results, StatusCode.GOOD);
-
-              ByteString serverNonce = NonceUtil.generateNonce(32);
-
               session.setClientAddress(context.clientAddress());
               session.setLastNonce(serverNonce);
               session.setLocaleIds(request.getLocaleIds());
-
-              ExtensionObject additionalHeader =
-                  activateSessionAdditionalHeader(request, newSecurityConfiguration, session);
 
               activated = true;
 
@@ -1011,6 +1020,14 @@ public class SessionManager {
       Identity identity =
           validateIdentityToken(session, identityToken, request.getUserTokenSignature());
 
+      StatusCode[] results = new StatusCode[clientSoftwareCertificates.length];
+      Arrays.fill(results, StatusCode.GOOD);
+
+      ByteString serverNonce = NonceUtil.generateNonce(32);
+
+      ExtensionObject additionalHeader =
+          activateSessionAdditionalHeader(request, session.getSecurityConfiguration(), session);
+
       // Move the session from created to active atomically with respect to the limit check in
       // createSession, so a concurrent CreateSession cannot evict a session that is activating.
       synchronized (sessionLock) {
@@ -1021,18 +1038,10 @@ public class SessionManager {
         activeSessions.put(authToken, session);
       }
 
-      StatusCode[] results = new StatusCode[clientSoftwareCertificates.length];
-      Arrays.fill(results, StatusCode.GOOD);
-
-      ByteString serverNonce = NonceUtil.generateNonce(32);
-
       session.setClientAddress(context.clientAddress());
       session.setIdentity(identity, identityToken);
       session.setLocaleIds(request.getLocaleIds());
       session.setLastNonce(serverNonce);
-
-      ExtensionObject additionalHeader =
-          activateSessionAdditionalHeader(request, session.getSecurityConfiguration(), session);
 
       return new ActivateSessionResponse(
           createResponseHeader(request, StatusCode.GOOD, additionalHeader),

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/SessionManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/SessionManager.java
@@ -911,6 +911,7 @@ public class SessionManager {
           ExtensionObject additionalHeader =
               activateSessionAdditionalHeader(request, securityConfiguration, session);
 
+          // The header can install a new key; keep the remaining commit operations non-throwing.
           session.setClientAddress(context.clientAddress());
           session.setIdentity(identity, identityToken);
           session.setLastNonce(serverNonce);
@@ -976,6 +977,8 @@ public class SessionManager {
               ExtensionObject additionalHeader =
                   activateSessionAdditionalHeader(request, newSecurityConfiguration, session);
 
+              // The header can install a new key; keep the remaining commit operations
+              // non-throwing.
               session.setSecureChannelId(secureChannelId);
 
               logger.debug(
@@ -1038,6 +1041,7 @@ public class SessionManager {
         activeSessions.put(authToken, session);
       }
 
+      // The header installed any candidate key; commit after the registry check must not throw.
       session.setClientAddress(context.clientAddress());
       session.setIdentity(identity, identityToken);
       session.setLocaleIds(request.getLocaleIds());

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractX509IdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractX509IdentityValidator.java
@@ -22,7 +22,6 @@ import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.security.ChannelBoundSignatureData;
 import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
 import org.eclipse.milo.opcua.stack.core.security.SecurityPolicyProfile;
-import org.eclipse.milo.opcua.stack.core.security.UserTokenSecurityPolicyRules;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.UserTokenType;
 import org.eclipse.milo.opcua.stack.core.types.structured.SignatureData;
@@ -91,12 +90,6 @@ public abstract class AbstractX509IdentityValidator extends AbstractIdentityVali
     } else {
       securityPolicy = SecurityPolicy.fromUri(securityPolicyUri);
     }
-
-    UserTokenSecurityPolicyRules.requireSamePublicKeyAlgorithmAsChannel(
-        session.getSecurityConfiguration().getSecurityMode(),
-        session.getSecurityConfiguration().getSecurityPolicy(),
-        securityPolicy,
-        securityPolicyUri != null && !securityPolicyUri.isEmpty());
 
     return securityPolicy;
   }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/package-info.java
@@ -26,6 +26,13 @@
  * common token validation, nonce check, size limits, and decryption path before handing the
  * resulting username and password to the application-specific authentication method.
  *
+ * <h2>Certificate-token signatures</h2>
+ *
+ * <p>A certificate token's advertised policy selects the user signature algorithm. Its public-key
+ * algorithm may differ from the SecureChannel's algorithm. The X.509 validator verifies that
+ * signature before calling application authentication; the channel restrictions for encrypted
+ * username or issued-token secrets do not apply to certificate tokens.
+ *
  * <h2>Extension guidance</h2>
  *
  * <p>Applications usually extend the abstract validators and implement only the final credential

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/package-info.java
@@ -46,6 +46,15 @@
  * participant shutdown therefore runs without external server visibility but before the standard
  * address space and event facilities are torn down.
  *
+ * <h2>Session response preparation</h2>
+ *
+ * <p>A Session owns a timeout as soon as it is constructed. Failed CreateSession preparation must
+ * close that provisional Session before returning an error. ActivateSession prepares its response
+ * additional header before committing identity, nonce, locale, or channel changes. A failed
+ * negotiation therefore leaves an existing Session usable on its previous channel and leaves an
+ * initial Session unactivated. Enhanced username-token keys consumed during validation remain
+ * single-use even if later response preparation fails.
+ *
  * <h2>Runtime boundaries</h2>
  *
  * <p>The SDK server package coordinates high-level server configuration and lifecycle. Certificate

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/SessionEndpointBindingTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/SessionEndpointBindingTest.java
@@ -42,12 +42,15 @@ import org.eclipse.milo.opcua.stack.core.security.CertificateGroup;
 import org.eclipse.milo.opcua.stack.core.security.CertificateManager;
 import org.eclipse.milo.opcua.stack.core.security.CertificateQuarantine;
 import org.eclipse.milo.opcua.stack.core.security.CertificateValidator;
+import org.eclipse.milo.opcua.stack.core.security.ChannelBoundSignatureData;
 import org.eclipse.milo.opcua.stack.core.security.DefaultCertificateManager;
+import org.eclipse.milo.opcua.stack.core.security.EnhancedUserTokenAdditionalHeader;
 import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
 import org.eclipse.milo.opcua.stack.core.security.TrustListManager;
 import org.eclipse.milo.opcua.stack.core.transport.TransportProfile;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.ApplicationType;
@@ -74,6 +77,8 @@ import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * OPC UA does not transmit an EndpointDescription identifier during OpenSecureChannel (Part 6,
@@ -382,6 +387,74 @@ public class SessionEndpointBindingTest {
       session.close(true);
     }
 
+    // Part 4 §5.7.3.1 binds activation to the last ServerNonce received by the client. A failed
+    // response-header negotiation must leave a signed retry using that delivered nonce valid.
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void securedReactivationRetriesWithTheLastDeliveredNonce(boolean replaceChannel)
+        throws Exception {
+      OpcUaServer server =
+          server(
+              manager(group(GROUP_A, certificateA)),
+              List.of(securedEndpoint(GROUP_A, ANONYMOUS_POLICY)));
+      SessionManager sessions = server.getSessionManager();
+      try {
+        EndpointDescription endpoint = endpointForPath(server, "/test");
+        var original =
+            new TestServiceRequestContext(
+                endpointUrl("/test"), securedChannel(1L, certificateA), endpoint);
+        var create = createSessionRequest(clientCertificate.byteString());
+        CreateSessionResponse created = sessions.createSession(original, create);
+        NodeId token = created.getAuthenticationToken();
+        var activated =
+            sessions.activateSession(
+                original,
+                signedActivation(token, created.getServerNonce(), create.getClientNonce(), null));
+        ByteString deliveredNonce = activated.getServerNonce();
+        var candidate =
+            replaceChannel
+                ? new TestServiceRequestContext(
+                    endpointUrl("/test"), securedChannel(2L, certificateA), endpoint)
+                : original;
+
+        UaException wrongNonce =
+            assertThrows(
+                UaException.class,
+                () ->
+                    sessions.activateSession(
+                        candidate,
+                        signedActivation(
+                            token, NonceUtil.generateNonce(32), create.getClientNonce(), null)));
+        assertEquals(
+            StatusCodes.Bad_ApplicationSignatureInvalid, wrongNonce.getStatusCode().value());
+
+        ExtensionObject rejected =
+            EnhancedUserTokenAdditionalHeader.createRequest(
+                server.getStaticEncodingContext(), SecurityPolicy.ECC_nistP256_AesGcm);
+        UaException failure =
+            assertThrows(
+                UaException.class,
+                () ->
+                    sessions.activateSession(
+                        candidate,
+                        signedActivation(
+                            token, deliveredNonce, create.getClientNonce(), rejected)));
+        assertEquals(StatusCodes.Bad_SecurityPolicyRejected, failure.getStatusCode().value());
+        assertEquals(1L, sessions.getSession(original, requestHeader(token)).getSecureChannelId());
+
+        // Sign only the nonce delivered in the previous successful response, never Session state.
+        var retried =
+            sessions.activateSession(
+                candidate, signedActivation(token, deliveredNonce, create.getClientNonce(), null));
+        assertNotEquals(deliveredNonce, retried.getServerNonce());
+        assertEquals(
+            replaceChannel ? 2L : 1L,
+            sessions.getSession(candidate, requestHeader(token)).getSecureChannelId());
+      } finally {
+        sessions.shutdown();
+      }
+    }
+
     /**
      * When a Session is reactivated onto a replacement SecureChannel, its endpoint association must
      * follow the endpoint selected by that new channel; identity validation runs against the new
@@ -553,6 +626,34 @@ public class SessionEndpointBindingTest {
         clientCertificateBytes,
         60_000.0,
         uint(0));
+  }
+
+  private static ActivateSessionRequest signedActivation(
+      NodeId token,
+      ByteString serverNonce,
+      ByteString clientNonce,
+      @Nullable ExtensionObject additionalHeader)
+      throws Exception {
+    byte[] data =
+        ChannelBoundSignatureData.clientSignatureData(
+            SecurityPolicy.Basic256Sha256.getProfile(),
+            ByteString.NULL_VALUE,
+            serverNonce,
+            certificateA.byteString(),
+            certificateA.byteString(),
+            clientCertificate.byteString(),
+            clientNonce);
+    SignatureData signature =
+        ChannelBoundSignatureData.sign(
+            SecurityPolicy.Basic256Sha256, clientCertificate.keyPair().getPrivate(), data);
+    return new ActivateSessionRequest(
+        new RequestHeader(
+            token, DateTime.now(), uint(1), uint(0), null, uint(10_000), additionalHeader),
+        signature,
+        null,
+        null,
+        null,
+        new SignatureData(null, null));
   }
 
   private static ActivateSessionRequest activateSessionRequest(NodeId authToken) {

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/SessionHeaderFailureTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/SessionHeaderFailureTest.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.net.InetAddress;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.channel.ServerSecureChannel;
+import org.eclipse.milo.opcua.stack.core.security.EnhancedUserTokenAdditionalHeader;
+import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
+import org.eclipse.milo.opcua.stack.core.transport.TransportProfile;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.ApplicationType;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.MessageSecurityMode;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.UserTokenType;
+import org.eclipse.milo.opcua.stack.core.types.structured.ActivateSessionRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.ApplicationDescription;
+import org.eclipse.milo.opcua.stack.core.types.structured.CreateSessionRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.CreateSessionResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
+import org.eclipse.milo.opcua.stack.core.types.structured.RequestHeader;
+import org.eclipse.milo.opcua.stack.core.types.structured.SignatureData;
+import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
+import org.eclipse.milo.opcua.stack.core.util.NonceUtil;
+import org.eclipse.milo.opcua.stack.transport.server.OpcServerTransport;
+import org.eclipse.milo.opcua.stack.transport.server.ServiceRequestContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/** Exercises failed header negotiation through real session creation and activation. */
+class SessionHeaderFailureTest {
+
+  private OpcUaServer server;
+  private SessionManager manager;
+  private ScheduledFuture<?> timeout;
+
+  @BeforeEach
+  void setUp() {
+    ScheduledExecutorService scheduler = mock(ScheduledExecutorService.class);
+    timeout = mock(ScheduledFuture.class);
+    doReturn(timeout)
+        .when(scheduler)
+        .schedule(any(Runnable.class), anyLong(), eq(TimeUnit.NANOSECONDS));
+
+    server =
+        new OpcUaServer(
+            OpcUaServerConfig.builder()
+                .setApplicationUri("urn:test:session-header")
+                .setProductUri("urn:test:product")
+                .setScheduledExecutor(scheduler)
+                .setEndpoints(Set.of(endpoint("/a"), endpoint("/b")))
+                .build(),
+            ignored -> mock(OpcServerTransport.class));
+    manager = server.getSessionManager();
+  }
+
+  @AfterEach
+  void tearDown() {
+    manager.shutdown();
+  }
+
+  /** A failed CreateSession must release its provisional timer without publishing a session. */
+  @Test
+  void failedCreateCancelsProvisionalTimeout() throws Exception {
+    SessionListener listener = mock(SessionListener.class);
+    manager.addSessionListener(listener);
+
+    UaException failure =
+        assertThrows(
+            UaException.class,
+            () -> manager.createSession(context(1, "/a"), createRequest(rejectedHeader())));
+
+    assertEquals(StatusCodes.Bad_SecurityPolicyRejected, failure.getStatusCode().value());
+    assertTrue(manager.getAllSessions().isEmpty());
+    verify(timeout).cancel(false);
+    manager.shutdown();
+    verifyNoInteractions(listener);
+  }
+
+  /** The initial activation must remain pending if preparing its response fails. */
+  @Test
+  void failedInitialActivationDoesNotAuthorizeServices() throws Exception {
+    ServiceRequestContext context = context(1, "/a");
+    CreateSessionResponse created = manager.createSession(context, createRequest(null));
+    Session session = manager.getAllSessions().get(0);
+    ByteString nonce = session.getLastNonce();
+
+    assertRejectedActivation(context, created.getAuthenticationToken());
+
+    assertAll(
+        () -> assertEquals(nonce, session.getLastNonce()),
+        () -> assertNull(session.getIdentity()),
+        () -> assertNull(session.getLocaleIds()),
+        () -> assertTrue(session.getClientUserIdHistory().isEmpty()),
+        () ->
+            assertEquals(
+                StatusCodes.Bad_SessionNotActivated,
+                assertThrows(
+                        UaException.class,
+                        () ->
+                            manager.getSession(
+                                context, header(created.getAuthenticationToken(), null)))
+                    .getStatusCode()
+                    .value()));
+  }
+
+  /** Neither identity refresh nor channel replacement may commit before its response is ready. */
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void failedReactivationPreservesPriorState(boolean replaceChannel) throws Exception {
+    ServiceRequestContext original = context(1, "/a");
+    CreateSessionResponse created = manager.createSession(original, createRequest(null));
+    NodeId token = created.getAuthenticationToken();
+    manager.activateSession(original, activateRequest(token, null, "en-US"));
+    Session session = manager.getAllSessions().get(0);
+    ByteString nonce = session.getLastNonce();
+    Object identity = session.getIdentity();
+    Object security = session.getSecurityConfiguration();
+    EndpointDescription endpoint = session.getEndpoint();
+    List<String> identityHistory = session.getClientUserIdHistory();
+
+    ServiceRequestContext candidate = replaceChannel ? context(2, "/b") : original;
+    assertRejectedActivation(candidate, token);
+
+    assertAll(
+        () -> assertEquals(1L, session.getSecureChannelId()),
+        () -> assertSame(endpoint, session.getEndpoint()),
+        () -> assertSame(security, session.getSecurityConfiguration()),
+        () -> assertSame(identity, session.getIdentity()),
+        () -> assertEquals(nonce, session.getLastNonce()),
+        () -> assertArrayEquals(new String[] {"en-US"}, session.getLocaleIds()),
+        () -> assertEquals(identityHistory, session.getClientUserIdHistory()),
+        () -> assertSame(session, manager.getSession(original, header(token, null))));
+
+    // The same request can subsequently succeed when it omits the rejected negotiation.
+    manager.activateSession(candidate, activateRequest(token, null, "de-DE"));
+    assertSame(session, manager.getSession(candidate, header(token, null)));
+    assertArrayEquals(new String[] {"de-DE"}, session.getLocaleIds());
+    assertNotEquals(nonce, session.getLastNonce());
+  }
+
+  private void assertRejectedActivation(ServiceRequestContext context, NodeId token)
+      throws Exception {
+    UaException failure =
+        assertThrows(
+            UaException.class,
+            () ->
+                manager.activateSession(
+                    context, activateRequest(token, rejectedHeader(), "de-DE")));
+    assertEquals(StatusCodes.Bad_SecurityPolicyRejected, failure.getStatusCode().value());
+  }
+
+  private ExtensionObject rejectedHeader() throws UaException {
+    return EnhancedUserTokenAdditionalHeader.createRequest(
+        server.getStaticEncodingContext(), SecurityPolicy.ECC_nistP256_AesGcm);
+  }
+
+  private ServiceRequestContext context(long channelId, String path) throws Exception {
+    var channel = new ServerSecureChannel();
+    channel.setChannelId(channelId);
+    channel.setSecurityPolicy(SecurityPolicy.None);
+    channel.setMessageSecurityMode(MessageSecurityMode.None);
+    EndpointDescription endpoint =
+        server.getApplicationContext().getEndpointDescriptions().stream()
+            .filter(e -> e.getEndpointUrl().endsWith(path))
+            .findFirst()
+            .orElseThrow();
+    ServiceRequestContext context = mock(ServiceRequestContext.class);
+    when(context.getSecureChannel()).thenReturn(channel);
+    when(context.getEndpoint()).thenReturn(Optional.of(endpoint));
+    when(context.getEndpointUrl()).thenReturn(endpoint.getEndpointUrl());
+    when(context.getTransportProfile()).thenReturn(TransportProfile.TCP_UASC_UABINARY);
+    when(context.clientAddress()).thenReturn(InetAddress.getLoopbackAddress());
+    return context;
+  }
+
+  private static EndpointConfig endpoint(String path) {
+    return EndpointConfig.newBuilder()
+        .setBindAddress("localhost")
+        .setBindPort(4840)
+        .setHostname("localhost")
+        .setPath(path)
+        .setSecurityPolicy(SecurityPolicy.None)
+        .setSecurityMode(MessageSecurityMode.None)
+        .addTokenPolicy(new UserTokenPolicy("anonymous", UserTokenType.Anonymous, null, null, null))
+        .build();
+  }
+
+  private static CreateSessionRequest createRequest(ExtensionObject additionalHeader) {
+    return new CreateSessionRequest(
+        header(NodeId.NULL_VALUE, additionalHeader),
+        new ApplicationDescription(
+            "urn:test:client",
+            "urn:test:product",
+            LocalizedText.english("test"),
+            ApplicationType.Client,
+            null,
+            null,
+            null),
+        null,
+        "opc.tcp://localhost:4840/a",
+        "header-test",
+        NonceUtil.generateNonce(32),
+        ByteString.NULL_VALUE,
+        60_000.0,
+        uint(0));
+  }
+
+  private static ActivateSessionRequest activateRequest(
+      NodeId token, ExtensionObject additionalHeader, String locale) {
+    return new ActivateSessionRequest(
+        header(token, additionalHeader),
+        new SignatureData(null, null),
+        null,
+        new String[] {locale},
+        null,
+        new SignatureData(null, null));
+  }
+
+  private static RequestHeader header(NodeId token, ExtensionObject additionalHeader) {
+    return new RequestHeader(
+        token, DateTime.now(), uint(1), uint(0), null, uint(10_000), additionalHeader);
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractX509IdentityValidatorTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractX509IdentityValidatorTest.java
@@ -37,6 +37,8 @@ import org.eclipse.milo.opcua.stack.core.types.structured.X509IdentityToken;
 import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateBuilder;
 import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateGenerator;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 class AbstractX509IdentityValidatorTest {
 
@@ -49,10 +51,10 @@ class AbstractX509IdentityValidatorTest {
             0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F
           });
 
-  // Part 4 (7.41): an explicit certificate user-token policy must use the same public-key family
-  // as the SecureChannel; the server rejects the mismatch before signature verification.
+  // The current transport cannot provide channel-bound signatures over a legacy secured channel.
+  // This runtime restriction is separate from the certificate-token policy's key algorithm.
   @Test
-  void rejectsExplicitCrossFamilyX509TokenPolicy() throws Exception {
+  void rejectsUnsupportedEnhancedSignatureOnLegacyChannel() throws Exception {
     CertificateMaterial user = eccCertificate("x509-user");
     Session session =
         session(SecurityPolicy.Basic256Sha256, MessageSecurityMode.SignAndEncrypt, null, null);
@@ -68,22 +70,24 @@ class AbstractX509IdentityValidatorTest {
                     policy(SecurityPolicy.ECC_nistP256_AesGcm),
                     new SignatureData(null, null)));
 
-    assertEquals(StatusCodes.Bad_SecurityPolicyRejected, exception.getStatusCode().getValue());
+    assertEquals(StatusCodes.Bad_IdentityTokenInvalid, exception.getStatusCode().getValue());
   }
 
   // A compatible explicit X509 token policy still verifies the user-token signature and
   // authenticates the certificate identity.
-  @Test
-  void acceptsCompatibleExplicitX509TokenPolicy() throws Exception {
-    CertificateMaterial server = rsaCertificate("server");
+  @ParameterizedTest
+  @EnumSource(
+      value = SecurityPolicy.class,
+      names = {"Basic256Sha256", "ECC_nistP256_AesGcm"})
+  void acceptsCompatibleExplicitX509TokenPolicy(SecurityPolicy channelPolicy) throws Exception {
+    CertificateMaterial server =
+        channelPolicy == SecurityPolicy.Basic256Sha256
+            ? rsaCertificate("server")
+            : eccCertificate("server");
     CertificateMaterial user = rsaCertificate("x509-user");
     UserTokenPolicy policy = policy(SecurityPolicy.Basic256Sha256);
     Session session =
-        session(
-            SecurityPolicy.Basic256Sha256,
-            MessageSecurityMode.SignAndEncrypt,
-            server.certificate(),
-            policy);
+        session(channelPolicy, MessageSecurityMode.SignAndEncrypt, server.certificate(), policy);
     SignatureData signature =
         ChannelBoundSignatureData.sign(
             SecurityPolicy.Basic256Sha256,

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/CertificateCompatibility.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/CertificateCompatibility.java
@@ -255,6 +255,25 @@ public final class CertificateCompatibility {
     }
   }
 
+  /**
+   * Check whether a public key supports the profile's signature algorithm and curve.
+   *
+   * <p>This check also applies to user identity certificates, which do not have the application
+   * certificate type and KeyUsage requirements enforced by {@link
+   * #checkCompatible(SecurityPolicyProfile, X509Certificate)}.
+   *
+   * @param securityPolicyProfile the profile used to sign or verify.
+   * @param publicKey the signing certificate's public key.
+   * @throws UaException if the public key is incompatible with the profile.
+   */
+  public static void checkPublicKey(
+      SecurityPolicyProfile securityPolicyProfile, PublicKey publicKey) throws UaException {
+
+    requireNonNull(securityPolicyProfile, "securityPolicyProfile");
+    requireNonNull(publicKey, "publicKey");
+    checkPublicKey(securityPolicyProfile.authAxis(), publicKey);
+  }
+
   private static void checkPublicKey(AuthAxis authAxis, PublicKey publicKey) throws UaException {
     switch (authAxis) {
       case NONE -> {}

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/UserTokenSecurityPolicyRules.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/UserTokenSecurityPolicyRules.java
@@ -20,9 +20,9 @@ import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
  * Enforcement of the OPC UA Part 4 (7.41) rules that constrain how a user identity token's {@link
  * SecurityPolicy} may relate to the carrying SecureChannel.
  *
- * <p>The rules are independent of the identity provider, so client and server username and
- * certificate identity paths share them here rather than each re-deriving the constraint. They have
- * different applicability and are exposed separately:
+ * <p>Client and server paths for encrypted user-token secrets share these checks. Certificate
+ * tokens are signed rather than encrypted and may use any valid user-token SecurityPolicy. The
+ * constraints for encrypted secrets are exposed separately:
  *
  * <ul>
  *   <li>{@link #requireSecuredChannelForEnhancedSecret} applies only to token types whose secret is
@@ -31,9 +31,9 @@ import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
  *       policies need. It must not be applied to signed certificate tokens, whose enhanced
  *       signatures are explicitly supported on a {@code None} channel (the reduced Part 4 6.1.8
  *       Table 101 layout).
- *   <li>{@link #requireSamePublicKeyAlgorithmAsChannel} applies to every user-token type: an
- *       explicitly specified user-token SecurityPolicy must share the SecureChannel's public-key
- *       algorithm family (RSA vs ECC).
+ *   <li>{@link #requireSamePublicKeyAlgorithmAsChannel} applies to username and issued-token
+ *       secrets: an explicitly specified SecurityPolicy must share the SecureChannel's public-key
+ *       algorithm family (RSA vs ECC). It does not apply to certificate tokens.
  * </ul>
  *
  * @see <a href="https://reference.opcfoundation.org/Core/Part4/v105/docs/7.41">
@@ -95,7 +95,7 @@ public final class UserTokenSecurityPolicyRules {
    * PublicKey algorithm (RSA vs ECC) as the SecureChannel. Only an explicitly specified, encrypting
    * (RSA or ECC) policy is constrained: an inherited policy already matches the channel, and an
    * explicit {@code None} policy (the plaintext-secret case) carries no PublicKey algorithm. The
-   * rule is independent of the user-token type, so username and certificate tokens both apply it.
+   * rule applies to username and issued-token secrets. Certificate tokens are exempt.
    *
    * @param endpoint the endpoint whose SecurityMode and SecurityPolicy describe the SecureChannel.
    * @param userTokenSecurityPolicy the resolved user-token security policy.


### PR DESCRIPTION
This PR repairs session failure cleanup and X509 authentication policy selection.

### Close unpublished sessions

Failed CreateSession header negotiation could leave a provisional session timer alive. The server now closes the unpublished session on failure and cancels its timeout. This follows Milo's resource-ownership contract.

### Preserve state when activation fails

Failed ActivateSession header negotiation could partially commit identity, nonce, locale, channel ownership, or active-session registration. The server now prepares the additional response header before changing that state, so a failed activation preserves the previously usable session. A secured-channel retry can still sign the nonce from the last successful response.

[Part 4 §5.7.3.1](https://reference.opcfoundation.org/specs/OPC-10000-4/5.7.3.1) states: "If no errors occur the Server replaces the user identity for the Session."

### Select an advertised policy compatible with the user certificate

X509 identity selection now checks the user's actual public key and EC curve while scanning advertised Certificate policies. It skips policies resolving to None and selects a compatible signing policy before requesting the private key. [Part 4 §7.40.5](https://reference.opcfoundation.org/specs/OPC-10000-4/7.40.5) requires that "the Server shall provide a distinct UserTokenPolicy for each CertificateKeyAlgorithm supported."

### Allow certificate tokens to use a different key family from the channel

Client and server also applied a key-family restriction to certificate tokens that belongs only to username and issued tokens. [Part 4 §7.41](https://reference.opcfoundation.org/specs/OPC-10000-4/7.41) says: "If the tokenType is CERTIFICATE, the securityPolicyUri may be any valid SecurityPolicy." RSA user certificates can therefore authenticate over an ECC SecureChannel. The username/issued-token key-family rule no longer rejects this valid combination. Existing runtime limitations for enhanced certificate-token signatures over legacy secured channels remain documented and tested.

### Verification

Verification passed: formatting, full clean compile, and selected session-header, endpoint-binding, X509, user-token, and certificate-compatibility tests. Detached-base regressions reproduce the timer leak, all three activation failure paths, incompatible policy selection, and incorrect cross-algorithm rejection. Additional regressions verify signed retries with the last delivered nonce on the same or a replacement channel, and skip explicit or inherited None before a usable certificate signing policy. Both secured retry cases also passed after adding an assertion that the original channel remains usable immediately after header rejection.
