### PR TITLE
Remove alias associations from every registered node manager

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/aliases/AliasLifecycleConsistencyTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/aliases/AliasLifecycleConsistencyTest.java
@@ -1,0 +1,285 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.aliases;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import org.eclipse.milo.opcua.sdk.core.Reference;
+import org.eclipse.milo.opcua.sdk.server.Session;
+import org.eclipse.milo.opcua.sdk.server.UaNodeManager;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectNode;
+import org.eclipse.milo.opcua.sdk.test.AbstractClientServerTest;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.structured.CallMethodRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.CallMethodResult;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class AliasLifecycleConsistencyTest extends AbstractClientServerTest {
+
+  private final AtomicInteger sequence = new AtomicInteger();
+  private final List<Reference> externalReferences = new ArrayList<>();
+  private UaNodeManager nodeManager;
+  private Set<NodeId> originalNodes;
+  private TestVersionStore store;
+  private AliasManager manager;
+  private String prefix;
+
+  @BeforeEach
+  void prepareFixture() {
+    testNamespace.configure((context, nodes) -> nodeManager = nodes);
+    originalNodes = Set.copyOf(nodeManager.getNodeIds());
+    prefix = "AliasConsistency" + sequence.incrementAndGet();
+    store = new TestVersionStore();
+    manager =
+        new AliasManager(
+            server,
+            AliasManagerConfig.builder()
+                .nodeNamespaceIndex(testNamespace.getNamespaceIndex())
+                .versionStore(store)
+                .configurationEnabled(true)
+                .authorizationPolicy(
+                    new AliasAuthorizationPolicy() {
+                      @Override
+                      public boolean checkFind(@Nullable Session session, NodeId categoryId) {
+                        return true;
+                      }
+
+                      @Override
+                      public boolean checkMutate(@Nullable Session session, NodeId categoryId) {
+                        return true;
+                      }
+                    })
+                .build());
+  }
+
+  @AfterEach
+  void cleanFixture() {
+    manager.shutdown();
+    externalReferences.forEach(
+        reference -> nodeManager.removeReferences(reference, server.getNamespaceTable()));
+    externalReferences.clear();
+    nodeManager.getNodes().stream()
+        .filter(node -> !originalNodes.contains(node.getNodeId()))
+        .forEach(UaNode::delete);
+  }
+
+  // AliasFor may be stored by either endpoint's registered manager. Successful public/wire
+  // deletion must remove both directions there, or the next lookup still returns the target.
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void deletingTargetRemovesReferencesOwnedByAnotherManager(boolean wire) throws Exception {
+    manager.startup();
+    NodeId first = newNodeId("TestInt32");
+    NodeId second = newNodeId("TestAnalogValue");
+    NodeId aliasId = manager.addAlias(NodeIds.Aliases, prefix, List.of(target(first)));
+    Reference external =
+        new Reference(second, NodeIds.AliasFor, aliasId.expanded(), Reference.Direction.INVERSE);
+    managed(second).addReference(external);
+    externalReferences.add(external);
+    manager.touch(NodeIds.Aliases);
+    assertEquals(Set.of(first, second), targets(NodeIds.Aliases, prefix));
+
+    if (wire) {
+      assertArrayEquals(
+          new StatusCode[] {StatusCode.GOOD}, deleteOverWire(NodeIds.Aliases, prefix, second));
+    } else {
+      manager.deleteAlias(NodeIds.Aliases, prefix, List.of(target(second)));
+    }
+
+    assertEquals(Set.of(first), targets(NodeIds.Aliases, prefix));
+    assertFalse(
+        nodeManager.getReferences(second).contains(external),
+        "inverse reference must also be removed");
+  }
+
+  // Whole-alias deletion must remove cross-manager references before the deterministic alias
+  // NodeId is reused, or an old target silently becomes part of the replacement alias.
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void deletingWholeAliasDoesNotResurrectTargetsFromAnotherManager(boolean wire) throws Exception {
+    manager.startup();
+    NodeId first = newNodeId("TestInt32");
+    NodeId second = newNodeId("TestAnalogValue");
+    NodeId aliasId = manager.addAlias(NodeIds.Aliases, prefix, List.of(target(first)));
+    Reference external =
+        new Reference(second, NodeIds.AliasFor, aliasId.expanded(), Reference.Direction.INVERSE);
+    managed(second).addReference(external);
+    externalReferences.add(external);
+    manager.touch(NodeIds.Aliases);
+    assertEquals(Set.of(first, second), targets(NodeIds.Aliases, prefix));
+
+    if (wire) {
+      assertArrayEquals(
+          new StatusCode[] {StatusCode.GOOD}, deleteOverWire(NodeIds.Aliases, prefix, null));
+    } else {
+      manager.deleteAlias(NodeIds.Aliases, prefix, null);
+    }
+    assertTrue(server.getAddressSpaceManager().getManagedNode(aliasId).isEmpty());
+    NodeId replacement = manager.addAlias(NodeIds.Aliases, prefix, List.of(target(first)));
+    assertEquals(aliasId, replacement);
+    assertEquals(
+        Set.of(first), targets(NodeIds.Aliases, prefix), "deleted targets must not reappear");
+    assertTrue(nodeManager.getReferences(aliasId).isEmpty());
+    assertFalse(nodeManager.getReferences(second).contains(external));
+  }
+
+  // Removing the last target deletes the alias from every category, including Organizes links
+  // stored outside the alias's manager. Reuse must not reconnect the deleted membership.
+  @Test
+  void deletingTargetlessAliasRemovesExternalOrganizingReferences() throws Exception {
+    manager.startup();
+    NodeId first = newNodeId("TestInt32");
+    NodeId aliasId = manager.addAlias(NodeIds.Aliases, prefix, List.of(target(first)));
+    AliasCategoryConfig other = category("Other", NodeIds.Aliases);
+    manager.addCategory(other);
+    Reference external =
+        new Reference(
+            other.categoryNodeId(),
+            NodeIds.Organizes,
+            aliasId.expanded(),
+            Reference.Direction.FORWARD);
+    managed(other.categoryNodeId()).addReference(external);
+    externalReferences.add(external);
+    manager.touch(other.categoryNodeId());
+    assertEquals(Set.of(first), targets(other.categoryNodeId(), prefix));
+
+    manager.deleteAlias(NodeIds.Aliases, prefix, List.of(target(first)));
+    assertTrue(server.getAddressSpaceManager().getManagedNode(aliasId).isEmpty());
+    assertEquals(aliasId, manager.addAlias(NodeIds.Aliases, prefix, List.of(target(first))));
+    assertTrue(
+        targets(other.categoryNodeId(), prefix).isEmpty(), "deleted membership must not reappear");
+    assertFalse(nodeManager.getReferences(other.categoryNodeId()).contains(external));
+    assertTrue(nodeManager.getReferences(aliasId).isEmpty());
+  }
+
+  // UaNode.delete traverses owned HasChild links. Global reference cleanup must preserve that
+  // traversal so deleting an alias cannot strand a component in its own manager.
+  @Test
+  void deletingWholeAliasStillDeletesItsOwnedChildren() throws Exception {
+    manager.startup();
+    NodeId aliasId =
+        manager.addAlias(NodeIds.Aliases, prefix, List.of(target(newNodeId("TestInt32"))));
+    UaNode alias = managed(aliasId);
+    NodeId childId = newNodeId(prefix + "Component");
+    UaObjectNode child =
+        new UaObjectNode.UaObjectNodeBuilder(alias.getNodeContext())
+            .setNodeId(childId)
+            .setBrowseName(newQualifiedName(prefix + "Component"))
+            .setDisplayName(LocalizedText.english("component"))
+            .build();
+    alias.getNodeManager().addNode(child);
+    alias.addReference(
+        new Reference(
+            aliasId, NodeIds.HasComponent, childId.expanded(), Reference.Direction.FORWARD));
+    assertTrue(server.getAddressSpaceManager().getManagedNode(childId).isPresent());
+
+    manager.deleteAlias(NodeIds.Aliases, prefix, null);
+
+    assertTrue(server.getAddressSpaceManager().getManagedNode(aliasId).isEmpty());
+    assertTrue(
+        server.getAddressSpaceManager().getManagedNode(childId).isEmpty(),
+        "owned child deletion must still follow HasComponent");
+  }
+
+  private AliasCategoryConfig category(String suffix, NodeId parent) {
+    return new AliasCategoryConfig(
+        newNodeId(prefix + suffix),
+        parent,
+        newQualifiedName(prefix + suffix),
+        nodeManager,
+        name -> newNodeId(prefix + suffix + "/" + name),
+        true,
+        false,
+        true);
+  }
+
+  private AliasTarget target(NodeId id) {
+    return new AliasTarget(id.expanded(), null, NodeIds.AliasFor);
+  }
+
+  private UaNode managed(NodeId id) {
+    return server.getAddressSpaceManager().getManagedNode(id).orElseThrow();
+  }
+
+  private Set<NodeId> targets(NodeId category, String name) throws UaException {
+    return manager.findAlias(category, name, null).stream()
+        .flatMap(alias -> Arrays.stream(alias.getReferencedNodes()))
+        .map(id -> id.toNodeId(server.getNamespaceTable()).orElseThrow())
+        .collect(Collectors.toSet());
+  }
+
+  private StatusCode[] deleteOverWire(NodeId category, String name, @Nullable NodeId target)
+      throws UaException {
+    NodeId method =
+        server
+            .getAddressSpaceManager()
+            .getManagedReferences(category, Reference.HAS_COMPONENT_PREDICATE)
+            .stream()
+            .map(
+                reference ->
+                    reference.getTargetNodeId().toNodeId(server.getNamespaceTable()).orElseThrow())
+            .filter(id -> "DeleteAliasesFromCategory".equals(managed(id).getBrowseName().name()))
+            .findFirst()
+            .orElseThrow();
+    CallMethodResult result =
+        client.call(
+                List.of(
+                    new CallMethodRequest(
+                        category,
+                        method,
+                        new Variant[] {
+                          new Variant(new String[] {name}),
+                          new Variant(
+                              new ExpandedNodeId[] {target == null ? null : target.expanded()})
+                        })))
+            .getResults()[0];
+    assertEquals(StatusCode.GOOD, result.getStatusCode());
+    return (StatusCode[]) result.getOutputArguments()[0].value();
+  }
+
+  private static final class TestVersionStore implements AliasVersionStore {
+    private final Map<ExpandedNodeId, UInteger> entries = new ConcurrentHashMap<>();
+
+    @Override
+    public Map<ExpandedNodeId, UInteger> load() {
+      return Map.copyOf(entries);
+    }
+
+    @Override
+    public void save(ExpandedNodeId categoryId, UInteger value) throws UaException {
+      entries.put(categoryId, value);
+    }
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/AddressSpaceManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/AddressSpaceManager.java
@@ -134,4 +134,18 @@ public class AddressSpaceManager extends AddressSpaceComposite {
         .flatMap(Collection::stream)
         .collect(Collectors.toList());
   }
+
+  /**
+   * Remove {@code reference} and its inverse from every registered {@link NodeManager}.
+   *
+   * <p>References may be stored by either endpoint's manager, or by another registered manager. Use
+   * this when removing an association collected through {@link #getManagedReferences(NodeId)}.
+   *
+   * @param reference the association to remove in both directions.
+   */
+  public void removeManagedReferences(Reference reference) {
+    for (NodeManager<UaNode> nodeManager : nodeManagers) {
+      nodeManager.removeReferences(reference, getServer().getNamespaceTable());
+    }
+  }
 }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/aliases/AliasManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/aliases/AliasManager.java
@@ -939,7 +939,7 @@ public final class AliasManager extends AbstractLifecycle {
           removeFromCategory(aliasNode, categoryId);
 
           if (getOrganizingCategories(aliasNodeId).isEmpty()) {
-            aliasNode.delete();
+            deleteAliasNode(aliasNode);
           }
         } finally {
           versionManager.publishPending();
@@ -994,7 +994,7 @@ public final class AliasManager extends AbstractLifecycle {
         versionManager.prepare(bumped);
 
         for (Reference reference : matching) {
-          aliasNode.removeReference(reference);
+          server.getAddressSpaceManager().removeManagedReferences(reference);
         }
 
         deleteIfTargetless(aliasNode);
@@ -1326,13 +1326,10 @@ public final class AliasManager extends AbstractLifecycle {
    * target that is not associated changes nothing and reports {@code Good}; §6.3.5 reserves {@code
    * Bad_NotFound} for an alias name the category does not contain.
    *
-   * <p>Validation happens before any mutation, and reference removal through the manager's own
-   * fragment cannot partially fail, so an entry ordinarily either fully applies or leaves its state
-   * untouched (§6.3.5: "If all targets for an AliasNames array entry cannot be deleted, then none
-   * of the targets are deleted"). Aliases living in an application {@link NodeManager} can throw
-   * unchecked mid-entry, however; such a failure is confined to its entry as {@code
-   * Bad_InternalError}, and any category whose new version was prepared before the mutation still
-   * gets its LastChange published.
+   * <p>Validation happens before any mutation. Reference removal spans every registered {@link
+   * NodeManager}. A custom NodeManager can throw unchecked mid-entry; such a failure is confined to
+   * its entry as {@code Bad_InternalError}, and any category whose new version was prepared before
+   * the mutation still gets its LastChange published.
    */
   private StatusCode deleteAliasEntry(
       NodeId categoryId, @Nullable String aliasName, @Nullable ExpandedNodeId targetNode) {
@@ -1369,7 +1366,7 @@ public final class AliasManager extends AbstractLifecycle {
           removeFromCategory(aliasNode, categoryId);
 
           if (getOrganizingCategories(aliasNodeId).isEmpty()) {
-            aliasNode.delete();
+            deleteAliasNode(aliasNode);
           }
         }
 
@@ -1407,7 +1404,7 @@ public final class AliasManager extends AbstractLifecycle {
         versionManager.prepare(bumped);
 
         for (Reference reference : matching) {
-          aliasNode.removeReference(reference);
+          server.getAddressSpaceManager().removeManagedReferences(reference);
         }
 
         deleteIfTargetless(aliasNode);
@@ -1936,9 +1933,19 @@ public final class AliasManager extends AbstractLifecycle {
 
     versionManager.prepare(getOrganizingCategories(aliasNodeId));
 
-    aliasNode.delete();
+    deleteAliasNode(aliasNode);
 
     return true;
+  }
+
+  private void deleteAliasNode(UaNode aliasNode) {
+    var addressSpaceManager = server.getAddressSpaceManager();
+    List<Reference> references = addressSpaceManager.getManagedReferences(aliasNode.getNodeId());
+
+    // Preserve UaNode.delete's traversal of owned HasChild references before removing the
+    // snapshotted associations from every registered manager.
+    aliasNode.delete();
+    references.forEach(addressSpaceManager::removeManagedReferences);
   }
 
   /** The forward {@code AliasFor}-or-subtype References of an alias Node. */
@@ -1978,28 +1985,16 @@ public final class AliasManager extends AbstractLifecycle {
     return categoryIds;
   }
 
-  /**
-   * Remove the Organizes linkage between {@code categoryId} and the alias, from both Nodes'
-   * NodeManagers — the linkage may have been stored by either side.
-   */
-  private void removeFromCategory(UaNode aliasNode, NodeId categoryId) {
-    NodeId aliasNodeId = aliasNode.getNodeId();
-
-    aliasNode.removeReference(
-        new Reference(
-            aliasNodeId, NodeIds.Organizes, categoryId.expanded(), Reference.Direction.INVERSE));
-
+  /** Remove both directions of a member's Organizes linkage from every registered manager. */
+  private void removeFromCategory(UaNode member, NodeId categoryId) {
     server
         .getAddressSpaceManager()
-        .getManagedNode(categoryId)
-        .ifPresent(
-            categoryNode ->
-                categoryNode.removeReference(
-                    new Reference(
-                        categoryId,
-                        NodeIds.Organizes,
-                        aliasNodeId.expanded(),
-                        Reference.Direction.FORWARD)));
+        .removeManagedReferences(
+            new Reference(
+                member.getNodeId(),
+                NodeIds.Organizes,
+                categoryId.expanded(),
+                Reference.Direction.INVERSE));
   }
 
   /**

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/aliases/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/aliases/package-info.java
@@ -59,11 +59,15 @@
  * trade-off is weak consistency under concurrent mutation — the same weak consistency Browse
  * already has — and that out-of-band AddressSpace edits do not bump {@code LastChange}; mutations
  * must flow through the manager (or be followed by an explicit {@code touch}) for version
- * correctness. Out-of-band edits carry one further caveat: References recorded in only one
- * direction (e.g. a category-side-only {@code Organizes} Reference loaded from a NodeSet without
- * its inverse) are still found by search, which follows the forward direction, but are invisible to
- * alias-side operations — organizing-category resolution during delete and ancestor discovery
- * during version propagation both walk inverse References and miss such linkage.
+ * correctness. Association removal covers every registered NodeManager that may store either
+ * direction, matching the scope of reference collection. Whole-alias deletion preserves the owning
+ * manager's child-node traversal and removes the alias's collected References from all registered
+ * managers, so NodeId reuse cannot restore a deleted target or category membership. Out-of-band
+ * edits carry one further caveat: References recorded in only one direction (e.g. a
+ * category-side-only {@code Organizes} Reference loaded from a NodeSet without its inverse) are
+ * still found by search, which follows the forward direction, but are invisible to alias-side
+ * operations — organizing-category resolution during delete and ancestor discovery during version
+ * propagation both walk inverse References and miss such linkage.
  *
  * <h2>Network mutation</h2>
  *

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/package-info.java
@@ -71,6 +71,14 @@
  * initial Session unactivated. Enhanced username-token keys consumed during validation remain
  * single-use even if later response preparation fails.
  *
+ * <h2>Reference storage</h2>
+ *
+ * <p>{@link org.eclipse.milo.opcua.sdk.server.AddressSpaceManager} aggregates references from every
+ * registered NodeManager. Reference ownership is independent of node ownership: either endpoint's
+ * manager, or another registered manager, can store an association. Removing an association through
+ * the address-space manager removes both directions from all registered stores, matching the scope
+ * used for discovery.
+ *
  * <h2>Runtime boundaries</h2>
  *
  * <p>The SDK server package coordinates high-level server configuration and lifecycle. Certificate


### PR DESCRIPTION
Alias deletion can leave AliasFor or Organizes references in another registered NodeManager, allowing a removed target or membership to reappear when an alias NodeId is reused. Remove associations from every registered manager. Whole-alias deletion snapshots these references, preserves the owning manager's child traversal, and then removes the collected associations. Existing custom-manager failure behavior and one-sided out-of-band reference limitations remain unchanged.

### Verification

Six cases cover public and wire target deletion, public and wire whole-alias deletion followed by NodeId reuse, targetless-alias category cleanup, and an owned-child deletion control.

Formatting, full clean compilation, and 141 selected tests passed for this branch.
