### PR TITLE
Retire copied Method handlers when their Condition is unregistered

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/conditions/ConditionDispatchLifecycleTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/conditions/ConditionDispatchLifecycleTest.java
@@ -10,9 +10,12 @@
 
 package org.eclipse.milo.opcua.sdk.server.conditions;
 
+import static java.util.Objects.requireNonNull;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -26,16 +29,21 @@ import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
 import org.eclipse.milo.opcua.sdk.server.Session;
 import org.eclipse.milo.opcua.sdk.server.events.EventContentFilter;
 import org.eclipse.milo.opcua.sdk.server.events.FilterContext;
+import org.eclipse.milo.opcua.sdk.server.methods.MethodInvocationHandler;
 import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaMethodNode;
 import org.eclipse.milo.opcua.sdk.test.AbstractClientServerTest;
 import org.eclipse.milo.opcua.stack.core.AttributeId;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.structured.CallMethodRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.CallMethodResult;
 import org.eclipse.milo.opcua.stack.core.types.structured.SimpleAttributeOperand;
 import org.junit.jupiter.api.Test;
 
@@ -83,6 +91,67 @@ class ConditionDispatchLifecycleTest extends AbstractClientServerTest {
     } finally {
       snapshots.forEach(ConditionEventSnapshot::delete);
     }
+  }
+
+  @Test
+  void unregisterRetiresCopiedAcknowledgementAndShelvingHandlers() throws Exception {
+    AlarmCondition alarm = newAlarm("retired");
+    alarm.setActive(true);
+    ByteString eventId = alarm.currentBranch().getLastEventId();
+    UaMethodNode acknowledge = requireNonNull(alarm.getNode().getAcknowledgeMethodNode());
+    var shelving = requireNonNull(alarm.getShelvingState());
+    UaMethodNode timedShelve = requireNonNull(shelving.getTimedShelveMethodNode());
+
+    server.getConditionManager().unregister(alarm);
+
+    assertEquals(
+        StatusCodes.Bad_NotImplemented,
+        call(
+                alarm.getConditionId(),
+                acknowledge.getNodeId(),
+                new Variant(eventId),
+                new Variant(LocalizedText.NULL_VALUE))
+            .getStatusCode()
+            .value());
+    assertEquals(
+        StatusCodes.Bad_NotImplemented,
+        call(shelving.getNodeId(), timedShelve.getNodeId(), new Variant(30_000.0))
+            .getStatusCode()
+            .value());
+    assertFalse(alarm.isAcked());
+    assertEquals("Unshelved", shelving.getCurrentState().text());
+    assertFalse(requireNonNull(alarm.getShelvingRuntime()).hasExpiryTimerForTesting());
+  }
+
+  @Test
+  void unregisterPreservesAnApplicationReplacementHandler() throws Exception {
+    AlarmCondition alarm = newAlarm("application-handler");
+    UaMethodNode method = requireNonNull(alarm.getNode().getAcknowledgeMethodNode());
+    MethodInvocationHandler replacement = MethodInvocationHandler.NODE_ID_UNKNOWN;
+    method.setInvocationHandler(replacement);
+
+    server.getConditionManager().unregister(alarm);
+
+    assertSame(replacement, method.getInvocationHandler());
+  }
+
+  @Test
+  void replacingBehaviorPreservesTheNewWrappersHandlers() throws Exception {
+    AlarmCondition original = newAlarm("replacement");
+    AlarmCondition replacement = AlarmCondition.attach(original.getNode());
+    server.getConditionManager().register(replacement);
+    replacement.setActive(true);
+    UaMethodNode acknowledge = requireNonNull(replacement.getNode().getAcknowledgeMethodNode());
+
+    CallMethodResult result =
+        call(
+            replacement.getConditionId(),
+            acknowledge.getNodeId(),
+            new Variant(replacement.currentBranch().getLastEventId()),
+            new Variant(LocalizedText.NULL_VALUE));
+
+    assertTrue(result.getStatusCode().isGood());
+    assertTrue(replacement.isAcked());
   }
 
   private AlarmCondition newAlarm(String name) throws Exception {
@@ -157,5 +226,11 @@ class ConditionDispatchLifecycleTest extends AbstractClientServerTest {
         Arrays.stream(path).map(name -> new QualifiedName(0, name)).toArray(QualifiedName[]::new),
         AttributeId.Value.uid(),
         null);
+  }
+
+  private CallMethodResult call(NodeId objectId, NodeId methodId, Variant... inputs)
+      throws Exception {
+    return requireNonNull(
+        client.call(List.of(new CallMethodRequest(objectId, methodId, inputs))).getResults())[0];
   }
 }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/Condition.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/Condition.java
