### PR TITLE
Detach surviving child categories when their parent is removed

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/aliases/AliasLifecycleConsistencyTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/aliases/AliasLifecycleConsistencyTest.java
@@ -213,6 +213,34 @@ class AliasLifecycleConsistencyTest extends AbstractClientServerTest {
         "owned child deletion must still follow HasComponent");
   }
 
+  // A child's parent reference was created after its parent journal. Parent removal must detach
+  // the surviving child so reuse of the parent's NodeId cannot silently reconnect its contents.
+  @Test
+  void removingParentDetachesSurvivingChildBeforeParentNodeIdReuse() throws Exception {
+    manager.startup();
+    AliasCategoryConfig parent = category("Parent", NodeIds.Aliases);
+    AliasCategoryConfig child = category("Child", parent.categoryNodeId());
+    manager.addCategory(parent);
+    manager.addCategory(child);
+    NodeId aliasId =
+        manager.addAlias(child.categoryNodeId(), prefix, List.of(target(newNodeId("TestInt32"))));
+    manager.removeCategory(parent.categoryNodeId());
+
+    assertTrue(server.getAddressSpaceManager().getManagedNode(child.categoryNodeId()).isPresent());
+    assertTrue(server.getAddressSpaceManager().getManagedNode(aliasId).isPresent());
+    assertFalse(
+        server
+            .getAddressSpaceManager()
+            .getManagedReferences(child.categoryNodeId(), Reference.ORGANIZED_BY_PREDICATE)
+            .stream()
+            .anyMatch(
+                reference ->
+                    reference.getTargetNodeId().equals(parent.categoryNodeId().expanded())));
+    manager.addCategory(parent);
+    assertTrue(manager.findAlias(parent.categoryNodeId(), prefix, null).isEmpty());
+    assertEquals(Set.of(newNodeId("TestInt32")), targets(child.categoryNodeId(), prefix));
+  }
+
   private AliasCategoryConfig category(String suffix, NodeId parent) {
     return new AliasCategoryConfig(
         newNodeId(prefix + suffix),

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/aliases/AliasManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/aliases/AliasManager.java
@@ -584,10 +584,10 @@ public final class AliasManager extends AbstractLifecycle {
    * Stop managing a category: unbind its Method handlers and, if the category was created by {@link
    * #addCategory}, delete the Nodes and References that creation added.
    *
-   * <p>Alias Nodes added to the category after its creation are not deleted — their {@code
-   * Organizes} linkage to the category is removed so no References target the deleted NodeId, but
-   * the alias Nodes themselves survive. Delete them first with {@link #deleteAlias} if they should
-   * not outlive the category.
+   * <p>Alias Nodes and child categories added after the category's creation survive. Their {@code
+   * Organizes} linkage to the deleted category is removed so recreating its NodeId does not
+   * reconnect them. Delete aliases first with {@link #deleteAlias} if they should not outlive the
+   * category.
    *
    * <p>When the category Node is deleted, {@code LastChange} is bumped for its former ancestor
    * categories (captured before deletion) and the category's own in-memory version entry is
@@ -640,16 +640,13 @@ public final class AliasManager extends AbstractLifecycle {
         }
 
         if (record.instantiationResult() != null) {
-          // Detach aliases organized after creation: deleteCreated removes only what the
-          // instantiation recorded, so their Organizes linkage would otherwise dangle on the
-          // alias side, pointing at the deleted category — and silently reattach if a category
-          // with the same NodeId were created later. The alias Nodes themselves survive, per
-          // this method's contract.
-          for (NodeId aliasNodeId : findOrganizedAliases(categoryId)) {
+          // A surviving member's linkage may have been added after this category's creation
+          // journal. Detach both aliases and child categories before deleting the parent.
+          for (NodeId memberId : findOrganizedMembers(categoryId)) {
             server
                 .getAddressSpaceManager()
-                .getManagedNode(aliasNodeId)
-                .ifPresent(aliasNode -> removeFromCategory(aliasNode, categoryId));
+                .getManagedNode(memberId)
+                .ifPresent(member -> removeFromCategory(member, categoryId));
           }
 
           record.instantiationResult().deleteCreated();
@@ -1822,8 +1819,8 @@ public final class AliasManager extends AbstractLifecycle {
         .orElse(null);
   }
 
-  /** Find every alias Object directly organized by {@code categoryId}, regardless of name. */
-  private List<NodeId> findOrganizedAliases(NodeId categoryId) {
+  /** Find alias Objects and child categories directly organized by {@code categoryId}. */
+  private List<NodeId> findOrganizedMembers(NodeId categoryId) {
     List<Reference> organizes =
         server
             .getAddressSpaceManager()
@@ -1834,7 +1831,9 @@ public final class AliasManager extends AbstractLifecycle {
       reference
           .getTargetNodeId()
           .toNodeId(server.getNamespaceTable())
-          .filter(aliasTypes::isAliasNameInstance)
+          .filter(
+              id ->
+                  aliasTypes.isAliasNameInstance(id) || aliasTypes.isAliasNameCategoryInstance(id))
           .ifPresent(found::add);
     }
     return found;

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/aliases/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/aliases/package-info.java
@@ -48,7 +48,9 @@
  * and unregisters its fragment: Nodes the manager hosts there (materialized Methods, alias Nodes
  * created in standard or adopted categories) leave the AddressSpace with it, while category and
  * alias Nodes hosted in application NodeManagers remain in place. Applications register their own
- * categories and aliases through the manager's programmatic API after startup.
+ * categories and aliases through the manager's programmatic API after startup. Removing a
+ * manager-created category detaches its surviving aliases and child categories before deleting the
+ * category itself.
  *
  * <h2>Data flow</h2>
  *


### PR DESCRIPTION
Removing a parent alias category left inverse Organizes links on surviving child categories. Recreating the parent NodeId could silently reconnect their contents. Detach both child categories and aliases before deleting a manager-created parent; the surviving nodes remain usable.

### Verification

The regression removes a parent with a child category and alias, verifies both survive without the old parent linkage, then recreates the parent and verifies it does not regain the child's contents.

Formatting, full clean compilation, and 142 selected tests passed for this branch.

Based on https://github.com/eclipse-milo/milo/pull/1896 so the diff contains only this fix.
