### PR TITLE
Complete reverse handshakes after executor rejection

### DIFF
--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseTcpClientTransport.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseTcpClientTransport.java
@@ -566,26 +566,31 @@ public final class ReverseTcpClientTransport extends AbstractUascClientTransport
             });
 
     handshakeFuture.whenComplete(
-        (secureChannel, ex) ->
-            config
-                .getExecutor()
-                .execute(
-                    () -> {
-                      if (secureChannel != null) {
-                        completeHandshake(targetFuture, secureChannel.getChannel());
-                      } else {
-                        Throwable failure = unwrap(ex);
-                        CompletableFuture<Channel> nextFuture =
-                            rearmOnFailure ? rearmAfterFailedClaim(targetFuture, channel) : null;
+        (secureChannel, ex) -> {
+          Runnable completion =
+              () -> {
+                if (secureChannel != null) {
+                  completeHandshake(targetFuture, secureChannel.getChannel());
+                } else {
+                  Throwable failure = unwrap(ex);
+                  CompletableFuture<Channel> nextFuture =
+                      rearmOnFailure ? rearmAfterFailedClaim(targetFuture, channel) : null;
 
-                        targetFuture.completeExceptionally(failure);
-                        channel.close();
+                  targetFuture.completeExceptionally(failure);
+                  channel.close();
 
-                        if (nextFuture != null) {
-                          registerForNextChannel(nextFuture);
-                        }
-                      }
-                    }));
+                  if (nextFuture != null) {
+                    registerForNextChannel(nextFuture);
+                  }
+                }
+              };
+          try {
+            config.getExecutor().execute(completion);
+          } catch (RejectedExecutionException rejected) {
+            // The handshake is finished; no remaining handshake deadline can settle connect.
+            completion.run();
+          }
+        });
   }
 
   private @Nullable CompletableFuture<Channel> rearmAfterFailedClaim(

--- a/opc-ua-sdk/sdk-client/src/test/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseTcpClientTransportTest.java
+++ b/opc-ua-sdk/sdk-client/src/test/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseTcpClientTransportTest.java
@@ -16,11 +16,13 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.netty.channel.Channel;
 import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.util.HashedWheelTimer;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -57,6 +59,8 @@ import org.eclipse.milo.opcua.stack.core.types.structured.ApplicationDescription
 import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
 import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
 import org.eclipse.milo.opcua.stack.transport.client.tcp.OpcTcpClientTransportConfig;
+import org.eclipse.milo.opcua.stack.transport.client.uasc.ClientSecureChannel;
+import org.eclipse.milo.opcua.stack.transport.client.uasc.UascClientAcknowledgeHandler;
 import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -364,6 +368,59 @@ class ReverseTcpClientTransportTest {
     } finally {
       channel.close();
       manager.shutdown();
+    }
+  }
+
+  // A completed SecureChannel handshake must reach connect callers even if executor dispatch
+  // rejects.
+  @Test
+  @SuppressWarnings("unchecked")
+  void rejectedHandshakeDispatchStillCompletesConnect() throws Exception {
+    executor =
+        new QueuingExecutorService() {
+          @Override
+          public void execute(Runnable task) {
+            throw new RejectedExecutionException("saturated");
+          }
+        };
+    EmbeddedChannel channel = new EmbeddedChannel();
+    HashedWheelTimer timer = new HashedWheelTimer();
+    ReverseTcpClientTransport transport =
+        new ReverseTcpClientTransport(
+            OpcTcpClientTransportConfig.newBuilder()
+                .setExecutor(executor)
+                .setScheduledExecutor(scheduledExecutor())
+                .setWheelTimer(timer)
+                .build(),
+            newConnection(channel));
+    OpcUaClient client = new OpcUaClient(clientConfig(), transport);
+    CompletableFuture<Channel> target = new CompletableFuture<>();
+    setField(transport, "started", true);
+    setField(transport, "disconnecting", false);
+    setField(transport, "channelFuture", target);
+    setField(
+        transport,
+        "applicationContext",
+        declaredField(OpcUaClient.class, "applicationContext").get(client));
+    try {
+      invokeInitializeClaimedConnection(transport, newConnection(channel), target);
+      channel.runPendingTasks();
+      UascClientAcknowledgeHandler acknowledge =
+          channel.pipeline().get(UascClientAcknowledgeHandler.class);
+      CompletableFuture<ClientSecureChannel> handshake =
+          (CompletableFuture<ClientSecureChannel>)
+              declaredField(UascClientAcknowledgeHandler.class, "handshakeFuture").get(acknowledge);
+      ClientSecureChannel secureChannel =
+          new ClientSecureChannel(SecurityPolicy.None, MessageSecurityMode.None);
+      secureChannel.setChannel(channel);
+      handshake.complete(secureChannel);
+      assertTrue(target.isDone(), "executor rejection must not lose the completed handshake");
+      assertSame(channel, target.get(5, TimeUnit.SECONDS));
+      assertTrue(channel.isOpen(), "a successful handshake remains usable");
+    } finally {
+      transport.disconnect().get(5, TimeUnit.SECONDS);
+      channel.finishAndReleaseAll();
+      timer.stop();
     }
   }
 


### PR DESCRIPTION
A completed SecureChannel handshake can lose its final callback when the configured executor rejects dispatch. The connect future then remains pending, with no remaining handshake deadline to settle it.

Run completed-handshake processing inline when dispatch rejects. A successful handshake still returns its usable channel; failure processing still performs cleanup. The regression completes the handshake future obtained from the real client pipeline and checks that connect receives the open channel under a rejecting executor.

## Verification

Formatting and full clean compile passed. The selected regression suites passed (84 tests, no failures or errors).

```sh
mise exec -- mvn -q -pl opc-ua-sdk/sdk-client -am verify '-Dtest=Reverse*' -Dsurefire.failIfNoSpecifiedTests=false
```

Based on https://github.com/eclipse-milo/milo/pull/1895 so the diff contains only this fix.
