### PR TITLE
Coordinate monitored-item reset with add and remove

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/SubscriptionLifecycleRecoveryTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/SubscriptionLifecycleRecoveryTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.subscriptions;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.client.OperationLimits;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.structured.CreateMonitoredItemsResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.CreateSubscriptionResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.MonitoredItemCreateResult;
+import org.eclipse.milo.opcua.stack.core.types.structured.ReadValueId;
+import org.eclipse.milo.opcua.stack.core.types.structured.SetPublishingModeResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/** Deterministic response, reset, and executor boundaries in the subscription lifecycle. */
+class SubscriptionLifecycleRecoveryTest {
+  private final ExecutorService workers = Executors.newCachedThreadPool();
+
+  @AfterEach
+  void stopWorkers() throws InterruptedException {
+    workers.shutdownNow();
+    assertTrue(workers.awaitTermination(5, TimeUnit.SECONDS));
+  }
+
+  @Test
+  void resetAndReaddPreserveTheMappedItemsClientHandle() throws Exception {
+    var fixture = new Fixture(Runnable::run);
+    fixture.create();
+    var item = new GatedResetItem();
+    fixture.subscription.addMonitoredItem(item);
+    item.applyCreateResult(createdItem(41));
+    fixture.subscription.removeMonitoredItem(item);
+
+    var reset = workers.submit(fixture.subscription::reset);
+    assertTrue(item.entered.await(5, TimeUnit.SECONDS));
+    var readded = new CompletableFuture<Void>();
+    Thread adding =
+        new Thread(
+            () -> {
+              try {
+                fixture.subscription.addMonitoredItem(item);
+                readded.complete(null);
+              } catch (Throwable t) {
+                readded.completeExceptionally(t);
+              }
+            });
+    adding.start();
+    try {
+      // Wait until add either acquires the collection lock or is blocked on reset's ownership.
+      // Releasing the reset before add reaches this boundary would miss the original interleaving.
+      long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+      while (!readded.isDone()
+          && adding.getState() != Thread.State.BLOCKED
+          && System.nanoTime() < deadline) {
+        Thread.yield();
+      }
+      assertTrue(readded.isDone() || adding.getState() == Thread.State.BLOCKED);
+    } finally {
+      item.release.countDown();
+      adding.join(5000);
+    }
+    reset.get(5, TimeUnit.SECONDS);
+    readded.get(5, TimeUnit.SECONDS);
+    assertTrue(fixture.subscription.getMonitoredItems().contains(item));
+    assertTrue(item.getClientHandle().isPresent(), "mapped items must retain a requestable handle");
+    fixture.create();
+    when(fixture.client.createMonitoredItems(any(), any(), anyList()))
+        .thenReturn(
+            new CreateMonitoredItemsResponse(
+                null, new MonitoredItemCreateResult[] {createdItem(42)}, null));
+    assertTrue(fixture.subscription.createMonitoredItems().get(0).isGood());
+  }
+
+  private static MonitoredItemCreateResult createdItem(int id) {
+    return new MonitoredItemCreateResult(StatusCode.GOOD, uint(id), 1000.0, uint(1), null);
+  }
+
+  private static ReadValueId readValueId() {
+    return new ReadValueId(new NodeId(2, "value"), uint(13), null, QualifiedName.NULL_VALUE);
+  }
+
+  private static class GatedResetItem extends OpcUaMonitoredItem {
+    final CountDownLatch entered = new CountDownLatch(1);
+    final CountDownLatch release = new CountDownLatch(1);
+
+    GatedResetItem() {
+      super(readValueId());
+    }
+
+    @Override
+    void reset() {
+      entered.countDown();
+      try {
+        assertTrue(release.await(5, TimeUnit.SECONDS));
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new AssertionError(e);
+      }
+      super.reset();
+    }
+  }
+
+  private static class Fixture {
+    final OpcUaClient client = mock(OpcUaClient.class, RETURNS_DEEP_STUBS);
+    final AtomicInteger ids = new AtomicInteger(10);
+    final OpcUaSubscription subscription;
+
+    Fixture(Executor executor) throws Exception {
+      var executorService = mock(ExecutorService.class);
+      doAnswer(
+              invocation -> {
+                executor.execute(invocation.getArgument(0));
+                return null;
+              })
+          .when(executorService)
+          .execute(any());
+      when(client.getTransport().getConfig().getExecutor()).thenReturn(executorService);
+      when(client.getPublishingManager().isPublishingSuspended()).thenReturn(true);
+      when(client.getOperationLimits()).thenReturn(limits());
+      when(client.createSubscriptionAsync(anyDouble(), any(), any(), any(), anyBoolean(), any()))
+          .thenAnswer(
+              invocation -> CompletableFuture.completedFuture(created(ids.incrementAndGet())));
+      when(client.setPublishingModeAsync(anyBoolean(), anyList()))
+          .thenReturn(
+              CompletableFuture.completedFuture(
+                  new SetPublishingModeResponse(null, new StatusCode[] {StatusCode.GOOD}, null)));
+      subscription = new OpcUaSubscription(client);
+    }
+
+    static OperationLimits limits() {
+      return new OperationLimits(
+          null, null, null, null, null, null, null, uint(100), null, null, null, null);
+    }
+
+    static CreateSubscriptionResponse created(int id) {
+      return new CreateSubscriptionResponse(null, uint(id), 1000.0, uint(50), uint(10));
+    }
+
+    void create() throws Exception {
+      subscription.createAsync().toCompletableFuture().get(5, TimeUnit.SECONDS);
+    }
+
+    OpcUaMonitoredItem addItem() {
+      var item = new OpcUaMonitoredItem(readValueId());
+      subscription.addMonitoredItem(item);
+      return item;
+    }
+  }
+}

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscription.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscription.java
@@ -2248,17 +2248,21 @@ public class OpcUaSubscription {
         modifications = null;
 
         monitoredItemPartitionSize.reset();
-        monitoredItems.values().forEach(OpcUaMonitoredItem::reset);
+        // Keep reset's handle cleanup atomic with add/remove, in the same lock order used
+        // when applying monitored-item service results.
+        synchronized (monitoredItemsLock) {
+          monitoredItems.values().forEach(OpcUaMonitoredItem::reset);
 
-        // MonitoredItemIds are scoped to the Subscription that no longer exists, so the items
-        // pending deletion are already gone and their ids must never be sent again. Detach them
-        // completely, including the ClientHandle, so they can be added to a Subscription again.
-        itemsToDelete.forEach(
-            item -> {
-              item.reset();
-              item.setClientHandle(null);
-            });
-        itemsToDelete.clear();
+          // MonitoredItemIds are scoped to the Subscription that no longer exists, so the items
+          // pending deletion are already gone and their ids must never be sent again. Detach them
+          // completely, including the ClientHandle, so they can be added to a Subscription again.
+          itemsToDelete.forEach(
+              item -> {
+                item.reset();
+                item.setClientHandle(null);
+              });
+          itemsToDelete.clear();
+        }
 
         syncState = SyncState.INITIAL;
       }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/package-info.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/package-info.java
