### PR TITLE
Resolve node identity outside the node manager monitor

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/AbstractNodeManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/AbstractNodeManager.java
@@ -13,7 +13,9 @@ package org.eclipse.milo.opcua.sdk.server;
 import com.google.common.collect.LinkedHashMultiset;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.concurrent.ConcurrentHashMap;
@@ -83,19 +85,25 @@ public class AbstractNodeManager<T extends Node> implements NodeManager<T> {
   }
 
   @Override
-  public synchronized Optional<T> addNode(T node) {
-    generation++;
-    return Optional.ofNullable(nodeMap.put(node.getNodeId(), node));
+  public Optional<T> addNode(T node) {
+    NodeId nodeId = node.getNodeId();
+    synchronized (this) {
+      generation++;
+      return Optional.ofNullable(nodeMap.put(nodeId, node));
+    }
   }
 
   @Override
-  public synchronized boolean addNodeIfAbsent(T node) {
-    if (nodeMap.containsKey(node.getNodeId())) {
-      return false;
-    } else {
-      nodeMap.put(node.getNodeId(), node);
-      generation++;
-      return true;
+  public boolean addNodeIfAbsent(T node) {
+    NodeId nodeId = node.getNodeId();
+    synchronized (this) {
+      if (nodeMap.containsKey(nodeId)) {
+        return false;
+      } else {
+        nodeMap.put(nodeId, node);
+        generation++;
+        return true;
+      }
     }
   }
 
@@ -186,12 +194,8 @@ public class AbstractNodeManager<T extends Node> implements NodeManager<T> {
   }
 
   @Override
-  public synchronized List<Reference> getReferences(NodeId nodeId, Predicate<Reference> filter) {
-    LinkedHashMultiset<Reference> references = referenceMap.get(nodeId);
-
-    return references != null
-        ? references.stream().filter(filter).toList()
-        : Collections.emptyList();
+  public List<Reference> getReferences(NodeId nodeId, Predicate<Reference> filter) {
+    return getReferences(nodeId).stream().filter(filter).toList();
   }
 
   /**
@@ -203,9 +207,18 @@ public class AbstractNodeManager<T extends Node> implements NodeManager<T> {
    * monitor.
    */
   @Override
-  public synchronized CommitResult commit(NodeManagerBatch<T> batch)
-      throws NodeManagerBatchException {
+  public CommitResult commit(NodeManagerBatch<T> batch) throws NodeManagerBatchException {
+    Map<NodeId, T> additions = new LinkedHashMap<>();
+    for (T node : batch.getNodeAdditions()) {
+      additions.put(node.getNodeId(), node);
+    }
+    synchronized (this) {
+      return commit(batch, additions);
+    }
+  }
 
+  private CommitResult commit(NodeManagerBatch<T> batch, Map<NodeId, T> additions)
+      throws NodeManagerBatchException {
     CommitResult nothingApplied = new CommitResult(List.of(), List.of());
 
     OptionalLong expectedGeneration = batch.getExpectedGeneration();
@@ -220,9 +233,9 @@ public class AbstractNodeManager<T extends Node> implements NodeManager<T> {
       }
     }
 
-    for (T node : batch.getNodeAdditions()) {
-      if (nodeMap.containsKey(node.getNodeId())) {
-        throw NodeManagerBatchException.nodeExists(node.getNodeId(), nothingApplied);
+    for (NodeId nodeId : additions.keySet()) {
+      if (nodeMap.containsKey(nodeId)) {
+        throw NodeManagerBatchException.nodeExists(nodeId, nothingApplied);
       }
     }
 
@@ -248,9 +261,9 @@ public class AbstractNodeManager<T extends Node> implements NodeManager<T> {
     List<NodeId> addedNodes = new ArrayList<>();
     List<Reference> addedReferences = new ArrayList<>();
     try {
-      for (T node : batch.getNodeAdditions()) {
-        nodeMap.put(node.getNodeId(), node);
-        addedNodes.add(node.getNodeId());
+      for (Map.Entry<NodeId, T> entry : additions.entrySet()) {
+        nodeMap.put(entry.getKey(), entry.getValue());
+        addedNodes.add(entry.getKey());
       }
       // Logical deduplication: only References not already present get a new occurrence.
       for (Reference reference : batch.getReferenceAdditions()) {

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/package-info.java
@@ -46,6 +46,14 @@
  * participant shutdown therefore runs without external server visibility but before the standard
  * address space and event facilities are torn down.
  *
+ * <h2>Node storage</h2>
+ *
+ * <p>{@link org.eclipse.milo.opcua.sdk.server.NodeManager} owns node identity and reference
+ * storage. The built-in manager serializes mutations and batch commits on its monitor. It resolves
+ * node attributes and invokes reference filters outside that monitor because attribute observers
+ * may call back into the manager while holding a node's monitor. Application managers that use the
+ * default batch primitives need a single writer.
+ *
  * <h2>Runtime boundaries</h2>
  *
  * <p>The SDK server package coordinates high-level server configuration and lifecycle. Certificate

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/NodeManagerLockingTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/NodeManagerLockingTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.milo.opcua.sdk.core.nodes.Node;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class NodeManagerLockingTest {
+
+  // Attribute observers run under the node monitor and may read manager references. Calling
+  // getNodeId while holding the manager monitor introduces the opposite lock order and deadlocks.
+  @ParameterizedTest
+  @ValueSource(strings = {"add", "conditional", "batch"})
+  void nodeIdentityIsResolvedOutsideTheManagerMonitor(String operation) throws Exception {
+    var manager = new AbstractNodeManager<Node>();
+    var node = mock(Node.class);
+    var nodeId = new NodeId(1, "Observed");
+    when(node.getNodeId())
+        .thenAnswer(
+            invocation -> {
+              assertFalse(
+                  Thread.holdsLock(manager),
+                  "node attribute access must not hold the manager monitor");
+              return nodeId;
+            });
+    switch (operation) {
+      case "add" -> manager.addNode(node);
+      case "conditional" -> manager.addNodeIfAbsent(node);
+      case "batch" -> manager.commit(NodeManagerBatch.<Node>builder().addNode(node).build());
+      default -> throw new AssertionError(operation);
+    }
+    assertSame(node, manager.getNode(nodeId).orElseThrow());
+  }
+}


### PR DESCRIPTION
Node registration can deadlock when an attribute observer holds a node monitor and calls the node manager while registration reads NodeId under the manager monitor. Resolve node identities before entering the manager monitor, and evaluate reference predicates over a copied list outside that monitor. Mutation and batch generation updates remain serialized.

### Verification

Three deterministic regression cases cover direct registration, conditional registration, and batch commit. They assert that node identity callbacks run outside the manager monitor and that registration succeeds.

Formatting, full clean compilation, and 24 selected tests passed for this branch.
