### PR TITLE
Release cancelled reverse connection claims

### DIFF
--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseConnectCandidateSnapshot.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseConnectCandidateSnapshot.java
@@ -38,7 +38,7 @@ import org.jspecify.annotations.Nullable;
  * @param completedAt the time the candidate reached a terminal manager state, or {@code null} while
  *     it can still be matched or claimed.
  * @param rejectionReason the manager-level reason the candidate was rejected, expired, or closed,
- *     or {@code null} for non-terminal and successfully claimed candidates.
+ *     or {@code null} for non-terminal and claimed candidates.
  * @param rejectionStatusCode the TCP error status associated with a rejected or expired candidate,
  *     or {@code null} when no error status applies.
  * @param diagnostic a human-readable diagnostic associated with rejection, expiry, or close events,

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseConnectCandidateState.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseConnectCandidateState.java
@@ -18,7 +18,7 @@ public enum ReverseConnectCandidateState {
   /** {@code ReverseHello} was decoded and verified, but no selector has claimed the socket yet. */
   PENDING,
 
-  /** A selector claimed the socket and ownership has been transferred to the caller. */
+  /** A selector reserved ownership of the socket; connection delivery may still be pending. */
   CLAIMED,
 
   /** The manager rejected the socket before it could be claimed. */

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseConnectManager.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseConnectManager.java
@@ -349,6 +349,13 @@ public final class ReverseConnectManager implements AutoCloseable {
       lock.unlock();
     }
 
+    registration.connectionFuture.whenComplete(
+        (connection, failure) -> {
+          if (failure != null) {
+            unregisterSelector(registration.id);
+          }
+        });
+
     if (stoppedException != null) {
       registration.connectionFuture.completeExceptionally(stoppedException);
     }
@@ -1249,7 +1256,13 @@ public final class ReverseConnectManager implements AutoCloseable {
 
     void completeAndFire(ReverseConnectManager manager) {
       if (connection != null && registration != null && snapshot != null) {
-        registration.connectionFuture.complete(connection);
+        if (!registration.connectionFuture.complete(connection)) {
+          manager.logger.debug(
+              "Closing claimed reverse-connect candidate {} because its registration future no"
+                  + " longer accepts delivery.",
+              snapshot.id());
+          connection.close();
+        }
         manager.fireCandidateClaimed(snapshot);
       }
     }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseConnectRegistration.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseConnectRegistration.java
@@ -49,7 +49,9 @@ public final class ReverseConnectRegistration implements AutoCloseable {
    * <p>The future completes with a {@link ReverseConnectConnection} after the first matching
    * candidate is claimed. It completes exceptionally if the registration is closed before a match,
    * if the selector throws while matching, or if the manager shuts down while the registration is
-   * still waiting.
+   * still waiting. Cancelling this future or completing it exceptionally (including through {@link
+   * CompletableFuture#orTimeout(long, java.util.concurrent.TimeUnit)}) unregisters the selector. If
+   * cancellation races a claim, the undeliverable connection is closed.
    *
    * @return the claim future.
    */

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/package-info.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/package-info.java
@@ -49,6 +49,11 @@
  * application rejected it, the pending limit was exceeded, the hold time expired, the manager
  * stopped, the peer closed the channel, or a selector threw.
  *
+ * <p>Claimed snapshots, callbacks, and counters record ownership reserved for a selector. Delivery
+ * to its registration future happens afterward. If cancellation or another exceptional completion
+ * prevents delivery, the manager closes the undelivered connection and logs a debug diagnostic; the
+ * recorded claim remains part of the manager's history.
+ *
  * <p>Listener callbacks are serialized on the manager callback executor. For a successfully claimed
  * candidate the callback order is accepted, then claimed if a selector was already waiting, or
  * accepted, pending, then claimed when the candidate first has to be parked. Rejected, expired, and
@@ -97,7 +102,9 @@
  * then lets the Session FSM create and maintain the Session as it would for outbound TCP.
  *
  * <p>Shutdown fences listener installation, including a startup still in application bootstrap
- * customization.
+ * customization. A selector owns only its pending claim: cancelling or exceptionally completing the
+ * registration future removes the selector, and a claim that races that completion closes its
+ * undeliverable channel.
  *
  * <h2>Security boundary</h2>
  *

--- a/opc-ua-sdk/sdk-client/src/test/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseConnectManagerTest.java
+++ b/opc-ua-sdk/sdk-client/src/test/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseConnectManagerTest.java
@@ -148,6 +148,44 @@ class ReverseConnectManagerTest {
     }
   }
 
+  // A cancelled raw registration must leave later candidates available to another caller.
+  @Test
+  void cancelledRegistrationDoesNotClaimLaterCandidate() throws Exception {
+    manager = newManagerBuilder().build();
+    manager.startup();
+    ReverseConnectRegistration abandoned = manager.registerSelector(ReverseConnectSelector.any());
+    abandoned.connectionFuture().cancel(false);
+    ReverseConnectRegistration replacement = manager.registerSelector(ReverseConnectSelector.any());
+    try (Socket socket = sendReverseHello(boundAddress(manager), endpointUrl())) {
+      ReverseConnectConnection connection = replacement.connectionFuture().get(5, TimeUnit.SECONDS);
+      assertEquals(1, manager.snapshot().claimedCount());
+      connection.close();
+      assertPeerClosed(socket);
+    }
+  }
+
+  // Completing a claim future can race cancellation after the manager relinquishes ownership.
+  @Test
+  void cancellationAfterClaimClosesUndeliverableConnection() throws Exception {
+    manager = newManagerBuilder().build();
+    manager.startup();
+    ReverseConnectRegistration registration = manager.registerSelector(candidate -> false);
+    try (Socket socket = sendReverseHello(boundAddress(manager), endpointUrl())) {
+      waitUntil(() -> manager.snapshot().pendingCandidates().size() == 1);
+      UUID candidateId = manager.snapshot().pendingCandidates().get(0).id();
+      Method claim =
+          ReverseConnectManager.class.getDeclaredMethod("claimCandidate", UUID.class, UUID.class);
+      claim.setAccessible(true);
+      Object handoff = claim.invoke(manager, candidateId, registration.id());
+      registration.connectionFuture().cancel(false);
+      Method complete =
+          handoff.getClass().getDeclaredMethod("completeAndFire", ReverseConnectManager.class);
+      complete.setAccessible(true);
+      complete.invoke(handoff, manager);
+      assertPeerClosed(socket);
+    }
+  }
+
   @Test
   void shutdownCancelsPreStartupRegistrations() {
     manager = newManagerBuilder().build();


### PR DESCRIPTION
Cancelling a registration's connection future can leave its selector active, allowing it to claim a later connection that nobody can receive. Cancellation can also race the interval between reserving a claim and delivering the connection.

Unregister selectors when their futures complete exceptionally, including cancellation and timeout. Close a claimed connection if its future rejects delivery, with a debug diagnostic identifying the candidate. Claimed snapshots and counters continue to record the ownership reservation. Socket regressions cover cancellation before a candidate arrives and after ownership has been reserved.

## Verification

Formatting and full clean compile passed. The selected regression suites passed (23 tests, no failures or errors).

```sh
mise exec -- mvn -q -pl opc-ua-sdk/sdk-client -am verify '-Dtest=ReverseConnectManagerTest' -Dsurefire.failIfNoSpecifiedTests=false
```

Based on https://github.com/eclipse-milo/milo/pull/1883 so the diff contains only this fix.
