### PR TITLE
Cover delayed monitored-item responses after recreation

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/SubscriptionLifecycleRecoveryTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/SubscriptionLifecycleRecoveryTest.java
@@ -11,6 +11,8 @@
 package org.eclipse.milo.opcua.sdk.client.subscriptions;
 
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -21,22 +23,30 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
 import org.eclipse.milo.opcua.sdk.client.OperationLimits;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.MonitoringMode;
 import org.eclipse.milo.opcua.stack.core.types.structured.CreateMonitoredItemsResponse;
 import org.eclipse.milo.opcua.stack.core.types.structured.CreateSubscriptionResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.DeleteMonitoredItemsResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.ModifyMonitoredItemsResponse;
 import org.eclipse.milo.opcua.stack.core.types.structured.MonitoredItemCreateResult;
+import org.eclipse.milo.opcua.stack.core.types.structured.MonitoredItemModifyResult;
 import org.eclipse.milo.opcua.stack.core.types.structured.ReadValueId;
+import org.eclipse.milo.opcua.stack.core.types.structured.SetMonitoringModeResponse;
 import org.eclipse.milo.opcua.stack.core.types.structured.SetPublishingModeResponse;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -98,6 +108,112 @@ class SubscriptionLifecycleRecoveryTest {
             new CreateMonitoredItemsResponse(
                 null, new MonitoredItemCreateResult[] {createdItem(42)}, null));
     assertTrue(fixture.subscription.createMonitoredItems().get(0).isGood());
+  }
+
+  @Test
+  void delayedCreateCannotPopulateRecreatedSubscription() throws Exception {
+    assertDelayedResponseIgnored(Operation.CREATE);
+  }
+
+  @Test
+  void delayedModifyCannotOverwriteRecreatedItem() throws Exception {
+    assertDelayedResponseIgnored(Operation.MODIFY);
+  }
+
+  @Test
+  void delayedDeleteCannotDetachRecreatedItem() throws Exception {
+    assertDelayedResponseIgnored(Operation.DELETE);
+  }
+
+  @Test
+  void delayedMonitoringModeCannotChangeRecreatedItem() throws Exception {
+    assertDelayedResponseIgnored(Operation.MODE);
+  }
+
+  private void assertDelayedResponseIgnored(Operation operation) throws Exception {
+    var fixture = new Fixture(Runnable::run);
+    fixture.create();
+    var item = fixture.addItem();
+    if (operation != Operation.CREATE) item.applyCreateResult(createdItem(41));
+    if (operation == Operation.MODIFY) item.setSamplingInterval(250.0);
+    if (operation == Operation.DELETE) fixture.subscription.removeMonitoredItem(item);
+    var entered = new CountDownLatch(1);
+    var release = new CountDownLatch(1);
+    var firstCall = new AtomicBoolean(true);
+    org.mockito.stubbing.Answer<Object> gate =
+        invocation -> {
+          if (firstCall.getAndSet(false)) {
+            entered.countDown();
+            assertTrue(release.await(5, TimeUnit.SECONDS));
+          }
+          return switch (operation) {
+            case CREATE ->
+                new CreateMonitoredItemsResponse(
+                    null, new MonitoredItemCreateResult[] {createdItem(41)}, null);
+            case MODIFY ->
+                new ModifyMonitoredItemsResponse(
+                    null,
+                    new MonitoredItemModifyResult[] {
+                      new MonitoredItemModifyResult(StatusCode.GOOD, 250.0, uint(1), null)
+                    },
+                    null);
+            case DELETE ->
+                new DeleteMonitoredItemsResponse(null, new StatusCode[] {StatusCode.GOOD}, null);
+            case MODE ->
+                new SetMonitoringModeResponse(null, new StatusCode[] {StatusCode.GOOD}, null);
+          };
+        };
+    switch (operation) {
+      case CREATE ->
+          when(fixture.client.createMonitoredItems(any(), any(), anyList())).thenAnswer(gate);
+      case MODIFY ->
+          when(fixture.client.modifyMonitoredItems(any(), any(), anyList())).thenAnswer(gate);
+      case DELETE -> when(fixture.client.deleteMonitoredItems(any(), anyList())).thenAnswer(gate);
+      case MODE -> when(fixture.client.setMonitoringMode(any(), any(), anyList())).thenAnswer(gate);
+    }
+    var oldId = fixture.subscription.getSubscriptionId().orElseThrow();
+    var pending =
+        workers.submit(
+            () ->
+                switch (operation) {
+                  case CREATE -> fixture.subscription.createMonitoredItems();
+                  case MODIFY -> fixture.subscription.modifyMonitoredItems();
+                  case DELETE -> fixture.subscription.deleteMonitoredItems();
+                  case MODE ->
+                      fixture.subscription.setMonitoringMode(
+                          MonitoringMode.Disabled, List.of(item));
+                });
+    assertTrue(entered.await(5, TimeUnit.SECONDS));
+    try {
+      fixture.subscription.reset();
+      fixture.create();
+      assertNotEquals(oldId, fixture.subscription.getSubscriptionId().orElseThrow());
+      if (operation == Operation.DELETE) fixture.subscription.addMonitoredItem(item);
+      if (operation != Operation.CREATE) item.applyCreateResult(createdItem(99));
+    } finally {
+      release.countDown();
+    }
+    var results = pending.get(5, TimeUnit.SECONDS);
+    assertEquals(1, results.size());
+    assertEquals(new StatusCode(StatusCodes.Bad_InvalidState), results.get(0).serviceResult());
+    assertTrue(item.getClientHandle().isPresent());
+    if (operation == Operation.CREATE) {
+      assertEquals(OpcUaMonitoredItem.SyncState.INITIAL, item.getSyncState());
+      assertTrue(item.getMonitoredItemId().isEmpty());
+      assertTrue(fixture.subscription.createMonitoredItems().get(0).isGood());
+    } else {
+      assertEquals(OpcUaMonitoredItem.SyncState.SYNCHRONIZED, item.getSyncState());
+      assertEquals(uint(99), item.getMonitoredItemId().orElseThrow());
+      assertEquals(1000.0, item.getRevisedSamplingInterval().orElseThrow());
+      assertEquals(MonitoringMode.Reporting, item.getMonitoringMode());
+    }
+  }
+
+  private enum Operation {
+    CREATE,
+    MODIFY,
+    DELETE,
+    MODE
   }
 
   private static MonitoredItemCreateResult createdItem(int id) {


### PR DESCRIPTION
Add deterministic regressions for service responses that return after their subscription has been reset and recreated. Cover CreateMonitoredItems, ModifyMonitoredItems, DeleteMonitoredItems, and SetMonitoringMode.

The incarnation guards are supplied by the existing operation-limit recovery change in #1863. These tests hold each real service invocation, recreate the subscription, then release the old successful response. They verify `Bad_InvalidState` and unchanged replacement item identity and state. Removing the four post-response guards makes all four cases fail.

OPC UA Part 4 §5.13.2.2 defines monitoredItemId scope: "This id is unique within the Subscription, but might not be unique within the Server or Session." [Specification](https://reference.opcfoundation.org/specs/OPC-10000-4/5.13.2.2)

## Verification

Formatting and full clean compile passed. The selected regression suites passed (5 tests, no failures or errors).

```sh
mise exec -- mvn -q -pl opc-ua-sdk/integration-tests -am verify '-Dtest=SubscriptionLifecycleRecoveryTest' -Dsurefire.failIfNoSpecifiedTests=false
```

Based on https://github.com/eclipse-milo/milo/pull/1907 so the diff contains only this fix.
