### PR TITLE
Isolate nested mutable values in attribute snapshots

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/AttributeSnapshot.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/AttributeSnapshot.java
@@ -63,8 +63,9 @@ import org.jspecify.annotations.Nullable;
  * (the source-side constituents — Variant, StatusCode, sourceTime — are preserved verbatim).
  *
  * <p>Mutable attribute values — arrays (e.g. ArrayDimensions, RolePermissions) and array-valued
- * {@link DataValue}s — are defensively copied on ingress and egress, so neither later mutation of
- * the node-owned value nor mutation of a value read from this snapshot can change the snapshot.
+ * {@link DataValue}s, including standard OPC UA structures and their nested fields, are defensively
+ * copied on ingress and egress. Custom Java values without a standard codec, and standard
+ * structures containing such values, pass through and must be immutable.
  */
 public final class AttributeSnapshot {
 
@@ -315,11 +316,46 @@ public final class AttributeSnapshot {
       return copyArray(value);
     }
     if (value instanceof DataValue dataValue) {
-      Object contained = dataValue.getValue().getValue();
-      if (contained != null && contained.getClass().isArray()) {
-        Object containedCopy = copyArray(contained);
-        return dataValue.copy(b -> b.setValue(new Variant(containedCopy)));
+      Variant copied = (Variant) defensiveCopy(dataValue.getValue());
+      return copied == dataValue.getValue() ? dataValue : dataValue.copy(b -> b.setValue(copied));
+    }
+    if (value instanceof Variant variant) {
+      Object contained = variant.getValue();
+      Object copied = contained == null ? null : defensiveCopy(contained);
+      return copied == contained ? variant : new Variant(copied);
+    }
+    if (value instanceof UaStructuredType structure && hasStandardCodec(structure)) {
+      try {
+        return ExtensionObject.encode(DefaultEncodingContext.INSTANCE, structure)
+            .decode(DefaultEncodingContext.INSTANCE);
+      } catch (UaSerializationException e) {
+        // Preserve the opaque, caller-immutable contract for unencodable nested custom values.
+        return value;
       }
+    }
+    if (value instanceof ByteString bytes) {
+      byte[] data = bytes.bytes();
+      return data == null ? ByteString.NULL_VALUE : ByteString.of(data.clone());
+    }
+    if (value instanceof ExtensionObject.Binary extension) {
+      return ExtensionObject.of(
+          (ByteString) defensiveCopy(extension.getBody()), extension.getEncodingOrTypeId());
+    }
+    if (value instanceof ExtensionObject.Xml extension) {
+      return ExtensionObject.of(extension.getBody(), extension.getEncodingOrTypeId());
+    }
+    if (value instanceof ExtensionObject.Json extension) {
+      return ExtensionObject.of(extension.getBody(), extension.getEncodingOrTypeId());
+    }
+    if (value instanceof Matrix matrix) {
+      Object elements = matrix.getElements();
+      return elements == null
+          ? new Matrix(null)
+          : new Matrix(
+              copyArray(elements),
+              matrix.getDimensions().clone(),
+              matrix.getDataType().orElseThrow(),
+              matrix.getDataTypeId().orElse(null));
     }
     return value;
   }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/package-info.java
@@ -22,8 +22,11 @@
  * classified and provenance preserved for diagnostics.
  *
  * <p>The cache coordinates explicit invalidation with pending compilations. A load that overlaps
- * invalidation retries against the current cache before returning a model. Fingerprints retain type
- * and element boundaries so apply can reject plans compiled against different attribute values.
+ * invalidation retries against the current cache before returning a model. Attribute snapshots copy
+ * arrays and standard OPC UA structures on both ingress and egress; application values without a
+ * standard codec, including standard structures that contain them, must be immutable. Fingerprints
+ * retain type and element boundaries so apply can reject plans compiled against different attribute
+ * values.
  *
  * <p><strong>Experimental:</strong> this package is new API, subject to adjustment for one minor
  * release based on experience from Milo's in-tree migrations and validation of the placeholder

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/AttributeSnapshotCompatibilityTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/AttributeSnapshotCompatibilityTest.java
@@ -10,14 +10,75 @@
 
 package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
 
+import static org.eclipse.milo.opcua.sdk.server.nodes.instantiation.TypeFixtures.path;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.eclipse.milo.opcua.stack.core.AttributeId;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.types.UaStructuredType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Matrix;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.ApplicationType;
+import org.eclipse.milo.opcua.stack.core.types.structured.Argument;
+import org.eclipse.milo.opcua.stack.core.types.structured.KeyValuePair;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class AttributeSnapshotCompatibilityTest {
+  // A standard outer codec does not guarantee that nested application values have standard
+  // codecs. Such values retain the documented opaque, caller-immutable snapshot contract.
+  @Test
+  void standardStructureContainingCustomValueCanStillCompile() throws Exception {
+    var value = new KeyValuePair(new QualifiedName(0, "custom"), new Variant(new OpaqueValue(42)));
+    var fx = TypeFixtures.create();
+    var type = fx.addObjectType("CustomValue", NodeIds.BaseObjectType);
+    var declaration =
+        fx.addVariableDeclaration(
+            type, "V", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+    declaration.setDataType(NodeIds.KeyValuePair);
+    declaration.setValue(new DataValue(new Variant(value)));
+    AttributeSnapshot snapshot = AttributeSnapshot.of(declaration);
+    assertSame(value, snapshot.value().getValue().getValue());
+    assertEquals(snapshot.contentHash(), AttributeSnapshot.of(declaration).contentHash());
+    var model = fx.compiler().compile(type.getNodeId());
+    assertSame(
+        value, model.get(path("V")).orElseThrow().attributes().value().getValue().getValue());
+  }
+
+  // Empty enum/structure matrices have a known builtin type but no element from which to derive
+  // a namespace-qualified DataType id. Missing metadata must not prevent snapshots or copying.
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void emptyMatricesKeepDimensionsWithoutInventingADataTypeId(boolean enumeration) {
+    Object elements = enumeration ? new ApplicationType[0] : new Argument[0];
+    var matrix = new Matrix(elements, new int[] {0, 0});
+    var snapshot =
+        AttributeSnapshot.builder()
+            .put(AttributeId.Value, new DataValue(new Variant(matrix)))
+            .build();
+    var copy = (Matrix) snapshot.value().getValue().getValue();
+    assertNotSame(elements, copy.getElements());
+    assertArrayEquals(new int[] {0, 0}, copy.getDimensions());
+    assertTrue(copy.getDataTypeId().isEmpty());
+    assertEquals(matrix.getDataType(), copy.getDataType());
+    String originalContent = snapshot.contentHash();
+    matrix.getDimensions()[0] = 7;
+    copy.getDimensions()[1] = 9;
+    assertArrayEquals(
+        new int[] {0, 0}, ((Matrix) snapshot.value().getValue().getValue()).getDimensions());
+    assertEquals(originalContent, snapshot.contentHash());
+  }
+
   // Binary bodies are common inside standard structures. Their fingerprint should scale with
   // payload bytes, while retaining content, length, element-boundary, and Java-type distinctions.
   @Test
@@ -36,5 +97,27 @@ class AttributeSnapshotCompatibilityTest {
 
   private static String fingerprint(Object value) {
     return AttributeSnapshot.builder().put(AttributeId.Value, value).build().contentHash();
+  }
+
+  private record OpaqueValue(int value) implements UaStructuredType {
+    @Override
+    public ExpandedNodeId getTypeId() {
+      return ExpandedNodeId.parse("nsu=urn:custom;i=1");
+    }
+
+    @Override
+    public ExpandedNodeId getBinaryEncodingId() {
+      return ExpandedNodeId.parse("nsu=urn:custom;i=2");
+    }
+
+    @Override
+    public ExpandedNodeId getXmlEncodingId() {
+      return ExpandedNodeId.NULL_VALUE;
+    }
+
+    @Override
+    public ExpandedNodeId getJsonEncodingId() {
+      return ExpandedNodeId.NULL_VALUE;
+    }
   }
 }

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/TypeModelConsistencyTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/TypeModelConsistencyTest.java
@@ -11,6 +11,8 @@
 package org.eclipse.milo.opcua.sdk.server.nodes.instantiation;
 
 import static org.eclipse.milo.opcua.sdk.server.nodes.instantiation.TypeFixtures.path;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -22,11 +24,17 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectNode;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Matrix;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.structured.Argument;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -128,5 +136,55 @@ class TypeModelConsistencyTest {
         error.getDiagnostics().stream()
             .anyMatch(d -> d.code() == InstantiationDiagnostic.Code.MODEL_CHANGED));
     assertTrue(target.getNodes().isEmpty());
+  }
+
+  // Method argument dimensions are nested inside structures. Each supported Variant container
+  // must isolate those dimensions from both declaration owners and snapshot readers.
+  @ParameterizedTest
+  @ValueSource(strings = {"scalar", "array", "matrix", "extension"})
+  void structuredValuesAreIsolatedOnIngressAndEgress(String container) {
+    var argument =
+        new Argument("A", NodeIds.Int32, 1, new UInteger[] {uint(3)}, LocalizedText.NULL_VALUE);
+    Object source =
+        switch (container) {
+          case "scalar" -> argument;
+          case "array" -> new Argument[] {argument};
+          case "matrix" -> new Matrix(new Argument[] {argument}, new int[] {1, 1});
+          case "extension" -> ExtensionObject.encode(DefaultEncodingContext.INSTANCE, argument);
+          default -> throw new AssertionError(container);
+        };
+    var fx = TypeFixtures.create();
+    var type = fx.addObjectType("Arguments", NodeIds.BaseObjectType);
+    var declaration =
+        fx.addVariableDeclaration(
+            type, "V", NodeIds.BaseDataVariableType, NodeIds.ModellingRule_Mandatory);
+    declaration.setDataType(NodeIds.Argument);
+    declaration.setValue(new DataValue(new Variant(source)));
+    AttributeSnapshot snapshot = AttributeSnapshot.of(declaration);
+    String originalContent = snapshot.contentHash();
+    Argument sourceArgument = unwrapArgument(source);
+    unwrapArgument(snapshot.value().getValue().getValue()).getArrayDimensions()[0] = uint(7);
+    assertEquals(
+        uint(3),
+        unwrapArgument(declaration.getValue().getValue().getValue()).getArrayDimensions()[0]);
+    assertEquals(
+        uint(3), unwrapArgument(snapshot.value().getValue().getValue()).getArrayDimensions()[0]);
+    sourceArgument.getArrayDimensions()[0] = uint(9);
+    assertEquals(
+        uint(3), unwrapArgument(snapshot.value().getValue().getValue()).getArrayDimensions()[0]);
+    assertEquals(originalContent, snapshot.contentHash());
+  }
+
+  private static Argument unwrapArgument(Object value) {
+    if (value instanceof Argument argument) {
+      return argument;
+    }
+    if (value instanceof Argument[] arguments) {
+      return arguments[0];
+    }
+    if (value instanceof Matrix matrix) {
+      return ((Argument[]) matrix.getElements())[0];
+    }
+    return (Argument) ((ExtensionObject) value).decode(DefaultEncodingContext.INSTANCE);
   }
 }


### PR DESCRIPTION
Snapshotting an Argument or a container of Arguments previously retained nested ArrayDimensions arrays. Mutating a snapshot result could change the live declaration, and mutating the source could change the snapshot. Copy standard structures and nested Variant/DataValue, ByteString, ExtensionObject, and Matrix contents on ingress and egress. Immutable scalar wrappers retain identity; custom values without a standard codec, including standard structures containing them, retain the documented caller-immutable contract.

[Part 3 §6.4.2](https://reference.opcfoundation.org/specs/OPC-10000-3/6.4.2) states: "If new copies are created, then the Attribute values of the InstanceDeclarations are used as the initial values." Snapshot isolation is Milo's mechanism for preserving those values.

### Verification

Seven added cases cover both mutation directions for scalar, array, Matrix, and ExtensionObject containers, a standard structure containing an opaque custom value, and empty enum/structure matrices without a derived DataType id. Existing scalar-identity assertions remain intact.

Formatting, full clean compilation, and 65 selected tests passed for this branch.

Based on https://github.com/eclipse-milo/milo/pull/1884 so the diff contains only this fix.
