### PR TITLE
Reject alias mutations that resume after shutdown

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/aliases/AliasLifecycleConsistencyTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/aliases/AliasLifecycleConsistencyTest.java
@@ -13,15 +13,21 @@ package org.eclipse.milo.opcua.sdk.server.aliases;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 import org.eclipse.milo.opcua.sdk.core.Reference;
 import org.eclipse.milo.opcua.sdk.server.Session;
@@ -44,6 +50,7 @@ import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -275,6 +282,72 @@ class AliasLifecycleConsistencyTest extends AbstractClientServerTest {
     assertEquals(Set.of(targetId), targets(other, prefix));
   }
 
+  // Pausing just before the mutation lock models a caller that passed its running check while
+  // shutdown wins the lock. Every public mutator must reject after shutdown and avoid persistence.
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "addCategory",
+        "adoptCategory",
+        "removeCategory",
+        "addAlias",
+        "deleteAlias",
+        "touch"
+      })
+  void publicMutationRechecksLifecycleAfterWaitingForLock(String operation) throws Exception {
+    manager.startup();
+    AliasCategoryConfig category = category("Category", NodeIds.Aliases);
+    manager.addCategory(category);
+    manager.addAlias(NodeIds.Aliases, prefix, List.of(target(newNodeId("TestInt32"))));
+    Executable mutation =
+        switch (operation) {
+          case "addCategory" -> () -> manager.addCategory(category("New", NodeIds.Aliases));
+          case "adoptCategory" -> () -> manager.adoptCategory(category.categoryNodeId());
+          case "removeCategory" -> () -> manager.removeCategory(category.categoryNodeId());
+          case "addAlias" ->
+              () ->
+                  manager.addAlias(
+                      NodeIds.Aliases,
+                      prefix + "AfterShutdown",
+                      List.of(target(newNodeId("TestInt32"))));
+          case "deleteAlias" -> () -> manager.deleteAlias(NodeIds.Aliases, prefix, null);
+          case "touch" -> () -> manager.touch(NodeIds.Aliases);
+          default -> throw new AssertionError(operation);
+        };
+    var gate = new PausingLock();
+    Field field = AliasManager.class.getDeclaredField("lock");
+    field.setAccessible(true);
+    field.set(manager, gate);
+    var executor = Executors.newSingleThreadExecutor();
+    try {
+      var result =
+          executor.submit(
+              () -> {
+                gate.pausedThread = Thread.currentThread();
+                try {
+                  mutation.execute();
+                  return null;
+                } catch (Throwable e) {
+                  return e;
+                }
+              });
+      gate.entered.get(10, TimeUnit.SECONDS);
+      manager.shutdown();
+      int savesAfterShutdown = store.saves.get();
+      gate.resume.complete(null);
+
+      assertInstanceOf(IllegalStateException.class, result.get(10, TimeUnit.SECONDS));
+      assertEquals(
+          savesAfterShutdown, store.saves.get(), "shutdown must fence later version writes");
+      assertTrue(
+          server.getAddressSpaceManager().getManagedNode(newNodeId(prefix + "New")).isEmpty());
+    } finally {
+      gate.resume.complete(null);
+      executor.shutdownNow();
+      assertTrue(executor.awaitTermination(10, TimeUnit.SECONDS));
+    }
+  }
+
   private AliasCategoryConfig category(String suffix, NodeId parent) {
     return new AliasCategoryConfig(
         newNodeId(prefix + suffix),
@@ -331,8 +404,28 @@ class AliasLifecycleConsistencyTest extends AbstractClientServerTest {
     return (StatusCode[]) result.getOutputArguments()[0].value();
   }
 
+  private static final class PausingLock extends ReentrantLock {
+    private volatile Thread pausedThread;
+    private final CompletableFuture<Void> entered = new CompletableFuture<>();
+    private final CompletableFuture<Void> resume = new CompletableFuture<>();
+
+    @Override
+    public void lock() {
+      if (Thread.currentThread() == pausedThread) {
+        entered.complete(null);
+        try {
+          resume.get(10, TimeUnit.SECONDS);
+        } catch (Exception e) {
+          throw new AssertionError(e);
+        }
+      }
+      super.lock();
+    }
+  }
+
   private static final class TestVersionStore implements AliasVersionStore {
     private final Map<ExpandedNodeId, UInteger> entries = new ConcurrentHashMap<>();
+    private final AtomicInteger saves = new AtomicInteger();
     private volatile ExpandedNodeId failOn;
 
     @Override
@@ -346,6 +439,7 @@ class AliasLifecycleConsistencyTest extends AbstractClientServerTest {
         throw new UaException(StatusCodes.Bad_ResourceUnavailable, "controlled save failure");
       }
       entries.put(categoryId, value);
+      saves.incrementAndGet();
     }
   }
 }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/aliases/AliasManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/aliases/AliasManager.java
