### PR TITLE
Preserve queued callbacks when executor dispatch fails

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/reverse/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/reverse/package-info.java
@@ -58,7 +58,9 @@
  * org.eclipse.milo.opcua.sdk.server.reverse.ReverseConnectAttemptEvent}s and retained on target
  * snapshots as the last status or a defensive copy of the last exception. Retry timing is delegated
  * to {@link org.eclipse.milo.opcua.sdk.server.reverse.ReverseConnectRetryPolicy}; the default
- * policy uses the target registration period.
+ * policy uses the target registration period. Listener dispatch uses a serial execution queue;
+ * executor rejection runs callbacks on the submitting thread so notification failures cannot
+ * abandon an attempt transition. Callbacks should return promptly even during executor overload.
  *
  * <p>Successful outbound UA-TCP connections are handed back to the normal server SecureChannel and
  * Session paths after the stack transport installs the standard server Hello handler. Client-side

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/reverse/ReverseConnectTargetManagerTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/reverse/ReverseConnectTargetManagerTest.java
@@ -21,15 +21,20 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.netty.channel.Channel;
 import io.netty.channel.embedded.EmbeddedChannel;
 import java.lang.reflect.Field;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -38,15 +43,18 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import org.eclipse.milo.opcua.stack.core.transport.TransportProfile;
 import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
 import org.eclipse.milo.opcua.stack.transport.server.ServerApplicationContext;
 import org.eclipse.milo.opcua.stack.transport.server.tcp.OpcTcpServerReverseConnectAttempt;
+import org.eclipse.milo.opcua.stack.transport.server.tcp.OpcTcpServerReverseConnectAttemptState;
 import org.eclipse.milo.opcua.stack.transport.server.tcp.OpcTcpServerReverseConnectParameters;
 import org.eclipse.milo.opcua.stack.transport.server.tcp.OpcTcpServerTransport;
 import org.eclipse.milo.opcua.stack.transport.server.tcp.OpcTcpServerTransportConfig;
