### PR TITLE
Observe keystore symlinks and their resolved targets

### DIFF
--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/KeyStoreCertificateStore.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/KeyStoreCertificateStore.java
@@ -454,54 +454,80 @@ public class KeyStoreCertificateStore implements CertificateStore, Closeable {
   }
 
   private void configureWatchService(File keyStoreFile) throws IOException {
-    Path keyStorePath = keyStoreFile.toPath();
-    Path watchedDirectory = keyStorePath.getParent();
-
+    Path keyStorePath = keyStoreFile.toPath().toAbsolutePath().normalize();
     watchService = FileSystems.getDefault().newWatchService();
 
-    // ENTRY_CREATE matters as much as ENTRY_MODIFY here: writing a file by renaming a temporary
-    // one over it is the usual way to replace a KeyStore safely, and a rename arrives as a
-    // creation. This store writes its own file that way.
-    WatchKey watchKey =
-        watchedDirectory.register(
-            watchService,
-            StandardWatchEventKinds.ENTRY_CREATE,
-            StandardWatchEventKinds.ENTRY_MODIFY);
-
-    watchThread = new Thread(() -> watchForChanges(watchKey, watchedDirectory, keyStorePath));
+    WatchedFile configured = watchFile(keyStorePath);
+    WatchedFile target = watchFile(keyStorePath.toRealPath());
+    watchThread = new Thread(() -> watchForChanges(configured, target));
     watchThread.setName("milo-key-store-watcher");
     watchThread.setDaemon(true);
     watchThread.start();
   }
 
