### PR TITLE
Allow certificate tokens to use a different key family from the channel

### DIFF
--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/identity/X509IdentityProvider.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/identity/X509IdentityProvider.java
@@ -25,7 +25,6 @@ import org.eclipse.milo.opcua.stack.core.security.CertificateCompatibility;
 import org.eclipse.milo.opcua.stack.core.security.ChannelBoundSignatureData;
 import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
 import org.eclipse.milo.opcua.stack.core.security.SecurityPolicyProfile;
-import org.eclipse.milo.opcua.stack.core.security.UserTokenSecurityPolicyRules;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.UserTokenType;
 import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
@@ -277,13 +276,7 @@ public class X509IdentityProvider implements IdentityProvider {
       throw new UaException(StatusCodes.Bad_SecurityPolicyRejected, t);
     }
 
-    // Part 4 (7.41): an explicitly specified certificate user-token policy must use the same
-    // public-key algorithm as the SecureChannel. The enhanced-secret/None rule does not apply to
-    // certificate tokens: they are signed, not encrypted, and an enhanced signature is supported on
-    // a None channel (the reduced Part 4 §6.1.8 Table 101 layout).
-    UserTokenSecurityPolicyRules.requireSamePublicKeyAlgorithmAsChannel(
-        endpoint, securityPolicy, explicitlySpecified);
-
+    // Part 4 (7.41) permits certificate-token policies to use a different key algorithm.
     return securityPolicy;
   }
 }

--- a/opc-ua-sdk/sdk-client/src/test/java/org/eclipse/milo/opcua/sdk/client/identity/UserTokenSecurityPolicyRulesTest.java
+++ b/opc-ua-sdk/sdk-client/src/test/java/org/eclipse/milo/opcua/sdk/client/identity/UserTokenSecurityPolicyRulesTest.java
@@ -179,7 +179,8 @@ class UserTokenSecurityPolicyRulesTest {
                 endpoint, SecurityPolicy.ECC_nistP256_AesGcm));
   }
 
-  // Certificate policies must match the configured user certificate.
+  // Certificate policies must match the configured user certificate. Encrypted-secret policy
+  // restrictions do not apply to their signatures.
 
   @Test
   void x509ProviderRejectsPolicyIncompatibleWithItsCertificate() throws Exception {

--- a/opc-ua-sdk/sdk-client/src/test/java/org/eclipse/milo/opcua/sdk/client/identity/X509PolicySelectionTest.java
+++ b/opc-ua-sdk/sdk-client/src/test/java/org/eclipse/milo/opcua/sdk/client/identity/X509PolicySelectionTest.java
@@ -141,6 +141,33 @@ class X509PolicySelectionTest {
   }
 
   @Test
+  void certificatePolicyCanUseADifferentKeyAlgorithmFromTheChannel() throws Exception {
+    KeyPair rsaKeys = SelfSignedCertificateGenerator.generateRsaKeyPair(2048);
+    X509Certificate rsaCertificate =
+        SelfSignedCertificateBuilder.forRsaApplicationCertificate(rsaKeys)
+            .setCommonName("rsa-user")
+            .setApplicationUri("urn:test:rsa-user")
+            .build();
+    X509IdentityProvider provider = new X509IdentityProvider(rsaCertificate, rsaKeys.getPrivate());
+    EndpointDescription endpoint =
+        endpoint(
+            SecurityPolicy.ECC_nistP256_AesGcm,
+            policy("ecc", SecurityPolicy.ECC_nistP256_AesGcm),
+            policy("rsa", SecurityPolicy.Basic256Sha256));
+    ByteString nonce = NonceUtil.generateNonce(32);
+
+    assertEquals(
+        SecurityPolicy.Basic256Sha256, provider.getUserTokenSecurityPolicy(endpoint).orElseThrow());
+    SignedIdentityToken signed = provider.getIdentityToken(endpoint, nonce);
+    assertEquals("rsa", signed.getToken().getPolicyId());
+    ChannelBoundSignatureData.verify(
+        SecurityPolicy.Basic256Sha256,
+        rsaCertificate,
+        ChannelBoundSignatureData.legacyUserTokenSignatureData(serverCertificate, nonce),
+        signed.getSignature());
+  }
+
+  @Test
   void failsSelectionWhenNoPolicyMatchesTheCertificate() {
     X509IdentityProvider provider =
         new X509IdentityProvider(userCertificate, userKeys.getPrivate());

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractX509IdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractX509IdentityValidator.java
@@ -22,7 +22,6 @@ import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.security.ChannelBoundSignatureData;
 import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
 import org.eclipse.milo.opcua.stack.core.security.SecurityPolicyProfile;
-import org.eclipse.milo.opcua.stack.core.security.UserTokenSecurityPolicyRules;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.UserTokenType;
 import org.eclipse.milo.opcua.stack.core.types.structured.SignatureData;
@@ -91,12 +90,6 @@ public abstract class AbstractX509IdentityValidator extends AbstractIdentityVali
     } else {
       securityPolicy = SecurityPolicy.fromUri(securityPolicyUri);
     }
-
-    UserTokenSecurityPolicyRules.requireSamePublicKeyAlgorithmAsChannel(
-        session.getSecurityConfiguration().getSecurityMode(),
-        session.getSecurityConfiguration().getSecurityPolicy(),
-        securityPolicy,
-        securityPolicyUri != null && !securityPolicyUri.isEmpty());
 
     return securityPolicy;
   }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/package-info.java