@@ -21,5 +21,8 @@
  * immutable registry snapshot; retaining it for each Publish request needs no registry lock or map
  * copy. Per-subscription processing and delivery queues preserve the order received from the
  * transport.
+ *
+ * <p>Reset and item add/remove operations coordinate collection membership and ClientHandle
+ * ownership; code requiring both locks takes the lifecycle lock before the item collection lock.
  */
 package org.eclipse.milo.opcua.sdk.client.subscriptions;


### PR DESCRIPTION
Reset and add/remove previously changed monitored-item collections under different locks. Readding an item during reset could leave it mapped without a ClientHandle, preventing a later create request.

Take the monitored-item collection lock during reset's membership and handle cleanup, using the existing lifecycle-before-collection lock order. The regression pauses reset at handle cleanup, interleaves readdition, then verifies that the retained item still has a requestable handle and can be recreated.

## Verification

Formatting and full clean compile passed. The selected regression suites passed (1 test, no failures or errors).

```sh
mise exec -- mvn -q -pl opc-ua-sdk/integration-tests -am verify '-Dtest=SubscriptionLifecycleRecoveryTest' -Dsurefire.failIfNoSpecifiedTests=false
```

Based on https://github.com/eclipse-milo/milo/pull/1904 so the diff contains only this fix.
