### PR TITLE
Register the legacy GDS dictionary independently of namespace zero

### DIFF
--- a/opc-ua-sdk/dtd-core/src/main/java/org/eclipse/milo/opcua/sdk/core/dtd/gds/BinaryDataTypeDictionaryInitializer.java
+++ b/opc-ua-sdk/dtd-core/src/main/java/org/eclipse/milo/opcua/sdk/core/dtd/gds/BinaryDataTypeDictionaryInitializer.java
@@ -10,20 +10,51 @@
 
 package org.eclipse.milo.opcua.sdk.core.dtd.gds;
 
+import java.io.ByteArrayInputStream;
+import java.util.Base64;
 import org.eclipse.milo.opcua.sdk.core.dtd.BinaryDataTypeCodec;
 import org.eclipse.milo.opcua.sdk.core.dtd.BinaryDataTypeDictionary;
+import org.eclipse.milo.opcua.sdk.core.dtd.BsdParser;
 import org.eclipse.milo.opcua.sdk.core.dtd.DataTypeDictionaryInitializer;
 import org.eclipse.milo.opcua.stack.core.NamespaceTable;
 import org.eclipse.milo.opcua.stack.core.gds.types.ApplicationRecordDataType;
 import org.eclipse.milo.opcua.stack.core.types.DataTypeDictionary;
