### PR TITLE
Preserve mask positions when optional structure fields are absent

### DIFF
--- a/opc-ua-sdk/codec-json/src/main/java/org/eclipse/milo/sdk/core/types/json/JsonStructCodec.java
+++ b/opc-ua-sdk/codec-json/src/main/java/org/eclipse/milo/sdk/core/types/json/JsonStructCodec.java
@@ -606,8 +606,11 @@ public class JsonStructCodec extends GenericDataTypeCodec<JsonStruct> {
     if (definition.getStructureType() == StructureType.StructureWithOptionalFields) {
       int optionalFieldIndex = 0;
       for (StructureField field : fields) {
-        if (field.getIsOptional() && value.getJsonObject().has(requireNonNull(field.getName()))) {
-          switchField = switchField | (1L << optionalFieldIndex++);
+        if (field.getIsOptional()) {
+          if (value.getJsonObject().has(requireNonNull(field.getName()))) {
+            switchField |= 1L << optionalFieldIndex;
+          }
+          optionalFieldIndex++;
         }
       }
       encoder.encodeUInt32("SwitchField", UInteger.valueOf(switchField));

--- a/opc-ua-sdk/codec-json/src/main/java/org/eclipse/milo/sdk/core/types/json/package-info.java
+++ b/opc-ua-sdk/codec-json/src/main/java/org/eclipse/milo/sdk/core/types/json/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/**
+ * Represents dynamic OPC UA structures as JSON objects while preserving their declared wire types.
+ *
+ * <p>A DataType tree supplies field definitions and inheritance information. Codecs map JSON
+ * members to those fields and use the encoding context for nested structured values. The JSON
+ * object holds application data; the definition determines field order, optional-field mask
+ * positions, and union selection when serializing through an OPC UA encoder.
+ *
+ * <p>Absent optional members remain absent after decoding and re-encoding. Their omission does not
+ * move the mask bits assigned to later fields.
+ */
+package org.eclipse.milo.sdk.core.types.json;

--- a/opc-ua-sdk/codec-json/src/test/java/org/eclipse/milo/sdk/core/types/json/JsonStructCodecTest.java
+++ b/opc-ua-sdk/codec-json/src/test/java/org/eclipse/milo/sdk/core/types/json/JsonStructCodecTest.java
@@ -658,6 +658,27 @@ class JsonStructCodecTest {
 
   private static Stream<Arguments> structWithOptionalScalarFieldsProvider() {
     return Stream.of(
+        // An omitted earlier optional field must not shift a later field's wire mask bit.
+        Arguments.of(
+            new StructWithOptionalScalarFields(
+                "required",
+                null,
+                1,
+                7,
+                2.0,
+                null,
+                new ConcreteTestType((short) 0, 0.0, "", false),
+                null)),
+        Arguments.of(
+            new StructWithOptionalScalarFields(
+                "required",
+                "present",
+                1,
+                null,
+                2.0,
+                3.0,
+                new ConcreteTestType((short) 0, 0.0, "", false),
+                null)),
         Arguments.of(
             new StructWithOptionalScalarFields(
                 "",
@@ -682,6 +703,17 @@ class JsonStructCodecTest {
 
   private static Stream<Arguments> structWithOptionalArrayFieldsProvider() {
     return Stream.of(
+        // Sparse optional arrays use the same mask positions as the declared field order.
+        Arguments.of(
+            new StructWithOptionalArrayFields(
+                new Integer[] {1},
+                null,
+                new String[] {"required"},
+                new String[] {"present"},
+                new Double[] {2.0},
+                null,
+                new ConcreteTestType[0],
+                null)),
         Arguments.of(
             new StructWithOptionalArrayFields(
                 new Integer[] {0, 0},

--- a/opc-ua-sdk/sdk-core/src/main/java/org/eclipse/milo/opcua/sdk/core/types/codec/DynamicStructCodec.java
+++ b/opc-ua-sdk/sdk-core/src/main/java/org/eclipse/milo/opcua/sdk/core/types/codec/DynamicStructCodec.java
@@ -112,9 +112,11 @@ public class DynamicStructCodec extends GenericDataTypeCodec<DynamicStructType> 
     if (definition.getStructureType() == StructureType.StructureWithOptionalFields) {
       int optionalFieldIndex = 0;
       for (StructureField field : fields) {
-        if (field.getIsOptional()
-            && struct.getMembers().containsKey(requireNonNull(field.getName()))) {
-          encodingMask = encodingMask | (1L << optionalFieldIndex++);
+        if (field.getIsOptional()) {
+          if (struct.getMembers().containsKey(requireNonNull(field.getName()))) {
+            encodingMask |= 1L << optionalFieldIndex;
+          }
+          optionalFieldIndex++;
         }
       }
       encoder.encodeUInt32("EncodingMask", UInteger.valueOf(encodingMask));

--- a/opc-ua-sdk/sdk-core/src/main/java/org/eclipse/milo/opcua/sdk/core/types/codec/package-info.java
+++ b/opc-ua-sdk/sdk-core/src/main/java/org/eclipse/milo/opcua/sdk/core/types/codec/package-info.java
@@ -8,6 +8,18 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
+/**
+ * Encodes and decodes dynamic values using the definitions in a DataType tree.
+ *
+ * <p>{@link org.eclipse.milo.opcua.sdk.core.types.codec.DynamicCodecFactory} selects a codec for
+ * each definition. The encoding context supplies nested codecs, while the tree resolves field types
+ * and their inherited builtin representation. Decoded values retain their DataType metadata so they
+ * can later be encoded through the same context.
+ *
+ * <p>Structure definitions determine wire field order and optional-field mask positions. Omitting a
+ * value does not change the position of any later optional field. Applications supply members by
+ * name; codecs translate those members into the declared wire layout.
+ */
 @NullMarked
 package org.eclipse.milo.opcua.sdk.core.types.codec;
 

--- a/opc-ua-sdk/sdk-core/src/test/java/org/eclipse/milo/opcua/sdk/core/types/DynamicTypeSerializationTest.java
+++ b/opc-ua-sdk/sdk-core/src/test/java/org/eclipse/milo/opcua/sdk/core/types/DynamicTypeSerializationTest.java
@@ -771,6 +771,27 @@ class DynamicTypeSerializationTest {
 
   private static Stream<Arguments> structWithOptionalScalarFieldsProvider() {
     return Stream.of(
+        // An omitted earlier optional field must not shift a later field's wire mask bit.
+        Arguments.of(
+            new StructWithOptionalScalarFields(
+                "required",
+                null,
+                1,
+                7,
+                2.0,
+                null,
+                new ConcreteTestType((short) 0, 0.0, "", false),
+                null)),
+        Arguments.of(
+            new StructWithOptionalScalarFields(
+                "required",
+                "present",
+                1,
+                null,
+                2.0,
+                3.0,
+                new ConcreteTestType((short) 0, 0.0, "", false),
+                null)),
         Arguments.of(
             new StructWithOptionalScalarFields(
                 "",
@@ -795,6 +816,17 @@ class DynamicTypeSerializationTest {
 
   private static Stream<Arguments> structWithOptionalArrayFieldsProvider() {
     return Stream.of(
+        // Sparse optional arrays use the same mask positions as the declared field order.
+        Arguments.of(
+            new StructWithOptionalArrayFields(
+                new Integer[] {1},
+                null,
+                new String[] {"required"},
+                new String[] {"present"},
+                new Double[] {2.0},
+                null,
+                new ConcreteTestType[0],
+                null)),
         Arguments.of(
             new StructWithOptionalArrayFields(
                 new Integer[] {0, 0},


### PR DESCRIPTION
When an earlier optional structure field was absent, dynamic codecs assigned a later present field the wrong mask bit. Binary encoding could silently write the wrong field, while the JSON-backed codec could read a missing member.

Both codecs now advance the optional-field index for every declared optional field, independently of whether its value is present. [Part 6 §5.2.7](https://reference.opcfoundation.org/specs/OPC-10000-6/5.2.7) specifies: "The first optional field is assigned bit '0', the second optional field is assigned bit '1'".

Regressions cover omitted scalar and array fields and compare the encoded values with an independent generated codec.

Formatting, a full clean compile, and the selected regression suites passed for this branch.
