### PR TITLE
Roll back started children after lifecycle startup fails

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/LifecycleManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/LifecycleManager.java
@@ -11,6 +11,8 @@
 package org.eclipse.milo.opcua.sdk.server;
 
 import com.google.common.collect.Lists;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
@@ -22,6 +24,10 @@ import java.util.concurrent.CopyOnWriteArrayList;
  *
  * <p>The order that sub-Lifecycles are shutdown can be controlled with the optional {@link
  * ShutdownOrder} parameter provided in {@link LifecycleManager#LifecycleManager(ShutdownOrder)}.
+ *
+ * <p>If a child fails during startup, successfully started children are shut down in reverse order.
+ * Cleanup failures are suppressed on the original startup failure. The failing child remains
+ * responsible for cleaning up resources acquired by its own incomplete startup.
  */
 public final class LifecycleManager extends AbstractLifecycle {
 
@@ -48,7 +54,24 @@ public final class LifecycleManager extends AbstractLifecycle {
 
   @Override
   protected void onStartup() {
-    lifecycles.forEach(Lifecycle::startup);
+    List<Lifecycle> started = new ArrayList<>();
+    try {
+      for (Lifecycle lifecycle : lifecycles) {
+        lifecycle.startup();
+        started.add(lifecycle);
+      }
+    } catch (Throwable startupFailure) {
+      for (int i = started.size() - 1; i >= 0; i--) {
+        try {
+          started.get(i).shutdown();
+        } catch (Throwable cleanupFailure) {
+          if (cleanupFailure != startupFailure) {
+            startupFailure.addSuppressed(cleanupFailure);
+          }
+        }
+      }
+      throw startupFailure;
+    }
   }
 
   @Override

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/package-info.java
@@ -46,6 +46,12 @@
  * participant shutdown therefore runs without external server visibility but before the standard
  * address space and event facilities are torn down.
  *
+ * <p>{@link org.eclipse.milo.opcua.sdk.server.LifecycleManager} applies the same ownership rule
+ * within composite components: failed child startup unwinds successfully started children in
+ * reverse order. A managed namespace therefore releases its base address-space registrations when a
+ * later child fails. Each failing child cleans up its own partial startup before propagating the
+ * failure.
+ *
  * <h2>Runtime boundaries</h2>
  *
  * <p>The SDK server package coordinates high-level server configuration and lifecycle. Certificate

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/LifecycleManagerTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/LifecycleManagerTest.java
@@ -11,11 +11,64 @@
 package org.eclipse.milo.opcua.sdk.server;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 public class LifecycleManagerTest {
+
+  // Startup failure must unwind acquired children even though subsequent shutdown is a no-op.
+  @ParameterizedTest
+  @EnumSource(LifecycleManager.ShutdownOrder.class)
+  void failedStartupRollsBackSuccessfulChildren(LifecycleManager.ShutdownOrder order) {
+    var manager = new LifecycleManager(order);
+    var events = new ArrayList<String>();
+    var startupFailure = new IllegalStateException("startup");
+    var cleanupFailure = new IllegalStateException("cleanup");
+    manager.addLifecycle(recordingLifecycle("a", events, null, null));
+    manager.addLifecycle(recordingLifecycle("b", events, null, cleanupFailure));
+    manager.addLifecycle(recordingLifecycle("c", events, startupFailure, null));
+    manager.addLifecycle(recordingLifecycle("d", events, null, null));
+
+    assertSame(startupFailure, assertThrows(IllegalStateException.class, manager::startup));
+    assertEquals(List.of("start-a", "start-b", "start-c", "stop-b", "stop-a"), events);
+    assertEquals(List.of(cleanupFailure), List.of(startupFailure.getSuppressed()));
+    assertFalse(manager.isRunning());
+
+    manager.shutdown();
+    assertEquals(List.of("start-a", "start-b", "start-c", "stop-b", "stop-a"), events);
+  }
+
+  private static Lifecycle recordingLifecycle(
+      String name,
+      List<String> events,
+      RuntimeException startupFailure,
+      RuntimeException cleanupFailure) {
+    return new Lifecycle() {
+      @Override
+      public void startup() {
+        events.add("start-" + name);
+        if (startupFailure != null) {
+          throw startupFailure;
+        }
+      }
+
+      @Override
+      public void shutdown() {
+        events.add("stop-" + name);
+        if (cleanupFailure != null) {
+          throw cleanupFailure;
+        }
+      }
+    };
+  }
 
   @Test
   public void testStartupShutdown() {

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/OpcUaServerLifecycleParticipantTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/OpcUaServerLifecycleParticipantTest.java
@@ -30,6 +30,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.eclipse.milo.opcua.sdk.server.items.DataItem;
+import org.eclipse.milo.opcua.sdk.server.items.MonitoredItem;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.security.DefaultCertificateManager;
@@ -446,6 +448,37 @@ class OpcUaServerLifecycleParticipantTest {
       releaseStartup.countDown();
       executor.shutdownNow();
     }
+  }
+
+  // Namespace registration is an earlier child lifecycle and must be removed on later failure.
+  @Test
+  void failedNamespaceStartupUnregistersItsNodeManager() {
+    OpcUaServer server = newServer(new RecordingTransport());
+    var failure = new IllegalStateException("namespace child startup");
+    var namespace =
+        new ManagedNamespaceWithLifecycle(server, "urn:test:failed-namespace") {
+          @Override
+          public void onDataItemsCreated(List<DataItem> dataItems) {}
+
+          @Override
+          public void onDataItemsModified(List<DataItem> dataItems) {}
+
+          @Override
+          public void onDataItemsDeleted(List<DataItem> dataItems) {}
+
+          @Override
+          public void onMonitoringModeChanged(List<MonitoredItem> monitoredItems) {}
+        };
+    namespace
+        .getLifecycleManager()
+        .addStartupTask(
+            () -> {
+              throw failure;
+            });
+
+    assertSame(failure, assertThrows(IllegalStateException.class, namespace::startup));
+    assertFalse(server.getAddressSpaceManager().isRegistered(namespace.getNodeManager()));
+    namespace.shutdown();
   }
 
   private OpcUaServer newServer(RecordingTransport transport) {


### PR DESCRIPTION
A failed child startup left earlier children running after `LifecycleManager` had become stopped. A later shutdown then did nothing, which could leave a managed namespace's node manager registered.

The manager now stops successfully started children in reverse order before propagating the startup failure. Cleanup continues after an individual shutdown failure, with cleanup exceptions attached to the original exception. A child whose own startup fails remains responsible for its partial initialization.

Regressions exercise both configured shutdown orders, cleanup failures, and real namespace registration cleanup.

Formatting, a full clean compile, and the selected regression suites passed for this branch.
