### PR TITLE
Allocate distinct diagnostics element identities after removal

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/SessionDiagnosticsVariableArray.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/SessionDiagnosticsVariableArray.java
@@ -17,6 +17,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import org.eclipse.milo.opcua.sdk.core.AccessLevel;
 import org.eclipse.milo.opcua.sdk.core.ValueRank;
 import org.eclipse.milo.opcua.sdk.server.AbstractLifecycle;
@@ -47,6 +48,8 @@ import org.slf4j.LoggerFactory;
 public class SessionDiagnosticsVariableArray extends AbstractLifecycle {
 
   private final Logger logger = LoggerFactory.getLogger(getClass());
+
+  private final AtomicLong nextElementId = new AtomicLong();
 
   private final AtomicBoolean diagnosticsEnabled = new AtomicBoolean(false);
 
@@ -161,7 +164,7 @@ public class SessionDiagnosticsVariableArray extends AbstractLifecycle {
 
   private void createSessionDiagnosticsVariable(Session session) {
     try {
-      int index = sessionDiagnosticsVariables.size();
+      long index = nextElementId.getAndIncrement();
       String id = Util.buildBrowseNamePath(node) + "[" + index + "]";
       NodeId elementNodeId = new NodeId(1, id);
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/SessionSecurityDiagnosticsVariableArray.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/SessionSecurityDiagnosticsVariableArray.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import org.eclipse.milo.opcua.sdk.core.AccessLevel;
 import org.eclipse.milo.opcua.sdk.core.ValueRank;
 import org.eclipse.milo.opcua.sdk.server.AbstractLifecycle;
@@ -60,6 +61,8 @@ import org.slf4j.LoggerFactory;
 public class SessionSecurityDiagnosticsVariableArray extends AbstractLifecycle {
 
   private final Logger logger = LoggerFactory.getLogger(getClass());
+
+  private final AtomicLong nextElementId = new AtomicLong();
 
   private final AtomicBoolean diagnosticsEnabled = new AtomicBoolean(false);
 
@@ -192,7 +195,7 @@ public class SessionSecurityDiagnosticsVariableArray extends AbstractLifecycle {
 
   private void createSessionSecurityDiagnosticsVariable(Session session) {
     try {
-      int index = sessionSecurityDiagnosticsVariables.size();
+      long index = nextElementId.getAndIncrement();
       String id = Util.buildBrowseNamePath(node) + "[" + index + "]";
       NodeId elementNodeId = new NodeId(1, id);
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/SubscriptionDiagnosticsVariableArray.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/SubscriptionDiagnosticsVariableArray.java
@@ -18,6 +18,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import org.eclipse.milo.opcua.sdk.core.AccessLevel;
 import org.eclipse.milo.opcua.sdk.core.ValueRank;
 import org.eclipse.milo.opcua.sdk.server.AbstractLifecycle;
@@ -48,6 +49,8 @@ import org.slf4j.LoggerFactory;
 public abstract class SubscriptionDiagnosticsVariableArray extends AbstractLifecycle {
 
   private final Logger logger = LoggerFactory.getLogger(getClass());
+
+  private final AtomicLong nextElementId = new AtomicLong();
 
   private final AtomicBoolean diagnosticsEnabled = new AtomicBoolean(false);
 
@@ -168,7 +171,7 @@ public abstract class SubscriptionDiagnosticsVariableArray extends AbstractLifec
 
   private void createSubscriptionDiagnosticsNode(Subscription subscription) {
     try {
-      int index = subscriptionDiagnosticsVariables.size();
+      long index = nextElementId.getAndIncrement();
       String id = Util.buildBrowseNamePath(node) + "[" + index + "]";
       NodeId elementNodeId = new NodeId(1, id);
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/**
+ * Connects standard diagnostics Variables to live server, Session, and Subscription state.
+ * Attribute filters obtain current diagnostic values when a Variable is read; the runtime objects
+ * remain the source of those values.
+ *
+ * <p>Array lifecycle components create typed child graphs through the node instantiator and store
+ * them in their supplied diagnostics node manager. They observe the diagnostics enabled flag and
+ * retire children as their owning Sessions or Subscriptions leave. Each array allocates child
+ * identifiers independently of its current element count, so removing an earlier entry does not
+ * reuse the identifier of a surviving child. These identifiers describe node identity, not an
+ * element's current position in the array Value.
+ *
+ * <p>Security diagnostics also carry the standard array's access metadata into each child graph. In
+ * restricted access mode, their attribute filters derive caller-visible access from the current
+ * Session's roles.
+ */
+package org.eclipse.milo.opcua.sdk.server.diagnostics.variables;

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/DiagnosticsArrayLifecycleTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/diagnostics/variables/DiagnosticsArrayLifecycleTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.diagnostics.variables;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.List;
+import org.eclipse.milo.opcua.sdk.server.Lifecycle;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServerConfig;
+import org.eclipse.milo.opcua.sdk.server.Session;
+import org.eclipse.milo.opcua.sdk.server.UaNodeManager;
+import org.eclipse.milo.opcua.sdk.server.model.objects.ServerDiagnosticsTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
+import org.eclipse.milo.opcua.sdk.server.subscriptions.Subscription;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.security.DefaultCertificateManager;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class DiagnosticsArrayLifecycleTest {
+
+  // Removing element zero from a two-element array must not make the next allocation collide with
+  // the surviving element and starve all later diagnostics creation. Exercise real instantiation,
+  // field setup, node removal, and parent references for each diagnostics array implementation.
+  @ParameterizedTest
+  @ValueSource(strings = {"session", "security", "subscription"})
+  void removingAnEarlierElementDoesNotBlockLaterDiagnostics(String kind) throws Exception {
+    var config =
+        OpcUaServerConfig.builder().setCertificateManager(new DefaultCertificateManager()).build();
+    var server = new OpcUaServer(config, transportProfile -> null);
+    var target = new UaNodeManager();
+    server.getAddressSpaceManager().register(target);
+    var diagnostics =
+        (ServerDiagnosticsTypeNode)
+            server
+                .getAddressSpaceManager()
+                .getManagedNode(NodeIds.Server_ServerDiagnostics)
+                .orElseThrow();
+    var summary = diagnostics.getSessionsDiagnosticsSummaryNode();
+
+    Object array;
+    UaNode parent;
+    Class<?> arrayClass;
+    String createMethod;
+    String elementsField;
+    Class<?> ownerClass;
+    switch (kind) {
+      case "session" -> {
+        parent = summary.getSessionDiagnosticsArrayNode();
+        array =
+            new SessionDiagnosticsVariableArray(summary.getSessionDiagnosticsArrayNode(), target);
+        arrayClass = SessionDiagnosticsVariableArray.class;
+        createMethod = "createSessionDiagnosticsVariable";
+        elementsField = "sessionDiagnosticsVariables";
+        ownerClass = Session.class;
+      }
+      case "security" -> {
+        parent = summary.getSessionSecurityDiagnosticsArrayNode();
+        array =
+            new SessionSecurityDiagnosticsVariableArray(
+                summary.getSessionSecurityDiagnosticsArrayNode(), target);
+        arrayClass = SessionSecurityDiagnosticsVariableArray.class;
+        createMethod = "createSessionSecurityDiagnosticsVariable";
+        elementsField = "sessionSecurityDiagnosticsVariables";
+        ownerClass = Session.class;
+      }
+      case "subscription" -> {
+        parent = diagnostics.getSubscriptionDiagnosticsArrayNode();
+        array =
+            new SubscriptionDiagnosticsVariableArray(
+                diagnostics.getSubscriptionDiagnosticsArrayNode(), target) {
+              @Override
+              protected List<Subscription> getSubscriptions() {
+                return List.of();
+              }
+            };
+        arrayClass = SubscriptionDiagnosticsVariableArray.class;
+        createMethod = "createSubscriptionDiagnosticsNode";
+        elementsField = "subscriptionDiagnosticsVariables";
+        ownerClass = Subscription.class;
+      }
+      default -> throw new AssertionError(kind);
+    }
+
+    // Isolate allocation from event delivery: invoke the same creation entry point the listeners
+    // call, then retire the first element exactly as their close callbacks do.
+    Method create = arrayClass.getDeclaredMethod(createMethod, ownerClass);
+    create.setAccessible(true);
+    Field field = arrayClass.getDeclaredField(elementsField);
+    field.setAccessible(true);
+    @SuppressWarnings("unchecked")
+    List<Lifecycle> elements = (List<Lifecycle>) field.get(array);
+    try {
+      create.invoke(array, owner(ownerClass, 0));
+      create.invoke(array, owner(ownerClass, 1));
+      assertEquals(2, elements.size(), "both initial elements must be created");
+      elements.remove(0).shutdown();
+      create.invoke(array, owner(ownerClass, 2));
+      create.invoke(array, owner(ownerClass, 3));
+      assertEquals(
+          3, elements.size(), "creation must continue after an earlier element is retired");
+      var references =
+          target.getReferences(parent.getNodeId()).stream()
+              .filter(r -> r.isForward() && r.getReferenceTypeId().equals(NodeIds.HasComponent))
+              .toList();
+      assertEquals(3, references.size());
+      assertEquals(3, references.stream().map(r -> r.getTargetNodeId()).distinct().count());
+      assertTrue(
+          references.stream()
+              .allMatch(
+                  r ->
+                      target.getNode(r.getTargetNodeId(), server.getNamespaceTable()).isPresent()));
+    } finally {
+      elements.forEach(Lifecycle::shutdown);
+      server.getAddressSpaceManager().unregister(target);
+    }
+  }
+
+  private static Object owner(Class<?> ownerClass, int index) {
+    if (ownerClass == Session.class) {
+      var session = mock(Session.class);
+      when(session.getSessionId()).thenReturn(new NodeId(1, "Session" + index));
+      return session;
+    }
+    var subscription = mock(Subscription.class);
+    when(subscription.getId()).thenReturn(uint(index + 1));
+    return subscription;
+  }
+}


### PR DESCRIPTION
Removing an earlier diagnostics entry can make later additions reuse an identifier still owned by another entry. Allocate monotonic element identities independently of the live array size for session, session-security, and subscription diagnostics.

[Part 5 §7.11](https://reference.opcfoundation.org/specs/OPC-10000-5/7.11) states: "For each entry of the array, instances of this type will provide a Variable of the SubscriptionDiagnosticsType VariableType". The same allocator correction preserves Milo's existing session and session-security child exposure.

### Verification

Three real server/instantiation cases add two entries, retire the first, add two more, and require three distinct live children with intact references.

Formatting, full clean compilation, and 3 selected tests passed for this branch.
