### PR TITLE
Remove imported trust material from its actual files

### DIFF
--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/FileBasedTrustListManager.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/FileBasedTrustListManager.java
@@ -20,9 +20,11 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardWatchEventKinds;
 import java.nio.file.WatchKey;
 import java.nio.file.WatchService;
@@ -176,25 +178,25 @@ public class FileBasedTrustListManager implements TrustListManager, Closeable {
           updated.issuerCertificates(),
           issuerCertsDir,
           FileBasedTrustListManager::writeCertificateToDir,
-          FileBasedTrustListManager::deleteCertificateFromDir);
+          FileBasedTrustListManager::deleteCertificatesFromDir);
       updateFiles(
           current.issuerCrls(),
           updated.issuerCrls(),
           issuerCrlDir,
           FileBasedTrustListManager::writeCrlToDir,
-          FileBasedTrustListManager::deleteCrlFromDir);
+          FileBasedTrustListManager::deleteCrlsFromDir);
       updateFiles(
           current.trustedCertificates(),
           updated.trustedCertificates(),
           trustedCertsDir,
           FileBasedTrustListManager::writeCertificateToDir,
-          FileBasedTrustListManager::deleteCertificateFromDir);
+          FileBasedTrustListManager::deleteCertificatesFromDir);
       updateFiles(
           current.trustedCrls(),
           updated.trustedCrls(),
           trustedCrlDir,
           FileBasedTrustListManager::writeCrlToDir,
-          FileBasedTrustListManager::deleteCrlFromDir);
+          FileBasedTrustListManager::deleteCrlsFromDir);
 
       TrustListSnapshot committed = updated.withLastUpdateTime(DateTime.now());
       snapshot.set(committed);