@@ -324,10 +324,10 @@ public final class AliasManager extends AbstractLifecycle {
    * @throws IllegalStateException if the manager is not running.
    */
   public AliasCategory addCategory(AliasCategoryConfig categoryConfig) throws UaException {
-    checkRunning();
-
     lock.lock();
     try {
+      checkRunning();
+
       String name = categoryConfig.browseName().getName();
       if (name == null || name.isEmpty()) {
         throw new UaException(
@@ -470,10 +470,10 @@ public final class AliasManager extends AbstractLifecycle {
    * @throws IllegalStateException if the manager is not running.
    */
   public AliasCategory adoptCategory(NodeId categoryId) throws UaException {
-    checkRunning();
-
     lock.lock();
     try {
+      checkRunning();
+
       if (categories.containsKey(categoryId)) {
         throw new UaException(
             StatusCodes.Bad_NodeIdExists,
@@ -603,10 +603,10 @@ public final class AliasManager extends AbstractLifecycle {
    * @throws IllegalStateException if the manager is not running.
    */
   public void removeCategory(NodeId categoryId) throws UaException {
-    checkRunning();
-
     lock.lock();
     try {
+      checkRunning();
+
       if (STANDARD_CATEGORY_IDS.contains(categoryId)) {
         throw new UaException(
             StatusCodes.Bad_InvalidArgument,
@@ -710,10 +710,10 @@ public final class AliasManager extends AbstractLifecycle {
   public NodeId addAlias(NodeId categoryId, String aliasName, List<AliasTarget> targets)
       throws UaException {
 
-    checkRunning();
-
     lock.lock();
     try {
+      checkRunning();
+
       CategoryRecord record = resolveCategoryRecord(categoryId);
 
       if (aliasName.isEmpty()) {
@@ -904,10 +904,10 @@ public final class AliasManager extends AbstractLifecycle {
   public void deleteAlias(NodeId categoryId, String aliasName, @Nullable List<AliasTarget> targets)
       throws UaException {
 
-    checkRunning();
-
     lock.lock();
     try {
+      checkRunning();
+
       resolveCategoryRecord(categoryId);
 
       NodeId aliasNodeId = findAliasInCategory(categoryId, aliasName);
@@ -1483,10 +1483,10 @@ public final class AliasManager extends AbstractLifecycle {
    * @throws IllegalStateException if the manager is not running.
    */
   public void touch(NodeId categoryId) throws UaException {
-    checkRunning();
-
     lock.lock();
     try {
+      checkRunning();
+
       versionManager.touch(categoryId);
     } finally {
       lock.unlock();

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/aliases/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/aliases/package-info.java
@@ -48,9 +48,10 @@
  * and unregisters its fragment: Nodes the manager hosts there (materialized Methods, alias Nodes
  * created in standard or adopted categories) leave the AddressSpace with it, while category and
  * alias Nodes hosted in application NodeManagers remain in place. Applications register their own
- * categories and aliases through the manager's programmatic API after startup. Removing a
- * manager-created category detaches its surviving aliases and child categories before deleting the
- * category itself.
+ * categories and aliases through the manager's programmatic API after startup. Public and wire
+ * mutations check lifecycle state while holding the mutation lock, so a caller waiting for that
+ * lock cannot mutate after shutdown completes. Removing a manager-created category detaches its
+ * surviving aliases and child categories before deleting the category itself.
  *
  * <h2>Data flow</h2>
  *


### PR DESCRIPTION
Six public alias mutations checked lifecycle state before taking the mutation lock. Shutdown could finish while a caller waited, after which the caller could still mutate the address space or version store. Check running state under the mutation lock in addCategory, adoptCategory, removeCategory, addAlias, deleteAlias, and touch.

### Verification

Six controlled interleavings pause immediately before lock acquisition, complete shutdown, resume each public mutator, and require IllegalStateException with no later persistence writes.

Formatting, full clean compilation, and 149 selected tests passed for this branch.

Based on https://github.com/eclipse-milo/milo/pull/1902 so the diff contains only this fix.
