### PR TITLE
Prepare activation responses before changing Session state

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/SessionManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/SessionManager.java
@@ -566,10 +566,13 @@ public class SessionManager {
         EccEncryptedSecret.createEphemeralKey(
             securityPolicy.getProfile(), signingKeyPair, ephemeralKeyPair);
 
+    ExtensionObject response =
+        EnhancedUserTokenAdditionalHeader.createResponse(
+            server.getStaticEncodingContext(), securityPolicy, ephemeralKey);
+
     session.setUserTokenEphemeralKeyPair(ephemeralKeyPair, ephemeralPublicKey);
 
-    return EnhancedUserTokenAdditionalHeader.createResponse(
-        server.getStaticEncodingContext(), securityPolicy, ephemeralKey);
+    return response;
   }
 
   private KeyPair selectUserTokenSigningKeyPair(
@@ -905,13 +908,14 @@ public class SessionManager {
 
           ByteString serverNonce = NonceUtil.generateNonce(32);
 
+          ExtensionObject additionalHeader =
+              activateSessionAdditionalHeader(request, securityConfiguration, session);
+
+          // The header can install a new key; keep the remaining commit operations non-throwing.
           session.setClientAddress(context.clientAddress());
           session.setIdentity(identity, identityToken);
           session.setLastNonce(serverNonce);
           session.setLocaleIds(request.getLocaleIds());
-
-          ExtensionObject additionalHeader =
-              activateSessionAdditionalHeader(request, securityConfiguration, session);
 
           return new ActivateSessionResponse(
               createResponseHeader(request, StatusCode.GOOD, additionalHeader),
@@ -965,6 +969,16 @@ public class SessionManager {
                     clientCertificateBytes, securityConfiguration.getClientCertificateBytes());
 
             if (sameIdentity && sameCertificate) {
+              StatusCode[] results = new StatusCode[clientSoftwareCertificates.length];
+              Arrays.fill(results, StatusCode.GOOD);
+
+              ByteString serverNonce = NonceUtil.generateNonce(32);
+
+              ExtensionObject additionalHeader =
+                  activateSessionAdditionalHeader(request, newSecurityConfiguration, session);
+
+              // The header can install a new key; keep the remaining commit operations
+              // non-throwing.
               session.setSecureChannelId(secureChannelId);
 
               logger.debug(
@@ -972,17 +986,9 @@ public class SessionManager {
                   session.getSessionId(),
                   secureChannelId);
 
-              StatusCode[] results = new StatusCode[clientSoftwareCertificates.length];
-              Arrays.fill(results, StatusCode.GOOD);
-
-              ByteString serverNonce = NonceUtil.generateNonce(32);
-
               session.setClientAddress(context.clientAddress());
               session.setLastNonce(serverNonce);
               session.setLocaleIds(request.getLocaleIds());
-
-              ExtensionObject additionalHeader =
-                  activateSessionAdditionalHeader(request, newSecurityConfiguration, session);
 
               activated = true;
 
@@ -1017,6 +1023,14 @@ public class SessionManager {
       Identity identity =
           validateIdentityToken(session, identityToken, request.getUserTokenSignature());
 
+      StatusCode[] results = new StatusCode[clientSoftwareCertificates.length];
+      Arrays.fill(results, StatusCode.GOOD);
+
+      ByteString serverNonce = NonceUtil.generateNonce(32);
+
+      ExtensionObject additionalHeader =
+          activateSessionAdditionalHeader(request, session.getSecurityConfiguration(), session);
+
       // Move the session from created to active atomically with respect to the limit check in
       // createSession, so a concurrent CreateSession cannot evict a session that is activating.
       synchronized (sessionLock) {
@@ -1027,18 +1041,11 @@ public class SessionManager {
         activeSessions.put(authToken, session);
       }
 
-      StatusCode[] results = new StatusCode[clientSoftwareCertificates.length];
-      Arrays.fill(results, StatusCode.GOOD);
-
-      ByteString serverNonce = NonceUtil.generateNonce(32);
-
+      // The header installed any candidate key; commit after the registry check must not throw.
       session.setClientAddress(context.clientAddress());
       session.setIdentity(identity, identityToken);
       session.setLocaleIds(request.getLocaleIds());
       session.setLastNonce(serverNonce);
-
-      ExtensionObject additionalHeader =
-          activateSessionAdditionalHeader(request, session.getSecurityConfiguration(), session);
 
       return new ActivateSessionResponse(
           createResponseHeader(request, StatusCode.GOOD, additionalHeader),

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/package-info.java
@@ -65,7 +65,11 @@
  * <h2>Session response preparation</h2>
  *
  * <p>A Session owns a timeout as soon as it is constructed. Failed CreateSession preparation must
- * close that provisional Session before returning an error.
+ * close that provisional Session before returning an error. ActivateSession prepares its response
+ * additional header before committing identity, nonce, locale, or channel changes. A failed
+ * negotiation therefore leaves an existing Session usable on its previous channel and leaves an
+ * initial Session unactivated. Enhanced username-token keys consumed during validation remain
+ * single-use even if later response preparation fails.
  *
  * <h2>Runtime boundaries</h2>
  *

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/SessionEndpointBindingTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/SessionEndpointBindingTest.java
@@ -42,12 +42,15 @@ import org.eclipse.milo.opcua.stack.core.security.CertificateGroup;
 import org.eclipse.milo.opcua.stack.core.security.CertificateManager;
 import org.eclipse.milo.opcua.stack.core.security.CertificateQuarantine;
 import org.eclipse.milo.opcua.stack.core.security.CertificateValidator;
+import org.eclipse.milo.opcua.stack.core.security.ChannelBoundSignatureData;
 import org.eclipse.milo.opcua.stack.core.security.DefaultCertificateManager;
+import org.eclipse.milo.opcua.stack.core.security.EnhancedUserTokenAdditionalHeader;
 import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
 import org.eclipse.milo.opcua.stack.core.security.TrustListManager;
 import org.eclipse.milo.opcua.stack.core.transport.TransportProfile;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.ApplicationType;
@@ -74,6 +77,8 @@ import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * OPC UA does not transmit an EndpointDescription identifier during OpenSecureChannel (Part 6,
@@ -382,6 +387,74 @@ public class SessionEndpointBindingTest {
       session.close(true);
     }
 
+    // Part 4 §5.7.3.1 binds activation to the last ServerNonce received by the client. A failed
+    // response-header negotiation must leave a signed retry using that delivered nonce valid.
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void securedReactivationRetriesWithTheLastDeliveredNonce(boolean replaceChannel)
+        throws Exception {
+      OpcUaServer server =
+          server(
+              manager(group(GROUP_A, certificateA)),
+              List.of(securedEndpoint(GROUP_A, ANONYMOUS_POLICY)));
+      SessionManager sessions = server.getSessionManager();
+      try {
+        EndpointDescription endpoint = endpointForPath(server, "/test");
+        var original =
+            new TestServiceRequestContext(
+                endpointUrl("/test"), securedChannel(1L, certificateA), endpoint);
+        var create = createSessionRequest(clientCertificate.byteString());
+        CreateSessionResponse created = sessions.createSession(original, create);
+        NodeId token = created.getAuthenticationToken();
+        var activated =
+            sessions.activateSession(
+                original,
+                signedActivation(token, created.getServerNonce(), create.getClientNonce(), null));
+        ByteString deliveredNonce = activated.getServerNonce();
+        var candidate =
+            replaceChannel
+                ? new TestServiceRequestContext(
+                    endpointUrl("/test"), securedChannel(2L, certificateA), endpoint)
+                : original;
+
+        UaException wrongNonce =
+            assertThrows(
+                UaException.class,
+                () ->
+                    sessions.activateSession(
+                        candidate,
+                        signedActivation(
+                            token, NonceUtil.generateNonce(32), create.getClientNonce(), null)));
+        assertEquals(
+            StatusCodes.Bad_ApplicationSignatureInvalid, wrongNonce.getStatusCode().value());
+
+        ExtensionObject rejected =
+            EnhancedUserTokenAdditionalHeader.createRequest(
+                server.getStaticEncodingContext(), SecurityPolicy.ECC_nistP256_AesGcm);
+        UaException failure =
+            assertThrows(
+                UaException.class,
+                () ->
+                    sessions.activateSession(
+                        candidate,
+                        signedActivation(
+                            token, deliveredNonce, create.getClientNonce(), rejected)));
+        assertEquals(StatusCodes.Bad_SecurityPolicyRejected, failure.getStatusCode().value());
+        assertEquals(1L, sessions.getSession(original, requestHeader(token)).getSecureChannelId());
+
+        // Sign only the nonce delivered in the previous successful response, never Session state.
+        var retried =
+            sessions.activateSession(
+                candidate, signedActivation(token, deliveredNonce, create.getClientNonce(), null));
+        assertNotEquals(deliveredNonce, retried.getServerNonce());
+        assertEquals(
+            replaceChannel ? 2L : 1L,
+            sessions.getSession(candidate, requestHeader(token)).getSecureChannelId());
+      } finally {
+        sessions.shutdown();
+      }
+    }
+
     /**
      * When a Session is reactivated onto a replacement SecureChannel, its endpoint association must
      * follow the endpoint selected by that new channel; identity validation runs against the new
@@ -553,6 +626,34 @@ public class SessionEndpointBindingTest {
         clientCertificateBytes,
         60_000.0,
         uint(0));
+  }
+
+  private static ActivateSessionRequest signedActivation(
+      NodeId token,
+      ByteString serverNonce,
+      ByteString clientNonce,
+      @Nullable ExtensionObject additionalHeader)
+      throws Exception {
+    byte[] data =
+        ChannelBoundSignatureData.clientSignatureData(
+            SecurityPolicy.Basic256Sha256.getProfile(),
+            ByteString.NULL_VALUE,
+            serverNonce,
+            certificateA.byteString(),
+            certificateA.byteString(),
+            clientCertificate.byteString(),
+            clientNonce);
+    SignatureData signature =
+        ChannelBoundSignatureData.sign(
+            SecurityPolicy.Basic256Sha256, clientCertificate.keyPair().getPrivate(), data);
+    return new ActivateSessionRequest(
+        new RequestHeader(
+            token, DateTime.now(), uint(1), uint(0), null, uint(10_000), additionalHeader),
+        signature,
+        null,
+        null,
+        null,
+        new SignatureData(null, null));
   }
 
   private static ActivateSessionRequest activateSessionRequest(NodeId authToken) {

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/SessionHeaderFailureTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/SessionHeaderFailureTest.java
@@ -11,7 +11,12 @@
 package org.eclipse.milo.opcua.sdk.server;
 
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -24,6 +29,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.net.InetAddress;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
@@ -43,10 +49,13 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.ApplicationType;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.MessageSecurityMode;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.UserTokenType;
+import org.eclipse.milo.opcua.stack.core.types.structured.ActivateSessionRequest;
 import org.eclipse.milo.opcua.stack.core.types.structured.ApplicationDescription;
 import org.eclipse.milo.opcua.stack.core.types.structured.CreateSessionRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.CreateSessionResponse;
 import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
 import org.eclipse.milo.opcua.stack.core.types.structured.RequestHeader;
+import org.eclipse.milo.opcua.stack.core.types.structured.SignatureData;
 import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
 import org.eclipse.milo.opcua.stack.core.util.NonceUtil;
 import org.eclipse.milo.opcua.stack.transport.server.OpcServerTransport;
@@ -54,6 +63,8 @@ import org.eclipse.milo.opcua.stack.transport.server.ServiceRequestContext;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /** Exercises failed header negotiation through real session creation and activation. */
 class SessionHeaderFailureTest {
@@ -103,6 +114,79 @@ class SessionHeaderFailureTest {
     verify(timeout).cancel(false);
     manager.shutdown();
     verifyNoInteractions(listener);
+  }
+
+  /** The initial activation must remain pending if preparing its response fails. */
+  @Test
+  void failedInitialActivationDoesNotAuthorizeServices() throws Exception {
+    ServiceRequestContext context = context(1, "/a");
+    CreateSessionResponse created = manager.createSession(context, createRequest(null));
+    Session session = manager.getAllSessions().get(0);
+    ByteString nonce = session.getLastNonce();
+
+    assertRejectedActivation(context, created.getAuthenticationToken());
+
+    assertAll(
+        () -> assertEquals(nonce, session.getLastNonce()),
+        () -> assertNull(session.getIdentity()),
+        () -> assertNull(session.getLocaleIds()),
+        () -> assertTrue(session.getClientUserIdHistory().isEmpty()),
+        () ->
+            assertEquals(
+                StatusCodes.Bad_SessionNotActivated,
+                assertThrows(
+                        UaException.class,
+                        () ->
+                            manager.getSession(
+                                context, header(created.getAuthenticationToken(), null)))
+                    .getStatusCode()
+                    .value()));
+  }
+
+  /** Neither identity refresh nor channel replacement may commit before its response is ready. */
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void failedReactivationPreservesPriorState(boolean replaceChannel) throws Exception {
+    ServiceRequestContext original = context(1, "/a");
+    CreateSessionResponse created = manager.createSession(original, createRequest(null));
+    NodeId token = created.getAuthenticationToken();
+    manager.activateSession(original, activateRequest(token, null, "en-US"));
+    Session session = manager.getAllSessions().get(0);
+    ByteString nonce = session.getLastNonce();
+    Object identity = session.getIdentity();
+    Object security = session.getSecurityConfiguration();
+    EndpointDescription endpoint = session.getEndpoint();
+    List<String> identityHistory = session.getClientUserIdHistory();
+
+    ServiceRequestContext candidate = replaceChannel ? context(2, "/b") : original;
+    assertRejectedActivation(candidate, token);
+
+    assertAll(
+        () -> assertEquals(1L, session.getSecureChannelId()),
+        () -> assertSame(endpoint, session.getEndpoint()),
+        () -> assertSame(security, session.getSecurityConfiguration()),
+        () -> assertSame(identity, session.getIdentity()),
+        () -> assertEquals(nonce, session.getLastNonce()),
+        () -> assertArrayEquals(new String[] {"en-US"}, session.getLocaleIds()),
+        () -> assertEquals(identityHistory, session.getClientUserIdHistory()),
+        () -> assertSame(session, manager.getSession(original, header(token, null))));
+
+    // The same request can subsequently succeed when it omits the rejected negotiation.
+    manager.activateSession(candidate, activateRequest(token, null, "de-DE"));
+    assertSame(session, manager.getSession(candidate, header(token, null)));
+    assertArrayEquals(new String[] {"de-DE"}, session.getLocaleIds());
+    assertNotEquals(nonce, session.getLastNonce());
+  }
+
+  private void assertRejectedActivation(ServiceRequestContext context, NodeId token)
+      throws Exception {
+    UaException failure =
+        assertThrows(
+            UaException.class,
+            () ->
+                manager.activateSession(
+                    context, activateRequest(token, rejectedHeader(), "de-DE")));
+    assertEquals(StatusCodes.Bad_SecurityPolicyRejected, failure.getStatusCode().value());
   }
 
   private ExtensionObject rejectedHeader() throws UaException {
@@ -159,6 +243,17 @@ class SessionHeaderFailureTest {
         ByteString.NULL_VALUE,
         60_000.0,
         uint(0));
+  }
+
+  private static ActivateSessionRequest activateRequest(
+      NodeId token, ExtensionObject additionalHeader, String locale) {
+    return new ActivateSessionRequest(
+        header(token, additionalHeader),
+        new SignatureData(null, null),
+        null,
+        new String[] {locale},
+        null,
+        new SignatureData(null, null));
   }
 
   private static RequestHeader header(NodeId token, ExtensionObject additionalHeader) {


### PR DESCRIPTION
Failed `ActivateSession` response-header negotiation could partially change identity, nonce, locale, channel ownership, or active-session registration. A client could lose its previously usable Session even though activation returned an error.

The server now prepares the additional response header before committing those changes. Failed initial activation leaves the Session pending; failed reactivation preserves the prior state and channel. A secured retry can still sign the nonce from the last successful response. Consumed enhanced username-token keys remain single-use.

[Part 4 §5.7.3.1](https://reference.opcfoundation.org/specs/OPC-10000-4/5.7.3.1) states: "If no errors occur the Server replaces the user identity for the Session."

Regressions cover initial activation, identity refresh, channel replacement, and signed retries over the same or a replacement secured channel.

Formatting, a full clean compile, and the selected regression suites passed for this branch.

Based on https://github.com/eclipse-milo/milo/pull/1894 so the diff contains only this fix.