@@ -376,6 +384,87 @@ class ReverseConnectTargetManagerTest {
     assertUnknownTargetFailure(handle::resume, target.getId());
     assertUnknownTargetFailure(handle::trigger, target.getId());
     assertUnknownTargetFailure(handle::remove, target.getId());
+  }
+
+  // State observers must not prevent an attempt from acquiring a transport when dispatch rejects.
+  @Test
+  void listenerExecutorRejectionDoesNotStrandScheduledAttempt() throws Exception {
+    try (ControlledAttempts fixture = new ControlledAttempts()) {
+      fixture.manager.addListener(new ReverseConnectTargetListener() {});
+      fixture.manager.startup();
+      fixture.rejectNotifications.set(true);
+      fixture.scheduled.remove().run();
+      assertEquals(1, fixture.transport.attempts.size());
+      fixture.rejectNotifications.set(false);
+      fixture.manager.trigger(fixture.target.getId()).get(5, TimeUnit.SECONDS);
+      assertEquals(
+          1, fixture.transport.attempts.size(), "the original attempt remains in progress");
+    }
+  }
+
+  private static final class ControlledAttempts implements AutoCloseable {
+    final Queue<Runnable> scheduled = new ArrayDeque<>();
+    final AtomicBoolean rejectNotifications = new AtomicBoolean();
+    final ControlledTransport transport = new ControlledTransport();
+    final ReverseConnectTarget target =
+        target("opc.tcp://localhost:12686/reverse-target-test", "opc.tcp://localhost:12687");
+    final ReverseConnectTargetManager manager;
+
+    ControlledAttempts() {
+      ExecutorService executor = mock(ExecutorService.class);
+      doAnswer(
+              invocation -> {
+                if (rejectNotifications.get()) {
+                  throw new RejectedExecutionException("saturated");
+                }
+                invocation.<Runnable>getArgument(0).run();
+                return null;
+              })
+          .when(executor)
+          .execute(any(Runnable.class));
+      ScheduledExecutorService scheduler = mock(ScheduledExecutorService.class);
+      when(scheduler.schedule(any(Runnable.class), anyLong(), any(TimeUnit.class)))
+          .thenAnswer(
+              invocation -> {
+                scheduled.add(invocation.getArgument(0));
+                return mock(ScheduledFuture.class);
+              });
+      manager =
+          new ReverseConnectTargetManager(
+              mock(ServerApplicationContext.class),
+              () -> List.of(endpointDescription(target.getEndpointUrl())),
+              profile -> transport,
+              "urn:eclipse:milo:test:server:reverse-targets",
+              executor,
+              scheduler,
+              Set.of(target));
+    }
+
+    @Override
+    public void close() {
+      manager.shutdown();
+    }
+  }
+
+  private static final class ControlledTransport extends OpcTcpServerTransport {
+    final List<OpcTcpServerReverseConnectAttempt> attempts = new ArrayList<>();
+    final List<CompletableFuture<Channel>> channels = new ArrayList<>();
+
+    ControlledTransport() {
+      super(OpcTcpServerTransportConfig.newBuilder().build());
+    }
+
+    @Override
+    public OpcTcpServerReverseConnectAttempt connectReverse(
+        OpcTcpServerReverseConnectParameters parameters) {
+      OpcTcpServerReverseConnectAttempt attempt = mock(OpcTcpServerReverseConnectAttempt.class);
+      CompletableFuture<Channel> channel = new CompletableFuture<>();
+      when(attempt.channelFuture()).thenReturn(channel);
+      when(attempt.state()).thenReturn(OpcTcpServerReverseConnectAttemptState.CONNECTING);
+      attempts.add(attempt);
+      channels.add(channel);
+      return attempt;
+    }
   }
 
   private static void assertUnknownTargetFailure(

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/ExecutionQueue.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/ExecutionQueue.java
@@ -10,7 +10,6 @@
 
 package org.eclipse.milo.opcua.stack.core.util;
 
-import com.google.common.base.Preconditions;
 import java.util.ArrayDeque;
 import java.util.concurrent.Executor;
 import org.slf4j.Logger;
@@ -25,6 +24,10 @@ import org.slf4j.LoggerFactory;
  *
  * <p>When {@code concurrency > 1} there are no guarantees beyond the fact that tasks are still
  * pulled from a queue to be executed.
+ *
+ * <p>If the executor throws a runtime exception during dispatch, the submitting thread runs queued
+ * tasks synchronously. Callbacks should return promptly because this fallback may run on an I/O or
+ * timer thread.
  */
 public class ExecutionQueue {
 
@@ -56,9 +59,8 @@ public class ExecutionQueue {
   public void submit(Runnable runnable) {
     synchronized (queueLock) {
       queue.add(runnable);
-
-      maybePollAndExecute();
     }
+    maybePollAndExecute();
   }
 
   /**
@@ -69,9 +71,8 @@ public class ExecutionQueue {
   public void submitToHead(Runnable runnable) {
     synchronized (queueLock) {
       queue.addFirst(runnable);
-
-      maybePollAndExecute();
     }
+    maybePollAndExecute();
   }
 
   /** Pause execution of queued {@link java.lang.Runnable}s. */
@@ -85,81 +86,99 @@ public class ExecutionQueue {
   public void resume() {
     synchronized (queueLock) {
       paused = false;
-
-      maybePollAndExecute();
     }
+    maybePollAndExecute();
   }
 
   private void maybePollAndExecute() {
     synchronized (queueLock) {
-      if (pending < concurrencyLimit && !paused && !queue.isEmpty()) {
-        executor.execute(new Task(queue.poll()));
-        pending++;
+      if (pending >= concurrencyLimit || paused || queue.isEmpty()) {
+        return;
       }
+      // Reserve the worker before dispatch, including when the executor runs it inline.
+      pending++;
+    }
+
+    Task task = new Task();
+    try {
+      executor.execute(task);
+    } catch (RuntimeException e) {
+      task.run();
     }
   }
 
   private class Task implements Runnable {
 
-    private final Runnable runnable;
-
-    Task(Runnable runnable) {
-      Preconditions.checkNotNull(runnable);
-
-      this.runnable = runnable;
-    }
+    // A continuation can run before execute() returns, either inline or on another worker.
+    // In that case the current invocation keeps ownership and drains the next batch itself.
+    private boolean running;
+    private boolean runAgain;
+    private boolean completed;
 
     @Override
     public void run() {
-      try {
-        runnable.run();
-      } catch (Throwable throwable) {
-        log.warn("Uncaught Throwable during execution.", throwable);
+      synchronized (this) {
+        if (completed) {
+          return;
+        }
+        if (running) {
+          runAgain = true;
+          return;
+        }
+        running = true;
       }
 
-      InlineTask inlineTask = null;
+      while (true) {
+        boolean moreTasks = runBatch();
+        if (moreTasks) {
+          try {
+            executor.execute(this);
+          } catch (RuntimeException e) {
+            synchronized (this) {
+              runAgain = true;
+            }
+          }
+        }
 
-      synchronized (queueLock) {
-        if (queue.isEmpty() || paused) {
-          pending--;
-        } else {
-          // pending count remains the same
-          inlineTask = new InlineTask(queue.poll());
+        synchronized (this) {
+          if (moreTasks && runAgain) {
+            runAgain = false;
+          } else {
+            running = false;
+            // A decorating executor can run this worker before reporting a dispatch failure.
+            // Its fallback invocation must not release a finished worker's reservation twice.
+            completed = !moreTasks;
+            return;
+          }
+        }
+      }
+    }
+
+    private boolean runBatch() {
+      for (int i = 0; i < 2; i++) {
+        Runnable runnable;
+        synchronized (queueLock) {
+          if (paused || queue.isEmpty()) {
+            pending--;
+            return false;
+          }
+          runnable = queue.remove();
+        }
+
+        try {
+          runnable.run();
+        } catch (Throwable throwable) {
+          log.warn("Uncaught Throwable during execution.", throwable);
         }
       }
 
-      if (inlineTask != null) {
-        inlineTask.run();
-      }
-    }
-  }
-
-  private class InlineTask implements Runnable {
-
-    private final Runnable runnable;
-
-    InlineTask(Runnable runnable) {
-      Preconditions.checkNotNull(runnable);
-
-      this.runnable = runnable;
-    }
-
-    @Override
-    public void run() {
-      try {
-        runnable.run();
-      } catch (Throwable throwable) {
-        log.warn("Uncaught Throwable during execution.", throwable);
-      }
-
       synchronized (queueLock) {
-        if (queue.isEmpty() || paused) {
+        if (paused || queue.isEmpty()) {
           pending--;
-        } else {
-          // pending count remains the same
-          executor.execute(new Task(queue.poll()));
+          return false;
         }
       }
+      return true;
     }
   }
 }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/package-info.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/**
+ * Shared protocol utilities and asynchronous coordination primitives used by transports and SDKs.
+ *
+ * <p>These utilities support endpoint and value handling, cryptographic operations, and task
+ * coordination. The calling transport or SDK retains authority over protocol validation and
+ * resource lifecycles; utility objects do not own its channels, sessions, or executor shutdown.
+ *
+ * <p>{@link org.eclipse.milo.opcua.stack.core.util.ExecutionQueue} serializes callbacks by default
+ * and can permit an explicit number of concurrent workers. It retains queued tasks when executor
+ * dispatch throws a runtime exception by running the worker on the submitting thread. Pausing stops
+ * new task execution after currently running callbacks finish; resuming makes queued tasks eligible
+ * again. Callbacks run outside the queue lock. Workers submit a continuation between small batches;
+ * scheduling among executor users depends on the supplied executor.
+ */
+package org.eclipse.milo.opcua.stack.core.util;

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/util/ExecutionQueueTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/util/ExecutionQueueTest.java
@@ -12,12 +12,22 @@ package org.eclipse.milo.opcua.stack.core.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,8 +38,192 @@ public class ExecutionQueueTest {
 
   private final ExecutorService executor = Executors.newCachedThreadPool();
 
+  @AfterEach
+  void tearDown() {
+    executor.shutdownNow();
+  }
+
+  // Delivery ownership cannot be lost when a configured bounded executor is temporarily full.
   @Test
-  public void testSubmitIsLinearWhenConcurrencyIs1() {
+  void rejectedSubmissionCompletesInline() {
+    ExecutionQueue queue =
+        new ExecutionQueue(
+            task -> {
+              throw new RejectedExecutionException("saturated");
+            });
+    AtomicInteger completed = new AtomicInteger();
+    queue.submit(completed::incrementAndGet);
+    queue.submit(completed::incrementAndGet);
+    assertEquals(2, completed.get());
+  }
+
+  // A worker must finish its backlog even if the executor rejects subsequent submissions.
+  @Test
+  void executorRejectionWhileDrainingDoesNotLoseQueuedTasks() {
+    AtomicReference<Runnable> worker = new AtomicReference<>();
+    ExecutionQueue queue =
+        new ExecutionQueue(
+            task -> {
+              if (!worker.compareAndSet(null, task)) {
+                throw new RejectedExecutionException("saturated");
+              }
+            });
+    List<Integer> completed = new ArrayList<>();
+    queue.submit(() -> completed.add(1));
+    queue.submit(() -> completed.add(2));
+    queue.submit(() -> completed.add(3));
+    worker.get().run();
+    queue.submit(() -> completed.add(4));
+    assertEquals(List.of(1, 2, 3, 4), completed);
+  }
+
+  // A custom executor may translate rejection to another runtime exception. Its reserved worker
+  // must still finish, and later submissions must acquire a fresh worker normally.
+  @Test
+  void executorFailureDuringInitialDispatchDoesNotStrandLaterSubmissions() {
+    AtomicInteger dispatches = new AtomicInteger();
+    ExecutionQueue queue =
+        new ExecutionQueue(
+            task -> {
+              if (dispatches.getAndIncrement() == 0) {
+                throw new IllegalStateException("executor unavailable");
+              }
+              task.run();
+            });
+    List<Integer> completed = new ArrayList<>();
+    queue.submit(() -> completed.add(1));
+    queue.submit(() -> completed.add(2));
+    assertEquals(List.of(1, 2), completed);
+    assertEquals(2, dispatches.get());
+  }
+
+  // Failure to dispatch a continuation cannot retain the running flag or worker reservation.
+  @Test
+  void executorFailureDuringContinuationDoesNotStrandLaterSubmissions() {
+    AtomicReference<Runnable> worker = new AtomicReference<>();
+    ExecutionQueue queue =
+        new ExecutionQueue(
+            task -> {
+              if (!worker.compareAndSet(null, task)) {
+                throw new IllegalStateException("executor unavailable");
+              }
+            });
+    List<Integer> completed = new ArrayList<>();
+    queue.submit(() -> completed.add(1));
+    queue.submit(() -> completed.add(2));
+    queue.submit(() -> completed.add(3));
+    worker.get().run();
+    queue.submit(() -> completed.add(4));
+    assertEquals(List.of(1, 2, 3, 4), completed);
+  }
+
+  // An executor decorator can throw after running a worker. Retrying that completed worker must
+  // not release its reservation twice and permit a later callback to overtake a blocked callback.
+  @Test
+  void executorFailureAfterRunningWorkerPreservesSerialExecution() throws Exception {
+    ExecutionQueue queue =
+        new ExecutionQueue(
+            task -> {
+              task.run();
+              throw new IllegalStateException("executor failed after execution");
+            });
+    AtomicInteger completed = new AtomicInteger();
+    queue.submit(completed::incrementAndGet);
+    assertEquals(1, completed.get());
+
+    CountDownLatch firstStarted = new CountDownLatch(1);
+    CountDownLatch releaseFirst = new CountDownLatch(1);
+    try {
+      var first =
+          executor.submit(
+              () ->
+                  queue.submit(
+                      () -> {
+                        firstStarted.countDown();
+                        try {
+                          assertTrue(releaseFirst.await(5, TimeUnit.SECONDS));
+                        } catch (InterruptedException e) {
+                          Thread.currentThread().interrupt();
+                          throw new AssertionError(e);
+                        }
+                      }));
+      assertTrue(firstStarted.await(5, TimeUnit.SECONDS));
+      queue.submit(completed::incrementAndGet);
+      assertEquals(1, completed.get(), "the second callback must wait for the first callback");
+      releaseFirst.countDown();
+      first.get(5, TimeUnit.SECONDS);
+      assertEquals(2, completed.get());
+      queue.submit(completed::incrementAndGet);
+      assertEquals(3, completed.get());
+    } finally {
+      releaseFirst.countDown();
+    }
+  }
+
+  // Direct executors and nested submissions must not recurse once per queued task.
+  @Test
+  void reentrantSubmissionWithDirectExecutorDrainsWithoutRecursion() {
+    ExecutionQueue queue = new ExecutionQueue(Runnable::run);
+    AtomicInteger completed = new AtomicInteger();
+    Runnable producer =
+        new Runnable() {
+          @Override
+          public void run() {
+            if (completed.incrementAndGet() < 100_000) {
+              queue.submit(this);
+            }
+          }
+        };
+    queue.submit(producer);
+    assertEquals(100_000, completed.get());
+  }
+
+  // A FIFO executor can run unrelated tasks between batches from a busy queue.
+  @Test
+  void fifoExecutorRunsOtherTasksBetweenBatches() {
+    Queue<Runnable> executorTasks = new ArrayDeque<>();
+    ExecutionQueue queue = new ExecutionQueue(executorTasks::add);
+    List<String> completed = new ArrayList<>();
+    queue.submit(() -> completed.add("first"));
+    queue.submit(() -> completed.add("second"));
+    queue.submit(() -> completed.add("third"));
+    executorTasks.add(() -> completed.add("other"));
+    while (!executorTasks.isEmpty()) {
+      executorTasks.remove().run();
+    }
+    assertEquals(List.of("first", "second", "other", "third"), completed);
+  }
+
+  // Rejection fallback must not hold the queue lock across application callbacks.
+  @Test
+  void rejectedWorkerDoesNotBlockConcurrentSubmissionWhileCallbackRuns() throws Exception {
+    ExecutionQueue queue =
+        new ExecutionQueue(
+            task -> {
+              throw new RejectedExecutionException("saturated");
+            });
+    ExecutorService submitter = Executors.newSingleThreadExecutor();
+    AtomicInteger completed = new AtomicInteger();
+    try {
+      queue.submit(
+          () -> {
+            try {
+              submitter
+                  .submit(() -> queue.submit(completed::incrementAndGet))
+                  .get(5, TimeUnit.SECONDS);
+              completed.incrementAndGet();
+            } catch (Exception e) {
+              throw new AssertionError(e);
+            }
+          });
+      assertEquals(2, completed.get());
+    } finally {
+      submitter.shutdownNow();
+    }
+  }
+
+  @Test
+  public void testSubmitIsLinearWhenConcurrencyIs1() throws Exception {
     ExecutionQueue queue = new ExecutionQueue(executor, 1);
 
     AtomicBoolean failed = new AtomicBoolean(false);
@@ -48,6 +242,10 @@ public class ExecutionQueueTest {
           });
     }
 
+    CompletableFuture<Void> drained = new CompletableFuture<>();
+    queue.submit(() -> drained.complete(null));
+    drained.get(30, TimeUnit.SECONDS);
+    assertEquals(1_000_000, n.get());
     assertFalse(failed.get());
   }
 
@@ -66,7 +264,7 @@ public class ExecutionQueueTest {
           });
     }
 
-    latch.await();
+    assertTrue(latch.await(30, TimeUnit.SECONDS));
     assertEquals(100000, count.get());
   }
 }

--- a/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/client/package-info.java
+++ b/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/client/package-info.java
@@ -45,8 +45,10 @@
  *
  * <h2>Threading</h2>
  *
- * <p>Request futures complete on the transport config's executor, never inline on a Netty event
- * loop or wheel-timer thread, so caller continuations cannot stall I/O or timeouts. Publish
- * responses are serialized through a dedicated {@code ExecutionQueue} to preserve ordering.
+ * <p>Request futures normally complete on the transport config's executor. If that executor rejects
+ * work, completion runs on the submitting thread so requests do not remain pending after their
+ * response or failure has been consumed. Caller continuations should return promptly because this
+ * fallback may run on an I/O or timer thread. Publish responses pass through a dedicated {@code
+ * ExecutionQueue} that preserves their order across normal dispatch and rejection fallback.
  */
 package org.eclipse.milo.opcua.stack.transport.client;

--- a/opc-ua-stack/transport/src/test/java/org/eclipse/milo/opcua/stack/transport/client/PublishResponseDispatchTest.java
+++ b/opc-ua-stack/transport/src/test/java/org/eclipse/milo/opcua/stack/transport/client/PublishResponseDispatchTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.transport.client;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import io.netty.channel.Channel;
+import io.netty.channel.embedded.EmbeddedChannel;
+import java.util.ArrayDeque;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.eclipse.milo.opcua.stack.core.types.UaResponseMessageType;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.structured.PublishRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.PublishResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.RequestHeader;
+import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.transport.client.tcp.OpcTcpClientTransportConfig;
+import org.junit.jupiter.api.Test;
+
+class PublishResponseDispatchTest {
+
+  // Once the pending request is removed, only response dispatch owns completion of its future.
+  @Test
+  void rejectedPublishResponseDispatchStillCompletesPendingRequest() throws Exception {
+    try (Fixture fixture = new Fixture()) {
+      CompletableFuture<UaResponseMessageType> pending = fixture.sendPublish();
+      fixture.executor.reject = true;
+      PublishResponse response = response();
+      fixture.transport.handleResponse(1, response);
+      fixture.transport.handleChannelInactive(fixture.channel);
+      assertSame(response, pending.get(5, TimeUnit.SECONDS));
+    }
+  }
+
+  // Rejection during a queue continuation must not lose this response or block later responses.
+  @Test
+  void queuedPublishResponsesAndLaterResponsesSurviveExecutorRejection() throws Exception {
+    try (Fixture fixture = new Fixture()) {
+      CompletableFuture<UaResponseMessageType> first = fixture.sendPublish();
+      CompletableFuture<UaResponseMessageType> second = fixture.sendPublish();
+      CompletableFuture<UaResponseMessageType> third = fixture.sendPublish();
+      PublishResponse response = response();
+      fixture.transport.handleResponse(1, response);
+      fixture.transport.handleResponse(2, response);
+      fixture.transport.handleResponse(3, response);
+      assertEquals(1, fixture.executor.tasks.size());
+      fixture.executor.reject = true;
+      fixture.executor.tasks.remove().run();
+      assertSame(response, first.get(5, TimeUnit.SECONDS));
+      assertSame(response, second.get(5, TimeUnit.SECONDS));
+      assertSame(response, third.get(5, TimeUnit.SECONDS));
+      CompletableFuture<UaResponseMessageType> later = fixture.sendPublish();
+      fixture.transport.handleResponse(4, response);
+      assertSame(response, later.get(5, TimeUnit.SECONDS));
+    }
+  }
+
+  private static PublishResponse response() {
+    return new PublishResponse(null, uint(1), null, false, null, null, null);
+  }
+
+  private static final class Fixture implements AutoCloseable {
+    final ControlledExecutor executor = new ControlledExecutor();
+    final EmbeddedChannel channel = new EmbeddedChannel();
+    final Transport transport =
+        new Transport(
+            OpcTcpClientTransportConfig.newBuilder().setExecutor(executor).build(), channel);
+
+    CompletableFuture<UaResponseMessageType> sendPublish() {
+      var header =
+          new RequestHeader(
+              NodeId.NULL_VALUE, DateTime.now(), uint(0), uint(0), null, uint(0), null);
+      return transport.sendRequestMessage(new PublishRequest(header, null));
+    }
+
+    @Override
+    public void close() {
+      channel.finishAndReleaseAll();
+      executor.shutdown();
+    }
+  }
+
+  private static final class Transport extends AbstractUascClientTransport {
+    private final Channel channel;
+
+    Transport(OpcClientTransportConfig config, Channel channel) {
+      super(config);
+      this.channel = channel;
+    }
+
+    @Override
+    protected CompletableFuture<Channel> getChannel() {
+      return CompletableFuture.completedFuture(channel);
+    }
+
+    @Override
+    public OpcClientTransportConfig getConfig() {
+      return config;
+    }
+
+    @Override
+    public CompletableFuture<Unit> connect(ClientApplicationContext context) {
+      return CompletableFuture.completedFuture(Unit.VALUE);
+    }
+
+    @Override
+    public CompletableFuture<Unit> disconnect() {
+      return CompletableFuture.completedFuture(Unit.VALUE);
+    }
+  }
+
+  private static final class ControlledExecutor extends AbstractExecutorService {
+    final Queue<Runnable> tasks = new ArrayDeque<>();
+    boolean reject;
+
+    @Override
+    public void execute(Runnable task) {
+      if (reject) {
+        throw new RejectedExecutionException("saturated");
+      }
+      tasks.add(task);
+    }
+
+    @Override
+    public void shutdown() {
+      reject = true;
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+      shutdown();
+      return List.copyOf(tasks);
+    }
+
+    @Override
+    public boolean isShutdown() {
+      return reject;
+    }
+
+    @Override
+    public boolean isTerminated() {
+      return reject;
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) {
+      return reject;
+    }
+  }
+}


### PR DESCRIPTION
When the configured executor rejects a queued callback, its worker reservation can remain held and later callbacks stop progressing. This can leave a received Publish response's future pending or stop a reverse server target before its connection attempt starts.

Reserve workers before dispatch and fall back to the submitting thread when dispatch fails. Keep ordered execution, bounded batches, and bounded stack depth with direct executors. A completed worker also ignores a second invocation when a decorating executor runs it and then throws.

Regressions cover initial and continuation rejection, custom executor failures, concurrent submissions, direct execution, pending Publish futures, and reverse target attempts. Callbacks may run on the submitting thread during fallback, so they should return promptly.

## Verification

Formatting and full clean compile passed. The selected regression suites passed (20 tests, no failures or errors).

```sh
mise exec -- mvn -q -pl opc-ua-sdk/sdk-server,opc-ua-stack/transport -am verify '-Dtest=ExecutionQueueTest,PublishResponseDispatchTest,ReverseConnectTargetManagerTest' -Dsurefire.failIfNoSpecifiedTests=false
```