-  private void watchForChanges(WatchKey watchKey, Path watchedDirectory, Path keyStorePath) {
+  private WatchedFile watchFile(Path path) throws IOException {
+    // Atomic replacement is reported as ENTRY_CREATE. ENTRY_DELETE keeps the current target
+    // watch active across a temporary disappearance while its replacement is being installed.
+    WatchKey key =
+        path.getParent()
+            .register(
+                watchService,
+                StandardWatchEventKinds.ENTRY_CREATE,
+                StandardWatchEventKinds.ENTRY_MODIFY,
+                StandardWatchEventKinds.ENTRY_DELETE);
+    return new WatchedFile(path, key);
+  }
+
+  private void watchForChanges(WatchedFile configured, WatchedFile initialTarget) {
+    WatchedFile target = initialTarget;
     while (true) {
       WatchKey key;
-
       try {
         key = watchService.take();
       } catch (ClosedWatchServiceException e) {
         return;
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
-
         return;
       }
 
-      if (key == watchKey
-          && key.pollEvents().stream()
-              .anyMatch(e -> isKeyStoreEvent(e, watchedDirectory, keyStorePath))) {
-
-        reload(keyStorePath);
+      List<WatchEvent<?>> events = key.pollEvents();
+      if (configured.matches(key, events) || target.matches(key, events)) {
+        try {
+          Path resolved = configured.path().toRealPath();
+          if (!resolved.equals(target.path()) || !target.key().isValid()) {
+            WatchedFile replacement = watchFile(resolved);
+            // Directory registrations share keys. Cancelling the old target must not cancel the
+            // configured-link watch or a replacement target in that same directory.
+            if (target.key() != configured.key() && target.key() != replacement.key()) {
+              target.key().cancel();
+            }
+            target = replacement;
+          }
+        } catch (ClosedWatchServiceException e) {
+          return;
+        } catch (IOException e) {
+          // Preserve the previous target watch while the file is missing or temporarily
+          // unreadable; its recreation can then trigger another resolution and reload.
+          logger.warn("Error resolving watched KeyStore at {}", configured.path(), e);
+        }
+        reload(configured.path());
       }
 
-      // A WatchKey stays signalled, and is never queued again, until it has been reset.
-      if (!key.reset()) {
-        logger.warn(
-            "No longer watching {} for changes: the watch key is no longer valid", keyStorePath);
-
-        return;
+      // Reset every delivered key, including obsolete target keys already cancelled above.
+      if (!key.reset() && (key == configured.key() || key == target.key())) {
+        logger.warn("KeyStore watch directory is no longer available: {}", key.watchable());
+        if (!configured.key().isValid() && !target.key().isValid()) {
+          return;
+        }
       }
+    }
+  }
+
+  private record WatchedFile(Path path, WatchKey key) {
+    boolean matches(WatchKey signalled, List<WatchEvent<?>> events) {
+      return signalled == key
+          && events.stream().anyMatch(event -> isKeyStoreEvent(event, path.getParent(), path));
     }
   }
 

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/package-info.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/package-info.java
@@ -125,7 +125,9 @@
  * identities with a read-modify-replace boundary. Each mutation incorporates KeyStore entries
  * committed before its disk read, including application-owned aliases, then atomically replaces the
  * file. Separate store instances and processes do not share a write lock, so applications must
- * coordinate writes that overlap.
+ * coordinate writes that overlap. When file watching is enabled, the store observes both the
+ * configured path and its resolved target. Replacing the configured symbolic link updates the
+ * target registration while retaining observation of the link itself.
  *
  * <p>{@link org.eclipse.milo.opcua.stack.core.security.DefaultCertificateManager} provides a
  * thread-safe mutable group registry. Applications own the groups and their backing stores,

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/security/KeyStoreSymlinkWatchTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/security/KeyStoreSymlinkWatchTest.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.core.security;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class KeyStoreSymlinkWatchTest {
+
+  @TempDir Path directory;
+
+  // The configured symlink and its real target are independent rotation points. A shared parent
+  // means both registrations use the same WatchKey, which must survive a later link retarget.
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void watchesTargetRotationsAndLinkRetargeting(boolean sameDirectory) throws Exception {
+    Path config = Files.createDirectory(directory.resolve("config"));
+    Path firstDirectory =
+        sameDirectory ? config : Files.createDirectory(directory.resolve("first"));
+    Path secondDirectory = Files.createDirectory(directory.resolve("second"));
+    Path firstTarget = firstDirectory.resolve("first.pfx");
+    Path secondTarget = secondDirectory.resolve("second.pfx");
+    Path link = config.resolve("identity.pfx");
+    var factory = new TestCertificateFactory();
+    var keyPair = factory.createRsaSha256KeyPair();
+    var entry =
+        new CertificateStore.Entry(
+            keyPair.getPrivate(), factory.createRsaSha256CertificateChain(keyPair));
+    NodeId first = new NodeId(2, "first");
+    NodeId second = new NodeId(2, "second");
+    NodeId rotated = new NodeId(2, "rotated");
+
+    try (var firstWriter = new KeyStoreCertificateStore(settings(firstTarget, false));
+        var secondWriter = new KeyStoreCertificateStore(settings(secondTarget, false))) {
+      firstWriter.initialize();
+      secondWriter.initialize();
+      secondWriter.set(second, entry);
+      try {
+        Files.createSymbolicLink(link, firstTarget);
+      } catch (IOException | UnsupportedOperationException e) {
+        assumeTrue(false, "symbolic links unavailable: " + e);
+      }
+      try (var watcher = new ObservingStore(settings(link, true))) {
+        watcher.initialize();
+        assertFalse(watcher.contains(first));
+        CompletableFuture<Void> changed = watcher.expect(first);
+        firstWriter.set(first, entry);
+        changed.get(30, TimeUnit.SECONDS);
+        assertNotNull(watcher.get(first));
+
+        changed = watcher.expect(second);
+        retarget(link, secondTarget);
+        changed.get(30, TimeUnit.SECONDS);
+        assertFalse(watcher.contains(first), "retargeting must replace the cached KeyStore");
+        changed = watcher.expect(rotated);
+        secondWriter.set(rotated, entry);
+        changed.get(30, TimeUnit.SECONDS);
+        assertNotNull(watcher.get(rotated));
+
+        // Returning to the original directory proves the configured-link watch was not cancelled
+        // when its original target shared the same WatchKey.
+        changed = watcher.expect(first);
+        retarget(link, firstTarget);
+        changed.get(30, TimeUnit.SECONDS);
+        assertTrue(watcher.contains(first));
+        assertFalse(watcher.contains(second));
+      }
+    }
+  }
+
+  private static void retarget(Path link, Path target) throws IOException {
+    Path replacement = link.resolveSibling("replacement-link");
+    Files.createSymbolicLink(replacement, target);
+    Files.move(
+        replacement, link, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+  }
+
+  private static KeyStoreCertificateStore.Settings settings(Path path, boolean watch) {
+    return new KeyStoreCertificateStore.Settings(
+        path, "password"::toCharArray, alias -> "password".toCharArray(), watch);
+  }
+
+  private static final class ObservingStore extends KeyStoreCertificateStore {
+    private final AtomicReference<ExpectedEntry> expected = new AtomicReference<>();
+
+    ObservingStore(Settings settings) {
+      super(settings);
+    }
+
+    CompletableFuture<Void> expect(NodeId typeId) {
+      var changed = new CompletableFuture<Void>();
+      expected.set(new ExpectedEntry(typeId, changed));
+      return changed;
+    }
+
+    @Override
+    void reload(Path path) {
+      super.reload(path);
+      ExpectedEntry entry = expected.get();
+      if (entry != null) {
+        try {
+          if (contains(entry.typeId())) {
+            entry.changed().complete(null);
+          }
+        } catch (Exception e) {
+          entry.changed().completeExceptionally(e);
+        }
+      }
+    }
+  }
+
+  private record ExpectedEntry(NodeId typeId, CompletableFuture<Void> changed) {}
+}


### PR DESCRIPTION
Keystore reads and writes follow a configured symbolic link, but watching only the configured parent misses atomic replacement of its target in another directory. Watch both the configured path and resolved target, refresh target registration when the link changes, and retain the configured watch when both paths share a WatchKey. Closing the watcher during retargeting exits normally.

### Verification

Two real WatchService cases cover targets initially in the same or a separate directory, target-only atomic rotation, link retargeting, rotation of the new target, and retargeting back. Callback futures have bounded deadlines; unsupported symlink creation is the only skip condition.

Formatting, full clean compilation, and 20 selected tests passed for this branch.
