### PR TITLE
Keep GDS client jars usable together as Java modules

### DIFF
--- a/docs/features/gds-client.md
+++ b/docs/features/gds-client.md
@@ -31,13 +31,14 @@ model does. It lives in subpackages of the existing modules:
 | `milo-stack-core` | `org.eclipse.milo.opcua.stack.core.gds`             | `GdsNodeIds` (one `ExpandedNodeId` per GDS node), `DataTypeInitializer`                          |
 | `milo-stack-core` | `org.eclipse.milo.opcua.stack.core.gds.types`       | `ApplicationRecordDataType` with its codec and `StructureDefinition`                             |
 | `milo-dtd-core`   | `org.eclipse.milo.opcua.sdk.core.dtd.gds`           | `BinaryDataTypeDictionaryInitializer` for the legacy type dictionary mechanism (deprecated)      |
-| `milo-sdk-client` | `org.eclipse.milo.opcua.sdk.client.gds`             | `ObjectTypeInitializer`, `VariableTypeInitializer`                                                |
+| `milo-sdk-client` | `org.eclipse.milo.opcua.sdk.client.gds.model`             | `ObjectTypeInitializer`, `VariableTypeInitializer`                                                |
 | `milo-sdk-client` | `org.eclipse.milo.opcua.sdk.client.gds.model.objects` | Client node classes for `DirectoryType`, `CertificateDirectoryType`, the KeyCredential and AuthorizationService types, and the GDS audit event types |
 | `milo-sdk-server` | `org.eclipse.milo.opcua.sdk.server.gds` and `.model.objects` | The server-side mirror of the same types, for a GDS hosted on Milo                        |
 
 The **client layer** is the module `opc-ua-sdk/sdk-client-gds` (artifact `milo-sdk-client-gds`,
-listed in `milo-bom`). It depends only on `milo-sdk-client` and shares the package
-`org.eclipse.milo.opcua.sdk.client.gds` with the generated client initializers:
+listed in `milo-bom`). It depends only on `milo-sdk-client` and owns the package
+`org.eclipse.milo.opcua.sdk.client.gds`. The generated initializers remain in the core SDK
+under `.gds.model`, so the two jars can be used together as Java modules:
 
 - `GdsClient` wraps a connected `OpcUaClient` and exposes every `DirectoryType` and
   `CertificateDirectoryType` method with a typed signature, plus reads of a CertificateGroup's
@@ -246,34 +247,31 @@ administrator can approve the request.
 
 ## Generated model
 
