### PR TITLE
Keep delayed Publish responses with their registration

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/PublishRegistrationReuseTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/PublishRegistrationReuseTest.java
@@ -1,0 +1,332 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.subscriptions;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ubyte;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.netty.util.HashedWheelTimer;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClientConfig;
+import org.eclipse.milo.opcua.sdk.client.OpcUaSession;
+import org.eclipse.milo.opcua.stack.core.Stack;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
+import org.eclipse.milo.opcua.stack.core.types.UaRequestMessageType;
+import org.eclipse.milo.opcua.stack.core.types.UaResponseMessageType;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.MessageSecurityMode;
+import org.eclipse.milo.opcua.stack.core.types.structured.CreateSubscriptionResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
+import org.eclipse.milo.opcua.stack.core.types.structured.NotificationMessage;
+import org.eclipse.milo.opcua.stack.core.types.structured.PublishRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.PublishResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.ResponseHeader;
+import org.eclipse.milo.opcua.stack.core.types.structured.SignedSoftwareCertificate;
+import org.eclipse.milo.opcua.stack.core.types.structured.StatusChangeNotification;
+import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
+import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.transport.client.ClientApplicationContext;
+import org.eclipse.milo.opcua.stack.transport.client.OpcClientTransport;
+import org.eclipse.milo.opcua.stack.transport.client.OpcClientTransportConfig;
+import org.eclipse.milo.opcua.stack.transport.client.tcp.OpcTcpClientTransportConfig;
+import org.junit.jupiter.api.Test;
+
+/** A response belongs to the subscription registration that existed when its request was sent. */
+class PublishRegistrationReuseTest {
+  @Test
+  void delayedTimeoutCannotResetRecreatedObjectWithSameId() throws Exception {
+    assertTimeoutOwnership(true, true);
+  }
+
+  @Test
+  void delayedTimeoutCannotResetReplacementObjectWithSameId() throws Exception {
+    assertTimeoutOwnership(true, false);
+  }
+
+  @Test
+  void currentTimeoutStillResetsItsSubscription() throws Exception {
+    assertTimeoutOwnership(false, true);
+  }
+
+  @Test
+  void requestQueuedBeforeFirstRegistrationCanServeThatSubscription() throws Exception {
+    assertRegistrationChurnDoesNotDiscardResponse(false);
+  }
+
+  @Test
+  void unrelatedRegistrationDoesNotDiscardExistingSubscriptionsResponse() throws Exception {
+    assertRegistrationChurnDoesNotDiscardResponse(true);
+  }
+
+  private void assertRegistrationChurnDoesNotDiscardResponse(boolean originalAlreadyRegistered)
+      throws Exception {
+    try (var transport = new Transport()) {
+      var client = new Client(transport);
+      var original = new OpcUaSubscription(client);
+      if (originalAlreadyRegistered)
+        original.createAsync().toCompletableFuture().get(5, TimeUnit.SECONDS);
+      var session =
+          new OpcUaSession(
+              new NodeId(1, "token"),
+              new NodeId(1, "session"),
+              "session",
+              60000,
+              uint(0),
+              ByteString.NULL_VALUE,
+              new SignedSoftwareCertificate[0]);
+      var pendingCount = new AtomicLong(1);
+      client.getPublishingManager().sendPublishRequest(session, pendingCount);
+      var response = client.pending;
+      if (originalAlreadyRegistered) {
+        client.nextSubscriptionId = 8;
+        new OpcUaSubscription(client).createAsync().toCompletableFuture().get(5, TimeUnit.SECONDS);
+      } else {
+        original.createAsync().toCompletableFuture().get(5, TimeUnit.SECONDS);
+      }
+      var status = new StatusChangeNotification(new StatusCode(StatusCodes.Bad_Timeout), null);
+      response.complete(
+          new PublishResponse(
+              header(),
+              uint(7),
+              new UInteger[] {uint(1)},
+              false,
+              new NotificationMessage(
+                  uint(1),
+                  DateTime.now(),
+                  new ExtensionObject[] {
+                    ExtensionObject.encode(client.getStaticEncodingContext(), status)
+                  }),
+              new StatusCode[0],
+              null));
+      transport.executor.drain();
+      assertEquals(0, pendingCount.get());
+      assertTrue(
+          original.getSubscriptionId().isEmpty(),
+          "valid timeout must reach its owner despite a registration after the request was sent");
+    }
+  }
+
+  private void assertTimeoutOwnership(boolean replace, boolean reuseObject) throws Exception {
+    try (var transport = new Transport()) {
+      var client = new Client(transport);
+      var statuses = new ArrayList<StatusCode>();
+      var original = new OpcUaSubscription(client);
+      original.setSubscriptionListener(
+          new OpcUaSubscription.SubscriptionListener() {
+            @Override
+            public void onStatusChanged(OpcUaSubscription s, StatusCode status) {
+              statuses.add(status);
+            }
+          });
+      original.createAsync().toCompletableFuture().get(5, TimeUnit.SECONDS);
+      var session =
+          new OpcUaSession(
+              new NodeId(1, "token"),
+              new NodeId(1, "session"),
+              "session",
+              60000,
+              uint(0),
+              ByteString.NULL_VALUE,
+              new SignedSoftwareCertificate[0]);
+      var pendingCount = new AtomicLong(1);
+      client.getPublishingManager().sendPublishRequest(session, pendingCount);
+      var response = client.pending;
+      OpcUaSubscription current = original;
+      if (replace) {
+        original.reset();
+        if (!reuseObject) {
+          current = new OpcUaSubscription(client);
+          current.setSubscriptionListener(
+              new OpcUaSubscription.SubscriptionListener() {
+                @Override
+                public void onStatusChanged(OpcUaSubscription s, StatusCode status) {
+                  statuses.add(status);
+                }
+              });
+        }
+        current.createAsync().toCompletableFuture().get(5, TimeUnit.SECONDS);
+      }
+      long incarnation = current.getIncarnation();
+      var status = new StatusChangeNotification(new StatusCode(StatusCodes.Bad_Timeout), null);
+      response.complete(
+          new PublishResponse(
+              header(),
+              uint(7),
+              new UInteger[] {uint(1)},
+              false,
+              new NotificationMessage(
+                  uint(1),
+                  DateTime.now(),
+                  new ExtensionObject[] {
+                    ExtensionObject.encode(client.getStaticEncodingContext(), status)
+                  }),
+              new StatusCode[0],
+              null));
+      transport.executor.drain();
+      assertEquals(
+          0, pendingCount.get(), "discarding a response must still release its pipeline slot");
+      if (replace) {
+        assertEquals(uint(7), current.getSubscriptionId().orElseThrow());
+        assertEquals(incarnation, current.getIncarnation());
+        assertTrue(
+            statuses.isEmpty(), "the replacement must not receive its predecessor's timeout");
+      } else {
+        assertTrue(current.getSubscriptionId().isEmpty());
+        assertEquals(List.of(new StatusCode(StatusCodes.Bad_Timeout)), statuses);
+      }
+    }
+  }
+
+  private static ResponseHeader header() {
+    return new ResponseHeader(DateTime.now(), uint(1), StatusCode.GOOD, null, null, null);
+  }
+
+  private static class ManualExecutor extends AbstractExecutorService {
+    final Deque<Runnable> tasks = new ArrayDeque<>();
+
+    @Override
+    public void execute(Runnable command) {
+      tasks.addLast(command);
+    }
+
+    void drain() {
+      int count = 0;
+      while (!tasks.isEmpty()) {
+        assertTrue(++count < 1000, "executor did not quiesce");
+        tasks.removeFirst().run();
+      }
+    }
+
+    @Override
+    public void shutdown() {}
+
+    @Override
+    public List<Runnable> shutdownNow() {
+      return List.of();
+    }
+
+    @Override
+    public boolean isShutdown() {
+      return false;
+    }
+
+    @Override
+    public boolean isTerminated() {
+      return false;
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) {
+      return false;
+    }
+  }
+
+  private static class Transport implements OpcClientTransport, AutoCloseable {
+    final ManualExecutor executor = new ManualExecutor();
+    final HashedWheelTimer timer = new HashedWheelTimer();
+    final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+    final OpcClientTransportConfig config =
+        OpcTcpClientTransportConfig.newBuilder()
+            .setExecutor(executor)
+            .setWheelTimer(timer)
+            .setScheduledExecutor(scheduler)
+            .build();
+
+    @Override
+    public OpcClientTransportConfig getConfig() {
+      return config;
+    }
+
+    @Override
+    public CompletableFuture<Unit> connect(ClientApplicationContext c) {
+      return CompletableFuture.completedFuture(Unit.VALUE);
+    }
+
+    @Override
+    public CompletableFuture<Unit> disconnect() {
+      return CompletableFuture.completedFuture(Unit.VALUE);
+    }
+
+    @Override
+    public CompletableFuture<UaResponseMessageType> sendRequestMessage(UaRequestMessageType r) {
+      throw new AssertionError(r);
+    }
+
+    @Override
+    public void close() {
+      scheduler.shutdownNow();
+      timer.stop();
+    }
+  }
+
+  private static class Client extends OpcUaClient {
+    CompletableFuture<UaResponseMessageType> pending;
+    int nextSubscriptionId = 7;
+
+    Client(Transport transport) {
+      super(
+          OpcUaClientConfig.builder()
+              .setEndpoint(
+                  new EndpointDescription(
+                      "opc.tcp://localhost:4840",
+                      null,
+                      ByteString.NULL_VALUE,
+                      MessageSecurityMode.None,
+                      SecurityPolicy.None.getUri(),
+                      new UserTokenPolicy[0],
+                      Stack.TCP_UASC_UABINARY_TRANSPORT_URI,
+                      ubyte(0)))
+              .setDiscoveryEndpoints(List.of())
+              .build(),
+          transport);
+    }
+
+    // Automatic Publish replenishment waits here. Each test sends exactly one controlled request.
+    @Override
+    public CompletableFuture<OpcUaSession> getSessionAsync() {
+      return new CompletableFuture<>();
+    }
+
+    @Override
+    public CompletableFuture<CreateSubscriptionResponse> createSubscriptionAsync(
+        double p, UInteger l, UInteger k, UInteger n, boolean enabled, UByte priority) {
+      return CompletableFuture.completedFuture(
+          new CreateSubscriptionResponse(header(), uint(nextSubscriptionId), p, l, k));
+    }
+
+    @Override
+    public CompletableFuture<UaResponseMessageType> sendRequestAsync(UaRequestMessageType request) {
+      assertInstanceOf(PublishRequest.class, request);
+      pending = new CompletableFuture<>();
+      return pending;
+    }
+  }
+}

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/PublishingManagerSessionIsolationTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/PublishingManagerSessionIsolationTest.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -202,7 +203,7 @@ public class PublishingManagerSessionIsolationTest {
       subscriptionDetailsClass =
           Class.forName(PublishingManager.class.getName() + "$SubscriptionDetails");
 
-      Map<UInteger, Object> details = subscriptionDetails(manager);
+      var details = new HashMap<UInteger, Object>();
 
       primaryDetails = newSubscriptionDetails(subscriptionId);
 
@@ -210,6 +211,7 @@ public class PublishingManagerSessionIsolationTest {
         UInteger id = uint(i + 1L);
         details.put(id, i == 0 ? primaryDetails : newSubscriptionDetails(id));
       }
+      setSubscriptionDetails(Map.copyOf(details));
     }
 
     UaSession newSession() {
@@ -227,8 +229,7 @@ public class PublishingManagerSessionIsolationTest {
     }
 
     void retainOnlyPrimarySubscription() throws Exception {
-      Map<UInteger, Object> details = subscriptionDetails(manager);
-      details.keySet().removeIf(id -> !id.equals(subscriptionId));
+      setSubscriptionDetails(Map.of(subscriptionId, primaryDetails));
     }
 
     void setResponder(
@@ -327,14 +328,12 @@ public class PublishingManagerSessionIsolationTest {
           subscription, id, (java.util.concurrent.Executor) Runnable::run);
     }
 
-    @SuppressWarnings("unchecked")
-    private static Map<UInteger, Object> subscriptionDetails(PublishingManager manager)
-        throws Exception {
+    private void setSubscriptionDetails(Map<UInteger, Object> details) throws Exception {
 
       Field field = PublishingManager.class.getDeclaredField("subscriptionDetails");
       field.setAccessible(true);
 
-      return (Map<UInteger, Object>) field.get(manager);
+      field.set(manager, details);
     }
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/PublishingManager.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/PublishingManager.java
@@ -15,6 +15,7 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -139,7 +140,11 @@ public class PublishingManager {
 
   private final ConcurrentMap<NodeId, AtomicLong> pendingCountMap = new ConcurrentHashMap<>();
 
-  private final Map<UInteger, SubscriptionDetails> subscriptionDetails = new ConcurrentHashMap<>();
+  private final Object registrationLock = new Object();
+
+  // Replace the immutable map only when registration changes. Each Publish request can retain
+  // its identity snapshot with one volatile read instead of copying the registry on the hot path.
+  private volatile Map<UInteger, SubscriptionDetails> subscriptionDetails = Map.of();
 
   /**
    * Incremented every time a Subscription is registered with or unregistered from this manager.
@@ -258,18 +263,17 @@ public class PublishingManager {
         .getSubscriptionId()
         .ifPresent(
             id -> {
-              SubscriptionDetails displaced =
-                  subscriptionDetails.put(id, new SubscriptionDetails(subscription, id, executor));
-
-              if (displaced != null) {
-                // The Server has reused this SubscriptionId while an entry was still registered
-                // under it. Displacement removed that entry from the map, so unregister() — which
-                // matches by (key, value) — can never succeed for it again; without this, work
-                // still queued for it would be applied as if its Subscription existed, forever.
-                displaced.registered = false;
+              // Construct outside registrationLock because this reads the subscription lifecycle.
+              var details = new SubscriptionDetails(subscription, id, executor);
+              synchronized (registrationLock) {
+                var updated = new HashMap<>(subscriptionDetails);
+                SubscriptionDetails displaced = updated.put(id, details);
+                if (displaced != null) {
+                  displaced.registered = false;
+                }
+                subscriptionDetails = Map.copyOf(updated);
+                subscriptionGeneration.incrementAndGet();
               }
-
-              subscriptionGeneration.incrementAndGet();
             });
 
     // The client wants a deeper pipeline than it did when any ceiling was learned, and Part 4
@@ -310,15 +314,18 @@ public class PublishingManager {
    *     it; {@code false} if something else unregistered it first.
    */
   private boolean unregister(SubscriptionDetails details) {
-    if (subscriptionDetails.remove(details.subscriptionId, details)) {
+    synchronized (registrationLock) {
+      if (subscriptionDetails.get(details.subscriptionId) != details) {
+        return false;
+      }
+
+      var updated = new HashMap<>(subscriptionDetails);
+      updated.remove(details.subscriptionId);
       details.registered = false;
-
+      subscriptionDetails = Map.copyOf(updated);
       subscriptionGeneration.incrementAndGet();
-
       return true;
     }
-
-    return false;
   }
 
   /**
@@ -876,6 +883,7 @@ public class PublishingManager {
     // Read before the request is built, so that a Subscription registered or unregistered while it
     // is in flight is seen as a change by the failure handler rather than missed.
     long generation = subscriptionGeneration.get();
+    Map<UInteger, SubscriptionDetails> requestRegistrations = subscriptionDetails;
 
     // Read for the same reason: a Session-level failure describes the Session the request was sent
     // on, and once another activation has been counted it no longer describes the client.
@@ -957,7 +965,12 @@ public class PublishingManager {
 
                   boolean queued = false;
 
-                  if (details != null) {
+                  SubscriptionDetails requestedDetails = requestRegistrations.get(subscriptionId);
+                  if (details != null
+                      && (requestedDetails == null || requestedDetails == details)) {
+                    // A queued Publish may serve a subscription created after the request. Only
+                    // reject a known id that now belongs to another registration: its delayed
+                    // response cannot safely be attributed to the replacement incarnation.
                     // Cheap and non-blocking: cancels and re-schedules a timer. The watchdog
                     // watches for the Server going quiet, so it is reset when the response is
                     // received rather than when it is eventually processed.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/package-info.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/**
+ * Maintains client-side Subscriptions, their desired MonitoredItems, and ordered notification
+ * delivery. {@link org.eclipse.milo.opcua.sdk.client.subscriptions.OpcUaSubscription} owns the
+ * desired configuration and server-assigned state. The publishing manager maintains the Session's
+ * Publish pipeline and routes responses to registered Subscriptions.
+ *
+ * <p>A reset starts a new incarnation of a Subscription object. Service responses captured for an
+ * earlier incarnation cannot update its replacement, and pending Publish responses retain their
+ * registration identities when server-assigned ids are reused. Publish requests may also serve a
+ * Subscription first registered after the request was sent. Registration changes publish an
+ * immutable registry snapshot; retaining it for each Publish request needs no registry lock or map
+ * copy. Per-subscription processing and delivery queues preserve the order received from the
+ * transport.
+ */
+package org.eclipse.milo.opcua.sdk.client.subscriptions;


### PR DESCRIPTION
A delayed Publish response can be routed to a replacement Subscription when the server reuses its numeric ID. An old `Bad_Timeout` status notification can then reset a healthy replacement. This change checks registration identity before routing the response.

## How Publish responses are routed

`PublishingManager` keeps Publish requests outstanding for the Session. A request carries acknowledgements for previously received messages; it does not select which Subscription must answer it. The response supplies the Subscription ID used for local routing.

OPC UA Part 4 §5.14.5.1 says:

> Since Publish requests are not directed to a specific Subscription, they may be used by any Subscription.

[Specification](https://reference.opcfoundation.org/Core/Part4/v105/docs/5.14.5)

Three identities matter here:

| Identity | Meaning |
| --- | --- |
| `OpcUaSubscription` | Java object holding configuration and MonitoredItems. It can survive reset and recreation. |
| `subscriptionId` | Server-assigned number, which the server can reuse. |
| `SubscriptionDetails` | One local registration with the publishing manager. Each registration gets a fresh instance. |

A registration captures the Subscription ID, Java object, and its incarnation counter. Reset advances that counter and retires the registration. Recreating the same object creates a new registration, even if the server assigns the same ID again.

```mermaid
flowchart TD
    response["PublishResponse: subscriptionId = 7"]
    route["PublishingManager: resolve ID 7 to a registration"]
    process["Registration's processing queue: sequence tracking, acknowledgements, Republish"]
    delivery["Subscription object's delivery queue: values, events, keep-alives, status callbacks"]
    response --> route
    route --> process
    process --> delivery
```

Processing can pause while recovering missing messages. Delivery can wait behind application callbacks. Both stages retain the selected registration so they can discard queued work after that registration is retired.

## Failure scenario

The existing guards protect work after it has been assigned to a registration. They miss a response that arrives after the registry entry has already been replaced:

```mermaid
sequenceDiagram
    participant C as Subscription lifecycle
    participant M as PublishingManager
    participant S as Server

    Note over M: registry[7] = registration A
    M->>S: Send Publish request
    Note over M: New: retain snapshot containing 7 to A
    C->>M: Reset old Subscription
    Note over M: A.registered = false
    C->>M: Register replacement with reused ID 7
    Note over M: registry[7] = registration B
    S-->>M: Delayed response for old Subscription, ID 7
    Note over M: Before: resolve ID 7 to B and queue the response
    Note over M: After: snapshot says A, current registry says B. Discard the response.
```

Before this change, the queued task carries B. B is registered and its captured incarnation is current, so later guards accept the old response. A `Bad_Timeout` StatusChangeNotification can therefore unregister and reset B. This is a status notification inside a successful Publish response, not a timeout of the Publish request itself.

## Change

Each request retains an immutable snapshot of the registry's ID-to-registration bindings. Response routing compares the saved and current registrations by object identity:

| Registration at request capture | Current registration for the response ID | Action |
| --- | --- | --- |
| A | A | Process with A |
| A | B | Discard |
| Absent | B | Process with B |
| Any | Absent | Discard |

The absent-at-capture case allows a queued Publish request to serve a Subscription registered afterward. Changing an unrelated registration also leaves the response valid. A registry-wide generation check would reject these valid cases.

When a known ID changes owners, the wire response cannot identify which local registration should receive it. The check conservatively discards that response, even if the replacement actually produced it.

Registration changes build and publish a new immutable map under a lock. Each Publish request captures one map reference with a volatile read, without copying the registry or acquiring that lock. The map bindings are immutable; the registrations retain their mutable processing state and retirement flag. Discarded responses still release their Publish pipeline slot.

## Verification

Regressions cover reused IDs with the same and different Subscription objects. Controls verify that a current registration still receives its timeout, an unrelated registration change does not discard its response, and a request queued before first registration can serve that Subscription. They also check that discarded responses release their pipeline slot.

Formatting and full clean compile passed. The selected regression suites passed (9 tests, no failures or errors).

```sh
mise exec -- mvn -q -pl opc-ua-sdk/integration-tests -am verify '-Dtest=PublishRegistrationReuseTest,PublishingManagerSessionIsolationTest' -Dsurefire.failIfNoSpecifiedTests=false
```

Based on https://github.com/eclipse-milo/milo/pull/1901 so the diff contains only this fix.

