### PR TITLE
Restore reverse discovery after disconnecting while stopped

### DIFF
--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseConnectAcceptor.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseConnectAcceptor.java
@@ -351,11 +351,7 @@ public final class ReverseConnectAcceptor implements AutoCloseable {
 
     ChannelStateObservable.TransitionListener listener =
         connected -> {
-          // After acceptor.stop() the listener is no longer removed from the transport, but it
-          // must not mutate bookkeeping for a stopped acceptor.
-          if (!running.get()) {
-            return;
-          }
+          // Delivered clients outlive stop(); keep ownership current across acceptor restarts.
           if (connected) {
             activeKeys.add(key);
           } else {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/package-info.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/package-info.java
@@ -106,6 +106,10 @@
  * registration future removes the selector, and a claim that races that completion closes its
  * undeliverable channel.
  *
+ * <p>Stopping an acceptor suppresses new discovery work while preserving ownership of delivered
+ * clients. Their channel transitions continue updating the reserved keys so restart can discover
+ * servers whose delivered clients disconnected during the stopped interval.
+ *
  * <h2>Security boundary</h2>
  *
  * <p>{@code ReverseHello} is only a routing and resource-admission hint. The types here

--- a/opc-ua-sdk/sdk-client/src/test/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseConnectAcceptorTest.java
+++ b/opc-ua-sdk/sdk-client/src/test/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseConnectAcceptorTest.java
@@ -126,6 +126,42 @@ class ReverseConnectAcceptorTest {
     }
   }
 
+  // Delivered clients remain caller-owned while stopped, but disconnected keys must be reusable.
+  @Test
+  void disconnectWhileStoppedAllowsRediscoveryAfterRestart() throws Exception {
+    ReverseConnectManager manager = newManager();
+    List<UUID> discovered = new ArrayList<>();
+    ReverseConnectAcceptor acceptor =
+        ReverseConnectAcceptor.builder(manager)
+            .setDiscoveryTransport(
+                builder -> {
+                  throw new IllegalStateException("discovery observed");
+                })
+            .setErrorListener((candidate, failure) -> discovered.add(candidate.id()))
+            .build();
+    EmbeddedChannel channel = new EmbeddedChannel();
+    FakeClientTransport transport = new FakeClientTransport(channel);
+    OpcUaClient client = new OpcUaClient(clientConfig(), transport);
+    try {
+      acceptor.start();
+      addActiveKey(acceptor, SERVER_URI);
+      assertTrue(invokeObserveProductionTransportForKeyRelease(acceptor, SERVER_URI, client));
+      acceptor.stop();
+      assertEquals(1, activeKeyCount(acceptor), "stopping must retain the connected client's key");
+      UUID pendingId = addPendingCandidate(manager, new EmbeddedChannel());
+      channel.close();
+      transport.listeners.forEach(listener -> listener.onStateTransition(false));
+      assertTrue(discovered.isEmpty(), "a stopped acceptor must not start discovery");
+      acceptor.start();
+      assertEquals(List.of(pendingId), discovered);
+      assertEquals(0, activeKeyCount(acceptor));
+    } finally {
+      channel.close();
+      acceptor.stop();
+      manager.shutdown();
+    }
+  }
+
   private ReverseConnectManager newManager() {
     return ReverseConnectManager.builder()
         .addBindAddress(new InetSocketAddress("127.0.0.1", 0))


### PR DESCRIPTION
An acceptor preserves caller-owned clients when it stops. If a delivered client disconnects during that interval, ignoring its channel transition leaves its discovery key reserved and prevents discovery after restart.

Continue updating delivered-client ownership while stopped. Discovery remains suspended until restart, which can then process candidates whose keys have been released. The regression stops an acceptor with a delivered client, disconnects that client, and verifies rediscovery after restart.

## Verification

Formatting and full clean compile passed. The selected regression suites passed (3 tests, no failures or errors).

```sh
mise exec -- mvn -q -pl opc-ua-sdk/sdk-client -am verify '-Dtest=ReverseConnectAcceptorTest' -Dsurefire.failIfNoSpecifiedTests=false
```

Based on https://github.com/eclipse-milo/milo/pull/1886 so the diff contains only this fix.