-The model is generated and checked in; no code generation runs in the Maven build. The source is
-the [opc-ua-gds-model](https://github.com/kevinherron/opc-ua-gds-model) repository at commit
-`efa229d` ("Regenerate model from GDS NodeSet2 1.05.07"), produced by the GDS generators in
-[opc-ua-codegen2](https://github.com/kevinherron/opc-ua-codegen2) from GDS NodeSet2 1.05.07 on a
-1.05.07 base, the same base as Milo's namespace 0 model. Every file is copied with its package
-rewritten and the Eclipse Milo license header prepended; nothing else changes.
+The model is generated and checked in; no code generation runs in the Maven build. It is produced
+from GDS NodeSet2 1.05.07 on a 1.05.07 base, the same base as Milo's namespace 0 model, by the same
+external code generator that produces the namespace 0 model. Every file is copied in with its
+package rewritten and the Eclipse Milo license header prepended; nothing else changes.
 
-| Source package (`opc-ua-gds-model`)          | Milo package                                          | Module            |
+| Source package          | Milo package                                          | Module            |
 |----------------------------------------------|-------------------------------------------------------|-------------------|
 | `com.digitalpetri.opcua.gds`                 | `org.eclipse.milo.opcua.stack.core.gds`               | `stack-core`      |
 | `com.digitalpetri.opcua.gds.types`           | `org.eclipse.milo.opcua.stack.core.gds.types`         | `stack-core`      |
 | `com.digitalpetri.opcua.gds` (`BinaryDataTypeDictionaryInitializer` only) | `org.eclipse.milo.opcua.sdk.core.dtd.gds` | `dtd-core` |
-| `com.digitalpetri.opcua.gds.client`          | `org.eclipse.milo.opcua.sdk.client.gds`               | `sdk-client`      |
+| `com.digitalpetri.opcua.gds.client`          | `org.eclipse.milo.opcua.sdk.client.gds.model`               | `sdk-client`      |
 | `com.digitalpetri.opcua.gds.client.objects`  | `org.eclipse.milo.opcua.sdk.client.gds.model.objects` | `sdk-client`      |
 | `com.digitalpetri.opcua.gds.server`          | `org.eclipse.milo.opcua.sdk.server.gds`               | `sdk-server`      |
 | `com.digitalpetri.opcua.gds.server.objects`  | `org.eclipse.milo.opcua.sdk.server.gds.model.objects` | `sdk-server`      |
 
 To pick up a new GDS NodeSet release:
 
-1. Regenerate in `opc-ua-gds-model` and commit there. Do not edit the Milo copy by hand.
-2. Copy `src/main/java` of `gds-model-core`, `gds-model-client`, and `gds-model-server` into the
-   Milo packages above, rewriting `package` and `import` lines by prefix (most specific prefix
-   first: `.client.objects` before `.client`, `.server.objects` before `.server`, `.types` before
-   the bare prefix). `BinaryDataTypeDictionaryInitializer` gets the `dtd-core` package because it
+1. Regenerate the model at its source. Do not edit the Milo copy by hand.
+2. Copy `src/main/java` of the generated core, client, and server model modules into the Milo
+   packages above, rewriting `package` and `import` lines by prefix (most specific prefix first:
+   `.client.objects` before `.client`, `.server.objects` before `.server`, `.types` before the
+   bare prefix). `BinaryDataTypeDictionaryInitializer` gets the `dtd-core` package because it
    extends `DataTypeDictionaryInitializer` from that module.
 3. Prepend the EPL-2.0 header, run `mise exec -- mvn -q spotless:apply`, and compile.
-4. Update the commit and NodeSet version recorded in each `package-info.java` and in this
-   document.
+4. Update the NodeSet version recorded in each `package-info.java` and in this document.
 5. Diff the Milo packages against the source with the prefixes rewritten; only the header and
    import order may differ.
 

--- a/docs/features/gds-client.md
+++ b/docs/features/gds-client.md
@@ -33,7 +33,7 @@ model does. It lives in subpackages of the existing modules:
 | `milo-dtd-core`   | `org.eclipse.milo.opcua.sdk.core.dtd.gds`           | `BinaryDataTypeDictionaryInitializer` for the legacy type dictionary mechanism (deprecated)      |
 | `milo-sdk-client` | `org.eclipse.milo.opcua.sdk.client.gds.model`             | `ObjectTypeInitializer`, `VariableTypeInitializer`                                                |
 | `milo-sdk-client` | `org.eclipse.milo.opcua.sdk.client.gds.model.objects` | Client node classes for `DirectoryType`, `CertificateDirectoryType`, the KeyCredential and AuthorizationService types, and the GDS audit event types |
-| `milo-sdk-server` | `org.eclipse.milo.opcua.sdk.server.gds` and `.model.objects` | The server-side mirror of the same types, for a GDS hosted on Milo                        |
+| `milo-sdk-server` | `org.eclipse.milo.opcua.sdk.server.gds.model` and `.objects` | The server-side mirror of the same types, for a GDS hosted on Milo                        |
 
 The **client layer** is the module `opc-ua-sdk/sdk-client-gds` (artifact `milo-sdk-client-gds`,
 listed in `milo-bom`). It depends only on `milo-sdk-client` and owns the package
@@ -259,7 +259,7 @@ package rewritten and the Eclipse Milo license header prepended; nothing else ch
 | `com.digitalpetri.opcua.gds` (`BinaryDataTypeDictionaryInitializer` only) | `org.eclipse.milo.opcua.sdk.core.dtd.gds` | `dtd-core` |
 | `com.digitalpetri.opcua.gds.client`          | `org.eclipse.milo.opcua.sdk.client.gds.model`               | `sdk-client`      |
 | `com.digitalpetri.opcua.gds.client.objects`  | `org.eclipse.milo.opcua.sdk.client.gds.model.objects` | `sdk-client`      |
-| `com.digitalpetri.opcua.gds.server`          | `org.eclipse.milo.opcua.sdk.server.gds`               | `sdk-server`      |
+| `com.digitalpetri.opcua.gds.server`          | `org.eclipse.milo.opcua.sdk.server.gds.model`         | `sdk-server`      |
 | `com.digitalpetri.opcua.gds.server.objects`  | `org.eclipse.milo.opcua.sdk.server.gds.model.objects` | `sdk-server`      |
 
 To pick up a new GDS NodeSet release:

--- a/docs/features/gds-client.md
+++ b/docs/features/gds-client.md
@@ -252,28 +252,42 @@ from GDS NodeSet2 1.05.07 on a 1.05.07 base, the same base as Milo's namespace 0
 external code generator that produces the namespace 0 model. Every file is copied in with its
 package rewritten and the Eclipse Milo license header prepended; nothing else changes.
 
-| Source package          | Milo package                                          | Module            |
-|----------------------------------------------|-------------------------------------------------------|-------------------|
-| `com.digitalpetri.opcua.gds`                 | `org.eclipse.milo.opcua.stack.core.gds`               | `stack-core`      |
-| `com.digitalpetri.opcua.gds.types`           | `org.eclipse.milo.opcua.stack.core.gds.types`         | `stack-core`      |
+The GDS generators use `com.digitalpetri.opcua.gds.client.model` and
+`com.digitalpetri.opcua.gds.server.model` as model roots. Initializers live directly in those
+packages, and typed nodes live in their `.objects` and `.variables` subpackages. Each generated
+package belongs to one module; handwritten APIs in separate modules use the parent packages.
+`PackageMap.create(...)` uses the supplied prefixes as-is, so new companion model generators
+should explicitly supply dedicated model roots.
+
+The following mappings apply to output regenerated with that convention. Older output placed
+initializers in `.client` and `.server` and typed nodes in `.client.objects` and `.server.objects`.
+When copying such output, map those packages to the same Milo model destinations below.
+
+| Source package | Milo package | Module |
+|-----------------------------------|--------------|--------|
+| `com.digitalpetri.opcua.gds` | `org.eclipse.milo.opcua.stack.core.gds` | `stack-core` |
+| `com.digitalpetri.opcua.gds.types` | `org.eclipse.milo.opcua.stack.core.gds.types` | `stack-core` |
 | `com.digitalpetri.opcua.gds` (`BinaryDataTypeDictionaryInitializer` only) | `org.eclipse.milo.opcua.sdk.core.dtd.gds` | `dtd-core` |
-| `com.digitalpetri.opcua.gds.client`          | `org.eclipse.milo.opcua.sdk.client.gds.model`               | `sdk-client`      |
-| `com.digitalpetri.opcua.gds.client.objects`  | `org.eclipse.milo.opcua.sdk.client.gds.model.objects` | `sdk-client`      |
-| `com.digitalpetri.opcua.gds.server`          | `org.eclipse.milo.opcua.sdk.server.gds.model`         | `sdk-server`      |
-| `com.digitalpetri.opcua.gds.server.objects`  | `org.eclipse.milo.opcua.sdk.server.gds.model.objects` | `sdk-server`      |
+| `com.digitalpetri.opcua.gds.client.model` (including subpackages) | `org.eclipse.milo.opcua.sdk.client.gds.model` (including subpackages) | `sdk-client` |
+| `com.digitalpetri.opcua.gds.server.model` (including subpackages) | `org.eclipse.milo.opcua.sdk.server.gds.model` (including subpackages) | `sdk-server` |
 
 To pick up a new GDS NodeSet release:
 
-1. Regenerate the model at its source. Do not edit the Milo copy by hand.
+1. Regenerate the model with the GDS generators using `.client.model` and `.server.model` package
+   roots. Do not edit the Milo copy by hand. Use a clean output directory and remove obsolete
+   generated files from the old packages when importing the new output; generation does not
+   delete files left by an earlier package layout.
 2. Copy `src/main/java` of the generated core, client, and server model modules into the Milo
    packages above, rewriting `package` and `import` lines by prefix (most specific prefix first:
-   `.client.objects` before `.client`, `.server.objects` before `.server`, `.types` before the
-   bare prefix). `BinaryDataTypeDictionaryInitializer` gets the `dtd-core` package because it
-   extends `DataTypeDictionaryInitializer` from that module.
+   `.client.model`, `.server.model`, and `.types` before the bare prefix).
+   `BinaryDataTypeDictionaryInitializer` gets the `dtd-core` package because it extends
+   `DataTypeDictionaryInitializer` from that module.
 3. Prepend the EPL-2.0 header, run `mise exec -- mvn -q spotless:apply`, and compile.
 4. Update the NodeSet version recorded in each `package-info.java` and in this document.
 5. Diff the Milo packages against the source with the prefixes rewritten; only the header and
    import order may differ.
+6. Run `GdsModulePathTest` and `GdsServerModelTest` in `opc-ua-sdk/integration-tests` to verify
+   module package ownership and server type registration.
 
 The GDS `DataTypeInitializer` and both `ObjectTypeInitializer`s take a `NamespaceTable` and must
 stay out of the namespace 0 startup path (`DefaultDataTypeManager.createAndInitialize` and the

--- a/opc-ua-sdk/dtd-core/src/main/java/org/eclipse/milo/opcua/sdk/core/dtd/gds/package-info.java
+++ b/opc-ua-sdk/dtd-core/src/main/java/org/eclipse/milo/opcua/sdk/core/dtd/gds/package-info.java
@@ -18,9 +18,7 @@
  * deprecated for removal; new code should register the codec through {@link
  * org.eclipse.milo.opcua.stack.core.gds.DataTypeInitializer} instead.
  *
- * <p>Generated code, copied from the {@code gds-model-core} module of <a
- * href="https://github.com/kevinherron/opc-ua-gds-model">opc-ua-gds-model</a> at commit {@code
- * efa229d}; see the regeneration notes in {@link org.eclipse.milo.opcua.stack.core.gds}.
+ * <p>Generated code; see the regeneration notes in {@link org.eclipse.milo.opcua.stack.core.gds}.
  */
 @Deprecated(forRemoval = true, since = "1.2.0")
 package org.eclipse.milo.opcua.sdk.core.dtd.gds;

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/GdsModulePathTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/GdsModulePathTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.milo.opcua.sdk.client.gds;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.module.Configuration;
+import java.lang.module.ModuleFinder;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.jar.Attributes;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class GdsModulePathTest {
+  @TempDir Path directory;
+
+  // Java's module resolver rejects split packages even though ordinary classpath calls work.
+  // Resolve the actual production classes from both required artifacts together.
+  @Test
+  void clientAndGdsArtifactsResolveTogetherAsAutomaticModules() throws Exception {
+    Path client = moduleJar(OpcUaClient.class, "org.eclipse.milo.opcua.sdk.client");
+    Path gds = moduleJar(GdsClient.class, "org.eclipse.milo.opcua.sdk.client.gds");
+    Configuration resolved =
+        ModuleLayer.boot()
+            .configuration()
+            .resolve(
+                ModuleFinder.of(client, gds),
+                ModuleFinder.of(),
+                Set.of(
+                    "org.eclipse.milo.opcua.sdk.client", "org.eclipse.milo.opcua.sdk.client.gds"));
+    assertEquals(2, resolved.modules().size());
+  }
+
+  private Path moduleJar(Class<?> representative, String moduleName) throws Exception {
+    Path source =
+        Path.of(representative.getProtectionDomain().getCodeSource().getLocation().toURI());
+    if (Files.isRegularFile(source)) {
+      return source;
+    }
+    // Maven may expose a reactor dependency's classes directory instead of its packaged JAR.
+    var manifest = new Manifest();
+    manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, "1.0");
+    manifest.getMainAttributes().putValue("Automatic-Module-Name", moduleName);
+    Path jar = directory.resolve(moduleName + ".jar");
+    try (var output = new JarOutputStream(Files.newOutputStream(jar), manifest);
+        var files = Files.walk(source)) {
+      for (Path file : files.filter(Files::isRegularFile).toList()) {
+        String name = source.relativize(file).toString().replace('\\', '/');
+        if (name.equals("META-INF/MANIFEST.MF")) continue;
+        output.putNextEntry(new JarEntry(name));
+        Files.copy(file, output);
+        output.closeEntry();
+      }
+    }
+    return jar;
+  }
+}

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/gds/GdsServerModelTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/gds/GdsServerModelTest.java
@@ -16,6 +16,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.stream.Stream;
 import org.eclipse.milo.opcua.sdk.client.gds.GdsClient;
 import org.eclipse.milo.opcua.sdk.server.ObjectTypeManager;
+import org.eclipse.milo.opcua.sdk.server.gds.model.ObjectTypeInitializer;
 import org.eclipse.milo.opcua.sdk.server.gds.model.objects.AccessTokenIssuedAuditEventTypeNode;
 import org.eclipse.milo.opcua.sdk.server.gds.model.objects.AccessTokenRequestedAuditEventTypeNode;
 import org.eclipse.milo.opcua.sdk.server.gds.model.objects.ApplicationRegistrationChangedAuditEventTypeNode;

--- a/opc-ua-sdk/sdk-client-gds/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/GdsClient.java
+++ b/opc-ua-sdk/sdk-client-gds/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/GdsClient.java
@@ -21,6 +21,8 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.client.gds.model.ObjectTypeInitializer;
+import org.eclipse.milo.opcua.sdk.client.gds.model.VariableTypeInitializer;
 import org.eclipse.milo.opcua.sdk.client.methods.UaMethodException;
 import org.eclipse.milo.opcua.stack.core.NamespaceTable;
 import org.eclipse.milo.opcua.stack.core.NodeIds;

--- a/opc-ua-sdk/sdk-client-gds/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/package-info.java
+++ b/opc-ua-sdk/sdk-client-gds/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/package-info.java
@@ -12,10 +12,10 @@
  * Client support for the OPC UA Global Discovery Server (GDS, OPC 10000-12): application
  * registration, certificate requests through the Pull Model, and trust list retrieval.
  *
- * <p>This package spans two modules. {@code milo-sdk-client} contributes the generated GDS model:
- * {@link org.eclipse.milo.opcua.sdk.client.gds.ObjectTypeInitializer}, {@link
- * org.eclipse.milo.opcua.sdk.client.gds.VariableTypeInitializer}, and the typed node classes in
- * {@code org.eclipse.milo.opcua.sdk.client.gds.model.objects}. {@code milo-sdk-client-gds}
+ * <p>GDS client support uses two modules. {@code milo-sdk-client} contributes the generated GDS
+ * model: {@link org.eclipse.milo.opcua.sdk.client.gds.model.ObjectTypeInitializer}, {@link
+ * org.eclipse.milo.opcua.sdk.client.gds.model.VariableTypeInitializer}, and the typed node classes
+ * in {@code org.eclipse.milo.opcua.sdk.client.gds.model.objects}. {@code milo-sdk-client-gds}
  * contributes the hand-written layer described here, which an application opts into by adding that
  * module as a dependency.
  *

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/ObjectTypeInitializer.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/ObjectTypeInitializer.java
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-package org.eclipse.milo.opcua.sdk.client.gds;
+package org.eclipse.milo.opcua.sdk.client.gds.model;
 
 import org.eclipse.milo.opcua.sdk.client.ObjectTypeManager;
 import org.eclipse.milo.opcua.sdk.client.gds.model.objects.AccessTokenIssuedAuditEventTypeNode;

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/VariableTypeInitializer.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/VariableTypeInitializer.java
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-package org.eclipse.milo.opcua.sdk.client.gds;
+package org.eclipse.milo.opcua.sdk.client.gds.model;
 
 import org.eclipse.milo.opcua.sdk.client.VariableTypeManager;
 import org.eclipse.milo.opcua.stack.core.NamespaceTable;

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/package-info.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/objects/package-info.java
@@ -24,21 +24,18 @@
  * <p>Instances of these classes are produced by {@link
  * org.eclipse.milo.opcua.sdk.client.AddressSpace} once the types are registered with the client's
  * {@link org.eclipse.milo.opcua.sdk.client.ObjectTypeManager} by {@link
- * org.eclipse.milo.opcua.sdk.client.gds.ObjectTypeInitializer}. That initializer resolves the GDS
- * namespace index through the client's live {@link
+ * org.eclipse.milo.opcua.sdk.client.gds.model.ObjectTypeInitializer}. That initializer resolves the
+ * GDS namespace index through the client's live {@link
  * org.eclipse.milo.opcua.stack.core.NamespaceTable}, so it can only run against a connected client
  * and is not part of the namespace 0 startup path.
  *
  * <h2>Regeneration</h2>
  *
  * <p>Every class in this package, together with {@link
- * org.eclipse.milo.opcua.sdk.client.gds.ObjectTypeInitializer} and {@link
- * org.eclipse.milo.opcua.sdk.client.gds.VariableTypeInitializer}, is generated and must not be
- * edited by hand. The source is the {@code gds-model-client} module of <a
- * href="https://github.com/kevinherron/opc-ua-gds-model">opc-ua-gds-model</a> at commit {@code
- * efa229d} (GDS NodeSet2 1.05.07), copied in with {@code com.digitalpetri.opcua.gds.client}
- * rewritten to {@code org.eclipse.milo.opcua.sdk.client.gds} and {@code
- * com.digitalpetri.opcua.gds.client.objects} rewritten to this package. See {@code
- * docs/features/gds-client.md} for the procedure.
+ * org.eclipse.milo.opcua.sdk.client.gds.model.ObjectTypeInitializer} and {@link
+ * org.eclipse.milo.opcua.sdk.client.gds.model.VariableTypeInitializer}, is generated from GDS
+ * NodeSet2 1.05.07 and must not be edited by hand. The generated sources are copied in with their
+ * client model packages rewritten to the Milo packages listed in {@code
+ * docs/features/gds-client.md}; see that document for the procedure.
  */
 package org.eclipse.milo.opcua.sdk.client.gds.model.objects;

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/package-info.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/model/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/**
+ * Client type registration for the OPC UA Global Discovery Server information model.
+ *
+ * <p>The initializers register the generated classes in {@link
+ * org.eclipse.milo.opcua.sdk.client.gds.model.objects} after the client knows the GDS namespace
+ * index. Applications normally enter through {@code GdsClient.create} in the separate {@code
+ * milo-sdk-client-gds} module. These model classes belong to {@code milo-sdk-client}; the higher
+ * level module owns the parent {@code org.eclipse.milo.opcua.sdk.client.gds} package.
+ *
+ * <p>Generated initializers follow the package mapping in {@code docs/features/gds-client.md}.
+ */
+package org.eclipse.milo.opcua.sdk.client.gds.model;

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/ObjectTypeInitializer.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/ObjectTypeInitializer.java
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-package org.eclipse.milo.opcua.sdk.server.gds;
+package org.eclipse.milo.opcua.sdk.server.gds.model;
 
 import org.eclipse.milo.opcua.sdk.server.ObjectTypeManager;
 import org.eclipse.milo.opcua.sdk.server.gds.model.objects.AccessTokenIssuedAuditEventTypeNode;

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/VariableTypeInitializer.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/VariableTypeInitializer.java
@@ -8,7 +8,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-package org.eclipse.milo.opcua.sdk.server.gds;
+package org.eclipse.milo.opcua.sdk.server.gds.model;
 
 import org.eclipse.milo.opcua.sdk.server.VariableTypeManager;
 import org.eclipse.milo.opcua.stack.core.NamespaceTable;

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/model/package-info.java
@@ -18,20 +18,20 @@
  * trust list storage are left to the hosting application. Nothing in the server SDK invokes this
  * package on its own.
  *
