### PR TITLE
Fence reverse listener binding after shutdown

### DIFF
--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseConnectManager.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseConnectManager.java
@@ -211,6 +211,10 @@ public final class ReverseConnectManager implements AutoCloseable {
           listenerQueue.pause();
           lock.lock();
           try {
+            if (!running) {
+              throw new CancellationException("ReverseConnectManager stopped during startup");
+            }
+
             ChannelFuture bindFuture = bootstrap.bind(listenerState.bindAddress).sync();
 
             listenerState.bindChannel = bindFuture.channel();

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/package-info.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/package-info.java
@@ -96,6 +96,9 @@
  * consumes one pre-claimed connection directly, installs the standard client UASC pipeline, and
  * then lets the Session FSM create and maintain the Session as it would for outbound TCP.
  *
+ * <p>Shutdown fences listener installation, including a startup still in application bootstrap
+ * customization.
+ *
  * <h2>Security boundary</h2>
  *
  * <p>{@code ReverseHello} is only a routing and resource-admission hint. The types here

--- a/opc-ua-sdk/sdk-client/src/test/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseConnectManagerTest.java
+++ b/opc-ua-sdk/sdk-client/src/test/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseConnectManagerTest.java
@@ -108,6 +108,46 @@ class ReverseConnectManagerTest {
     assertFalse(stopped.listeners().get(0).bound());
   }
 
+  // A shutdown completed during application customization must fence the later listener bind.
+  @Test
+  void shutdownDuringStartupPreventsLateListenerBind() throws Exception {
+    CountDownLatch customizing = new CountDownLatch(1);
+    CountDownLatch resumeStartup = new CountDownLatch(1);
+    manager =
+        newManagerBuilder()
+            .setBootstrapCustomizer(
+                bootstrap -> {
+                  customizing.countDown();
+                  try {
+                    assertTrue(resumeStartup.await(5, TimeUnit.SECONDS));
+                  } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new AssertionError(e);
+                  }
+                })
+            .build();
+    ExecutorService startupExecutor = Executors.newSingleThreadExecutor();
+    try {
+      Future<?> startup =
+          startupExecutor.submit(
+              () -> {
+                manager.startup();
+                return null;
+              });
+      assertTrue(customizing.await(5, TimeUnit.SECONDS));
+      manager.shutdown();
+      resumeStartup.countDown();
+      ExecutionException failure =
+          assertThrows(ExecutionException.class, () -> startup.get(5, TimeUnit.SECONDS));
+      assertInstanceOf(CancellationException.class, failure.getCause());
+      assertFalse(manager.snapshot().running());
+      assertFalse(manager.snapshot().listeners().get(0).bound());
+    } finally {
+      resumeStartup.countDown();
+      startupExecutor.shutdownNow();
+    }
+  }
+
   @Test
   void shutdownCancelsPreStartupRegistrations() {
     manager = newManagerBuilder().build();


### PR DESCRIPTION
Shutdown can finish while a reverse manager's startup is inside application bootstrap customization. When customization returns, startup could still bind a listener and leave a socket open after shutdown.

Recheck the running state under the existing lock immediately before binding. A deterministic regression pauses customization, completes shutdown, then resumes startup and verifies that startup is cancelled and no listener becomes bound. This enforces the manager's documented synchronous shutdown contract.

## Verification

Formatting and full clean compile passed. The selected regression suites passed (21 tests, no failures or errors).

```sh
mise exec -- mvn -q -pl opc-ua-sdk/sdk-client -am verify '-Dtest=ReverseConnectManagerTest' -Dsurefire.failIfNoSpecifiedTests=false
```
