### PR TITLE
Deliver reverse channel transitions in lifecycle order

### DIFF
--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseTcpClientTransport.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseTcpClientTransport.java
@@ -13,6 +13,8 @@ package org.eclipse.milo.opcua.sdk.client.reverse;
 import static java.util.Objects.requireNonNull;
 
 import io.netty.channel.Channel;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -67,6 +69,9 @@ public final class ReverseTcpClientTransport extends AbstractUascClientTransport
   private final OpcTcpClientTransportConfig config;
   private final List<ChannelStateObservable.TransitionListener> transitionListeners =
       new CopyOnWriteArrayList<>();
+
+  private final Deque<Boolean> pendingTransitions = new ArrayDeque<>();
+  private boolean notifyingTransitions = false;
 
   private CompletableFuture<Channel> channelFuture = new CompletableFuture<>();
 
@@ -175,6 +180,9 @@ public final class ReverseTcpClientTransport extends AbstractUascClientTransport
               && !channelFuture.isCancelled();
 
       currentChannel = null;
+      if (emitSyntheticDisconnect) {
+        pendingTransitions.add(false);
+      }
 
       if (channelFuture.isDone()) {
         channelFuture = new CompletableFuture<>();
@@ -189,7 +197,7 @@ public final class ReverseTcpClientTransport extends AbstractUascClientTransport
     }
 
     if (emitSyntheticDisconnect) {
-      notifyTransitionListeners(false);
+      drainTransitionNotifications();
     }
 
     if (futureToRegister != null) {
@@ -280,6 +288,9 @@ public final class ReverseTcpClientTransport extends AbstractUascClientTransport
         directConnectionConsumed = true;
       }
       currentChannel = null;
+      if (notifyDisconnected) {
+        pendingTransitions.add(false);
+      }
 
       if (directConnection != null) {
         enterDirectTerminalStateLocked(
@@ -315,7 +326,7 @@ public final class ReverseTcpClientTransport extends AbstractUascClientTransport
             future -> {
               if (future.isSuccess()) {
                 if (notifyDisconnected) {
-                  notifyTransitionListeners(false);
+                  drainTransitionNotifications();
                 }
                 disconnectFuture.complete(Unit.VALUE);
               } else {
@@ -594,11 +605,8 @@ public final class ReverseTcpClientTransport extends AbstractUascClientTransport
       stale = disconnecting || targetFuture != channelFuture;
       if (!stale) {
         currentChannel = channel;
-        // Complete inside the lock so a concurrent disconnect() observes futureToCancel.isDone()
-        // and emits a matching connected=false transition. Completing outside the lock allows the
-        // disconnect to interleave between the publish of currentChannel and the future
-        // completion, suppressing its matching disconnect notification and producing an orphan
-        // connected=true event.
+        // Reserve the notification before completion can invoke a reentrant close callback.
+        pendingTransitions.add(true);
         targetFuture.complete(channel);
       }
     }
@@ -606,7 +614,7 @@ public final class ReverseTcpClientTransport extends AbstractUascClientTransport
     if (stale) {
       channel.close();
     } else {
-      notifyTransitionListeners(true);
+      drainTransitionNotifications();
     }
   }
 
@@ -625,6 +633,10 @@ public final class ReverseTcpClientTransport extends AbstractUascClientTransport
             channelFuture.isDone()
                 && !channelFuture.isCompletedExceptionally()
                 && !channelFuture.isCancelled();
+
+        if (notifyDisconnected) {
+          pendingTransitions.add(false);
+        }
 
         if (started && !disconnecting) {
           closedFuture = channelFuture;
@@ -648,7 +660,7 @@ public final class ReverseTcpClientTransport extends AbstractUascClientTransport
     }
 
     if (notifyDisconnected) {
-      notifyTransitionListeners(false);
+      drainTransitionNotifications();
     }
   }
 
@@ -680,12 +692,36 @@ public final class ReverseTcpClientTransport extends AbstractUascClientTransport
     channelFuture = CompletableFuture.failedFuture(failure);
   }
 
