### PR TITLE
Decode XML Variants independently of indentation

### DIFF
--- a/opc-ua-stack/encoding-xml/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlDecoder.java
+++ b/opc-ua-stack/encoding-xml/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlDecoder.java
@@ -607,7 +607,8 @@ public class OpcUaXmlDecoder implements UaDecoder, AutoCloseable {
       Node node = currentNode;
 
       try {
-        currentNode = node.getFirstChild().getFirstChild();
+        Node valueNode = firstElementChild(node);
+        currentNode = valueNode != null ? firstElementChild(valueNode) : null;
 
         if (currentNode == null) {
           return Variant.NULL_VALUE;
@@ -652,39 +653,26 @@ public class OpcUaXmlDecoder implements UaDecoder, AutoCloseable {
 
         return array;
       } else if (nodeName.equals("Matrix")) {
-        List<Integer> dimensions = new ArrayList<>();
-        Node child = node.getFirstChild();
-        for (int i = 0; i < child.getChildNodes().getLength(); i++) {
-          currentNode = child.getChildNodes().item(i);
-
-          if (currentNode.getNodeType() == Node.ELEMENT_NODE) {
-            dimensions.add(decodeInt32("Int32"));
-          }
+        Node dimensionsNode = firstElementChild(node);
+        if (dimensionsNode == null) {
+          return Matrix.ofNull();
         }
 
-        List<Object> elements = new ArrayList<>();
-        child = child.getNextSibling();
-        for (int i = 0; i < child.getChildNodes().getLength(); i++) {
-          currentNode = child.getChildNodes().item(i);
-
-          if (currentNode.getNodeType() == Node.ELEMENT_NODE) {
-            String type = currentNode.getLocalName();
-            elements.add(readBuiltinType(type, type));
-          }
+        Node elementsNode = nextElementSibling(dimensionsNode);
+        Node element = elementsNode != null ? firstElementChild(elementsNode) : null;
+        if (element == null) {
+          throw new UaSerializationException(
+              StatusCodes.Bad_DecodingError, "Matrix has dimensions but no elements");
         }
 
-        Class<?> clazz = elements.get(0).getClass();
-        Object array = Array.newInstance(clazz, elements.size());
-        for (int i = 0; i < elements.size(); i++) {
-          Array.set(array, i, elements.get(i));
+        OpcUaDataType dataType;
+        try {
+          dataType = OpcUaDataType.valueOf(element.getLocalName());
+        } catch (IllegalArgumentException e) {
+          throw new UaSerializationException(StatusCodes.Bad_DecodingError, e);
         }
-
-        int[] dims = new int[dimensions.size()];
-        for (int i = 0; i < dimensions.size(); i++) {
-          dims[i] = dimensions.get(i);
-        }
-
-        return new Matrix(array, dims);
+        currentNode = node;
+        return decodeMatrix("Matrix", dataType);
       } else {
         return readBuiltinType(nodeName, nodeName);
       }

--- a/opc-ua-stack/encoding-xml/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/xml/package-info.java
+++ b/opc-ua-stack/encoding-xml/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/xml/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/**
+ * Converts OPC UA values between XML and the stack's Java value types.
+ *
+ * <p>Encoders and decoders use an encoding context for namespaces, limits, and structured-type
+ * codecs. A decoder owns its XML cursor and should be used for one input at a time. Element
+ * boundaries determine the value layout; indentation and comments between elements do not carry
+ * values.
+ *
+ * <p>Variants identify their contained builtin type from the XML element name. Matrix decoding
+ * validates dimensions, element types, and element counts for both Variants and directly decoded
+ * matrices. Structured values are delegated to the codecs registered in the context.
+ */
+package org.eclipse.milo.opcua.stack.core.encoding.xml;

--- a/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlVariantWhitespaceTest.java
+++ b/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlVariantWhitespaceTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.core.encoding.xml;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaSerializationException;
+import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Matrix;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class OpcUaXmlVariantWhitespaceTest {
+
+  // The public value decoder must report malformed matrix element names as decoding failures.
+  @Test
+  void unknownMatrixElementFailsWithDecodingStatus() throws Exception {
+    String xml =
+        "<Matrix><Dimensions><Int32>1</Int32></Dimensions>"
+            + "<Elements><Unknown>7</Unknown></Elements></Matrix>";
+    try (var decoder = new OpcUaXmlDecoder(DefaultEncodingContext.INSTANCE, xml)) {
+      UaSerializationException failure =
+          assertThrows(UaSerializationException.class, decoder::decodeVariantValue);
+      assertEquals(StatusCodes.Bad_DecodingError, failure.getStatusCode().value());
+    }
+  }
+
+  // Formatting and comments around Value must not turn a valid scalar into a null Variant.
+  @ParameterizedTest
+  @ValueSource(strings = {"", "\n  ", "\n<!-- comment -->\n"})
+  void scalarIgnoresWhitespaceBetweenElements(String spacing) throws Exception {
+    String xml = "<Test>" + spacing + "<Value>" + spacing + "<Int32>7</Int32></Value></Test>";
+    try (var decoder = new OpcUaXmlDecoder(DefaultEncodingContext.INSTANCE, xml)) {
+      assertEquals(new Variant(7), decoder.decodeVariant("Test"));
+    }
+  }
+
+  // Matrix dimensions and elements have the same meaning in compact and indented XML.
+  @ParameterizedTest
+  @ValueSource(strings = {"", "\n  ", "\n<!-- comment -->\n"})
+  void matrixIgnoresWhitespaceBetweenElements(String spacing) throws Exception {
+    String xml = matrixXml(spacing, "<Int32>7</Int32><Int32>8</Int32>");
+    try (var decoder = new OpcUaXmlDecoder(DefaultEncodingContext.INSTANCE, xml)) {
+      assertEquals(
+          new Variant(new Matrix(new Integer[] {7, 8}, new int[] {1, 2})),
+          decoder.decodeVariant("Test"));
+    }
+  }
+
+  // Variant matrices must use the same shape validation as direct matrix decoding.
+  @ParameterizedTest
+  @ValueSource(strings = {"<Int32>7</Int32>", "<Int32>7</Int32><String>8</String>"})
+  void malformedMatrixFailsDecoding(String elements) throws Exception {
+    try (var decoder =
+        new OpcUaXmlDecoder(DefaultEncodingContext.INSTANCE, matrixXml("\n  ", elements))) {
+      assertThrows(UaSerializationException.class, () -> decoder.decodeVariant("Test"));
+    }
+  }
+
+  private static String matrixXml(String spacing, String elements) {
+    return "<Test><Value><Matrix>"
+        + spacing
+        + "<Dimensions><Int32>1</Int32><Int32>2</Int32></Dimensions>"
+        + spacing
+        + "<Elements>"
+        + elements
+        + "</Elements></Matrix></Value></Test>";
+  }
+}


### PR DESCRIPTION
Indentation or comments inside an XML Variant could produce a null scalar or make matrix decoding traverse the wrong nodes. The decoder now skips non-element nodes and uses the existing matrix decoder for shape and element-type validation. Invalid matrix types report `Bad_DecodingError`.

[Part 6 §5.3.1.17](https://reference.opcfoundation.org/specs/OPC-10000-6/5.3.1.17) says a scalar Variant "shall contain a single child element with the name of the built-in type" and defines the Matrix Dimensions/Elements structure.

Regressions compare compact, indented, and commented values and exercise malformed matrices.

Formatting, a full clean compile, and the selected regression suites passed for this branch.
