### PR TITLE
Stop type discovery when the Browse continuation token is empty

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/typetree/ClientBrowseUtilsTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/typetree/ClientBrowseUtilsTest.java
@@ -10,10 +10,13 @@
 
 package org.eclipse.milo.opcua.sdk.client.typetree;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -25,6 +28,34 @@ import org.eclipse.milo.opcua.stack.core.types.structured.BrowseResult;
 import org.junit.jupiter.api.Test;
 
 class ClientBrowseUtilsTest {
+
+  // Empty and null tokens both mean Browse is complete and must never reach BrowseNext.
+  @Test
+  void terminalContinuationPointsDoNotSendAnotherRequest() throws UaException {
+    var client = mock(OpcUaClient.class);
+
+    assertEquals(List.of(), ClientBrowseUtils.maybeBrowseNext(client, null));
+    assertEquals(List.of(), ClientBrowseUtils.maybeBrowseNext(client, ByteString.NULL_VALUE));
+    assertEquals(List.of(), ClientBrowseUtils.maybeBrowseNext(client, ByteString.of(new byte[0])));
+    verifyNoInteractions(client);
+  }
+
+  // A final empty token must stop the loop after the valid continuation request.
+  @Test
+  void emptyContinuationPointInResponseFinishesBrowse() throws UaException {
+    var client = mock(OpcUaClient.class);
+    var response = mock(BrowseNextResponse.class);
+    var result = mock(BrowseResult.class);
+    var continuationPoint = ByteString.of(new byte[] {1});
+    when(client.browseNext(false, List.of(continuationPoint))).thenReturn(response);
+    when(response.getResults()).thenReturn(new BrowseResult[] {result});
+    when(result.getContinuationPoint()).thenReturn(ByteString.of(new byte[0]));
+
+    assertEquals(List.of(), ClientBrowseUtils.maybeBrowseNext(client, continuationPoint));
+
+    verify(client).browseNext(false, List.of(continuationPoint));
+    verifyNoMoreInteractions(client);
+  }
 
   @Test
   void releasesContinuationPointWhenBrowseNextLimitIsReached() throws UaException {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/typetree/ClientBrowseUtils.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/typetree/ClientBrowseUtils.java
@@ -231,7 +231,7 @@ final class ClientBrowseUtils {
 
     int iterations = 0;
 
-    while (continuationPoint != null && continuationPoint.isNotNull()) {
+    while (continuationPoint != null && !continuationPoint.isNullOrEmpty()) {
       if (++iterations > MAX_BROWSE_NEXT_ITERATIONS) {
         var limitException =
             new UaException(

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/typetree/package-info.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/typetree/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/**
+ * Discovers server type metadata and makes it available to client codecs and address-space APIs.
+ *
+ * <p>Type-tree factories select eager discovery or lazy resolution. Builders read definitions and
+ * browse inheritance and encoding references within a session, honoring operation limits and
+ * following continuation points until the server returns a null or empty token. Lazy trees resolve
+ * types on demand and discard stale work when their session or cache generation changes.
+ */
+package org.eclipse.milo.opcua.sdk.client.typetree;


### PR DESCRIPTION
Type-tree discovery sent `BrowseNext` after a server returned an empty continuation token. A completed Browse could therefore trigger unnecessary requests and eventually fail tree construction.

The browse helper now stops for both null and empty tokens, matching its terminal-token contract. [Part 4 §7.9](https://reference.opcfoundation.org/specs/OPC-10000-4/7.9) states: "The Server allocates a ContinuationPoint if there are more results to return."

Regressions cover empty tokens in the initial and final response, with null-terminal and nonterminal controls.

Formatting, a full clean compile, and the selected regression suites passed for this branch.