- * <p>{@link org.eclipse.milo.opcua.sdk.server.gds.ObjectTypeInitializer} registers the node classes
- * with the server's {@link org.eclipse.milo.opcua.sdk.server.ObjectTypeManager}. It resolves the
- * GDS namespace index through the server's {@link
+ * <p>{@link org.eclipse.milo.opcua.sdk.server.gds.model.ObjectTypeInitializer} registers the node
+ * classes with the server's {@link org.eclipse.milo.opcua.sdk.server.ObjectTypeManager}. It
+ * resolves the GDS namespace index through the server's {@link
  * org.eclipse.milo.opcua.stack.core.NamespaceTable}, so the hosting application must add the GDS
  * namespace URI to the table before calling it, and the call is not part of the namespace 0 startup
- * path. {@link org.eclipse.milo.opcua.sdk.server.gds.VariableTypeInitializer} is empty because the
- * GDS namespace defines no VariableTypes. The {@code ApplicationRecordDataType} codec is registered
- * separately with {@link org.eclipse.milo.opcua.stack.core.gds.DataTypeInitializer}.
+ * path. {@link org.eclipse.milo.opcua.sdk.server.gds.model.VariableTypeInitializer} is empty
+ * because the GDS namespace defines no VariableTypes. The {@code ApplicationRecordDataType} codec
+ * is registered separately with {@link org.eclipse.milo.opcua.stack.core.gds.DataTypeInitializer}.
  *
  * <h2>Regeneration</h2>
  *
