### PR TITLE
Prepare every category version before deleting one alias entry

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/aliases/AliasLifecycleConsistencyTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/aliases/AliasLifecycleConsistencyTest.java
@@ -30,6 +30,7 @@ import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectNode;
 import org.eclipse.milo.opcua.sdk.test.AbstractClientServerTest;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
@@ -86,6 +87,7 @@ class AliasLifecycleConsistencyTest extends AbstractClientServerTest {
 
   @AfterEach
   void cleanFixture() {
+    store.failOn = null;
     manager.shutdown();
     externalReferences.forEach(
         reference -> nodeManager.removeReferences(reference, server.getNamespaceTable()));
@@ -241,6 +243,38 @@ class AliasLifecycleConsistencyTest extends AbstractClientServerTest {
     assertEquals(Set.of(newNodeId("TestInt32")), targets(child.categoryNodeId(), prefix));
   }
 
+  // Part 17 §6.3.5 requires all-or-none deletion per entry. A later same-name alias can introduce
+  // an additional affected category whose version save fails; earlier aliases must remain intact.
+  @Test
+  void failedVersionSaveLeavesEveryAliasInOneWireDeletionEntryUntouched() throws Exception {
+    manager.startup();
+    NodeId category = category("Category", NodeIds.Aliases).categoryNodeId();
+    NodeId other = category("Other", NodeIds.Aliases).categoryNodeId();
+    manager.addCategory(category("Category", NodeIds.Aliases));
+    manager.addCategory(category("Other", NodeIds.Aliases));
+    NodeId targetId = newNodeId("TestInt32");
+    NodeId first = manager.addAlias(category, prefix, List.of(target(targetId)));
+    NodeId second = manager.addAlias(other, prefix, List.of(target(targetId)));
+    managed(second)
+        .addReference(
+            new Reference(
+                second, NodeIds.Organizes, category.expanded(), Reference.Direction.INVERSE));
+    manager.touch(category);
+    assertEquals(2, manager.findAlias(category, prefix, null).size());
+    store.failOn = other.expanded(server.getNamespaceTable());
+
+    assertArrayEquals(
+        new StatusCode[] {StatusCode.of(StatusCodes.Bad_InternalError)},
+        deleteOverWire(category, prefix, targetId));
+
+    assertTrue(
+        server.getAddressSpaceManager().getManagedNode(first).isPresent(),
+        "first alias must survive later save failure");
+    assertTrue(server.getAddressSpaceManager().getManagedNode(second).isPresent());
+    assertEquals(2, manager.findAlias(category, prefix, null).size());
+    assertEquals(Set.of(targetId), targets(other, prefix));
+  }
+
   private AliasCategoryConfig category(String suffix, NodeId parent) {
     return new AliasCategoryConfig(
         newNodeId(prefix + suffix),
@@ -299,6 +333,7 @@ class AliasLifecycleConsistencyTest extends AbstractClientServerTest {
 
   private static final class TestVersionStore implements AliasVersionStore {
     private final Map<ExpandedNodeId, UInteger> entries = new ConcurrentHashMap<>();
+    private volatile ExpandedNodeId failOn;
 
     @Override
     public Map<ExpandedNodeId, UInteger> load() {
@@ -307,6 +342,9 @@ class AliasLifecycleConsistencyTest extends AbstractClientServerTest {
 
     @Override
     public void save(ExpandedNodeId categoryId, UInteger value) throws UaException {
+      if (categoryId.equals(failOn)) {
+        throw new UaException(StatusCodes.Bad_ResourceUnavailable, "controlled save failure");
+      }
       entries.put(categoryId, value);
     }
   }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/aliases/AliasManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/aliases/AliasManager.java
@@ -15,6 +15,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -1323,10 +1324,10 @@ public final class AliasManager extends AbstractLifecycle {
    * target that is not associated changes nothing and reports {@code Good}; §6.3.5 reserves {@code
    * Bad_NotFound} for an alias name the category does not contain.
    *
-   * <p>Validation happens before any mutation. Reference removal spans every registered {@link
-   * NodeManager}. A custom NodeManager can throw unchecked mid-entry; such a failure is confined to
-   * its entry as {@code Bad_InternalError}, and any category whose new version was prepared before
-   * the mutation still gets its LastChange published.
+   * <p>Validation and category-version persistence happen before any mutation. Reference removal
+   * spans every registered {@link NodeManager}. A custom NodeManager can throw unchecked mid-entry;
+   * such a failure is confined to its entry as {@code Bad_InternalError}, and any category whose
+   * new version was prepared before the mutation still gets its LastChange published.
    */
   private StatusCode deleteAliasEntry(
       NodeId categoryId, @Nullable String aliasName, @Nullable ExpandedNodeId targetNode) {
@@ -1376,6 +1377,9 @@ public final class AliasManager extends AbstractLifecycle {
         return StatusCode.GOOD;
       }
 
+      var removals = new LinkedHashMap<UaNode, List<Reference>>();
+      var bumped = new LinkedHashSet<NodeId>();
+
       for (NodeId aliasNodeId : aliasNodeIds) {
         UaNode aliasNode = server.getAddressSpaceManager().getManagedNode(aliasNodeId).orElse(null);
         if (aliasNode == null) {
@@ -1387,24 +1391,23 @@ public final class AliasManager extends AbstractLifecycle {
         List<Reference> matching =
             findTargetReferences(aliasNodeId, targetNodeId, aliasTypes::isAliasForOrSubtype);
 
-        if (matching.isEmpty()) {
-          continue;
+        if (!matching.isEmpty()) {
+          removals.put(aliasNode, matching);
+          bumped.add(categoryId);
+          bumped.addAll(getOrganizingCategories(aliasNodeId));
         }
+      }
 
-        // A target change is observable from every category that organizes the alias, not just
-        // the one addressed, so all of them get a LastChange bump. Prepared BEFORE the mutation
-        // so a failed save fails the entry before this alias is touched, and the bumps publish
-        // even if a Reference removal throws partway through.
-        var bumped = new ArrayList<NodeId>();
-        bumped.add(categoryId);
-        bumped.addAll(getOrganizingCategories(aliasNodeId));
-        versionManager.prepare(bumped);
+      // One entry can affect several same-name aliases and their other organizing categories.
+      // Persist the entire union before the first deletion, so any save failure leaves every
+      // alias in this entry untouched.
+      versionManager.prepare(bumped);
 
-        for (Reference reference : matching) {
+      for (var removal : removals.entrySet()) {
+        for (Reference reference : removal.getValue()) {
           server.getAddressSpaceManager().removeManagedReferences(reference);
         }
-
-        deleteIfTargetless(aliasNode);
+        deleteIfTargetless(removal.getKey());
       }
 
       return StatusCode.GOOD;

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/aliases/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/aliases/package-info.java
@@ -99,10 +99,12 @@
  * describe is applied or the value is published: a failed save aborts the operation (or fails the
  * entry) with {@code Bad_InternalError} and nothing changed, so no Client can ever observe an
  * unpersisted {@code LastChange} value — after a restart the sequence therefore never repeats an
- * observed value for different content, which would leave Client caches undetectably stale.
- * Likewise a failed load at startup fails startup, because silently reset versions would violate
- * the persistence contract undetectably. Categories whose {@code LastChange} Property does not
- * exist (it is Optional per category) still participate in propagation; only the Property write is
+ * observed value for different content, which would leave Client caches undetectably stale. A
+ * deletion entry prepares the union of categories affected by every matching alias before deleting
+ * any association, so a later category's save failure leaves the whole entry untouched. Likewise a
+ * failed load at startup fails startup, because silently reset versions would violate the
+ * persistence contract undetectably. Categories whose {@code LastChange} Property does not exist
+ * (it is Optional per category) still participate in propagation; only the Property write is
  * skipped.
  */
 @NullMarked


### PR DESCRIPTION
A single wire deletion entry can match multiple same-name aliases. Persisting category versions one alias at a time allowed a later save failure to leave earlier aliases deleted. Collect the complete affected category union and persist it before the entry's first deletion.

[Part 17 §6.3.5](https://reference.opcfoundation.org/specs/OPC-10000-17/6.3.5) requires: "If all targets for an AliasNames array entry cannot be deleted, then none of the targets are deleted." Unchecked failures from custom NodeManagers retain the existing best-effort behavior.

### Verification

A real wire deletion matches two aliases; the second introduces another category whose version save fails. The service returns Bad_InternalError and both aliases and their target associations remain intact.

Formatting, full clean compilation, and 143 selected tests passed for this branch.

Based on https://github.com/eclipse-milo/milo/pull/1899 so the diff contains only this fix.