@@ -290,7 +292,7 @@ public class FileBasedTrustListManager implements TrustListManager, Closeable {
       List<T> replacement,
       Path directory,
       BiConsumer<T, Path> write,
-      BiConsumer<T, Path> delete) {
+      BiConsumer<Set<T>, Path> delete) {
 
     if (current.equals(replacement)) {
       return;
@@ -300,7 +302,10 @@ public class FileBasedTrustListManager implements TrustListManager, Closeable {
     Set<T> replacementSet = Set.copyOf(replacement);
 
     Sets.difference(replacementSet, currentSet).forEach(entry -> write.accept(entry, directory));
-    Sets.difference(currentSet, replacementSet).forEach(entry -> delete.accept(entry, directory));
+    Set<T> removed = Sets.difference(currentSet, replacementSet);
+    if (!removed.isEmpty()) {
+      delete.accept(removed, directory);
+    }
   }
 
   private void synchronizeIssuerCertificates() {
@@ -400,18 +405,20 @@ public class FileBasedTrustListManager implements TrustListManager, Closeable {
     }
   }
 
-  private static void deleteCertificateFromDir(X509Certificate certificate, Path path) {
-    try {
-      String thumbprint = ByteBufUtil.hexDump(sha1(certificate.getEncoded()));
-      File file = path.resolve(String.format("%s.der", thumbprint)).toFile();
-
-      if (file.exists()) {
-        Files.delete(file.toPath());
-
-        LOGGER.debug("Deleted certificate: {}", file.getAbsolutePath());
+  private static void deleteCertificatesFromDir(Set<X509Certificate> certificates, Path directory) {
+    try (var files = Files.list(directory)) {
+      for (Path file : files.toList()) {
+        if (decodeCertificateFile(file).filter(certificates::contains).isPresent()) {
+          try {
+            Files.delete(file);
+            LOGGER.debug("Deleted certificate: {}", file);
+          } catch (IOException e) {
+            LOGGER.error("Error deleting certificate: {}", file, e);
+          }
+        }
       }
-    } catch (Exception e) {
-      LOGGER.error("Error deleting certificate", e);
+    } catch (IOException e) {
+      LOGGER.error("Error listing certificate directory: {}", directory, e);
     }
   }
 
@@ -432,18 +439,52 @@ public class FileBasedTrustListManager implements TrustListManager, Closeable {
     }
   }
 
-  private static void deleteCrlFromDir(X509CRL crl, Path path) {
-    try {
-      String thumbprint = ByteBufUtil.hexDump(sha1(crl.getEncoded()));
-      File file = path.resolve(String.format("%s.crl", thumbprint)).toFile();
-
-      if (file.exists()) {
-        Files.delete(file.toPath());
-
-        LOGGER.debug("Deleted CRL: {}", file.getAbsolutePath());
+  private static void deleteCrlsFromDir(Set<X509CRL> removed, Path directory) {
+    try (var files = Files.list(directory)) {
+      for (Path file : files.toList()) {
+        List<X509CRL> contents = decodeCrlFile(file).orElse(List.of());
+        List<X509CRL> retained = contents.stream().filter(crl -> !removed.contains(crl)).toList();
+        if (retained.size() == contents.size()) {
+          continue;
+        }
+        try {
+          if (retained.isEmpty()) {
+            Files.delete(file);
+            LOGGER.debug("Deleted CRL file: {}", file);
+          } else {
+            replaceCrlFile(file, retained);
+            LOGGER.debug("Removed CRLs from bundle: {}", file);
+          }
+        } catch (Exception e) {
+          LOGGER.error("Error removing CRLs from file: {}", file, e);
+        }
       }
-    } catch (Exception e) {
-      LOGGER.error("Error deleting CRL", e);
+    } catch (IOException e) {
+      LOGGER.error("Error listing CRL directory: {}", directory, e);
+    }
+  }
+
+  private static void replaceCrlFile(Path file, List<X509CRL> crls) throws Exception {
+    // Write the surviving members completely before replacing a bundle, so an encoding or write
+    // failure cannot destroy the unrelated CRLs that it also contains.
+    Path temporary = Files.createTempFile(file.getParent(), ".crl-", ".tmp");
+    try {
+      if (file.getFileSystem().supportedFileAttributeViews().contains("posix")) {
+        Files.setPosixFilePermissions(temporary, Files.getPosixFilePermissions(file));
+      }
+      try (var output = Files.newOutputStream(temporary)) {
+        for (X509CRL crl : crls) {
+          output.write(crl.getEncoded());
+        }
+      }
+      try {
+        Files.move(
+            temporary, file, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+      } catch (AtomicMoveNotSupportedException e) {
+        Files.move(temporary, file, StandardCopyOption.REPLACE_EXISTING);
+      }
+    } finally {
+      Files.deleteIfExists(temporary);
     }
   }
 

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/package-info.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/package-info.java
@@ -127,6 +127,12 @@
  * file. Separate store instances and processes do not share a write lock, so applications must
  * coordinate writes that overlap.
  *
+ * <p>{@link org.eclipse.milo.opcua.stack.core.security.FileBasedTrustListManager} accepts imported
+ * certificate and CRL files independently of their names. Removal finds those files by their
+ * decoded contents; removing CRLs from a bundle preserves its unrelated entries. Persistence
+ * remains best-effort on I/O failure, and a subsequent directory reload reconciles the published
+ * snapshot with the files that remain.
+ *
  * <p>{@link org.eclipse.milo.opcua.stack.core.security.DefaultCertificateManager} provides a
  * thread-safe mutable group registry. Applications own the groups and their backing stores,
  * trust-list managers, and quarantines. Removing or replacing a group returns it to the application

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/security/FileBasedTrustListPersistenceTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/security/FileBasedTrustListPersistenceTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.core.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.security.KeyPair;
+import java.security.cert.X509CRL;
+import java.security.cert.X509Certificate;
+import java.util.Base64;
+import java.util.List;
+import java.util.Set;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.util.CrlTestUtil;
+import org.eclipse.milo.opcua.stack.core.util.DigestUtil;
+import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateBuilder;
+import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateGenerator;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class FileBasedTrustListPersistenceTest {
+
+  @TempDir Path directory;
+
+  // Every filename accepted by import must participate in removal, including duplicate files.
+  // Checking a freshly opened manager distinguishes persistence from an in-memory snapshot edit.
+  @ParameterizedTest
+  @CsvSource({"trusted,remove", "trusted,replace", "issuer,remove", "issuer,replace"})
+  void removingImportedCertificatesSurvivesRestart(String list, String operation) throws Exception {
+    Material removed = material("Removed");
+    Material retained = material("Retained");
+    Path certificates = Files.createDirectories(directory.resolve(list).resolve("certs"));
+    Path imported = certificates.resolve("operator-certificate.pem");
+    Path duplicate = certificates.resolve("another-name.cer");
+    Files.writeString(imported, pem("CERTIFICATE", removed.certificate().getEncoded()));
+    Files.write(duplicate, removed.certificate().getEncoded());
+    Files.write(certificates.resolve("retained.cer"), retained.certificate().getEncoded());
+
+    try (var manager = FileBasedTrustListManager.createAndInitialize(directory)) {
+      assertEquals(
+          Set.of(removed.certificate(), retained.certificate()),
+          Set.copyOf(certificates(manager, list)),
+          "imports expose distinct certificate entries");
+      if (operation.equals("remove")) {
+        ByteString thumbprint = ByteString.of(DigestUtil.sha1(removed.certificate().getEncoded()));
+        boolean changed =
+            list.equals("trusted")
+                ? manager.removeTrustedCertificate(thumbprint)
+                : manager.removeIssuerCertificate(thumbprint);
+        assertTrue(changed);
+      } else if (list.equals("trusted")) {
+        manager.setTrustedCertificates(List.of(retained.certificate()));
+      } else {
+        manager.setIssuerCertificates(List.of(retained.certificate()));
+      }
+      assertEquals(List.of(retained.certificate()), certificates(manager, list));
+    }
+
+    try (var reopened = FileBasedTrustListManager.createAndInitialize(directory)) {
+      assertEquals(List.of(retained.certificate()), certificates(reopened, list));
+      assertFalse(Files.exists(imported));
+      assertFalse(Files.exists(duplicate));
+    }
+  }
+
+  // One accepted CRL file can contain multiple CRLs. Removing a member must persist without
+  // deleting unrelated members of that bundle or leaving another copy of the removed CRL.
+  @ParameterizedTest
+  @ValueSource(strings = {"trusted", "issuer"})
+  void replacingImportedCrlsPreservesOtherBundleMembersAcrossRestart(String list) throws Exception {
+    Material removed = material("Removed");
+    Material retained = material("Retained");
+    Material alsoRetained = material("AlsoRetained");
+    Path crls = Files.createDirectories(directory.resolve(list).resolve("crl"));
+    Path bundle = crls.resolve("operator-bundle.pem");
+    Files.writeString(
+        bundle,
+        pem("X509 CRL", removed.crl().getEncoded())
+            + pem("X509 CRL", retained.crl().getEncoded())
+            + pem("X509 CRL", alsoRetained.crl().getEncoded()));
+    Files.write(crls.resolve("duplicate.revocations"), removed.crl().getEncoded());
+    boolean posix = bundle.getFileSystem().supportedFileAttributeViews().contains("posix");
+    if (posix) {
+      Files.setPosixFilePermissions(bundle, PosixFilePermissions.fromString("rw-r-----"));
+    }
+
+    try (var manager = FileBasedTrustListManager.createAndInitialize(directory)) {
+      assertEquals(
+          Set.of(removed.crl(), retained.crl(), alsoRetained.crl()),
+          Set.copyOf(crls(manager, list)),
+          "imports expose distinct CRL entries");
+      if (list.equals("trusted")) {
+        manager.setTrustedCrls(List.of(retained.crl(), alsoRetained.crl()));
+      } else {
+        manager.setIssuerCrls(List.of(retained.crl(), alsoRetained.crl()));
+      }
+      assertEquals(List.of(retained.crl(), alsoRetained.crl()), crls(manager, list));
+    }
+
+    try (var reopened = FileBasedTrustListManager.createAndInitialize(directory)) {
+      assertEquals(List.of(retained.crl(), alsoRetained.crl()), crls(reopened, list));
+      if (posix) {
+        assertEquals(
+            PosixFilePermissions.fromString("rw-r-----"),
+            Files.getPosixFilePermissions(bundle),
+            "rewriting must preserve group read access");
+      }
+    }
+  }
+
+  private static List<X509Certificate> certificates(
+      FileBasedTrustListManager manager, String list) {
+    return list.equals("trusted")
+        ? manager.getTrustedCertificates()
+        : manager.getIssuerCertificates();
+  }
+
+  private static List<X509CRL> crls(FileBasedTrustListManager manager, String list) {
+    return list.equals("trusted") ? manager.getTrustedCrls() : manager.getIssuerCrls();
+  }
+
+  private static Material material(String name) throws Exception {
+    KeyPair keyPair = SelfSignedCertificateGenerator.generateRsaKeyPair(2048);
+    X509Certificate certificate =
+        new SelfSignedCertificateBuilder(keyPair)
+            .setCommonName(name)
+            .setApplicationUri("urn:eclipse:milo:test:" + name)
+            .build();
+    return new Material(certificate, CrlTestUtil.generateCrl(certificate, keyPair.getPrivate()));
+  }
+
+  private static String pem(String type, byte[] bytes) {
+    return "-----BEGIN "
+        + type
+        + "-----\n"
+        + Base64.getMimeEncoder(64, new byte[] {'\n'}).encodeToString(bytes)
+        + "\n-----END "
+        + type
+        + "-----\n";
+  }
+
+  private record Material(X509Certificate certificate, X509CRL crl) {}
+}


### PR DESCRIPTION
Imported certificates and CRLs can use arbitrary filenames, but removal previously deleted only the generated hash filename. Removed entries could return after reload. Locate accepted files by decoded content, remove matching certificate files, and rewrite CRL bundles with unrelated entries and existing POSIX permissions preserved. Rewritten bundles contain concatenated DER-encoded CRLs; I/O failure handling remains best effort.

[Part 12 §7.8.2.7](https://reference.opcfoundation.org/specs/OPC-10000-12/7.8.2.7) describes RemoveCertificate: "The RemoveCertificate Method allows a Client to remove a single Certificate from the TrustList." File naming and persistence are Milo implementation contracts, not a mandated disk algorithm.

### Verification

Six real filesystem cases cover trusted/issuer certificates, removal/list replacement, duplicate arbitrary filenames, CRL bundle survivors, permissions, in-memory state, and close/reopen persistence.

Formatting, full clean compilation, and 40 selected tests passed for this branch.
