### PR TITLE
Preserve type and element boundaries in model fingerprints

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/AttributeSnapshot.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/AttributeSnapshot.java
@@ -14,6 +14,7 @@ import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumMap;
+import java.util.HexFormat;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -25,8 +26,16 @@ import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectTypeNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableTypeNode;
 import org.eclipse.milo.opcua.stack.core.AttributeId;
+import org.eclipse.milo.opcua.stack.core.UaSerializationException;
+import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
+import org.eclipse.milo.opcua.stack.core.types.UaStructuredType;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Matrix;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.jspecify.annotations.Nullable;
@@ -232,44 +241,63 @@ public final class AttributeSnapshot {
     return sb.toString();
   }
 
-  /**
-   * A canonical, content-complete string of an attribute value. Arrays render element-wise
-   * (identity-based {@code Object.toString} never leaks in: {@link DataValue} and {@link Variant}
-   * are decomposed so contained arrays also render element-wise).
-   */
+  /** Type tags and length prefixes keep values and array element boundaries unambiguous. */
   private static String canonicalString(@Nullable Object value) {
     if (value == null) {
-      return "null";
+      return "N;";
     }
-    if (value instanceof Object[] array) {
-      return Arrays.deepToString(array);
-    }
-    if (value.getClass().isArray()) {
+    StringBuilder contents = new StringBuilder();
+    if (value instanceof byte[] bytes) {
+      contents.append(bytes.length).append(':').append(HexFormat.of().formatHex(bytes));
+    } else if (value.getClass().isArray()) {
       int length = Array.getLength(value);
-      StringBuilder sb = new StringBuilder("[");
+      contents.append(length).append(':');
       for (int i = 0; i < length; i++) {
-        if (i > 0) {
-          sb.append(", ");
-        }
-        sb.append(Array.get(value, i));
+        contents.append(canonicalString(Array.get(value, i)));
       }
-      return sb.append(']').toString();
+    } else if (value instanceof DataValue dataValue) {
+      contents.append(canonicalString(dataValue.getValue()));
+      contents.append(canonicalString(dataValue.getStatusCode()));
+      contents.append(canonicalString(dataValue.getSourceTime()));
+      contents.append(canonicalString(dataValue.getSourcePicoseconds()));
+    } else if (value instanceof Variant variant) {
+      contents.append(canonicalString(variant.getValue()));
+    } else if (value instanceof LocalizedText text) {
+      contents.append(canonicalString(text.getLocale()));
+      contents.append(canonicalString(text.getText()));
+    } else if (value instanceof QualifiedName name) {
+      contents.append(canonicalString(name.getNamespaceIndex()));
+      contents.append(canonicalString(name.getName()));
+    } else if (value instanceof Matrix matrix) {
+      contents.append(canonicalString(matrix.getDimensions()));
+      contents.append(canonicalString(matrix.getElements()));
+      contents.append(canonicalString(matrix.getDataTypeId().orElse(null)));
+    } else if (value instanceof UaStructuredType structure && hasStandardCodec(structure)) {
+      try {
+        contents.append(
+            canonicalString(ExtensionObject.encode(DefaultEncodingContext.INSTANCE, structure)));
+      } catch (UaSerializationException e) {
+        // A standard outer structure may contain an application-defined value without a codec.
+        contents.append(value);
+      }
+    } else if (value instanceof ExtensionObject extension) {
+      contents.append(canonicalString(extension.getEncodingOrTypeId()));
+      contents.append(canonicalString(extension.getBody()));
+    } else if (value instanceof ByteString bytes) {
+      contents.append(canonicalString(bytes.bytes()));
+    } else {
+      contents.append(value);
     }
-    if (value instanceof DataValue dataValue) {
-      return "DataValue{"
-          + canonicalString(dataValue.getValue().getValue())
-          + ", status="
-          + dataValue.getStatusCode()
-          + ", sourceTime="
-          + dataValue.getSourceTime()
-          + ", sourcePicoseconds="
-          + dataValue.getSourcePicoseconds()
-          + "}";
-    }
-    if (value instanceof Variant variant) {
-      return "Variant{" + canonicalString(variant.getValue()) + "}";
-    }
-    return String.valueOf(value);
+    String type = value.getClass().getName();
+    return type.length() + ":" + type + contents.length() + ":" + contents;
+  }
+
+  private static boolean hasStandardCodec(UaStructuredType structure) {
+    return structure
+        .getBinaryEncodingId()
+        .toNodeId(DefaultEncodingContext.INSTANCE.getNamespaceTable())
+        .map(id -> DefaultEncodingContext.INSTANCE.getDataTypeManager().getCodec(id) != null)
+        .orElse(false);
   }
 
   /** Array-aware, null-safe hash of an attribute value, used by {@link #hashCode}. */

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/package-info.java
@@ -22,7 +22,8 @@
  * classified and provenance preserved for diagnostics.
  *
  * <p>The cache coordinates explicit invalidation with pending compilations. A load that overlaps
- * invalidation retries against the current cache before returning a model.
+ * invalidation retries against the current cache before returning a model. Fingerprints retain type
+ * and element boundaries so apply can reject plans compiled against different attribute values.
  *
  * <p><strong>Experimental:</strong> this package is new API, subject to adjustment for one minor
  * release based on experience from Milo's in-tree migrations and validation of the placeholder

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/AttributeSnapshotCompatibilityTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/AttributeSnapshotCompatibilityTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.eclipse.milo.opcua.stack.core.AttributeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.junit.jupiter.api.Test;
+
+class AttributeSnapshotCompatibilityTest {
+  // Binary bodies are common inside standard structures. Their fingerprint should scale with
+  // payload bytes, while retaining content, length, element-boundary, and Java-type distinctions.
+  @Test
+  void binaryFingerprintsStayCompactAndDistinguishContentAndFraming() {
+    byte[] bytes = new byte[4096];
+    String original = fingerprint(ByteString.of(bytes));
+    assertTrue(original.length() < bytes.length * 3, "binary payload should have compact framing");
+    bytes[bytes.length - 1] = 1;
+    assertNotEquals(original, fingerprint(ByteString.of(bytes)));
+    assertNotEquals(fingerprint(new byte[] {1, 23}), fingerprint(new byte[] {12, 3}));
+    assertNotEquals(fingerprint(new byte[] {1}), fingerprint(new byte[] {0, 1}));
+    assertNotEquals(fingerprint(new byte[] {1}), fingerprint(new Byte[] {1}));
+    assertNotEquals(fingerprint(new byte[] {1}), fingerprint(ByteString.of(new byte[] {1})));
+    assertNotEquals(fingerprint(ByteString.NULL_VALUE), fingerprint(ByteString.of(new byte[0])));
+  }
+
+  private static String fingerprint(Object value) {
+    return AttributeSnapshot.builder().put(AttributeId.Value, value).build().contentHash();
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/TypeModelConsistencyTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/TypeModelConsistencyTest.java
@@ -11,6 +11,8 @@
 package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
 
 import static org.eclipse.milo.opcua.sdk.server.nodes.instantiation.TypeFixtures.path;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
@@ -20,7 +22,12 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectNode;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -89,5 +96,37 @@ class TypeModelConsistencyTest {
       executor.shutdownNow();
       assertTrue(executor.awaitTermination(10, TimeUnit.SECONDS));
     }
+  }
+
+  // String rendering collapses {"a, b"} and {"a", "b"}; apply must still reject the stale plan.
+  @Test
+  void arrayElementBoundariesChangeTheRevisionAndRejectAStalePlan() throws Exception {
+    var fx = TypeFixtures.create();
+    var type = fx.addObjectType("Strings", NodeIds.BaseObjectType);
+    var declaration =
+        fx.addVariableDeclaration(
+            type, "V", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+    declaration.setDataType(NodeIds.String);
+    declaration.setValueRank(1);
+    declaration.setValue(
+        new DataValue(new Variant(new String[] {"a, b"}), StatusCode.GOOD, DateTime.MIN_VALUE));
+    var target = fx.newTargetManager();
+    var instantiator = fx.instantiator();
+    var plan =
+        instantiator.plan(
+            InstantiationRequest.of(UaObjectNode.class, type.getNodeId())
+                .nodeId(fx.newNodeId("Instance"))
+                .target(target)
+                .build());
+    long original = fx.typeModelCache().getOrCompile(type.getNodeId()).modelRevision();
+    declaration.setValue(
+        new DataValue(new Variant(new String[] {"a", "b"}), StatusCode.GOOD, DateTime.MIN_VALUE));
+    fx.typeModelCache().invalidate(declaration.getNodeId());
+    assertNotEquals(original, fx.typeModelCache().getOrCompile(type.getNodeId()).modelRevision());
+    var error = assertThrows(InstantiationException.class, () -> instantiator.apply(plan));
+    assertTrue(
+        error.getDiagnostics().stream()
+            .anyMatch(d -> d.code() == InstantiationDiagnostic.Code.MODEL_CHANGED));
+    assertTrue(target.getNodes().isEmpty());
   }
 }


### PR DESCRIPTION
Attribute rendering can give different values the same model revision, allowing a stale instantiation plan to apply. Fingerprints now frame Java types, lengths, and nested element boundaries. Standard structures use their binary codecs, unsupported nested application values retain the opaque contract, and binary payloads use compact hexadecimal framing.

[Part 3 §6.4.2](https://reference.opcfoundation.org/specs/OPC-10000-3/6.4.2) states: "If new copies are created, then the Attribute values of the InstanceDeclarations are used as the initial values." Apply-time freshness checks are a Milo contract supporting that behavior.

### Verification

The stale-plan regression distinguishes a one-element string array containing a comma from a two-element array and requires MODEL_CHANGED with no target nodes created. Binary fingerprint checks preserve content, length, type, leading-zero, and null/empty distinctions while bounding size.

Formatting, full clean compilation, and 89 selected tests passed for this branch.

Based on https://github.com/eclipse-milo/milo/pull/1881 so the diff contains only this fix.