@@ -26,6 +26,13 @@
  * common token validation, nonce check, size limits, and decryption path before handing the
  * resulting username and password to the application-specific authentication method.
  *
+ * <h2>Certificate-token signatures</h2>
+ *
+ * <p>A certificate token's advertised policy selects the user signature algorithm. Its public-key
+ * algorithm may differ from the SecureChannel's algorithm. The X.509 validator verifies that
+ * signature before calling application authentication; the channel restrictions for encrypted
+ * username or issued-token secrets do not apply to certificate tokens.
+ *
  * <h2>Extension guidance</h2>
  *
  * <p>Applications usually extend the abstract validators and implement only the final credential

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractX509IdentityValidatorTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractX509IdentityValidatorTest.java
@@ -37,6 +37,8 @@ import org.eclipse.milo.opcua.stack.core.types.structured.X509IdentityToken;
 import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateBuilder;
 import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateGenerator;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 class AbstractX509IdentityValidatorTest {
 
@@ -49,10 +51,10 @@ class AbstractX509IdentityValidatorTest {
             0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F
           });
 
-  // Part 4 (7.41): an explicit certificate user-token policy must use the same public-key family
-  // as the SecureChannel; the server rejects the mismatch before signature verification.
+  // The current transport cannot provide channel-bound signatures over a legacy secured channel.
+  // This runtime restriction is separate from the certificate-token policy's key algorithm.
   @Test
-  void rejectsExplicitCrossFamilyX509TokenPolicy() throws Exception {
+  void rejectsUnsupportedEnhancedSignatureOnLegacyChannel() throws Exception {
     CertificateMaterial user = eccCertificate("x509-user");
     Session session =
         session(SecurityPolicy.Basic256Sha256, MessageSecurityMode.SignAndEncrypt, null, null);
@@ -68,22 +70,24 @@ class AbstractX509IdentityValidatorTest {
                     policy(SecurityPolicy.ECC_nistP256_AesGcm),
                     new SignatureData(null, null)));
 
-    assertEquals(StatusCodes.Bad_SecurityPolicyRejected, exception.getStatusCode().getValue());
+    assertEquals(StatusCodes.Bad_IdentityTokenInvalid, exception.getStatusCode().getValue());
   }
 
   // A compatible explicit X509 token policy still verifies the user-token signature and
   // authenticates the certificate identity.
