### PR TITLE
Resolve shelving expiry before selecting Condition event fields

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/conditions/ConditionDispatchLifecycleTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/conditions/ConditionDispatchLifecycleTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.conditions;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.eclipse.milo.opcua.sdk.server.EventListener;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.sdk.server.Session;
+import org.eclipse.milo.opcua.sdk.server.events.EventContentFilter;
+import org.eclipse.milo.opcua.sdk.server.events.FilterContext;
+import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
+import org.eclipse.milo.opcua.sdk.test.AbstractClientServerTest;
+import org.eclipse.milo.opcua.stack.core.AttributeId;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.structured.SimpleAttributeOperand;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Real event selection, refresh copying, and wire dispatch across Condition lifecycle boundaries.
+ */
+class ConditionDispatchLifecycleTest extends AbstractClientServerTest {
+
+  @Test
+  void expiredRestoreCannotChangeAnEventDuringFieldSelection() throws Exception {
+    AlarmCondition alarm = restoredExpiredAlarm("event");
+    List<Variant[]> events = new ArrayList<>();
+    EventListener listener =
+        event -> {
+          if (event.getNodeId().equals(alarm.getConditionId())) {
+            events.add(select(event));
+          }
+        };
+    server.getEventNotifier().register(listener);
+    try {
+      alarm.setSeverity(ushort(701));
+      assertFalse(events.isEmpty());
+      for (Variant[] fields : events) {
+        assertEquals(fields[0], fields[4], "one event must have one EventId");
+        assertEquals(fields[1], fields[5], "shelving state must be stable during selection");
+        assertEquals(Boolean.FALSE, fields[1].getValue());
+        assertEquals("Unshelved", ((LocalizedText) fields[2].getValue()).text());
+      }
+    } finally {
+      server.getEventNotifier().unregister(listener);
+    }
+  }
+
+  @Test
+  void refreshResolvesExpiredRestoreBeforeCopyingFields() throws Exception {
+    AlarmCondition alarm = restoredExpiredAlarm("refresh");
+    List<ConditionEventSnapshot> snapshots = alarm.createRefreshSnapshots();
+    try {
+      assertEquals(1, snapshots.size());
+      Variant[] fields = select(snapshots.get(0).getEventNode());
+      assertEquals(Boolean.FALSE, fields[1].getValue());
+      assertEquals("Unshelved", ((LocalizedText) fields[2].getValue()).text());
+      assertEquals(0.0, fields[3].getValue());
+      assertEquals(alarm.currentBranch().getLastEventId(), fields[0].getValue());
+    } finally {
+      snapshots.forEach(ConditionEventSnapshot::delete);
+    }
+  }
+
+  private AlarmCondition newAlarm(String name) throws Exception {
+    AlarmCondition alarm =
+        AlarmCondition.create(
+            testNamespace.getNodeContext(),
+            b ->
+                b.nodeId(newNodeId(name))
+                    .browseName(newQualifiedName(name))
+                    .severity(ushort(700))
+                    .withShelving(Duration.ofMinutes(5)));
+    server.getConditionManager().register(alarm);
+    return alarm;
+  }
+
+  private AlarmCondition restoredExpiredAlarm(String name) throws Exception {
+    AlarmCondition alarm = newAlarm(name);
+    ByteString eventId = ByteString.of(new byte[] {1, 2, 3, 4});
+    DateTime eventTime = DateTime.now();
+    alarm.restoreSnapshot(
+        new ConditionSnapshot(
+            true,
+            ushort(700),
+            ushort(700),
+            null,
+            null,
+            null,
+            new ConditionSnapshot.ShelvingSnapshot(
+                ShelvedState.TIMED_SHELVED, new DateTime(Instant.now().minusSeconds(1))),
+            List.of(
+                new ConditionSnapshot.BranchSnapshot(
+                    NodeId.NULL_VALUE,
+                    false,
+                    null,
+                    true,
+                    Set.of(),
+                    null,
+                    true,
+                    eventId,
+                    eventTime,
+                    List.of(
+                        new ConditionSnapshot.AcceptedEventId(
+                            eventId, false, false, true, true))))));
+    return alarm;
+  }
+
+  private Variant[] select(BaseEventTypeNode event) {
+    FilterContext context =
+        new FilterContext() {
+          @Override
+          public OpcUaServer getServer() {
+            return server;
+          }
+
+          @Override
+          public Optional<Session> getSession() {
+            return Optional.empty();
+          }
+        };
+    return EventContentFilter.select(
+        context,
+        new SimpleAttributeOperand[] {
+          field("EventId"), field("SuppressedOrShelved"), field("ShelvingState", "CurrentState"),
+          field("ShelvingState", "UnshelveTime"), field("EventId"), field("SuppressedOrShelved")
+        },
+        event);
+  }
+
+  private static SimpleAttributeOperand field(String... path) {
+    return new SimpleAttributeOperand(
+        NodeIds.AlarmConditionType,
+        Arrays.stream(path).map(name -> new QualifiedName(0, name)).toArray(QualifiedName[]::new),
+        AttributeId.Value.uid(),
+        null);
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/AlarmCondition.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/AlarmCondition.java
@@ -224,6 +224,11 @@ public class AlarmCondition extends AcknowledgeableCondition {
   }
 
   @Override
+  void prepareEventState() {
+    applyShelvingExpiryIfDue();
+  }
+
+  @Override
   Optional<UaMethodNode> findMethodNode(NodeId methodId) {
     return shelvingRuntime != null ? shelvingRuntime.findMethodNode(methodId) : Optional.empty();
   }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/Condition.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/Condition.java
@@ -105,6 +105,9 @@ public class Condition {
   private final Map<NodeId, MethodInvocationHandler> sharedMethodHandlers =
       new ConcurrentHashMap<>();
 
+  /** Suppresses lazy read-side transitions while one event's fields are selected or copied. */
+  private int eventFieldReadDepth;
+
   private volatile ConditionMethodInterceptor interceptor = NOOP_INTERCEPTOR;
 
   /**
@@ -584,6 +587,7 @@ public class Condition {
   protected void withStateChange(String message, StateMutation mutation) {
     lock.lock();
     try {
+      prepareEventState();
       DateTime now = DateTime.now();
 
       boolean wasRetained = trunk.isRetained();
@@ -651,6 +655,7 @@ public class Condition {
   List<ConditionEventSnapshot> createRefreshSnapshots() throws UaException {
     lock.lock();
     try {
+      prepareEventState();
       if (!trunk.isRetained()) {
         return List.of();
       }
@@ -671,7 +676,12 @@ public class Condition {
       // The replayed EventId is now client-visible: a later restore may not invalidate it.
       live = true;
 
-      return List.of(ConditionEventSnapshot.create(server, node, trunk));
+      eventFieldReadDepth++;
+      try {
+        return List.of(ConditionEventSnapshot.create(server, node, trunk));
+      } finally {
+        eventFieldReadDepth--;
+      }
     } finally {
       lock.unlock();
     }
@@ -834,7 +844,20 @@ public class Condition {
 
     trunk.recordEvent(eventId, time);
 
-    server.getEventNotifier().fire(node);
+    eventFieldReadDepth++;
+    try {
+      server.getEventNotifier().fire(node);
+    } finally {
+      eventFieldReadDepth--;
+    }
+  }
+
+  /** Resolve deferred runtime transitions before assigning or exposing an event identity. */
+  void prepareEventState() {}
+
+  /** Whether the calling thread is selecting or copying one event under this Condition's lock. */
+  final boolean isReadingEventFields() {
+    return lock.isHeldByCurrentThread() && eventFieldReadDepth > 0;
   }
 
   void handleEnable(InvocationContext context) throws UaException {

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/ShelvingRuntime.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/ShelvingRuntime.java
@@ -78,6 +78,7 @@ final class ShelvingRuntime {
 
   // Guarded by the owning Condition's lock.
   private long shelveGeneration = 0;
+  private boolean transitionInProgress;
   private @Nullable ScheduledFuture<?> expiryTimer;
   private boolean expiryTimerSuppressed = false;
   private boolean shutdown = false;
@@ -360,6 +361,7 @@ final class ShelvingRuntime {
     DateTime deadline = unshelveDeadline;
 
     if (!shutdown
+        && !transitionInProgress
         && state != ShelvedState.UNSHELVED
         && deadline != null
         && System.currentTimeMillis() >= deadline.getJavaTime()) {
@@ -370,9 +372,15 @@ final class ShelvingRuntime {
   private void shelveTransition(
       ShelvedState target, @Nullable Function<DateTime, DateTime> deadline) {
 
-    alarm.withStateChange(
-        target.stateName(),
-        now -> applyTransition(target, deadline != null ? deadline.apply(now) : null, now));
+    boolean previous = transitionInProgress;
+    transitionInProgress = true;
+    try {
+      alarm.withStateChange(
+          target.stateName(),
+          now -> applyTransition(target, deadline != null ? deadline.apply(now) : null, now));
+    } finally {
+      transitionInProgress = previous;
+    }
   }
 
   private void applyTransition(ShelvedState target, @Nullable DateTime deadline, DateTime time) {
@@ -584,10 +592,14 @@ final class ShelvingRuntime {
   }
 
   private double computeUnshelveTime() {
-    // A read is a shelving touch. Apply due expiry under the Condition lock before producing the
-    // value; event-field extraction may recursively read UnshelveTime, but by then the state is
-    // already Unshelved and this check is a no-op.
-    alarm.runLocked(this::applyExpiryIfDue);
+    // An ordinary read still supplies the lazy fallback. Event selection and refresh copying have
+    // already resolved expiry and must not change state if the deadline passes between fields.
+    alarm.runLocked(
+        () -> {
+          if (!alarm.isReadingEventFields()) {
+            applyExpiryIfDue();
+          }
+        });
 
     ReadSnapshot snapshot = readSnapshot;
     ShelvedState state = snapshot.state();

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/package-info.java
@@ -49,6 +49,11 @@
  * Condition through the ConditionManager, leaving the shared node and any application-installed
  * handler unchanged.
  *
+ * <p>Deferred shelving expiry is resolved before event emission or refresh copying. Field reads
+ * within those operations cannot trigger another expiry transition, so one event retains one
+ * EventId and one shelving state. Ordinary UnshelveTime reads still apply the lazy expiry fallback
+ * when a timer prompt was lost or delayed.
+ *
  * <h2>Limit-alarm data flow</h2>
  *
  * <p>Limit-alarm behavior separates domain evaluation from Condition state application. The {@code


### PR DESCRIPTION
Lazy shelving expiry could change a Condition's EventId and shelving state while fields were being selected for one notification or copied for refresh. Clients could receive fields from different states under one event.

Expiry now resolves before event emission and refresh copying. Field reads during either operation cannot trigger a further expiry transition. Ordinary `UnshelveTime` reads retain the lazy fallback for a lost or delayed timer prompt.

[Part 5 §6.4.2](https://reference.opcfoundation.org/specs/OPC-10000-5/6.4.2) states: "EventId is generated by the Server to uniquely identify a particular Event Notification."

Regressions select repeated identity/state fields from real events and inspect refresh snapshots after restoring an expired shelving state.

Formatting, a full clean compile, and the selected regression suites passed for this branch.
