### PR TITLE
Keep server startup completion private from callers

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServer.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServer.java
@@ -201,17 +201,18 @@ public class OpcUaServer extends AbstractServiceHandler {
 
   private final Map<TransportProfile, OpcServerTransport> transports = new ConcurrentHashMap<>();
 
-  // lifecycleState, startupFuture, and shutdownFuture are guarded by lifecycleLock.
+  // lifecycleState and the lifecycle futures are guarded by lifecycleLock.
   // lifecycleParticipants is mutated under the lock and only while state is NEW, so the startup
   // thread may iterate it unlocked once the state leaves NEW and registration is closed.
   // startedParticipants is confined to the thread executing startup; teardown reads it only after
-  // startupFuture completes, which orders the accesses.
+  // the private startupCompletion completes, which orders the accesses.
   private final Object lifecycleLock = new Object();
   private final List<Lifecycle> lifecycleParticipants = new ArrayList<>();
   private final List<Lifecycle> startedParticipants = new ArrayList<>();
 
   private ServerLifecycleState lifecycleState = ServerLifecycleState.NEW;
   private @Nullable CompletableFuture<OpcUaServer> startupFuture;
+  private @Nullable CompletableFuture<OpcUaServer> startupCompletion;
   private @Nullable CompletableFuture<OpcUaServer> shutdownFuture;
 
   private final EventBus eventBus = new EventBus("server");
@@ -384,6 +385,8 @@ public class OpcUaServer extends AbstractServiceHandler {
    *
    * <p>Startup is single-flight. Concurrent or subsequent calls return the same future. Once
    * startup begins, the server is terminal: a failed or shut-down server cannot be started again.
+   * Cancelling or completing the returned future does not stop startup or release shutdown's wait
+   * for the startup work to finish.
    *
    * <p>A {@link #shutdown()} requested before endpoints are bound abandons startup and fails this
    * future; a later request lets startup complete and then tears the server down.
@@ -392,6 +395,7 @@ public class OpcUaServer extends AbstractServiceHandler {
    */
   public CompletableFuture<OpcUaServer> startup() {
     CompletableFuture<OpcUaServer> future;
+    CompletableFuture<OpcUaServer> result;
 
     synchronized (lifecycleLock) {
       if (startupFuture != null) {
@@ -405,7 +409,10 @@ public class OpcUaServer extends AbstractServiceHandler {
       }
 
       lifecycleState = ServerLifecycleState.STARTING;
-      startupFuture = future = new CompletableFuture<>();
+      startupCompletion = future = new CompletableFuture<>();
+      // The public result may be cancelled or completed by a caller. Only the private future
+      // establishes when shutdown can safely inspect participants and release core facilities.
+      startupFuture = result = new CompletableFuture<>();
     }
 
     try {
@@ -420,6 +427,7 @@ public class OpcUaServer extends AbstractServiceHandler {
       }
 
       future.complete(this);
+      result.complete(this);
     } catch (Throwable t) {
       rollbackStartup(t);
 
@@ -430,9 +438,10 @@ public class OpcUaServer extends AbstractServiceHandler {
       }
 
       future.completeExceptionally(t);
+      result.completeExceptionally(t);
     }
 
-    return future;
+    return result;
   }
 
   private void startupInternal() throws UaException {
@@ -614,7 +623,7 @@ public class OpcUaServer extends AbstractServiceHandler {
       }
 
       shutdownFuture = newShutdownFuture = new CompletableFuture<>();
-      startupToAwait = startupFuture;
+      startupToAwait = startupCompletion;
       lifecycleState = ServerLifecycleState.SHUTTING_DOWN;
     }
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/package-info.java
@@ -44,7 +44,8 @@
  * reverse-connect endpoints. Startup rollback and terminal shutdown stop only successfully started
  * participants, in reverse order. On normal shutdown, transports and sessions are quiesced first;
  * participant shutdown therefore runs without external server visibility but before the standard
- * address space and event facilities are torn down.
+ * address space and event facilities are torn down. Shutdown waits for the actual startup work,
+ * even if an application cancels or completes the public startup result.
  *
  * <p>{@link org.eclipse.milo.opcua.sdk.server.LifecycleManager} applies the same ownership rule
  * within composite components: failed child startup unwinds successfully started children in

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/OpcUaServerLifecycleParticipantTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/OpcUaServerLifecycleParticipantTest.java
@@ -42,6 +42,8 @@ import org.eclipse.milo.opcua.stack.transport.server.OpcServerTransport;
 import org.eclipse.milo.opcua.stack.transport.server.ServerApplicationContext;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class OpcUaServerLifecycleParticipantTest {
 
@@ -148,10 +150,14 @@ class OpcUaServerLifecycleParticipantTest {
     server.addLifecycleParticipant(
         participant(() -> events.add("start-c"), () -> events.add("stop-c")));
 
+    CompletableFuture<OpcUaServer> startup = server.startup();
+    CompletableFuture<Throwable> callbackFailure = new CompletableFuture<>();
+    startup.whenComplete((result, failure) -> callbackFailure.complete(failure));
     ExecutionException ex =
-        assertThrows(ExecutionException.class, () -> server.startup().get(5, TimeUnit.SECONDS));
+        assertThrows(ExecutionException.class, () -> startup.get(5, TimeUnit.SECONDS));
 
     assertSame(startupFailure, ex.getCause());
+    assertSame(startupFailure, callbackFailure.get(5, TimeUnit.SECONDS));
     assertEquals(List.of("start-a", "start-b", "stop-a"), events);
     assertFalse(transport.bound);
 
@@ -447,6 +453,56 @@ class OpcUaServerLifecycleParticipantTest {
     } finally {
       releaseStartup.countDown();
       executor.shutdownNow();
+    }
+  }
+
+  // A cancelled or externally completed result is not evidence that the startup callback returned.
+  @ParameterizedTest
+  @ValueSource(strings = {"cancel", "complete", "fail"})
+  void publicStartupCompletionCannotReleaseShutdownBarrier(String completion) throws Exception {
+    var startupEntered = new CountDownLatch(1);
+    var releaseStartup = new CountDownLatch(1);
+    var participantStopped = new AtomicBoolean();
+    OpcUaServer server = newServer(new RecordingTransport());
+    server.addLifecycleParticipant(
+        participant(
+            () -> {
+              startupEntered.countDown();
+              await(releaseStartup);
+            },
+            () -> {
+              assertTrue(server.getEventInstantiator().isRunning());
+              assertTrue(
+                  server
+                      .getAddressSpaceManager()
+                      .isRegistered(server.getOpcUaNamespace().getNodeManager()));
+              participantStopped.set(true);
+            }));
+
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    try {
+      Future<CompletableFuture<OpcUaServer>> firstCall = executor.submit(server::startup);
+      assertTrue(startupEntered.await(5, TimeUnit.SECONDS));
+      CompletableFuture<OpcUaServer> result = server.startup();
+      switch (completion) {
+        case "cancel" -> assertTrue(result.cancel(false));
+        case "complete" -> assertTrue(result.complete(server));
+        case "fail" ->
+            assertTrue(result.completeExceptionally(new IllegalStateException("caller")));
+        default -> throw new AssertionError(completion);
+      }
+
+      CompletableFuture<OpcUaServer> shutdown = server.shutdown();
+      assertFalse(shutdown.isDone(), "shutdown must await the participant callback");
+      assertTrue(server.getEventInstantiator().isRunning());
+      releaseStartup.countDown();
+      assertSame(result, firstCall.get(5, TimeUnit.SECONDS));
+      shutdown.get(5, TimeUnit.SECONDS);
+      assertTrue(participantStopped.get());
+    } finally {
+      releaseStartup.countDown();
+      executor.shutdown();
+      assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
     }
   }
 


### PR DESCRIPTION
An application could cancel or complete the shared `OpcUaServer.startup()` future while a lifecycle participant was still starting. Shutdown treated that public result as proof that startup had finished and could remove core facilities before the participant's cleanup.

A private completion future now controls shutdown ordering. Callers still receive the same shared public result, and callbacks still receive the original startup exception. Completing or cancelling that result cannot release the internal startup wait.

Regressions hold a participant inside startup, mutate the public future through cancellation or either completion method, and verify that shutdown waits while core facilities remain available.

Formatting, a full clean compile, and the selected regression suites passed for this branch.

Based on https://github.com/eclipse-milo/milo/pull/1876 so the diff contains only this fix.