+import org.eclipse.milo.opcua.stack.core.types.DataTypeManager;
+import org.opcfoundation.opcua.binaryschema.TypeDictionary;
 
 public class BinaryDataTypeDictionaryInitializer extends DataTypeDictionaryInitializer {
+  @Override
+  public void initialize(NamespaceTable namespaceTable, DataTypeManager dataTypeManager) {
+    if (dataTypeManager.getTypeDictionary("http://opcfoundation.org/UA/GDS/") != null) {
+      return;
+    }
+    try {
+      TypeDictionary schema =
+          BsdParser.parse(
+              new ByteArrayInputStream(
+                  Base64.getDecoder()
+                      .decode(
+                          String.join(
+                              "",
+                              "PG9wYzpUeXBlRGljdGlvbmFyeQ0KICB4bWxuczpvcGM9Imh0dHA6Ly9vcGNmb3VuZGF0aW9uLm9yZy9CaW5hcnlTY2hlbWEvIg0KICB4bWxuczp4c2k9Imh0dHA6Ly93d3cudzMub3JnLzIwMDEvWE1MU2NoZW1hLWluc3RhbmNlIg0KICB4bWxuczp1YT0iaHR0cDovL29wY2ZvdW5kYXRpb24ub3JnL1VBLyINCiAgeG1sbnM6dG5zPSJodHRwOi8vb3BjZm91bmRhdGlvbi5vcmcvVUEvR0RTLyINCiAgRGVmYXVsdEJ5dGVPcmRlcj0iTGl0dGxlRW5kaWFuIg0KICBUYXJnZXROYW1lc3BhY2U9Imh0dHA6Ly9vcGNmb3VuZGF0aW9uLm9yZy9VQS9HRFMvIg0KPg0KICA8b3BjOkltcG9ydCBOYW1lc3BhY2U9Imh0dHA6Ly9vcGNmb3VuZGF0aW9uLm9yZy9VQS8iIExvY2F0aW9uPSJPcGMuVWEuQmluYXJ5U2NoZW1hLmJzZCIvPg0KDQogIDxvcGM6U3RydWN0dXJlZFR5cGUgTmFtZT0iQXBwbGljYXRpb25SZWNvcmREYXRhVHlwZSIgQmFzZVR5cGU9InVhOkV4dGVuc2lvbk9iamVjdCI+DQogICAgPG9wYzpGaWVsZCBOYW1lPSJBcHBsaWNhdGlvbklkIiBUeXBlTmFtZT0idWE6Tm9kZUlkIiAvPg0KICAgIDxvcGM6RmllbGQgTmFtZT0iQXBwbGljYXRpb25VcmkiIFR5cGVOYW1lPSJvcGM6U3RyaW5nIiAvPg0KICAgIDxvcGM6RmllbGQgTmFtZT0iQXBwbGljYXRpb25UeXBlIiBUeXBlTmFtZT0idWE6QXBwbGljYXRpb25UeXBlIiAvPg0KICAgIDxvcGM6RmllbGQgTmFtZT0iTm9PZkFwcGxpY2F0aW9uTmFtZXMiIFR5cGVOYW1lPSJvcGM6SW50MzIiIC8+DQogICAgPG9wYzpGaWVsZCBOYW1lPSJBcHBsaWNhdGlvbk5hbWVzIiBUeXBlTmFtZT0idWE6TG9jYWxpemVkVGV4dCIgTGVuZ3RoRmllbGQ9Ik5vT2ZBcHBsaWNhdGlvbk5hbWVzIiAvPg0KICAgIDxvcGM6RmllbGQgTmFtZT0iUHJvZHVjdFVyaSIgVHlwZU5hbWU9Im9wYzpTdHJpbmciIC8+DQogICAgPG9wYzpGaWVsZCBOYW1lPSJOb09mRGlzY292ZXJ5VXJscyIgVHlwZU5hbWU9Im9wYzpJbnQzMiIgLz4NCiAgICA8b3BjOkZpZWxkIE5hbWU9IkRpc2NvdmVyeVVybHMiIFR5cGVOYW1lPSJvcGM6U3RyaW5nIiBMZW5ndGhGaWVsZD0iTm9PZkRpc2NvdmVyeVVybHMiIC8+DQogICAgPG9wYzpGaWVsZCBOYW1lPSJOb09mU2VydmVyQ2FwYWJpbGl0aWVzIiBUeXBlTmFtZT0ib3BjOkludDMyIiAvPg0KICAgIDxvcGM6RmllbGQgTmFtZT0iU2VydmVyQ2FwYWJpbGl0aWVzIiBUeXBlTmFtZT0ib3BjOlN0cmluZyIgTGVuZ3RoRmllbGQ9Ik5vT2ZTZXJ2ZXJDYXBhYmlsaXRpZXMiIC8+DQogIDwvb3BjOlN0cnVjdHVyZWRUeXBlPg0KDQo8L29wYzpUeXBlRGljdGlvbmFyeT4="))));
+      BinaryDataTypeDictionary dictionary = new BinaryDataTypeDictionary(schema);
+      initializeStructs(namespaceTable, dictionary);
+      dataTypeManager.registerTypeDictionary(dictionary);
+      for (DataTypeDictionary.Type type : dictionary.getTypes()) {
+        dataTypeManager.registerType(
+            type.getDataTypeId(), type.getCodec(), type.getEncodingId(), null, null);
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
   @Override
   protected void initializeStructs(
       NamespaceTable namespaceTable, DataTypeDictionary binaryDictionary) throws Exception {
     binaryDictionary.registerType(
         new BinaryDataTypeDictionary.BinaryType(
-            "1:ApplicationRecordDataType",
+            "ApplicationRecordDataType",
             ApplicationRecordDataType.TYPE_ID.toNodeIdOrThrow(namespaceTable),
             ApplicationRecordDataType.BINARY_ENCODING_ID.toNodeIdOrThrow(namespaceTable),
             BinaryDataTypeCodec.from(new ApplicationRecordDataType.Codec())));

--- a/opc-ua-sdk/dtd-core/src/main/java/org/eclipse/milo/opcua/sdk/core/dtd/gds/package-info.java
+++ b/opc-ua-sdk/dtd-core/src/main/java/org/eclipse/milo/opcua/sdk/core/dtd/gds/package-info.java
@@ -12,11 +12,12 @@
  * Legacy DataTypeDictionary registration for the OPC UA Global Discovery Server namespace.
  *
  * <p>{@link org.eclipse.milo.opcua.sdk.core.dtd.gds.BinaryDataTypeDictionaryInitializer} adds the
- * {@code ApplicationRecordDataType} entry to the OPC UA Binary type dictionary, for applications
- * that still exchange type information through OPC UA 1.03-style dictionaries instead of the
- * DataTypeDefinition attribute. Like the rest of {@code org.eclipse.milo.opcua.sdk.core.dtd} it is
- * deprecated for removal; new code should register the codec through {@link
- * org.eclipse.milo.opcua.stack.core.gds.DataTypeInitializer} instead.
+ * {@code ApplicationRecordDataType} entry to a dictionary for the GDS namespace, independently of
+ * standard dictionary initialization order, for applications that still exchange type information
+ * through OPC UA 1.03-style dictionaries instead of the DataTypeDefinition attribute. Like the rest
+ * of {@code org.eclipse.milo.opcua.sdk.core.dtd} it is deprecated for removal; new code should
+ * register the codec through {@link org.eclipse.milo.opcua.stack.core.gds.DataTypeInitializer}
+ * instead.
  *
  * <p>Generated code; see the regeneration notes in {@link org.eclipse.milo.opcua.stack.core.gds}.
  */

--- a/opc-ua-sdk/dtd-core/src/test/java/org/eclipse/milo/opcua/sdk/core/dtd/GdsDictionaryInitializationTest.java
+++ b/opc-ua-sdk/dtd-core/src/test/java/org/eclipse/milo/opcua/sdk/core/dtd/GdsDictionaryInitializationTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.milo.opcua.sdk.core.dtd;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.eclipse.milo.opcua.stack.core.NamespaceTable;
+import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
+import org.eclipse.milo.opcua.stack.core.gds.types.ApplicationRecordDataType;
+import org.eclipse.milo.opcua.stack.core.types.DataTypeManager;
+import org.eclipse.milo.opcua.stack.core.types.DefaultDataTypeManager;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.ApplicationType;
+import org.junit.jupiter.api.Test;
+
+class GdsDictionaryInitializationTest {
+  private static final String GDS_URI = "http://opcfoundation.org/UA/GDS/";
+
+  // Standard initialization must not hide the separate GDS namespace's legacy dictionary/codec.
+  @Test
+  void standardThenGdsRegistersIndependentDictionaryAndCodec() throws Exception {
+    verifyInitialization(true);
+  }
+
+  // GDS-first registration must not install a partial standard dictionary and block its codecs.
+  @Test
+  void gdsThenStandardRegistersIndependentDictionaryAndCodec() throws Exception {
+    verifyInitialization(false);
+  }
+
+  private void verifyInitialization(boolean standardFirst) throws Exception {
+    var namespaces = new NamespaceTable();
+    namespaces.add("urn:unrelated");
+    namespaces.add(GDS_URI);
+    var manager = new DefaultDataTypeManager();
+    var standard = new BinaryDataTypeDictionaryInitializer();
+    var gds = new org.eclipse.milo.opcua.sdk.core.dtd.gds.BinaryDataTypeDictionaryInitializer();
+    if (standardFirst) standard.initialize(namespaces, manager);
+    gds.initialize(namespaces, manager);
+    if (!standardFirst) standard.initialize(namespaces, manager);
+    // Repeated registration remains idempotent for both namespaces.
+    gds.initialize(namespaces, manager);
+    standard.initialize(namespaces, manager);
+
+    BinaryDataTypeDictionary dictionary =
+        (BinaryDataTypeDictionary) manager.getTypeDictionary(GDS_URI);
+    assertNotNull(dictionary, "GDS needs its own dictionary regardless of initialization order");
+    assertNotNull(dictionary.getType("ApplicationRecordDataType"));
+    assertNotNull(dictionary.getTypeDescription("ApplicationRecordDataType"));
+    assertNull(
+        manager
+            .getTypeDictionary("http://opcfoundation.org/UA/")
+            .getType("1:ApplicationRecordDataType"));
+    assertNotNull(
+        manager.getCodec(ApplicationRecordDataType.BINARY_ENCODING_ID.toNodeIdOrThrow(namespaces)));
+
+    var context =
+        new DefaultEncodingContext() {
+          @Override
+          public NamespaceTable getNamespaceTable() {
+            return namespaces;
+          }
+
+          @Override
+          public DataTypeManager getDataTypeManager() {
+            return manager;
+          }
+        };
+    var record =
+        new ApplicationRecordDataType(
+            new NodeId(2, "app"),
+            "urn:test:gds",
+            ApplicationType.Client,
+            new LocalizedText[] {LocalizedText.english("Test")},
+            "urn:test:product",
+            null,
+            null);
+    ExtensionObject encoded = ExtensionObject.encode(context, record);
+    assertEquals(record, encoded.decode(context));
+  }
+}


### PR DESCRIPTION
Initializing the standard legacy dictionary first skipped GDS codec registration. Initializing GDS first could instead register its entries in the standard dictionary.

The regenerated adapter now registers an independent dictionary for the GDS namespace and uses unqualified type names. Initialization order no longer changes where the GDS codecs are registered.

Regressions initialize the dictionaries in both orders and round-trip a GDS ExtensionObject.

Formatting, a full clean compile, and the selected regression suites passed for this branch.

Based on https://github.com/eclipse-milo/milo/pull/1917 so the diff contains only this fix.