@@ -104,6 +104,8 @@ public class Condition {
   private final Set<FilterRegistration> filterRegistrations = ConcurrentHashMap.newKeySet();
   private final Map<NodeId, MethodInvocationHandler> sharedMethodHandlers =
       new ConcurrentHashMap<>();
+  private final Map<UaMethodNode, MethodInvocationHandler> ownedMethodHandlers =
+      new ConcurrentHashMap<>();
 
   /** Suppresses lazy read-side transitions while one event's fields are selected or copied. */
   private int eventFieldReadDepth;
@@ -1024,6 +1026,7 @@ public class Condition {
 
     if (discovered.exclusivelyOwned()) {
       method.setInvocationHandler(invocationHandler);
+      ownedMethodHandlers.put(method, invocationHandler);
     } else if (method.getInvocationHandler() == MethodInvocationHandler.NOT_IMPLEMENTED) {
       sharedMethodHandlers.put(method.getNodeId(), invocationHandler);
     }
@@ -1052,6 +1055,11 @@ public class Condition {
 
   /** Release runtime resources when this Condition is unregistered or the server shuts down. */
   void shutdown() {
+    ownedMethodHandlers.forEach(
+        (method, handler) ->
+            method.compareAndSetInvocationHandler(
+                handler, MethodInvocationHandler.NOT_IMPLEMENTED));
+    ownedMethodHandlers.clear();
     for (FilterRegistration registration : filterRegistrations) {
       registration.node().getFilterChain().remove(registration.filter());
     }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/package-info.java
@@ -49,6 +49,10 @@
  * Condition through the ConditionManager, leaving the shared node and any application-installed
  * handler unchanged.
  *
+ * <p>Unregistering retires handlers installed on copied Methods only while they still belong to
+ * that behavior, preserving later application or replacement handlers. Calls that already obtained
+ * a handler may finish against the retired behavior.
+ *
  * <p>Deferred shelving expiry is resolved before event emission or refresh copying. Field reads
  * within those operations cannot trigger another expiry transition, so one event retains one
  * EventId and one shelving state. Ordinary UnshelveTime reads still apply the lazy expiry fallback

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/UaMethodNode.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/UaMethodNode.java
@@ -18,6 +18,7 @@ import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -44,7 +45,8 @@ import org.jspecify.annotations.Nullable;
 
 public class UaMethodNode extends UaNode implements MethodNode {
 
-  private volatile MethodInvocationHandler handler = MethodInvocationHandler.NOT_IMPLEMENTED;
+  private final AtomicReference<MethodInvocationHandler> handler =
+      new AtomicReference<>(MethodInvocationHandler.NOT_IMPLEMENTED);
 
   private Boolean executable;
   private Boolean userExecutable;
@@ -185,11 +187,26 @@ public class UaMethodNode extends UaNode implements MethodNode {
   }
 
   public MethodInvocationHandler getInvocationHandler() {
-    return handler;
+    return handler.get();
   }
 
   public void setInvocationHandler(MethodInvocationHandler handler) {
-    this.handler = handler;
+    this.handler.set(handler);
+  }
+
+  /**
+   * Replace the invocation handler only while the current handler is {@code expected} by identity.
+   *
+   * <p>Behavior owners can release their dispatch without removing a handler installed later by
+   * another owner or by the application.
+   *
+   * @param expected the handler owned by the caller.
+   * @param replacement the handler to install if ownership has not changed.
+   * @return whether the replacement was applied.
+   */
+  public boolean compareAndSetInvocationHandler(
+      MethodInvocationHandler expected, MethodInvocationHandler replacement) {
+    return handler.compareAndSet(expected, replacement);
   }
 
   /**

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/package-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/**
+ * Mutable server nodes used by generated information models and application address spaces.
+ *
+ * <p>A node owns its attributes and attribute filters; its NodeManager owns registration and
+ * reference storage. Generated model nodes add typed accessors over these primitives. Applications
+ * can extend the node classes or install filters and method handlers to provide runtime behavior.
+ *
+ * <p>Method handlers may belong to a separate lifecycle owner, such as a Condition wrapper. Such
+ * owners should release their handler with {@link
+ * org.eclipse.milo.opcua.sdk.server.nodes.UaMethodNode#compareAndSetInvocationHandler} so cleanup
+ * cannot remove a handler installed later. A call that already obtained the old handler may finish
+ * after replacement; changing the handler controls subsequent dispatch.
+ */
+package org.eclipse.milo.opcua.sdk.server.nodes;


### PR DESCRIPTION
Copied Method nodes could retain handlers belonging to a Condition behavior after it was unregistered. Later calls could still acknowledge or shelve that retired behavior.

The Condition now records the handlers it installs and removes each one only while it still owns that exact handler. Application handlers and handlers installed by a replacement behavior survive cleanup. A call that already obtained the old handler may finish.

Regressions exercise wire calls after unregistering, preserve an application replacement handler, and verify that a replacement Condition's handlers remain usable.

Formatting, a full clean compile, and the selected regression suites passed for this branch.

Based on https://github.com/eclipse-milo/milo/pull/1906 so the diff contains only this fix.
