### PR TITLE
Preserve replacement nodes during instantiation cleanup

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/AbstractNodeManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/AbstractNodeManager.java
@@ -108,6 +108,17 @@ public class AbstractNodeManager<T extends Node> implements NodeManager<T> {
   }
 
   @Override
+  public synchronized boolean removeNodeIfSame(NodeId nodeId, T expectedNode) {
+    return NodeManager.super.removeNodeIfSame(nodeId, expectedNode);
+  }
+
+  @Override
+  public synchronized boolean removeReferenceIfSame(
+      Reference reference, Map<NodeId, T> expectedNodes, NamespaceTable namespaceTable) {
+    return NodeManager.super.removeReferenceIfSame(reference, expectedNodes, namespaceTable);
+  }
+
+  @Override
   public Optional<T> getNode(NodeId nodeId) {
     return Optional.ofNullable(nodeMap.get(nodeId));
   }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/NodeManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/NodeManager.java
@@ -12,6 +12,7 @@ package org.eclipse.milo.opcua.sdk.server;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.function.Predicate;
@@ -189,6 +190,61 @@ public interface NodeManager<T extends Node> {
    */
   default Optional<T> removeNode(T node) {
     return removeNode(node.getNodeId());
+  }
+
+  /**
+   * Remove the node only while the stored object is {@code expectedNode} by identity.
+   *
+   * <p>The default implementation requires a single writer. Atomic managers must override it.
+   *
+   * @param nodeId the node identifier.
+   * @param expectedNode the exact object owned by the caller.
+   * @return whether the node was removed.
+   */
+  default boolean removeNodeIfSame(NodeId nodeId, T expectedNode) {
+    if (getNode(nodeId).orElse(null) != expectedNode) {
+      return false;
+    }
+    return removeNode(nodeId).isPresent();
+  }
+
+  /**
+   * Remove a journaled reference only while the stored occurrence retains its identity and none of
+   * its journaled endpoints has been replaced.
+   *
+   * <p>The default implementation requires a single writer and retains ownership by object
+   * identity: {@link #getReferences(NodeId)} must return the same Reference instances supplied to
+   * {@link #addReference(Reference)}. Managers that reconstruct references from external storage
+   * must override this method with an equivalent ownership check. Atomic managers must also
+   * override it. Missing endpoints allow removal of dangling references left after a node was
+   * removed directly.
+   *
+   * @param reference the exact reference object added by a commit.
+   * @param expectedNodes the journal's node identifiers and object identities.
+   * @param namespaceTable the namespace table used to resolve the target identifier.
+   * @return whether the reference was removed.
+   */
+  default boolean removeReferenceIfSame(
+      Reference reference, Map<NodeId, T> expectedNodes, NamespaceTable namespaceTable) {
+    if (hasReplacement(reference.getSourceNodeId(), expectedNodes)
+        || reference
+            .getTargetNodeId()
+            .toNodeId(namespaceTable)
+            .map(nodeId -> hasReplacement(nodeId, expectedNodes))
+            .orElse(false)) {
+      return false;
+    }
+    if (getReferences(reference.getSourceNodeId()).stream().noneMatch(r -> r == reference)) {
+      return false;
+    }
+    removeReference(reference);
+    return true;
+  }
+
+  private boolean hasReplacement(NodeId nodeId, Map<NodeId, T> expectedNodes) {
+    T expected = expectedNodes.get(nodeId);
+    T current = getNode(nodeId).orElse(null);
+    return expected != null && current != null && current != expected;
   }
 
   /**

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/InstantiationResult.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/InstantiationResult.java
@@ -19,6 +19,7 @@ import org.eclipse.milo.opcua.sdk.server.NodeManager;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -182,13 +183,20 @@ public final class InstantiationResult<T extends UaNode> {
     }
 
     RuntimeException failure = null;
+    Map<NodeId, UaNode> expectedNodes = new LinkedHashMap<>();
+    for (MaterializedNode node : materializedNodes) {
+      expectedNodes.put(node.nodeId(), node.node());
+    }
 
     for (MaterializedReference reference : references) {
       if (!reference.added()) {
         continue;
       }
       try {
-        target.removeReference(reference.reference());
+        target.removeReferenceIfSame(
+            reference.reference(),
+            expectedNodes,
+            root.getNodeContext().getServer().getNamespaceTable());
       } catch (RuntimeException e) {
         failure = suppress(failure, e);
       }
@@ -199,7 +207,7 @@ public final class InstantiationResult<T extends UaNode> {
         continue;
       }
       try {
-        target.removeNode(node.nodeId());
+        target.removeNodeIfSame(node.nodeId(), node.node());
       } catch (RuntimeException e) {
         failure = suppress(failure, e);
       }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/NodeInstantiator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/NodeInstantiator.java
@@ -2310,10 +2310,14 @@ public final class NodeInstantiator {
      */
     private List<InstantiationDiagnostic> rollBack(NodeManager.CommitResult applied) {
       List<InstantiationDiagnostic> findings = new ArrayList<>();
+      Map<NodeId, UaNode> expectedNodes = new LinkedHashMap<>();
+      for (UaNode node : staged.values()) {
+        expectedNodes.put(node.getNodeId(), node);
+      }
 
       for (Reference reference : applied.addedReferences()) {
         try {
-          target.removeReference(reference);
+          target.removeReferenceIfSame(reference, expectedNodes, server.getNamespaceTable());
         } catch (Exception e) {
           findings.add(
               InstantiationDiagnostic.applyError(
@@ -2326,7 +2330,7 @@ public final class NodeInstantiator {
 
       for (NodeId nodeId : applied.addedNodes()) {
         try {
-          target.removeNode(nodeId);
+          target.removeNodeIfSame(nodeId, Objects.requireNonNull(expectedNodes.get(nodeId)));
         } catch (Exception e) {
           findings.add(
               InstantiationDiagnostic.applyError(

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/package-info.java
@@ -21,6 +21,11 @@
  * org.eclipse.milo.opcua.sdk.server.nodes.instantiation.BrowsePath}, with every ModellingRule
  * classified and provenance preserved for diagnostics.
  *
+ * <p>Instantiation results own the node and reference additions recorded by their commit. Cleanup
+ * and rollback check object identity before removing those additions, preserving replacements
+ * installed later under the same identifiers. Built-in node managers make those checks atomic with
+ * removal. Custom managers using the default storage primitives require a single writer.
+ *
  * <p><strong>Experimental:</strong> this package is new API, subject to adjustment for one minor
  * release based on experience from Milo's in-tree migrations and validation of the placeholder
  * surface against real companion-specification workloads, after which it freezes. The legacy {@code

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/package-info.java
@@ -49,10 +49,11 @@
  * <h2>Node storage</h2>
  *
  * <p>{@link org.eclipse.milo.opcua.sdk.server.NodeManager} owns node identity and reference
- * storage. The built-in manager serializes mutations and batch commits on its monitor. It resolves
- * node attributes and invokes reference filters outside that monitor because attribute observers
- * may call back into the manager while holding a node's monitor. Application managers that use the
- * default batch primitives need a single writer.
+ * storage. The built-in manager serializes mutations, batch commits, and identity-conditional
+ * cleanup on its monitor. It resolves node attributes and invokes reference filters outside that
+ * monitor because attribute observers may call back into the manager while holding a node's
+ * monitor. Application managers that use the default batch and cleanup primitives need a single
+ * writer.
  *
  * <h2>Runtime boundaries</h2>
  *

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/InstantiationOwnershipTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/InstantiationOwnershipTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
+
+import static org.eclipse.milo.opcua.sdk.server.nodes.instantiation.TypeFixtures.path;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.eclipse.milo.opcua.sdk.core.Reference;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectNode;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.junit.jupiter.api.Test;
+
+class InstantiationOwnershipTest {
+
+  // A result retains historical provenance after ordinary node deletion. Reusing the same IDs
+  // must not transfer ownership of the replacement instance or its references to the old result.
+  @Test
+  void deletingAnOldResultPreservesReplacementNodesAndReferences() throws Exception {
+    var fx = TypeFixtures.create();
+    var type = fx.addObjectType("Type", NodeIds.BaseObjectType);
+    fx.addObjectDeclaration(type, "Child", NodeIds.BaseObjectType, NodeIds.ModellingRule_Mandatory);
+    var target = fx.newTargetManager();
+    fx.registerWithAddressSpace(target);
+    var instantiator = fx.instantiator();
+    var request =
+        InstantiationRequest.of(UaObjectNode.class, type.getNodeId())
+            .nodeId(fx.newNodeId("Instance"))
+            .target(target)
+            .build();
+    var original = instantiator.instantiate(request);
+    original.root().delete();
+    assertTrue(target.getNodes().isEmpty(), "ordinary deletion removes the old graph");
+    var replacement = instantiator.instantiate(request);
+    List<Reference> replacementReferences =
+        replacement.materializedNodes().stream()
+            .flatMap(node -> target.getReferences(node.nodeId()).stream())
+            .toList();
+
+    original.deleteCreated();
+
+    for (MaterializedNode node : replacement.materializedNodes()) {
+      assertSame(node.node(), target.getNode(node.nodeId()).orElseThrow());
+    }
+    assertEquals(
+        replacementReferences,
+        replacement.materializedNodes().stream()
+            .flatMap(node -> target.getReferences(node.nodeId()).stream())
+            .toList());
+    replacement.deleteCreated();
+    assertTrue(target.getNodes().isEmpty(), "the replacement result still owns its graph");
+  }
+
+  // Reference equality describes an edge, not ownership of a later remove/re-add occurrence.
+  @Test
+  void deletingAnOldResultPreservesAnEqualReplacementReference() throws Exception {
+    var fx = TypeFixtures.create();
+    var type = fx.addObjectType("Type", NodeIds.BaseObjectType);
+    var target = fx.newTargetManager();
+    var result =
+        fx.instantiator()
+            .instantiate(
+                InstantiationRequest.of(UaObjectNode.class, type.getNodeId())
+                    .nodeId(fx.newNodeId("Instance"))
+                    .target(target)
+                    .build());
+    Reference original =
+        result.references().stream()
+            .filter(MaterializedReference::added)
+            .map(MaterializedReference::reference)
+            .findFirst()
+            .orElseThrow();
+    target.removeReference(original);
+    Reference replacement =
+        new Reference(
+            original.getSourceNodeId(),
+            original.getReferenceTypeId(),
+            original.getTargetNodeId(),
+            original.getDirection());
+    target.addReference(replacement);
+    result.deleteCreated();
+    assertEquals(List.of(replacement), target.getReferences(replacement.getSourceNodeId()));
+  }
+
+  // Binders run after commit and can invoke ordinary node APIs. A failing binder must not roll
+  // back a replacement that another owner installed under one of the committed identifiers.
+  @Test
+  void rollbackPreservesANodeReplacedByAFailingBinder() throws Exception {
+    var fx = TypeFixtures.create();
+    var type = fx.addObjectType("Type", NodeIds.BaseObjectType);
+    fx.addMethodDeclaration(type, "M", NodeIds.ModellingRule_Mandatory);
+    var target = fx.newTargetManager();
+    var replacement =
+        new UaObjectNode(
+            fx.context(),
+            fx.newNodeId("Instance"),
+            TypeFixtures.qn("Replacement"),
+            LocalizedText.english("Replacement"),
+            LocalizedText.NULL_VALUE,
+            UInteger.MIN,
+            UInteger.MIN);
+    assertThrows(
+        InstantiationException.class,
+        () ->
+            fx.instantiator()
+                .instantiate(
+                    InstantiationRequest.of(UaObjectNode.class, type.getNodeId())
+                        .nodeId(replacement.getNodeId())
+                        .target(target)
+                        .bindMethod(
+                            path("M"),
+                            method -> {
+                              target.addNode(replacement);
+                              throw new IllegalStateException("binder failed after replacement");
+                            })
+                        .build()));
+    assertSame(replacement, target.getNode(replacement.getNodeId()).orElseThrow());
+  }
+}


### PR DESCRIPTION
An old instantiation result can delete a replacement node or a removed-and-readded reference when their identifiers match its journal. Cleanup and rollback now verify the exact stored node and reference identities before removal. Built-in managers make these checks atomic; custom managers using the default implementation require a single writer and retained Reference instances.

### Verification

Three regression cases preserve a replacement instance during old-result cleanup, preserve an equal replacement reference, and preserve a replacement root during binder-failure rollback.

Formatting, full clean compilation, and 55 selected tests passed for this branch.

Based on https://github.com/eclipse-milo/milo/pull/1875 so the diff contains only this fix.
