### PR TITLE
Select a user token policy compatible with the certificate

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/session/EccSessionIntegrationTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/session/EccSessionIntegrationTest.java
@@ -734,9 +734,9 @@ class EccSessionIntegrationTest {
     }
   }
 
-  // Part 4 (7.41) requires an explicitly specified certificate user-token policy to use the same
-  // public-key algorithm as the SecureChannel. The client must reject an ECC token policy over an
-  // RSA channel before attempting to construct the identity signature.
+  // Part 4 (6.1.8, Table 101) requires channel-bound inputs for an enhanced user-token signature.
+  // A legacy secured channel cannot supply them, so the only advertised certificate policy is
+  // unusable. Exhausting the advertised policies must reject the identity before signing.
   @Test
   void rejectsEnhancedX509TokenOverLegacyChannel() throws Exception {
     SecurityPolicy channelPolicy = SecurityPolicy.Basic256Sha256;
@@ -772,7 +772,7 @@ class EccSessionIntegrationTest {
       try {
         UaException exception = assertThrows(UaException.class, client::connect);
 
-        assertEquals(StatusCodes.Bad_SecurityPolicyRejected, exception.getStatusCode().getValue());
+        assertEquals(StatusCodes.Bad_IdentityTokenRejected, exception.getStatusCode().getValue());
       } finally {
         disconnectQuietly(client);
       }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/identity/X509IdentityProvider.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/identity/X509IdentityProvider.java
@@ -19,9 +19,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
-import java.util.stream.Stream;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.security.CertificateCompatibility;
 import org.eclipse.milo.opcua.stack.core.security.ChannelBoundSignatureData;
 import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
 import org.eclipse.milo.opcua.stack.core.security.SecurityPolicyProfile;
@@ -40,7 +40,8 @@ import org.jspecify.annotations.Nullable;
  * An {@link IdentityProvider} that authenticates with a certificate user-token policy.
  *
  * <p>The provider sends the configured certificate chain as the user identity token and signs the
- * server certificate plus nonce when the selected user-token security policy requires a signature.
+ * server certificate plus nonce with the selected signing policy. Certificate policies resolving to
+ * SecurityPolicy.None are skipped because they cannot prove possession of the private key.
  * Certificate-token policies do not use the enhanced username-secret additional-header exchange,
  * even when the certificate-token policy itself uses an ECC or RSA-DH security policy.
  */
@@ -222,14 +223,43 @@ public class X509IdentityProvider implements IdentityProvider {
         inputs.clientNonce());
   }
 
-  private static UserTokenPolicy selectTokenPolicy(EndpointDescription endpoint) throws Exception {
+  private UserTokenPolicy selectTokenPolicy(EndpointDescription endpoint) throws UaException {
     UserTokenPolicy[] userIdentityTokens =
         requireNonNullElse(endpoint.getUserIdentityTokens(), new UserTokenPolicy[0]);
 
-    return Stream.of(userIdentityTokens)
-        .filter(t -> t.getTokenType() == UserTokenType.Certificate)
-        .findFirst()
-        .orElseThrow(() -> new Exception("no x509 certificate token policy found"));
+    if (certificateChain.isEmpty()) {
+      throw new UaException(StatusCodes.Bad_IdentityTokenInvalid, "no user certificate configured");
+    }
+
+    X509Certificate certificate = certificateChain.get(0);
+    UaException lastFailure = null;
+
+    for (UserTokenPolicy tokenPolicy : userIdentityTokens) {
+      if (tokenPolicy == null || tokenPolicy.getTokenType() != UserTokenType.Certificate) {
+        continue;
+      }
+
+      try {
+        SecurityPolicy securityPolicy = resolveSecurityPolicy(endpoint, tokenPolicy);
+        if (securityPolicy == SecurityPolicy.None) {
+          throw new UaException(
+              StatusCodes.Bad_SecurityPolicyRejected,
+              "certificate user token requires a signing policy");
+        }
+        CertificateCompatibility.checkPublicKey(
+            securityPolicy.getProfile(), certificate.getPublicKey());
+        ChannelBoundSignatureData.checkUserTokenChannelCompatibility(
+            securityPolicy.getProfile(), SecurityPolicy.fromUri(endpoint.getSecurityPolicyUri()));
+        return tokenPolicy;
+      } catch (UaException e) {
+        lastFailure = e;
+      }
+    }
+
+    throw new UaException(
+        StatusCodes.Bad_IdentityTokenRejected,
+        "no compatible x509 certificate token policy found",
+        lastFailure);
   }
 
   private static SecurityPolicy resolveSecurityPolicy(

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/identity/package-info.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/identity/package-info.java
@@ -17,6 +17,11 @@
  * providers: anonymous, username/password, X.509 certificate, or a composite provider that tries
  * several providers in order.
  *
+ * <p>The X.509 provider tries advertised certificate-token policies in order and selects the first
+ * signing policy compatible with both the user certificate's public key and the SecureChannel.
+ * Policies resolving to SecurityPolicy.None are skipped. Selection uses the public key, including
+ * its curve, so it does not access a supplied private key until signing.
+ *
  * <h2>Session handoff</h2>
  *
  * <p>Some user-token policies need data learned during CreateSession before the provider can build

--- a/opc-ua-sdk/sdk-client/src/test/java/org/eclipse/milo/opcua/sdk/client/identity/UserTokenSecurityPolicyRulesTest.java
+++ b/opc-ua-sdk/sdk-client/src/test/java/org/eclipse/milo/opcua/sdk/client/identity/UserTokenSecurityPolicyRulesTest.java
@@ -179,11 +179,10 @@ class UserTokenSecurityPolicyRulesTest {
                 endpoint, SecurityPolicy.ECC_nistP256_AesGcm));
   }
 
-  // ---- X509IdentityProvider wiring: the certificate provider applies the public-key-family rule,
-  // but not the enhanced-secret rule (its token is signed, not encrypted) ----
+  // Certificate policies must match the configured user certificate.
 
   @Test
-  void x509ProviderRejectsExplicitCrossFamilyCertificateTokenPolicy() throws Exception {
+  void x509ProviderRejectsPolicyIncompatibleWithItsCertificate() throws Exception {
     X509IdentityProvider provider = rsaX509Provider();
     EndpointDescription endpoint =
         endpointWithCertificateToken(
@@ -194,8 +193,8 @@ class UserTokenSecurityPolicyRulesTest {
     UaException ex =
         assertThrows(UaException.class, () -> provider.getUserTokenSecurityPolicy(endpoint));
 
-    assertEquals(StatusCodes.Bad_SecurityPolicyRejected, ex.getStatusCode().getValue());
-    assertTrue(ex.getMessage().contains("public-key algorithm"));
+    assertEquals(StatusCodes.Bad_IdentityTokenRejected, ex.getStatusCode().getValue());
+    assertTrue(ex.getMessage().contains("no compatible"));
   }
 
   // The enhanced-secret rule must NOT be applied to certificate tokens: an enhanced X509 signature
@@ -203,7 +202,13 @@ class UserTokenSecurityPolicyRulesTest {
   // rejected the way an enhanced username secret would be.
   @Test
   void x509ProviderAllowsEnhancedCertificateTokenPolicyOnNoneChannel() throws Exception {
-    X509IdentityProvider provider = rsaX509Provider();
+    KeyPair keys = SelfSignedCertificateGenerator.generateNistP256KeyPair();
+    X509Certificate certificate =
+        SelfSignedCertificateBuilder.forEccApplicationCertificate(keys)
+            .setCommonName("user")
+            .setApplicationUri("urn:test:user")
+            .build();
+    X509IdentityProvider provider = new X509IdentityProvider(certificate, keys.getPrivate());
     EndpointDescription endpoint =
         endpointWithCertificateToken(
             SecurityPolicy.None,

--- a/opc-ua-sdk/sdk-client/src/test/java/org/eclipse/milo/opcua/sdk/client/identity/X509PolicySelectionTest.java
+++ b/opc-ua-sdk/sdk-client/src/test/java/org/eclipse/milo/opcua/sdk/client/identity/X509PolicySelectionTest.java
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.identity;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ubyte;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.security.KeyPair;
+import java.security.cert.X509Certificate;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.eclipse.milo.opcua.stack.core.security.ChannelBoundSignatureData;
+import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.ApplicationType;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.MessageSecurityMode;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.UserTokenType;
+import org.eclipse.milo.opcua.stack.core.types.structured.ApplicationDescription;
+import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
+import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
+import org.eclipse.milo.opcua.stack.core.util.NonceUtil;
+import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateBuilder;
+import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateGenerator;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/** Policy advertisement order must not prevent a compatible certificate identity from signing. */
+class X509PolicySelectionTest {
+
+  private static KeyPair userKeys;
+  private static X509Certificate userCertificate;
+  private static ByteString serverCertificate;
+
+  @BeforeAll
+  static void createCertificates() throws Exception {
+    userKeys = SelfSignedCertificateGenerator.generateNistP256KeyPair();
+    userCertificate =
+        SelfSignedCertificateBuilder.forEccApplicationCertificate(userKeys)
+            .setCommonName("user")
+            .setApplicationUri("urn:test:user")
+            .build();
+    KeyPair serverKeys = SelfSignedCertificateGenerator.generateRsaKeyPair(2048);
+    serverCertificate =
+        ByteString.of(
+            SelfSignedCertificateBuilder.forRsaApplicationCertificate(serverKeys)
+                .setCommonName("server")
+                .setApplicationUri("urn:test:server")
+                .build()
+                .getEncoded());
+  }
+
+  /** Includes a different EC curve, since a shared key algorithm alone is insufficient. */
+  @ParameterizedTest
+  @EnumSource(
+      value = SecurityPolicy.class,
+      names = {"Basic256Sha256", "ECC_nistP384_AesGcm"})
+  void skipsIncompatiblePolicyAndProducesVerifiableSignature(SecurityPolicy incompatible)
+      throws Exception {
+    SecurityPolicy compatible = SecurityPolicy.ECC_nistP256_AesGcm;
+    EndpointDescription endpoint =
+        endpoint(
+            SecurityPolicy.None,
+            policy("incompatible", incompatible),
+            policy("compatible", compatible));
+    assertSignsWithCompatiblePolicy(endpoint);
+  }
+
+  // A certificate identity must prove possession of its private key. Both explicit None and
+  // inherited None are unusable even when advertised before a valid signing policy.
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void skipsCertificatePoliciesThatResolveToNone(boolean inherited) throws Exception {
+    assertSignsWithCompatiblePolicy(
+        endpoint(
+            SecurityPolicy.None,
+            new UserTokenPolicy(
+                "none",
+                UserTokenType.Certificate,
+                null,
+                null,
+                inherited ? null : SecurityPolicy.None.getUri()),
+            policy("compatible", SecurityPolicy.ECC_nistP256_AesGcm)));
+  }
+
+  private void assertSignsWithCompatiblePolicy(EndpointDescription endpoint) throws Exception {
+    SecurityPolicy compatible = SecurityPolicy.ECC_nistP256_AesGcm;
+    AtomicInteger privateKeyReads = new AtomicInteger();
+    X509IdentityProvider provider =
+        new X509IdentityProvider(
+            userCertificate,
+            () -> {
+              privateKeyReads.incrementAndGet();
+              return userKeys.getPrivate();
+            });
+
+    assertEquals(compatible, provider.getUserTokenSecurityPolicy(endpoint).orElseThrow());
+    assertTrue(provider.getEnhancedUserTokenSecurityPolicy(endpoint).isEmpty());
+    assertEquals(0, privateKeyReads.get(), "policy selection must not access the private key");
+
+    ByteString serverNonce = NonceUtil.generateNonce(32);
+    ByteString clientNonce = NonceUtil.generateNonce(32);
+    var inputs =
+        new ChannelSignatureInputs(
+            ByteString.NULL_VALUE,
+            clientNonce,
+            serverCertificate,
+            serverCertificate,
+            ByteString.NULL_VALUE);
+    SignedIdentityToken signed =
+        provider.getIdentityToken(
+            new IdentityProviderContext(endpoint, serverNonce, null, null, null, null, inputs));
+
+    assertEquals("compatible", signed.getToken().getPolicyId());
+    assertEquals(1, privateKeyReads.get());
+    byte[] signedData =
+        ChannelBoundSignatureData.userTokenSignatureData(
+            compatible.getProfile(),
+            false,
+            ByteString.NULL_VALUE,
+            serverNonce,
+            serverCertificate,
+            ByteString.NULL_VALUE,
+            ByteString.NULL_VALUE,
+            ByteString.NULL_VALUE,
+            clientNonce);
+    ChannelBoundSignatureData.verify(
+        compatible, userCertificate, signedData, signed.getSignature());
+  }
+
+  @Test
+  void failsSelectionWhenNoPolicyMatchesTheCertificate() {
+    X509IdentityProvider provider =
+        new X509IdentityProvider(userCertificate, userKeys.getPrivate());
+    assertThrows(
+        Exception.class,
+        () ->
+            provider.getUserTokenSecurityPolicy(
+                endpoint(SecurityPolicy.None, policy("rsa", SecurityPolicy.Basic256Sha256))));
+  }
+
+  @Test
+  void preservesAdvertisedOrderAmongCompatiblePolicies() throws Exception {
+    X509IdentityProvider provider =
+        new X509IdentityProvider(userCertificate, userKeys.getPrivate());
+    SecurityPolicy first = SecurityPolicy.ECC_nistP256_ChaChaPoly;
+    assertEquals(
+        first,
+        provider
+            .getUserTokenSecurityPolicy(
+                endpoint(
+                    SecurityPolicy.None,
+                    policy("first", first),
+                    policy("second", SecurityPolicy.ECC_nistP256_AesGcm)))
+            .orElseThrow());
+  }
+
+  @Test
+  void inheritsChannelPolicyWhenTokenPolicyOmitsItsUri() throws Exception {
+    X509IdentityProvider provider =
+        new X509IdentityProvider(userCertificate, userKeys.getPrivate());
+    SecurityPolicy channel = SecurityPolicy.ECC_nistP256_AesGcm;
+    assertEquals(
+        channel,
+        provider
+            .getUserTokenSecurityPolicy(
+                endpoint(
+                    channel,
+                    new UserTokenPolicy("inherited", UserTokenType.Certificate, null, null, null)))
+            .orElseThrow());
+  }
+
+  private static UserTokenPolicy policy(String id, SecurityPolicy policy) {
+    return new UserTokenPolicy(id, UserTokenType.Certificate, null, null, policy.getUri());
+  }
+
+  private static EndpointDescription endpoint(SecurityPolicy channel, UserTokenPolicy... policies) {
+    return new EndpointDescription(
+        "opc.tcp://localhost:4840/test",
+        new ApplicationDescription(
+            "urn:test:server",
+            "urn:test:product",
+            LocalizedText.english("test"),
+            ApplicationType.Server,
+            null,
+            null,
+            null),
+        serverCertificate,
+        channel == SecurityPolicy.None
+            ? MessageSecurityMode.None
+            : MessageSecurityMode.SignAndEncrypt,
+        channel.getUri(),
+        policies,
+        "http://opcfoundation.org/UA-Profile/Transport/uatcp-uasc-uabinary",
+        ubyte(0));
+  }
+}

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/CertificateCompatibility.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/CertificateCompatibility.java
@@ -255,6 +255,25 @@ public final class CertificateCompatibility {
     }
   }
 
+  /**
+   * Check whether a public key supports the profile's signature algorithm and curve.
+   *
+   * <p>This check also applies to user identity certificates, which do not have the application
+   * certificate type and KeyUsage requirements enforced by {@link
+   * #checkCompatible(SecurityPolicyProfile, X509Certificate)}.
+   *
+   * @param securityPolicyProfile the profile used to sign or verify.
+   * @param publicKey the signing certificate's public key.
+   * @throws UaException if the public key is incompatible with the profile.
+   */
+  public static void checkPublicKey(
+      SecurityPolicyProfile securityPolicyProfile, PublicKey publicKey) throws UaException {
+
+    requireNonNull(securityPolicyProfile, "securityPolicyProfile");
+    requireNonNull(publicKey, "publicKey");
+    checkPublicKey(securityPolicyProfile.authAxis(), publicKey);
+  }
+
   private static void checkPublicKey(AuthAxis authAxis, PublicKey publicKey) throws UaException {
     switch (authAxis) {
       case NONE -> {}


### PR DESCRIPTION
The X.509 identity provider selected the first advertised Certificate policy even when its signing algorithm or EC curve was incompatible with the user's certificate. Authentication could fail despite a usable policy appearing later.

Selection now checks the actual public key while scanning policies in advertised order. It skips policies resolving to `SecurityPolicy.None` and requests the private key only when signing with the selected policy. If no policy is usable, selection reports `Bad_IdentityTokenRejected`.

[Part 4 §7.40.5](https://reference.opcfoundation.org/specs/OPC-10000-4/7.40.5) requires that "the Server shall provide a distinct UserTokenPolicy for each CertificateKeyAlgorithm supported."

Regressions verify signatures after incompatible or unsigned policies, preserve advertised order, and cover inherited policies and a certificate with no compatible policy.

Formatting, a full clean compile, and the selected regression suites passed for this branch.
