### PR TITLE
Drain subscription transitions after executor rejection

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/SubscriptionLifecycleRecoveryTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/SubscriptionLifecycleRecoveryTest.java
@@ -23,12 +23,14 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -108,6 +110,40 @@ class SubscriptionLifecycleRecoveryTest {
             new CreateMonitoredItemsResponse(
                 null, new MonitoredItemCreateResult[] {createdItem(42)}, null));
     assertTrue(fixture.subscription.createMonitoredItems().get(0).isGood());
+  }
+
+  @Test
+  void rejectedTransitionHandoffPreservesSuccessAndDrainsWaiters() throws Exception {
+    assertHandoffCompletes(
+        command -> {
+          throw new RejectedExecutionException("executor stopped");
+        });
+  }
+
+  @Test
+  void directTransitionHandoffDrainsWithoutRecursion() throws Exception {
+    assertHandoffCompletes(Runnable::run);
+  }
+
+  private void assertHandoffCompletes(Executor executor) throws Exception {
+    var fixture = new Fixture(executor);
+    var response = new CompletableFuture<CreateSubscriptionResponse>();
+    when(fixture.client.createSubscriptionAsync(
+            anyDouble(), any(), any(), any(), anyBoolean(), any()))
+        .thenReturn(response);
+    var create = fixture.subscription.createAsync().toCompletableFuture();
+    var queued = new ArrayList<CompletableFuture<?>>();
+    for (int i = 0; i < 10_000; i++) {
+      queued.add(fixture.subscription.modifyAsync().toCompletableFuture());
+    }
+    response.complete(Fixture.created(21));
+    create.get(5, TimeUnit.SECONDS);
+    CompletableFuture.allOf(queued.toArray(CompletableFuture[]::new)).get(5, TimeUnit.SECONDS);
+    fixture
+        .subscription
+        .setPublishingModeAsync(false)
+        .toCompletableFuture()
+        .get(5, TimeUnit.SECONDS);
   }
 
   @Test

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscription.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscription.java
@@ -15,6 +15,7 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
 
 import com.google.common.primitives.Ints;
+import com.google.common.util.concurrent.MoreExecutors;
 import java.math.BigInteger;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -29,6 +30,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -238,13 +241,26 @@ public class OpcUaSubscription {
   private volatile @Nullable SubscriptionListener listener;
 
   private final TaskQueue deliveryQueue;
+  private final Executor transitionHandoffExecutor;
 
   private final OpcUaClient client;
 
   public OpcUaSubscription(OpcUaClient client) {
     this.client = client;
 
-    deliveryQueue = new TaskQueue(client.getTransport().getConfig().getExecutor());
+    Executor executor = client.getTransport().getConfig().getExecutor();
+    deliveryQueue = new TaskQueue(executor);
+    transitionHandoffExecutor =
+        MoreExecutors.newSequentialExecutor(
+            command -> {
+              try {
+                executor.execute(command);
+              } catch (RejectedExecutionException e) {
+                // Finishing a transition must release its successor even when the executor shuts
+                // down.
+                command.run();
+              }
+            });
   }
 
   /**
@@ -732,11 +748,9 @@ public class OpcUaSubscription {
     }
 
     if (next != null) {
-      // Completed asynchronously rather than on this stack: a queued transition that completes
-      // synchronously — nothing pending to send, or an immediate Bad_InvalidState — would re-enter
-      // this method inline, one frame per waiter, and enough waiters is a StackOverflowError that
-      // leaves the slot claimed forever.
-      next.completeAsync(() -> Unit.VALUE, client.getTransport().getConfig().getExecutor());
+      // The sequential executor trampolines direct execution and rejected handoffs. A long queue
+      // of synchronous transitions cannot recurse, and no completion runs under lifecycleLock.
+      transitionHandoffExecutor.execute(() -> next.complete(Unit.VALUE));
     }
   }
 

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/package-info.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/package-info.java
@@ -22,7 +22,10 @@
  * copy. Per-subscription processing and delivery queues preserve the order received from the
  * transport.
  *
- * <p>Reset and item add/remove operations coordinate collection membership and ClientHandle
- * ownership; code requiring both locks takes the lifecycle lock before the item collection lock.
+ * <p>Lifecycle operations claim a serial transition slot without holding a lock across service
+ * calls. Completing a transition hands the slot to the next waiter through a serial executor, with
+ * inline fallback when the caller-owned transport executor rejects dispatch. Reset and item
+ * add/remove operations coordinate collection membership and ClientHandle ownership; code requiring
+ * both locks takes the lifecycle lock before the item collection lock.
  */
 package org.eclipse.milo.opcua.sdk.client.subscriptions;


### PR DESCRIPTION
Executor rejection during a subscription transition handoff can fail an already successful create and leave queued lifecycle operations waiting indefinitely. A direct executor can also recurse through a long run of synchronous completions.

Use a sequential handoff executor with caller-thread fallback when dispatch rejects. Complete successors outside the lifecycle lock and drain reentrant handoffs iteratively. Regressions queue 10,000 transitions behind a pending create under rejecting and direct executors, then verify every waiter and a later operation complete.

## Verification

Formatting and full clean compile passed. The selected regression suites passed (7 tests, no failures or errors).

```sh
mise exec -- mvn -q -pl opc-ua-sdk/integration-tests -am verify '-Dtest=SubscriptionLifecycleRecoveryTest' -Dsurefire.failIfNoSpecifiedTests=false
```

Based on https://github.com/eclipse-milo/milo/pull/1910 so the diff contains only this fix.
