### PR TITLE
Resolve shared shelving Methods through their nested Object

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/conditions/ConditionDispatchLifecycleTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/conditions/ConditionDispatchLifecycleTest.java
@@ -30,8 +30,11 @@ import org.eclipse.milo.opcua.sdk.server.Session;
 import org.eclipse.milo.opcua.sdk.server.events.EventContentFilter;
 import org.eclipse.milo.opcua.sdk.server.events.FilterContext;
 import org.eclipse.milo.opcua.sdk.server.methods.MethodInvocationHandler;
+import org.eclipse.milo.opcua.sdk.server.model.objects.AlarmConditionTypeNode;
 import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaMethodNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.instantiation.InstantiationRequest;
+import org.eclipse.milo.opcua.sdk.server.nodes.instantiation.MethodInstantiation;
 import org.eclipse.milo.opcua.sdk.test.AbstractClientServerTest;
 import org.eclipse.milo.opcua.stack.core.AttributeId;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
@@ -152,6 +155,69 @@ class ConditionDispatchLifecycleTest extends AbstractClientServerTest {
 
     assertTrue(result.getStatusCode().isGood());
     assertTrue(replacement.isAcked());
+  }
+
+  @Test
+  void sharedShelvingMethodResolvesItsNestedObjectWithoutChangingTheTypeHandler() throws Exception {
+    AlarmCondition alarm = newSharedAlarm("shared");
+    var shelving = requireNonNull(alarm.getShelvingState());
+    UaMethodNode method = requireNonNull(shelving.getTimedShelveMethodNode());
+    MethodInvocationHandler typeHandler = method.getInvocationHandler();
+
+    CallMethodResult result = call(shelving.getNodeId(), method.getNodeId(), new Variant(30_000.0));
+
+    assertTrue(result.getStatusCode().isGood(), () -> result.getStatusCode().toString());
+    assertEquals("TimedShelved", shelving.getCurrentState().text());
+    assertSame(typeHandler, method.getInvocationHandler());
+    CallMethodResult unshelve =
+        call(alarm.getConditionId(), requireNonNull(shelving.getUnshelveMethodNode()).getNodeId());
+    assertTrue(unshelve.getStatusCode().isGood(), () -> unshelve.getStatusCode().toString());
+    assertEquals("Unshelved", shelving.getCurrentState().text());
+    assertSame(typeHandler, method.getInvocationHandler());
+  }
+
+  // The nested state machine exposes shelving Methods only. An otherwise valid Acknowledge
+  // call must use the ConditionId and must not mutate the alarm through ShelvingState.
+  @Test
+  void nestedShelvingObjectCannotInvokeAnAlarmMethod() throws Exception {
+    AlarmCondition alarm = newSharedAlarm("shared-method-owner");
+    var shelving = requireNonNull(alarm.getShelvingState());
+    UaMethodNode acknowledge = requireNonNull(alarm.getNode().getAcknowledgeMethodNode());
+    Variant[] inputs = {
+      new Variant(alarm.currentBranch().getLastEventId()), new Variant(LocalizedText.NULL_VALUE)
+    };
+
+    CallMethodResult rejected = call(shelving.getNodeId(), acknowledge.getNodeId(), inputs);
+
+    assertEquals(StatusCodes.Bad_MethodInvalid, rejected.getStatusCode().value());
+    assertFalse(alarm.isAcked());
+    CallMethodResult accepted = call(alarm.getConditionId(), acknowledge.getNodeId(), inputs);
+    assertTrue(accepted.getStatusCode().isGood(), () -> accepted.getStatusCode().toString());
+    assertTrue(alarm.isAcked());
+  }
+
+  private AlarmCondition newSharedAlarm(String name) throws Exception {
+    AlarmConditionTypeNode node =
+        server
+            .getNodeInstantiator()
+            .instantiate(
+                InstantiationRequest.of(AlarmConditionTypeNode.class, NodeIds.AlarmConditionType)
+                    .nodeId(newNodeId(name))
+                    .browseName(newQualifiedName(name))
+                    .target(testNamespace.getNodeManager())
+                    .methodInstantiation(MethodInstantiation.SHARE)
+                    .includeOptionals(
+                        d ->
+                            Set.of("ShelvingState", "LastTransition")
+                                .contains(d.browseName().name()))
+                    .build())
+            .root();
+    node.setEventType(NodeIds.AlarmConditionType);
+    node.setSeverity(ushort(700));
+    AlarmCondition alarm = AlarmCondition.attach(node);
+    server.getConditionManager().register(alarm);
+    alarm.setActive(true);
+    return alarm;
   }
 
   private AlarmCondition newAlarm(String name) throws Exception {

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/Condition.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/Condition.java
@@ -1042,7 +1042,8 @@ public class Condition {
   }
 
   /**
-   * Find a Method exposed through ConditionId dispatch but owned by a nested state machine.
+   * Find a Method owned by a nested state machine and also exposed through ConditionId dispatch.
+   * The manager uses this lookup to restrict calls targeting the nested ObjectId to its Methods.
    * Subclasses override for the nested methods they support.
    */
   Optional<UaMethodNode> findMethodNode(NodeId methodId) {

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/DefaultConditionManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/DefaultConditionManager.java
@@ -23,7 +23,10 @@ import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
 import org.eclipse.milo.opcua.sdk.server.Session;
 import org.eclipse.milo.opcua.sdk.server.events.EventNotifierScope;
 import org.eclipse.milo.opcua.sdk.server.items.MonitoredEventItem;
+import org.eclipse.milo.opcua.sdk.server.methods.MethodInvocationHandler;
 import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
+import org.eclipse.milo.opcua.sdk.server.model.objects.ShelvedStateMachineTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaMethodNode;
 import org.eclipse.milo.opcua.sdk.server.subscriptions.Subscription;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
@@ -102,6 +105,55 @@ public class DefaultConditionManager implements ConditionManager {
   @Override
   public Optional<Condition> findCondition(NodeId conditionId) {
     return Optional.ofNullable(conditions.get(conditionId));
+  }
+
+  @Override
+  public Optional<MethodInvocationHandler> findMethodInvocationHandler(
+      NodeId objectId, NodeId methodId) {
+    return findMethodOwner(objectId, methodId)
+        .flatMap(condition -> condition.findMethodInvocationHandler(methodId));
+  }
+
+  @Override
+  public Optional<UaMethodNode> findMethodNode(NodeId objectId, NodeId methodId) {
+    return findMethodOwner(objectId, methodId)
+        .flatMap(condition -> condition.findMethodNode(methodId));
+  }
+
+  private Optional<Condition> findMethodOwner(NodeId objectId, NodeId methodId) {
+    Condition direct = conditions.get(objectId);
+    if (direct != null) {
+      return Optional.of(direct);
+    }
+
+    // A ShelvingState ObjectId names a nested state machine, while its behavior belongs to the
+    // registered AlarmCondition. Verify its parent ownership and restrict this route to Methods
+    // actually exposed by the nested state machine.
+    return server
+        .getAddressSpaceManager()
+        .getManagedNode(objectId)
+        .filter(ShelvedStateMachineTypeNode.class::isInstance)
+        .flatMap(
+            node ->
+                node.getReferences().stream()
+                    .filter(
+                        reference ->
+                            !reference.isForward()
+                                && reference.getReferenceTypeId().equals(NodeIds.HasComponent))
+                    .map(
+                        reference ->
+                            reference
+                                .getTargetNodeId()
+                                .toNodeId(server.getNamespaceTable())
+                                .map(conditions::get)
+                                .orElse(null))
+                    .filter(
+                        condition ->
+                            condition instanceof AlarmCondition alarm
+                                && alarm.getShelvingState() != null
+                                && alarm.getShelvingState().getNodeId().equals(objectId)
+                                && alarm.findMethodNode(methodId).isPresent())
+                    .findFirst());
   }
 
   @Override

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/package-info.java
@@ -49,9 +49,10 @@
  * Condition through the ConditionManager, leaving the shared node and any application-installed
  * handler unchanged.
  *
- * <p>Unregistering retires handlers installed on copied Methods only while they still belong to
- * that behavior, preserving later application or replacement handlers. Calls that already obtained
- * a handler may finish against the retired behavior.
+ * <p>The default manager resolves shared shelving Methods through either the ConditionId or the
+ * nested ShelvingState ObjectId. Unregistering retires handlers installed on copied Methods only
+ * while they still belong to that behavior, preserving later application or replacement handlers.
+ * Calls that already obtained a handler may finish against the retired behavior.
  *
  * <p>Deferred shelving expiry is resolved before event emission or refresh copying. Field reads
  * within those operations cannot trigger another expiry transition, so one event retains one


### PR DESCRIPTION
A shared shelving Method could not find its Condition behavior when called through the nested ShelvingState ObjectId. Calls using the ConditionId worked, but the normal nested-object target failed.

The default manager now resolves the owning alarm through the shelving object's actual parent reference and verifies that the requested Method belongs to that state machine. Both supported shelving call targets work without changing the shared type Method's handler. An Acknowledge call still requires the ConditionId.

[Part 9 §5.8.17.4](https://reference.opcfoundation.org/specs/OPC-10000-9/5.8.17.4) defines the shelving object's NodeId as the normal target and requires that "all Servers shall also allow Clients to call the TimedShelve Method by specifying ConditionId as the ObjectId".

Wire regressions cover both shelving targets and reject Acknowledge through the nested object before proving that the same call succeeds through the ConditionId.

Formatting, a full clean compile, and the selected regression suites passed for this branch.

Based on https://github.com/eclipse-milo/milo/pull/1909 so the diff contains only this fix.
