### PR TITLE
Fence type model compilation against concurrent invalidation

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/TypeModelCache.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/TypeModelCache.java
@@ -48,7 +48,7 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
  */
 public class TypeModelCache {
 
-  private final Cache<NodeId, TypeInstantiationModel> models = CacheBuilder.newBuilder().build();
+  private volatile Cache<NodeId, TypeInstantiationModel> models = CacheBuilder.newBuilder().build();
 
   private final Supplier<TypeModelCompiler> compilerFactory;
 
@@ -89,7 +89,16 @@ public class TypeModelCache {
       throws ModelCompilationException {
 
     try {
-      return models.get(typeDefinitionId, () -> compilerFactory.get().compile(typeDefinitionId));
+      while (true) {
+        Cache<NodeId, TypeInstantiationModel> current = models;
+        TypeInstantiationModel model =
+            current.get(typeDefinitionId, () -> compilerFactory.get().compile(typeDefinitionId));
+        synchronized (this) {
+          if (models == current) {
+            return model;
+          }
+        }
+      }
     } catch (ExecutionException e) {
       // compile(...)'s only checked exception; Guava wraps it here.
       throw (ModelCompilationException) e.getCause();
@@ -120,16 +129,23 @@ public class TypeModelCache {
    *
    * @param nodeId the {@link NodeId} of the changed node.
    */
-  public void invalidate(NodeId nodeId) {
+  public synchronized void invalidate(NodeId nodeId) {
+    Cache<NodeId, TypeInstantiationModel> retained = CacheBuilder.newBuilder().build();
     models
         .asMap()
-        .entrySet()
-        .removeIf(e -> e.getKey().equals(nodeId) || e.getValue().dependencies().contains(nodeId));
+        .forEach(
+            (typeId, model) -> {
+              if (!typeId.equals(nodeId) && !model.dependencies().contains(nodeId)) {
+                retained.put(typeId, model);
+              }
+            });
+    // Pending loads have unknown dependencies. Retiring the cache also retires their publication.
+    models = retained;
   }
 
   /** Invalidate every cached model. */
-  public void invalidateAll() {
-    models.invalidateAll();
+  public synchronized void invalidateAll() {
+    models = CacheBuilder.newBuilder().build();
   }
 
   /**

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/package-info.java
@@ -21,6 +21,9 @@
  * org.eclipse.milo.opcua.sdk.server.nodes.instantiation.BrowsePath}, with every ModellingRule
  * classified and provenance preserved for diagnostics.
  *
+ * <p>The cache coordinates explicit invalidation with pending compilations. A load that overlaps
+ * invalidation retries against the current cache before returning a model.
+ *
  * <p><strong>Experimental:</strong> this package is new API, subject to adjustment for one minor
  * release based on experience from Milo's in-tree migrations and validation of the placeholder
  * surface against real companion-specification workloads, after which it freezes. The legacy {@code

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/TypeModelConsistencyTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/TypeModelConsistencyTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
+
+import static org.eclipse.milo.opcua.sdk.server.nodes.instantiation.TypeFixtures.path;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectNode;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class TypeModelConsistencyTest {
+
+  // An invalidation must fence loaders that already read the old declaration graph, including
+  // loaders of dependent types whose dependencies are not known until compilation returns.
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void invalidationDuringCompilationCannotPublishOrReturnTheOldModel(boolean invalidateAll)
+      throws Exception {
+    var fx = TypeFixtures.create();
+    var base = fx.addObjectType("Base", NodeIds.BaseObjectType);
+    var type = fx.addObjectType("Derived", base.getNodeId());
+    var compiled = new CountDownLatch(1);
+    var release = new CountDownLatch(1);
+    var pauseFirst = new AtomicBoolean(true);
+    fx.rebuildReferenceTypeTree();
+    var cache =
+        new TypeModelCache(
+            () ->
+                new TypeModelCompiler(fx.server()) {
+                  @Override
+                  public TypeInstantiationModel compile(NodeId typeId)
+                      throws ModelCompilationException {
+                    TypeInstantiationModel model = super.compile(typeId);
+                    if (pauseFirst.compareAndSet(true, false)) {
+                      compiled.countDown();
+                      try {
+                        if (!release.await(10, TimeUnit.SECONDS)) {
+                          throw new AssertionError("test did not release compilation");
+                        }
+                      } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new AssertionError(e);
+                      }
+                    }
+                    return model;
+                  }
+                });
+    when(fx.server().getTypeModelCache()).thenReturn(cache);
+    var executor = Executors.newSingleThreadExecutor();
+    try {
+      var pending = executor.submit(() -> cache.getOrCompile(type.getNodeId()));
+      assertTrue(compiled.await(10, TimeUnit.SECONDS));
+      fx.addVariableDeclaration(
+          base, "Added", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+      if (invalidateAll) {
+        cache.invalidateAll();
+      } else {
+        cache.invalidate(base.getNodeId());
+      }
+      release.countDown();
+      assertTrue(pending.get(10, TimeUnit.SECONDS).get(path("Added")).isPresent());
+      assertTrue(cache.getOrCompile(type.getNodeId()).get(path("Added")).isPresent());
+      var result =
+          fx.instantiator()
+              .instantiate(
+                  InstantiationRequest.of(UaObjectNode.class, type.getNodeId())
+                      .nodeId(fx.newNodeId("Instance"))
+                      .target(fx.newTargetManager())
+                      .build());
+      assertTrue(result.node(path("Added")).isPresent());
+    } finally {
+      release.countDown();
+      executor.shutdownNow();
+      assertTrue(executor.awaitTermination(10, TimeUnit.SECONDS));
+    }
+  }
+}


### PR DESCRIPTION
Invalidating a type while its compilation is pending can let the old model return and become cached afterward. Invalidation now retires pending loads, retains already-compiled unrelated models, and retries a load that completed against a retired cache. This keeps newly added Mandatory declarations visible to later instantiation.

[Part 3 §6.4.4.4.1](https://reference.opcfoundation.org/specs/OPC-10000-3/6.4.4.4.1) states that "for each existing BrowsePath on the instance a similar Node shall exist". The cache invalidation mechanism is a Milo API contract.

### Verification

Two latch-controlled cases pause a real compilation, add a Mandatory child, invalidate either its base type or the entire cache, and verify both returned/cached models and actual instantiation contain the child.

Formatting, full clean compilation, and 12 selected tests passed for this branch.
