### PR TITLE
Resolve overridden declaration references to effective instances

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/TypeModelCompiler.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/TypeModelCompiler.java
@@ -1502,6 +1502,13 @@ public class TypeModelCompiler {
       pathsByDeclarationId
           .computeIfAbsent(d.declarationNodeId(), k -> new ArrayList<>())
           .add(d.browsePath());
+      for (NodeId overriddenId : d.overriddenDeclarations()) {
+        List<BrowsePath> paths =
+            pathsByDeclarationId.computeIfAbsent(overriddenId, k -> new ArrayList<>());
+        if (!paths.contains(d.browsePath())) {
+          paths.add(d.browsePath());
+        }
+      }
     }
 
     List<Row> resolved = new ArrayList<>(table.rows.size());

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/TypeModelConsistencyTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/nodes/instantiation/TypeModelConsistencyTest.java
@@ -18,10 +18,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.eclipse.milo.opcua.sdk.core.Reference;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectNode;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
 import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
@@ -186,5 +188,50 @@ class TypeModelConsistencyTest {
       return ((Argument[]) matrix.getElements())[0];
     }
     return (Argument) ((ExtensionObject) value).decode(DefaultEncodingContext.INSTANCE);
+  }
+
+  // Part 3 declaration overrides change the effective instance at a path. References to any
+  // declaration in that chain must point to that instance, without an extra edge into type space.
+  @Test
+  void referencesToOverriddenDeclarationsResolveToTheEffectiveInstance() throws Exception {
+    var fx = TypeFixtures.create();
+    var referenceType = fx.addReferenceType("RelatedTo", NodeIds.NonHierarchicalReferences);
+    var base = fx.addObjectType("Base", NodeIds.BaseObjectType);
+    var original =
+        fx.addObjectDeclaration(base, "Y", NodeIds.BaseObjectType, NodeIds.ModellingRule_Mandatory);
+    var derived = fx.addObjectType("Derived", base.getNodeId());
+    fx.addObjectDeclaration(derived, "Y", NodeIds.BaseObjectType, NodeIds.ModellingRule_Mandatory);
+    var z =
+        fx.addObjectDeclaration(
+            derived, "Z", NodeIds.BaseObjectType, NodeIds.ModellingRule_Mandatory);
+    fx.nodeManager()
+        .addReferences(
+            new Reference(
+                z.getNodeId(), referenceType.getNodeId(), original.getNodeId().expanded(), true),
+            fx.namespaceTable());
+    var model = fx.compiler().compile(derived.getNodeId());
+    List<ReferenceRow> rows =
+        model.references().stream()
+            .filter(row -> row.referenceTypeId().equals(referenceType.getNodeId()))
+            .toList();
+    assertEquals(
+        List.of(ReferenceRow.relative(path("Z"), referenceType.getNodeId(), path("Y"))), rows);
+    var target = fx.newTargetManager();
+    var result =
+        fx.instantiator()
+            .instantiate(
+                InstantiationRequest.of(UaObjectNode.class, derived.getNodeId())
+                    .nodeId(fx.newNodeId("Instance"))
+                    .target(target)
+                    .build());
+    NodeId instanceY = result.node(path("Y")).orElseThrow().getNodeId();
+    NodeId instanceZ = result.node(path("Z")).orElseThrow().getNodeId();
+    var outgoing =
+        target.getReferences(instanceZ).stream()
+            .filter(r -> r.getReferenceTypeId().equals(referenceType.getNodeId()))
+            .toList();
+    assertEquals(
+        List.of(new Reference(instanceZ, referenceType.getNodeId(), instanceY.expanded(), true)),
+        outgoing);
   }
 }


### PR DESCRIPTION
A reference targeting an overridden declaration could produce both an instance reference and an extra edge back into type space. Index every declaration in an override chain at its effective BrowsePath, so Milo's existing reference replication policy resolves the target to the effective instance.

[Part 3 §6.3.3.3](https://reference.opcfoundation.org/specs/OPC-10000-3/6.3.3.3) states: "A subtype overrides an InstanceDeclaration by specifying an InstanceDeclaration with the same BrowsePath." This fix preserves Milo's chosen replication policy; the specification does not require every server to copy every nonhierarchical reference.

### Verification

A regression constructs a compatible declaration override and a custom nonhierarchical reference to the original declaration, then verifies the compiled row and live instance contain exactly the effective instance-to-instance edge.

Formatting, full clean compilation, and 93 selected tests passed for this branch.

Based on https://github.com/eclipse-milo/milo/pull/1887 so the diff contains only this fix.
