### PR TITLE
Settle reverse connect after claim dispatch rejection

### DIFF
--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseTcpClientTransport.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseTcpClientTransport.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.RejectedExecutionException;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.util.Unit;
@@ -393,13 +394,21 @@ public final class ReverseTcpClientTransport extends AbstractUascClientTransport
     nextRegistration
         .connectionFuture()
         .whenComplete(
-            (connection, ex) ->
+            (connection, ex) -> {
+              try {
                 config
                     .getExecutor()
                     .execute(
                         () ->
                             handleClaimedConnection(
-                                nextRegistration, targetFuture, connection, ex)));
+                                nextRegistration, targetFuture, connection, ex));
+              } catch (RejectedExecutionException rejected) {
+                if (connection != null) {
+                  connection.close();
+                }
+                handleClaimedConnection(nextRegistration, targetFuture, null, rejected);
+              }
+            });
 
     if (stale) {
       nextRegistration.close();

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/package-info.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/package-info.java
@@ -104,8 +104,9 @@
  * <p>Shutdown fences listener installation, including a startup still in application bootstrap
  * customization. A selector owns only its pending claim: cancelling or exceptionally completing the
  * registration future removes the selector, and a claim that races that completion closes its
- * undeliverable channel. Channel observers receive connected and disconnected transitions serially
- * in state-change order, including when a callback itself disconnects the transport.
+ * undeliverable channel. A transport dispatch failure also releases the claimed channel and fails
+ * the waiting connect operation. Channel observers receive connected and disconnected transitions
+ * serially in state-change order, including when a callback itself disconnects the transport.
  *
  * <p>Stopping an acceptor suppresses new discovery work while preserving ownership of delivered
  * clients. Their channel transitions continue updating the reserved keys so restart can discover

--- a/opc-ua-sdk/sdk-client/src/test/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseTcpClientTransportTest.java
+++ b/opc-ua-sdk/sdk-client/src/test/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseTcpClientTransportTest.java
@@ -39,6 +39,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
@@ -320,6 +321,52 @@ class ReverseTcpClientTransportTest {
     }
   }
 
+  // Once a manager hands off a channel, rejection must settle connect and close the socket.
+  @Test
+  void rejectedClaimDispatchClosesChannelAndFailsConnect() throws Exception {
+    QueuingExecutorService rejectingExecutor =
+        new QueuingExecutorService() {
+          @Override
+          public void execute(Runnable task) {
+            throw new RejectedExecutionException("saturated");
+          }
+        };
+    executor = rejectingExecutor;
+    ReverseConnectManager manager =
+        ReverseConnectManager.builder()
+            .addBindAddress(new InetSocketAddress("127.0.0.1", 0))
+            .setExecutor(Runnable::run)
+            .setScheduler(scheduledExecutor())
+            .build();
+    EmbeddedChannel channel = new EmbeddedChannel();
+    ReverseTcpClientTransport transport =
+        new ReverseTcpClientTransport(
+            transportConfig(rejectingExecutor), manager, ReverseConnectSelector.any());
+    CompletableFuture<Channel> target = new CompletableFuture<>();
+    try {
+      addPendingCandidate(manager, channel);
+      setField(transport, "started", true);
+      setField(transport, "disconnecting", false);
+      setField(transport, "channelFuture", target);
+      setField(transport, "waitingForReverseConnection", true);
+      Method register =
+          ReverseTcpClientTransport.class.getDeclaredMethod(
+              "registerForNextChannel", CompletableFuture.class);
+      register.setAccessible(true);
+      register.invoke(transport, target);
+      assertTrue(
+          target.isCompletedExceptionally(), "dispatch failure must settle connect immediately");
+      assertFalse(channel.isOpen(), "the manager no longer owns this claimed channel");
+      assertFalse(
+          (boolean)
+              declaredField(ReverseTcpClientTransport.class, "waitingForReverseConnection")
+                  .get(transport));
+    } finally {
+      channel.close();
+      manager.shutdown();
+    }
+  }
+
   private OpcTcpClientTransportConfig transportConfig() {
     return transportConfig(executor());
   }
@@ -510,7 +557,7 @@ class ReverseTcpClientTransportTest {
     }
   }
 
-  private static final class QueuingExecutorService extends AbstractExecutorService {
+  private static class QueuingExecutorService extends AbstractExecutorService {
 
     private final List<Runnable> tasks = Collections.synchronizedList(new ArrayList<>());
 


### PR DESCRIPTION
After the manager transfers a candidate channel, executor rejection can prevent the transport from accepting it. The connect future remains pending even though the manager no longer owns the channel.

Catch rejection at the claim handoff, close the transferred channel, clear the matching waiting state, and fail the connect future. The regression transfers an embedded candidate through a real manager registration and verifies immediate exceptional completion and channel cleanup.

## Verification

Formatting and full clean compile passed. The selected regression suites passed (9 tests, no failures or errors).

```sh
mise exec -- mvn -q -pl opc-ua-sdk/sdk-client -am verify '-Dtest=ReverseTcpClientTransportTest' -Dsurefire.failIfNoSpecifiedTests=false
```

Based on https://github.com/eclipse-milo/milo/pull/1893 so the diff contains only this fix.