-  @Test
-  void acceptsCompatibleExplicitX509TokenPolicy() throws Exception {
-    CertificateMaterial server = rsaCertificate("server");
+  @ParameterizedTest
+  @EnumSource(
+      value = SecurityPolicy.class,
+      names = {"Basic256Sha256", "ECC_nistP256_AesGcm"})
+  void acceptsCompatibleExplicitX509TokenPolicy(SecurityPolicy channelPolicy) throws Exception {
+    CertificateMaterial server =
+        channelPolicy == SecurityPolicy.Basic256Sha256
+            ? rsaCertificate("server")
+            : eccCertificate("server");
     CertificateMaterial user = rsaCertificate("x509-user");
     UserTokenPolicy policy = policy(SecurityPolicy.Basic256Sha256);
     Session session =
-        session(
-            SecurityPolicy.Basic256Sha256,
-            MessageSecurityMode.SignAndEncrypt,
-            server.certificate(),
-            policy);
+        session(channelPolicy, MessageSecurityMode.SignAndEncrypt, server.certificate(), policy);
     SignatureData signature =
         ChannelBoundSignatureData.sign(
             SecurityPolicy.Basic256Sha256,

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/UserTokenSecurityPolicyRules.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/UserTokenSecurityPolicyRules.java
@@ -20,9 +20,9 @@ import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
  * Enforcement of the OPC UA Part 4 (7.41) rules that constrain how a user identity token's {@link
  * SecurityPolicy} may relate to the carrying SecureChannel.
  *
- * <p>The rules are independent of the identity provider, so client and server username and
- * certificate identity paths share them here rather than each re-deriving the constraint. They have
- * different applicability and are exposed separately:
+ * <p>Client and server paths for encrypted user-token secrets share these checks. Certificate
+ * tokens are signed rather than encrypted and may use any valid user-token SecurityPolicy. The
+ * constraints for encrypted secrets are exposed separately:
  *
  * <ul>
  *   <li>{@link #requireSecuredChannelForEnhancedSecret} applies only to token types whose secret is
@@ -31,9 +31,9 @@ import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
  *       policies need. It must not be applied to signed certificate tokens, whose enhanced
  *       signatures are explicitly supported on a {@code None} channel (the reduced Part 4 6.1.8
  *       Table 101 layout).
- *   <li>{@link #requireSamePublicKeyAlgorithmAsChannel} applies to every user-token type: an
- *       explicitly specified user-token SecurityPolicy must share the SecureChannel's public-key
- *       algorithm family (RSA vs ECC).
+ *   <li>{@link #requireSamePublicKeyAlgorithmAsChannel} applies to username and issued-token
+ *       secrets: an explicitly specified SecurityPolicy must share the SecureChannel's public-key
+ *       algorithm family (RSA vs ECC). It does not apply to certificate tokens.
  * </ul>
  *
  * @see <a href="https://reference.opcfoundation.org/Core/Part4/v105/docs/7.41">
@@ -95,7 +95,7 @@ public final class UserTokenSecurityPolicyRules {
    * PublicKey algorithm (RSA vs ECC) as the SecureChannel. Only an explicitly specified, encrypting
    * (RSA or ECC) policy is constrained: an inherited policy already matches the channel, and an
    * explicit {@code None} policy (the plaintext-secret case) carries no PublicKey algorithm. The
-   * rule is independent of the user-token type, so username and certificate tokens both apply it.
+   * rule applies to username and issued-token secrets. Certificate tokens are exempt.
    *
    * @param endpoint the endpoint whose SecurityMode and SecurityPolicy describe the SecureChannel.
    * @param userTokenSecurityPolicy the resolved user-token security policy.


### PR DESCRIPTION
Client and server rejected certificate user tokens whose key family differed from the SecureChannel's. This incorrectly prevented an RSA user certificate from authenticating over an ECC channel.

The certificate identity paths now apply the certificate signature policy without the key-family restriction used for encrypted username and issued tokens. [Part 4 §7.41](https://reference.opcfoundation.org/specs/OPC-10000-4/7.41) explicitly permits this combination: "If the tokenType is CERTIFICATE, the securityPolicyUri may be any valid SecurityPolicy."

Regressions create and validate the cross-algorithm signature. The existing restrictions for encrypted user-token secrets remain covered by their policy tests.

Formatting, a full clean compile, and the selected regression suites passed for this branch.

Based on https://github.com/eclipse-milo/milo/pull/1900 so the diff contains only this fix.