-  private void notifyTransitionListeners(boolean connected) {
-    for (ChannelStateObservable.TransitionListener listener : transitionListeners) {
-      try {
-        listener.onStateTransition(connected);
-      } catch (Throwable t) {
-        logger.warn("Channel state transition listener failed.", t);
+  private void drainTransitionNotifications() {
+    // Future completion under lock can reenter connect/disconnect. The outer operation drains
+    // after unlocking so user listeners never run inside the transport's state critical section.
+    if (Thread.holdsLock(lock)) {
+      return;
+    }
+
+    synchronized (lock) {
+      if (notifyingTransitions) {
+        return;
+      }
+      notifyingTransitions = true;
+    }
+
+    while (true) {
+      Boolean connected;
+      synchronized (lock) {
+        connected = pendingTransitions.poll();
+        if (connected == null) {
+          notifyingTransitions = false;
+          return;
+        }
+      }
+
+      for (ChannelStateObservable.TransitionListener listener : transitionListeners) {
+        try {
+          listener.onStateTransition(connected);
+        } catch (Throwable t) {
+          logger.warn("Channel state transition listener failed.", t);
+        }
       }
     }
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/package-info.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/package-info.java
@@ -104,7 +104,8 @@
  * <p>Shutdown fences listener installation, including a startup still in application bootstrap
  * customization. A selector owns only its pending claim: cancelling or exceptionally completing the
  * registration future removes the selector, and a claim that races that completion closes its
- * undeliverable channel.
+ * undeliverable channel. Channel observers receive connected and disconnected transitions serially
+ * in state-change order, including when a callback itself disconnects the transport.
  *
  * <p>Stopping an acceptor suppresses new discovery work while preserving ownership of delivered
  * clients. Their channel transitions continue updating the reserved keys so restart can discover

--- a/opc-ua-sdk/sdk-client/src/test/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseTcpClientTransportTest.java
+++ b/opc-ua-sdk/sdk-client/src/test/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseTcpClientTransportTest.java
@@ -262,6 +262,64 @@ class ReverseTcpClientTransportTest {
     return new ReverseTcpClientTransport(transportConfig(), newConnection(channel));
   }
 
+  // A listener can synchronously close the channel; every observer must see the same order.
+  @Test
+  void reentrantCloseDoesNotOvertakeConnectedNotification() throws Exception {
+    EmbeddedChannel channel = new EmbeddedChannel();
+    ReverseTcpClientTransport transport = newTransport(channel);
+    CompletableFuture<Channel> activeFuture = new CompletableFuture<>();
+    List<Boolean> transitions = new ArrayList<>();
+    setField(transport, "started", true);
+    setField(transport, "disconnecting", false);
+    setField(transport, "channelFuture", activeFuture);
+    transport.addTransitionListener(
+        connected -> {
+          if (connected) {
+            try {
+              invokeOnChannelClosed(transport, channel);
+            } catch (Exception e) {
+              throw new AssertionError(e);
+            }
+          }
+        });
+    transport.addTransitionListener(transitions::add);
+    try {
+      invokeCompleteHandshake(transport, activeFuture, channel);
+      assertEquals(List.of(true, false), transitions);
+      assertNull(transport.getCurrentChannel());
+    } finally {
+      channel.close();
+    }
+  }
+
+  // User future callbacks can close a channel before the handshake callback starts notifying.
+  @Test
+  void futureCompletionCloseDoesNotOvertakeConnectedNotification() throws Exception {
+    EmbeddedChannel channel = new EmbeddedChannel();
+    ReverseTcpClientTransport transport = newTransport(channel);
+    CompletableFuture<Channel> activeFuture = new CompletableFuture<>();
+    List<Boolean> transitions = new ArrayList<>();
+    setField(transport, "started", true);
+    setField(transport, "disconnecting", false);
+    setField(transport, "channelFuture", activeFuture);
+    transport.addTransitionListener(transitions::add);
+    activeFuture.thenRun(
+        () -> {
+          try {
+            invokeOnChannelClosed(transport, channel);
+          } catch (Exception e) {
+            throw new AssertionError(e);
+          }
+        });
+    try {
+      invokeCompleteHandshake(transport, activeFuture, channel);
+      assertEquals(List.of(true, false), transitions);
+      assertNull(transport.getCurrentChannel());
+    } finally {
+      channel.close();
+    }
+  }
+
   private OpcTcpClientTransportConfig transportConfig() {
     return transportConfig(executor());
   }


### PR DESCRIPTION
A connection-future continuation or the first channel observer can synchronously disconnect a newly connected transport before the remaining observers receive its connected event. Those observers then see disconnected before connected.

Reserve transition events with their state changes and drain them serially outside the transport lock. Reentrant notifications wait until the current event reaches every observer. Two regressions cover disconnecting from an observer and from a connection-future continuation.

This follows `ChannelStateObservable`'s contract: "Implementations should keep listener invocation ordered with their own channel lifecycle."

## Verification

Formatting and full clean compile passed. The selected regression suites passed (8 tests, no failures or errors).

```sh
mise exec -- mvn -q -pl opc-ua-sdk/sdk-client -am verify '-Dtest=ReverseTcpClientTransportTest' -Dsurefire.failIfNoSpecifiedTests=false
```

Based on https://github.com/eclipse-milo/milo/pull/1889 so the diff contains only this fix.
