### PR TITLE
Preserve category versions when their node identifiers are reused

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/aliases/AliasLifecycleConsistencyTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/aliases/AliasLifecycleConsistencyTest.java
@@ -32,6 +32,7 @@ import java.util.stream.Collectors;
 import org.eclipse.milo.opcua.sdk.core.Reference;
 import org.eclipse.milo.opcua.sdk.server.Session;
 import org.eclipse.milo.opcua.sdk.server.UaNodeManager;
+import org.eclipse.milo.opcua.sdk.server.model.objects.AliasNameCategoryType;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectNode;
 import org.eclipse.milo.opcua.sdk.test.AbstractClientServerTest;
@@ -348,6 +349,35 @@ class AliasLifecycleConsistencyTest extends AbstractClientServerTest {
     }
   }
 
+  // A stored version ahead of wall time makes NodeId reuse deterministic without a timing race.
+  // Both deleting stores and stores that retain entries must preserve the live manager's sequence.
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void recreatedCategoryAdvancesBeyondItsPreviousContents(boolean deleteStoredEntry)
+      throws Exception {
+    AliasCategoryConfig category = category("Versioned", NodeIds.Aliases);
+    store.deleteEntries = deleteStoredEntry;
+    store.entries.put(
+        category.categoryNodeId().expanded(server.getNamespaceTable()),
+        UInteger.valueOf(4_000_000_000L));
+    manager.startup();
+    manager.addCategory(category);
+    manager.addAlias(
+        category.categoryNodeId(), prefix + "Old", List.of(target(newNodeId("TestInt32"))));
+    long before = lastChange(category.categoryNodeId());
+    manager.removeCategory(category.categoryNodeId());
+    manager.addCategory(category);
+    manager.addAlias(
+        category.categoryNodeId(), prefix + "New", List.of(target(newNodeId("TestAnalogValue"))));
+
+    assertTrue(
+        lastChange(category.categoryNodeId()) > before,
+        "different category contents require a new version");
+    assertTrue(manager.findAlias(category.categoryNodeId(), prefix + "Old", null).isEmpty());
+    assertEquals(
+        Set.of(newNodeId("TestAnalogValue")), targets(category.categoryNodeId(), prefix + "New"));
+  }
+
   private AliasCategoryConfig category(String suffix, NodeId parent) {
     return new AliasCategoryConfig(
         newNodeId(prefix + suffix),
@@ -373,6 +403,17 @@ class AliasLifecycleConsistencyTest extends AbstractClientServerTest {
         .flatMap(alias -> Arrays.stream(alias.getReferencedNodes()))
         .map(id -> id.toNodeId(server.getNamespaceTable()).orElseThrow())
         .collect(Collectors.toSet());
+  }
+
+  private long lastChange(NodeId categoryId) {
+    return ((UInteger)
+            managed(categoryId)
+                .getPropertyNode(AliasNameCategoryType.LAST_CHANGE)
+                .orElseThrow()
+                .getValue()
+                .value()
+                .value())
+        .longValue();
   }
 
   private StatusCode[] deleteOverWire(NodeId category, String name, @Nullable NodeId target)
@@ -427,6 +468,7 @@ class AliasLifecycleConsistencyTest extends AbstractClientServerTest {
     private final Map<ExpandedNodeId, UInteger> entries = new ConcurrentHashMap<>();
     private final AtomicInteger saves = new AtomicInteger();
     private volatile ExpandedNodeId failOn;
+    private boolean deleteEntries;
 
     @Override
     public Map<ExpandedNodeId, UInteger> load() {
@@ -440,6 +482,11 @@ class AliasLifecycleConsistencyTest extends AbstractClientServerTest {
       }
       entries.put(categoryId, value);
       saves.incrementAndGet();
+    }
+
+    @Override
+    public void delete(ExpandedNodeId categoryId) {
+      if (deleteEntries) entries.remove(categoryId);
     }
   }
 }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/aliases/AliasManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/aliases/AliasManager.java
@@ -591,9 +591,10 @@ public final class AliasManager extends AbstractLifecycle {
    * category.
    *
    * <p>When the category Node is deleted, {@code LastChange} is bumped for its former ancestor
-   * categories (captured before deletion) and the category's own in-memory version entry is
-   * dropped. Removing an <em>adopted</em> category only unbinds handlers — the AddressSpace is
-   * unchanged, so no version is bumped.
+   * categories (captured before deletion). The category's version high-water mark is retained for
+   * the manager's lifetime so recreating its NodeId continues the sequence. Removing an
+   * <em>adopted</em> category only unbinds handlers — the AddressSpace is unchanged, so no version
+   * is bumped.
    *
    * @param categoryId the NodeId of the category to remove.
    * @throws UaException with {@code Bad_InvalidArgument} if {@code categoryId} is a standard

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/aliases/AliasVersionManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/aliases/AliasVersionManager.java
@@ -50,7 +50,9 @@ import org.slf4j.LoggerFactory;
  * the prepared values to the {@code LastChange} Property Nodes, called from a {@code finally} so
  * values whose mutation partially applied are still published. Because no value becomes observable
  * before it is persisted, a restart can never re-produce an observed {@code LastChange} value for
- * different content — the failure mode that would leave Client caches undetectably stale.
+ * different content while its stored entry is retained. Removed categories keep their in-memory
+ * high-water mark for the manager's lifetime; retention across restarts depends on the store's
+ * deletion policy.
  *
  * <p>Store entries are keyed by namespace-URI-qualified {@link ExpandedNodeId}s (see {@link
  * AliasVersionStore}); this class converts to and from runtime NodeIds at the store boundary.
@@ -263,18 +265,18 @@ class AliasVersionManager {
   }
 
   /**
-   * Drop the version entry of a category that no longer exists, in memory and — best-effort — in
-   * the store.
+   * Remove pending publication and clean up the stored entry of a category that no longer exists,
+   * retaining its in-memory high-water mark for the manager's lifetime.
    *
    * <p>The store delete is cleanup, not correctness: a failure is logged and the removal proceeds,
    * and stores whose {@link AliasVersionStore#delete} is the default no-op simply keep the entry. A
-   * leftover entry is inert unless a category with the same NodeId is created again, in which case
-   * the monotonic version sequence resumes from the persisted value — which is the safe direction.
+   * retained entry also preserves the sequence across a manager restart. A store that deletes the
+   * entry gives up that restart guarantee for the removed category. Recreating the NodeId within
+   * this manager always resumes above the previous version, regardless of store deletion.
    *
    * @param categoryId the NodeId of the removed category.
    */
   void remove(NodeId categoryId) {
-    versions.remove(categoryId);
     pending.remove(categoryId);
 
     try {

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/aliases/AliasVersionStore.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/aliases/AliasVersionStore.java
@@ -71,8 +71,11 @@ public interface AliasVersionStore {
    * <p>Called when a manager-created category is removed, so durable stores do not accumulate
    * entries forever. Best-effort cleanup: a thrown exception is logged by the caller and the
    * removal proceeds — a leftover entry is inert unless a category with the same NodeId is created
-   * again, in which case the version sequence resumes from it, which is harmless. The default
-   * implementation does nothing, for stores that prefer to keep (or externally expire) old entries.
+   * again, in which case the version sequence resumes from it. Within the same manager lifetime, an
+   * in-memory high-water mark preserves the sequence even if the stored entry is deleted. Across
+   * manager restarts, preserving the sequence for reused NodeIds requires retaining their entries.
+   * The default implementation does nothing, for stores that prefer to keep (or externally expire)
+   * old entries.
    *
    * @param categoryId the namespace-URI-qualified ExpandedNodeId of the removed category.
    * @throws UaException if the entry cannot be removed.

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/aliases/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/aliases/package-info.java
@@ -99,14 +99,15 @@
  * org.eclipse.milo.opcua.sdk.server.aliases.AliasVersionStore} <em>before</em> the mutation they
  * describe is applied or the value is published: a failed save aborts the operation (or fails the
  * entry) with {@code Bad_InternalError} and nothing changed, so no Client can ever observe an
- * unpersisted {@code LastChange} value — after a restart the sequence therefore never repeats an
- * observed value for different content, which would leave Client caches undetectably stale. A
- * deletion entry prepares the union of categories affected by every matching alias before deleting
- * any association, so a later category's save failure leaves the whole entry untouched. Likewise a
- * failed load at startup fails startup, because silently reset versions would violate the
- * persistence contract undetectably. Categories whose {@code LastChange} Property does not exist
- * (it is Optional per category) still participate in propagation; only the Property write is
- * skipped.
+ * unpersisted {@code LastChange} value. A deletion entry prepares the union of categories affected
+ * by every matching alias before deleting any association, so a later category's save failure
+ * leaves the whole entry untouched. Likewise a failed load at startup fails startup, because
+ * silently reset versions would violate the persistence contract undetectably. Categories whose
+ * {@code LastChange} Property does not exist (it is Optional per category) still participate in
+ * propagation; only the Property write is skipped. Removed categories retain an in-memory version
+ * high-water mark for the manager's lifetime, so reusing a category NodeId cannot repeat a version
+ * for different contents. Across restarts, that guarantee for removed categories depends on the
+ * version store retaining their entries; the root category is never removed.
  */
 @NullMarked
 package org.eclipse.milo.opcua.sdk.server.aliases;


### PR DESCRIPTION
Removing a category erased its in-memory version, so recreating the same NodeId could repeat LastChange for different contents. Retain the high-water mark for the manager lifetime while keeping best-effort stored-entry cleanup. Across restarts, preserving the sequence for a removed category still depends on the store retaining its entry.

[Part 17 §6.3.1](https://reference.opcfoundation.org/specs/OPC-10000-17/6.3.1) states: "The LastChange shall be persisted." Same-manager NodeId reuse follows Milo's version-store contract; this PR does not claim the clause prescribes its internal retention mechanism.

### Verification

Two cases seed a persisted version ahead of wall time, remove and recreate the category, change its contents, and require a larger version with either a deleting or retaining store.

Formatting, full clean compilation, and 151 selected tests passed for this branch.

Based on https://github.com/eclipse-milo/milo/pull/1905 so the diff contains only this fix.