- * <p>Every class in this package and its {@code model.objects} subpackage is generated from GDS NodeSet2
+ * <p>Every class in this package and its {@code objects} subpackage is generated from GDS NodeSet2
  * 1.05.07 and must not be edited by hand. The generated sources are copied in with their server
  * model packages rewritten to the Milo packages listed in {@code docs/features/gds-client.md}; see
  * that document for the procedure.
  */
-package org.eclipse.milo.opcua.sdk.server.gds;
+package org.eclipse.milo.opcua.sdk.server.gds.model;

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/gds/package-info.java
@@ -29,12 +29,9 @@
  *
  * <h2>Regeneration</h2>
  *
- * <p>Every class in this package and its {@code model.objects} subpackage is generated and must not
- * be edited by hand. The source is the {@code gds-model-server} module of <a
- * href="https://github.com/kevinherron/opc-ua-gds-model">opc-ua-gds-model</a> at commit {@code
- * efa229d} (GDS NodeSet2 1.05.07), copied in with {@code com.digitalpetri.opcua.gds.server}
- * rewritten to this package and {@code com.digitalpetri.opcua.gds.server.objects} rewritten to
- * {@code org.eclipse.milo.opcua.sdk.server.gds.model.objects}. See {@code
- * docs/features/gds-client.md} for the procedure.
+ * <p>Every class in this package and its {@code model.objects} subpackage is generated from GDS NodeSet2
+ * 1.05.07 and must not be edited by hand. The generated sources are copied in with their server
+ * model packages rewritten to the Milo packages listed in {@code docs/features/gds-client.md}; see
+ * that document for the procedure.
  */
 package org.eclipse.milo.opcua.sdk.server.gds;

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/gds/package-info.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/gds/package-info.java
@@ -32,11 +32,10 @@
  * <h2>Regeneration</h2>
  *
  * <p>Every class in this package and in {@code org.eclipse.milo.opcua.stack.core.gds.types} is
