### PR TITLE
Keep subscription reset independent of limits lookup

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/SubscriptionLifecycleRecoveryTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/SubscriptionLifecycleRecoveryTest.java
@@ -45,6 +45,7 @@ import org.eclipse.milo.opcua.stack.core.types.structured.CreateMonitoredItemsRe
 import org.eclipse.milo.opcua.stack.core.types.structured.CreateSubscriptionResponse;
 import org.eclipse.milo.opcua.stack.core.types.structured.DeleteMonitoredItemsResponse;
 import org.eclipse.milo.opcua.stack.core.types.structured.ModifyMonitoredItemsResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.MonitoredItemCreateRequest;
 import org.eclipse.milo.opcua.stack.core.types.structured.MonitoredItemCreateResult;
 import org.eclipse.milo.opcua.stack.core.types.structured.MonitoredItemModifyResult;
 import org.eclipse.milo.opcua.stack.core.types.structured.ReadValueId;
@@ -144,6 +145,67 @@ class SubscriptionLifecycleRecoveryTest {
         .setPublishingModeAsync(false)
         .toCompletableFuture()
         .get(5, TimeUnit.SECONDS);
+  }
+
+  @Test
+  void transferCleanupDoesNotWaitForLimitsThatNeedSessionActivation() throws Exception {
+    var fixture = new Fixture(Runnable::run);
+    fixture.create();
+    fixture.addItem();
+    var limitsEntered = new CountDownLatch(1);
+    var sessionActive = new CompletableFuture<OperationLimits>();
+    when(fixture.client.getOperationLimits())
+        .thenAnswer(
+            invocation -> {
+              limitsEntered.countDown();
+              return sessionActive.get(10, TimeUnit.SECONDS);
+            });
+    var create =
+        workers.submit(
+            () -> {
+              return fixture.subscription.createMonitoredItems();
+            });
+    assertTrue(limitsEntered.await(5, TimeUnit.SECONDS));
+    var cleanup =
+        workers.submit(
+            () -> {
+              fixture.subscription.handleTransferFailure(
+                  new StatusCode(StatusCodes.Bad_SubscriptionIdInvalid));
+              // Session initialization must finish transfer cleanup before publishing its active
+              // Session.
+              sessionActive.complete(Fixture.limits());
+            });
+    try {
+      cleanup.get(5, TimeUnit.SECONDS);
+      assertTrue(sessionActive.isDone());
+      assertEquals(
+          new StatusCode(StatusCodes.Bad_InvalidState),
+          create.get(5, TimeUnit.SECONDS).get(0).serviceResult());
+    } finally {
+      sessionActive.complete(Fixture.limits());
+      cleanup.get(5, TimeUnit.SECONDS);
+      create.get(5, TimeUnit.SECONDS);
+    }
+
+    // Completing the discarded lookup must not restore its old cached partition size.
+    when(fixture.client.getOperationLimits())
+        .thenReturn(
+            new OperationLimits(
+                null, null, null, null, null, null, null, uint(1), null, null, null, null));
+    fixture.create();
+    fixture.addItem();
+    var calls = new AtomicInteger();
+    when(fixture.client.createMonitoredItems(any(), any(), anyList()))
+        .thenAnswer(
+            invocation -> {
+              calls.incrementAndGet();
+              List<MonitoredItemCreateRequest> requests = invocation.getArgument(2);
+              var results = new MonitoredItemCreateResult[requests.size()];
+              for (int i = 0; i < results.length; i++) results[i] = createdItem(100 + i);
+              return new CreateMonitoredItemsResponse(null, results, null);
+            });
+    assertEquals(2, fixture.subscription.createMonitoredItems().size());
+    assertEquals(2, calls.get(), "replacement must discover the current singleton server limit");
   }
 
   @Test

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscription.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscription.java
@@ -66,7 +66,7 @@ import org.eclipse.milo.opcua.stack.core.types.structured.MonitoredItemModifyRes
 import org.eclipse.milo.opcua.stack.core.types.structured.MonitoredItemNotification;
 import org.eclipse.milo.opcua.stack.core.types.structured.SetMonitoringModeResponse;
 import org.eclipse.milo.opcua.stack.core.types.structured.SetPublishingModeResponse;
-import org.eclipse.milo.opcua.stack.core.util.Lazy;
+import org.eclipse.milo.opcua.stack.core.util.NonBlockingLazy;
 import org.eclipse.milo.opcua.stack.core.util.TaskQueue;
 import org.eclipse.milo.opcua.stack.core.util.Unit;
 import org.jspecify.annotations.Nullable;
@@ -233,7 +233,7 @@ public class OpcUaSubscription {
   private volatile double watchdogMultiplier = 1.5;
 
   private volatile UInteger maxMonitoredItemsPerCall = uint(DEFAULT_MAX_MONITORED_ITEMS_PER_CALL);
-  private final Lazy<UInteger> monitoredItemPartitionSize = new Lazy<>();
+  private final NonBlockingLazy<UInteger> monitoredItemPartitionSize = new NonBlockingLazy<>();
   private volatile long monitoredItemPartitionGeneration;
 
   private volatile @Nullable Object userObject;

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/package-info.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/package-info.java
@@ -27,5 +27,9 @@
  * inline fallback when the caller-owned transport executor rejects dispatch. Reset and item
  * add/remove operations coordinate collection membership and ClientHandle ownership; code requiring
  * both locks takes the lifecycle lock before the item collection lock.
+ *
+ * <p>Discovering a monitored-item partition limit may wait for Session activation and server I/O.
+ * Reset invalidates that cache without waiting for an in-progress lookup, because Session recovery
+ * itself may need to reset Subscriptions before activation can finish.
  */
 package org.eclipse.milo.opcua.sdk.client.subscriptions;


### PR DESCRIPTION
Subscription transfer cleanup can wait for a cached operation-limit lookup whose Read request itself needs Session activation. Activation cannot finish until cleanup returns, creating a dependency cycle.

Use the existing nonblocking lazy cache so reset invalidates an active lookup without waiting for its supplier. The regression releases the lookup only after transfer cleanup completes, verifies stale item work returns `Bad_InvalidState`, and confirms the replacement discovers the current limit rather than restoring the discarded cache value.

## Verification

Formatting and full clean compile passed. The selected regression suites passed (218 tests, no failures or errors).

```sh
mise exec -- mvn -q -pl opc-ua-sdk/integration-tests -am verify '-Dtest=Session*,*Subscription*,*MonitoredItem*,Publish*,Publishing*' -Dsurefire.failIfNoSpecifiedTests=false
```

Based on https://github.com/eclipse-milo/milo/pull/1913 so the diff contains only this fix.