- * generated and must not be edited by hand. The source is the {@code gds-model-core} module of <a
- * href="https://github.com/kevinherron/opc-ua-gds-model">opc-ua-gds-model</a> at commit {@code
- * efa229d} (GDS NodeSet2 1.05.07 on a 1.05.07 base model), copied in with the package prefix {@code
- * com.digitalpetri.opcua.gds} rewritten to {@code org.eclipse.milo.opcua.stack.core.gds} and the
- * Eclipse Milo license header prepended. To pick up a newer NodeSet, regenerate in that repository
- * first, then recopy; the procedure is documented in {@code docs/features/gds-client.md}.
+ * generated from GDS NodeSet2 1.05.07 on a 1.05.07 base model and must not be edited by hand. The
+ * generated sources are copied in with their package prefix rewritten to {@code
+ * org.eclipse.milo.opcua.stack.core.gds} and the Eclipse Milo license header prepended. To pick up
+ * a newer NodeSet, regenerate and recopy; the procedure is documented in {@code
+ * docs/features/gds-client.md}.
  */
 package org.eclipse.milo.opcua.stack.core.gds;


### PR DESCRIPTION
Using `milo-sdk-client` and `milo-sdk-client-gds` together on the Java module path failed because both jars contained `org.eclipse.milo.opcua.sdk.client.gds`.

The generated client type initializers now live under `org.eclipse.milo.opcua.sdk.client.gds.model`, leaving the parent package to the GDS client module. The server initializers also move to `org.eclipse.milo.opcua.sdk.server.gds.model` for parity. Registration imports, package documentation, and regeneration mappings follow the new locations. The regeneration guide covers the dedicated source model roots, migration from older output, and removal of obsolete package files.

The module-path regression builds actual module artifacts from compiled classes and resources and resolves them together, reproducing the original split-package failure. The existing server model test verifies all 15 GDS object type registrations at the assigned namespace index.

Validation: formatting, a full clean compile, and `GdsModulePathTest` plus `GdsServerModelTest` passed.