### PR TITLE
Authenticate Abort chunks and preserve the following message

### DIFF
--- a/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/client/uasc/UascClientMessageHandler.java
+++ b/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/client/uasc/UascClientMessageHandler.java
@@ -626,13 +626,13 @@ public class UascClientMessageHandler extends ByteToMessageCodec<UascRequest> {
 
     chunkBuffers.add(buffer.retain());
 
-    if (maxChunkCount > 0 && chunkBuffers.size() > maxChunkCount) {
+    char chunkType = (char) buffer.getByte(3);
+
+    if (chunkType != 'A' && maxChunkCount > 0 && chunkBuffers.size() > maxChunkCount) {
       throw new UaException(
           StatusCodes.Bad_TcpMessageTooLarge,
           String.format("max chunk count exceeded (%s)", maxChunkCount));
     }
-
-    char chunkType = (char) buffer.getByte(3);
 
     return (chunkType == 'A' || chunkType == 'F');
   }

--- a/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/client/uasc/package-info.java
+++ b/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/client/uasc/package-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/**
+ * Establishes and renews client SecureChannels and carries service messages over UASC. The client
+ * message handler owns its connection's chunk encoder, decoder, and partial-response buffers.
+ * OpenSecureChannel and symmetric service traffic share the directional sequence stream across
+ * token renewals.
+ *
+ * <p>Intermediate response chunks remain retained until a final or Abort chunk arrives. The core
+ * decoder then validates security and sequence state and takes ownership of those buffers. An
+ * authenticated Abort fails the affected request without invalidating the channel's sequence
+ * stream. An Abort may follow the maximum allowed number of intermediate chunks; its size and
+ * security checks still apply, and the decoder releases the accumulated message.
+ *
+ * <p>Channel state and buffer ownership follow the Netty event loop. The transport receives decoded
+ * responses and owns their request-future completion; this package handles framing, cryptographic
+ * state, handshake completion, and renewal scheduling.
+ */
+package org.eclipse.milo.opcua.stack.transport.client.uasc;

--- a/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/server/uasc/UascServerAsymmetricHandler.java
+++ b/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/server/uasc/UascServerAsymmetricHandler.java
@@ -216,231 +216,226 @@ public class UascServerAsymmetricHandler extends ByteToMessageDecoder implements
 
     char chunkType = (char) buffer.readByte();
 
-    if (chunkType == 'A') {
-      chunkBuffers.releaseAll();
-      headerRef.set(null);
-    } else {
-      buffer.skipBytes(4); // Skip messageSize
+    buffer.skipBytes(4); // Skip messageSize
 
-      final long secureChannelId = buffer.readUnsignedIntLE();
+    final long secureChannelId = buffer.readUnsignedIntLE();
 
-      final AsymmetricSecurityHeader header =
-          AsymmetricSecurityHeader.decode(
-              buffer, application.getEncodingContext().getEncodingLimits());
+    final AsymmetricSecurityHeader header =
+        AsymmetricSecurityHeader.decode(
+            buffer, application.getEncodingContext().getEncodingLimits());
 
-      if (!headerRef.compareAndSet(null, header)) {
-        if (!header.equals(headerRef.get())) {
+    if (!headerRef.compareAndSet(null, header)) {
+      if (!header.equals(headerRef.get())) {
+        throw new UaException(
+            StatusCodes.Bad_SecurityChecksFailed,
+            "subsequent AsymmetricSecurityHeader did not match");
+      }
+    }
+
+    if (secureChannelId != 0) {
+      if (secureChannel == null) {
+        throw new UaException(
+            StatusCodes.Bad_TcpSecureChannelUnknown,
+            "unknown secure channel id: " + secureChannelId);
+      }
+
+      if (secureChannelId != secureChannel.getChannelId()) {
+        throw new UaException(
+            StatusCodes.Bad_TcpSecureChannelUnknown,
+            "unknown secure channel id: " + secureChannelId);
+      }
+    }
+
+    if (secureChannel == null) {
+      secureChannel = new ServerSecureChannel();
+      secureChannel.setChannelId(application.getNextSecureChannelId());
+
+      String securityPolicyUri = header.getSecurityPolicyUri();
+      SecurityPolicy securityPolicy = SecurityPolicy.fromUri(securityPolicyUri);
+
+      secureChannel.setSecurityPolicy(securityPolicy);
+
+      if (securityPolicy != SecurityPolicy.None) {
+        if (header.getReceiverThumbprint().isNullOrEmpty()) {
+          // Part 6 6.7.2.3: the receiver certificate thumbprint identifies the public key used
+          // to encrypt the message and is required whenever the OPN is asymmetrically secured.
+          // Reject explicitly rather than relying on certificate or endpoint lookups to fail,
+          // so the client receives an ERR message identifying the actual problem.
           throw new UaException(
               StatusCodes.Bad_SecurityChecksFailed,
-              "subsequent AsymmetricSecurityHeader did not match");
+              "receiverCertificateThumbprint must be present when SecurityPolicy is not None");
+        }
+
+        CertificateManager certificateManager = application.getCertificateManager();
+
+        Optional<X509Certificate[]> localCertificateChain =
+            certificateManager.getCertificateChain(header.getReceiverThumbprint());
+
+        Optional<KeyPair> keyPair = certificateManager.getKeyPair(header.getReceiverThumbprint());
+
+        if (localCertificateChain.isPresent() && keyPair.isPresent()) {
+          secureChannel.setRemoteCertificate(header.getSenderCertificate().bytesOrEmpty());
+
+          CertificateGroup certificateGroup =
+              application
+                  .getCertificateManager()
+                  .getCertificateGroup(header.getReceiverThumbprint())
+                  .orElseThrow(
+                      () ->
+                          new UaException(
+                              StatusCodes.Bad_SecurityChecksFailed,
+                              "no certificate group for provided thumbprint"));
+
+          CertificateValidator certificateValidator = certificateGroup.getCertificateValidator();
+
+          certificateValidator.validateCertificateChain(
+              secureChannel.getRemoteCertificateChain(), null, null, securityPolicy.getProfile());
+
+          X509Certificate[] chain = localCertificateChain.get();
+          if (securityPolicy.getProfile().secureChannelEnhancements()) {
+            CertificateCompatibility.checkCompatible(securityPolicy.getProfile(), chain[0]);
+          }
+
+          secureChannel.setLocalCertificate(chain[0]);
+          secureChannel.setLocalCertificateChain(chain);
+          secureChannel.setKeyPair(keyPair.get());
+        } else {
+          throw new UaException(
+              StatusCodes.Bad_SecurityChecksFailed, "no certificate for provided thumbprint");
         }
       }
+    }
 
-      if (secureChannelId != 0) {
-        if (secureChannel == null) {
-          throw new UaException(
-              StatusCodes.Bad_TcpSecureChannelUnknown,
-              "unknown secure channel id: " + secureChannelId);
-        }
+    // Before attempting decryption, ensure the SecurityPolicy used in the
+    // AsymmetricSecurityHeader is one that is supported by the configured
+    // endpoints.
 
-        if (secureChannelId != secureChannel.getChannelId()) {
-          throw new UaException(
-              StatusCodes.Bad_TcpSecureChannelUnknown,
-              "unknown secure channel id: " + secureChannelId);
-        }
+    String endpointUrl = ctx.channel().attr(UascServerHelloHandler.ENDPOINT_URL_KEY).get();
+
+    if (application.getEndpointDescriptions().stream()
+        .noneMatch(
+            e -> {
+              boolean transportMatch =
+                  Objects.equals(e.getTransportProfileUri(), transportProfile.getUri());
+
+              boolean pathMatch =
+                  Objects.equals(
+                      EndpointUtil.getPath(e.getEndpointUrl()), EndpointUtil.getPath(endpointUrl));
+
+              boolean securityPolicyMatch =
+                  Objects.equals(
+                      e.getSecurityPolicyUri(), secureChannel.getSecurityPolicy().getUri());
+
+              boolean thumbprintMatch = true;
+              if (!header.getReceiverThumbprint().isNullOrEmpty()) {
+                thumbprintMatch =
+                    Arrays.equals(
+                        DigestUtil.sha1(e.getServerCertificate().bytesOrEmpty()),
+                        header.getReceiverThumbprint().bytesOrEmpty());
+              }
+
+              // allow a matched endpoint OR any unsecured connection, regardless of the
+              // endpoint security, so that the receiving ServerApplication can decide if
+              // it wants to allow unsecured Discovery services.
+              return transportMatch
+                  && pathMatch
+                  && thumbprintMatch
+                  && (securityPolicyMatch
+                      || secureChannel.getSecurityPolicy() == SecurityPolicy.None);
+            })) {
+
+      String message =
+          String.format(
+              "no matching endpoint found: "
+                  + "transportProfile=%s, endpointUrl=%s, securityPolicy=%s",
+              transportProfile, endpointUrl, secureChannel.getSecurityPolicy());
+
+      throw new UaException(StatusCodes.Bad_SecurityChecksFailed, message);
+    }
+
+    //noinspection DuplicatedCode
+    int chunkSize = buffer.readerIndex(0).readableBytes();
+
+    if (chunkSize > maxChunkSize) {
+      throw new UaException(
+          StatusCodes.Bad_TcpMessageTooLarge,
+          String.format("max chunk size exceeded (%s)", maxChunkSize));
+    }
+
+    chunkBuffers.add(buffer);
+
+    if (chunkType != 'A' && maxChunkCount > 0 && chunkBuffers.size() > maxChunkCount) {
+      throw new UaException(
+          StatusCodes.Bad_TcpMessageTooLarge,
+          String.format("max chunk count exceeded (%s)", maxChunkCount));
+    }
+
+    // Abort terminates a message only after all accumulated chunks pass security and sequence
+    // checks. The decoder consumes the Abort sequence number before reporting
+    // MessageAbortException.
+    if (chunkType == 'F' || chunkType == 'A') {
+      final List<ByteBuf> buffersToDecode = chunkBuffers.takeAll();
+      headerRef.set(null);
+
+      ByteBuf message;
+      long requestId;
+      byte[] requestSignature;
+
+      try {
+        ChunkDecoder.DecodedMessage decodedMessage =
+            chunkDecoder.decodeAsymmetric(secureChannel, buffersToDecode);
+
+        message = decodedMessage.getMessage();
+        requestId = decodedMessage.getRequestId();
+        requestSignature = decodedMessage.getSignature();
+      } catch (MessageAbortException e) {
+        logger.warn(
+            "Received message abort chunk; error={}, reason={}", e.getStatusCode(), e.getMessage());
+        return;
+      } catch (MessageDecodeException e) {
+        logger.error("Error decoding asymmetric message", e);
+
+        ctx.executor()
+            .schedule(() -> ctx.close(), new Random().nextInt(1000), TimeUnit.MILLISECONDS);
+
+        return;
       }
 
-      if (secureChannel == null) {
-        secureChannel = new ServerSecureChannel();
-        secureChannel.setChannelId(application.getNextSecureChannelId());
+      try {
+        OpenSecureChannelRequest request =
+            (OpenSecureChannelRequest) binaryDecoder.setBuffer(message).decodeMessage(null);
 
-        String securityPolicyUri = header.getSecurityPolicyUri();
-        SecurityPolicy securityPolicy = SecurityPolicy.fromUri(securityPolicyUri);
+        logger.debug(
+            "Received OpenSecureChannelRequest ({}, id={}).",
+            request.getRequestType(),
+            secureChannelId);
 
-        secureChannel.setSecurityPolicy(securityPolicy);
-
-        if (securityPolicy != SecurityPolicy.None) {
-          if (header.getReceiverThumbprint().isNullOrEmpty()) {
-            // Part 6 6.7.2.3: the receiver certificate thumbprint identifies the public key used
-            // to encrypt the message and is required whenever the OPN is asymmetrically secured.
-            // Reject explicitly rather than relying on certificate or endpoint lookups to fail,
-            // so the client receives an ERR message identifying the actual problem.
+        if (request.getRequestType() == SecurityTokenRequestType.Renew) {
+          if (secureChannelId == 0L) {
             throw new UaException(
                 StatusCodes.Bad_SecurityChecksFailed,
-                "receiverCertificateThumbprint must be present when SecurityPolicy is not None");
+                "secure channel renewal for secureChannelId=0");
           }
-
-          CertificateManager certificateManager = application.getCertificateManager();
-
-          Optional<X509Certificate[]> localCertificateChain =
-              certificateManager.getCertificateChain(header.getReceiverThumbprint());
-
-          Optional<KeyPair> keyPair = certificateManager.getKeyPair(header.getReceiverThumbprint());
-
-          if (localCertificateChain.isPresent() && keyPair.isPresent()) {
-            secureChannel.setRemoteCertificate(header.getSenderCertificate().bytesOrEmpty());
-
-            CertificateGroup certificateGroup =
-                application
-                    .getCertificateManager()
-                    .getCertificateGroup(header.getReceiverThumbprint())
-                    .orElseThrow(
-                        () ->
-                            new UaException(
-                                StatusCodes.Bad_SecurityChecksFailed,
-                                "no certificate group for provided thumbprint"));
-
-            CertificateValidator certificateValidator = certificateGroup.getCertificateValidator();
-
-            certificateValidator.validateCertificateChain(
-                secureChannel.getRemoteCertificateChain(), null, null, securityPolicy.getProfile());
-
-            X509Certificate[] chain = localCertificateChain.get();
-            if (securityPolicy.getProfile().secureChannelEnhancements()) {
-              CertificateCompatibility.checkCompatible(securityPolicy.getProfile(), chain[0]);
-            }
-
-            secureChannel.setLocalCertificate(chain[0]);
-            secureChannel.setLocalCertificateChain(chain);
-            secureChannel.setKeyPair(keyPair.get());
-          } else {
-            throw new UaException(
-                StatusCodes.Bad_SecurityChecksFailed, "no certificate for provided thumbprint");
-          }
-        }
-      }
-
-      // Before attempting decryption, ensure the SecurityPolicy used in the
-      // AsymmetricSecurityHeader is one that is supported by the configured
-      // endpoints.
-
-      String endpointUrl = ctx.channel().attr(UascServerHelloHandler.ENDPOINT_URL_KEY).get();
-
-      if (application.getEndpointDescriptions().stream()
-          .noneMatch(
-              e -> {
-                boolean transportMatch =
-                    Objects.equals(e.getTransportProfileUri(), transportProfile.getUri());
-
-                boolean pathMatch =
-                    Objects.equals(
-                        EndpointUtil.getPath(e.getEndpointUrl()),
-                        EndpointUtil.getPath(endpointUrl));
-
-                boolean securityPolicyMatch =
-                    Objects.equals(
-                        e.getSecurityPolicyUri(), secureChannel.getSecurityPolicy().getUri());
-
-                boolean thumbprintMatch = true;
-                if (!header.getReceiverThumbprint().isNullOrEmpty()) {
-                  thumbprintMatch =
-                      Arrays.equals(
-                          DigestUtil.sha1(e.getServerCertificate().bytesOrEmpty()),
-                          header.getReceiverThumbprint().bytesOrEmpty());
-                }
-
-                // allow a matched endpoint OR any unsecured connection, regardless of the
-                // endpoint security, so that the receiving ServerApplication can decide if
-                // it wants to allow unsecured Discovery services.
-                return transportMatch
-                    && pathMatch
-                    && thumbprintMatch
-                    && (securityPolicyMatch
-                        || secureChannel.getSecurityPolicy() == SecurityPolicy.None);
-              })) {
-
-        String message =
-            String.format(
-                "no matching endpoint found: "
-                    + "transportProfile=%s, endpointUrl=%s, securityPolicy=%s",
-                transportProfile, endpointUrl, secureChannel.getSecurityPolicy());
-
-        throw new UaException(StatusCodes.Bad_SecurityChecksFailed, message);
-      }
-
-      //noinspection DuplicatedCode
-      int chunkSize = buffer.readerIndex(0).readableBytes();
-
-      if (chunkSize > maxChunkSize) {
-        throw new UaException(
-            StatusCodes.Bad_TcpMessageTooLarge,
-            String.format("max chunk size exceeded (%s)", maxChunkSize));
-      }
-
-      chunkBuffers.add(buffer);
-
-      if (maxChunkCount > 0 && chunkBuffers.size() > maxChunkCount) {
-        throw new UaException(
-            StatusCodes.Bad_TcpMessageTooLarge,
-            String.format("max chunk count exceeded (%s)", maxChunkCount));
-      }
-
-      if (chunkType == 'F') {
-        final List<ByteBuf> buffersToDecode = chunkBuffers.takeAll();
-        headerRef.set(null);
-
-        ByteBuf message;
-        long requestId;
-        byte[] requestSignature;
-
-        try {
-          ChunkDecoder.DecodedMessage decodedMessage =
-              chunkDecoder.decodeAsymmetric(secureChannel, buffersToDecode);
-
-          message = decodedMessage.getMessage();
-          requestId = decodedMessage.getRequestId();
-          requestSignature = decodedMessage.getSignature();
-        } catch (MessageAbortException e) {
-          logger.warn(
-              "Received message abort chunk; error={}, reason={}",
-              e.getStatusCode(),
-              e.getMessage());
-          return;
-        } catch (MessageDecodeException e) {
-          logger.error("Error decoding asymmetric message", e);
-
-          ctx.executor()
-              .schedule(() -> ctx.close(), new Random().nextInt(1000), TimeUnit.MILLISECONDS);
-
-          return;
+        } else if (request.getRequestType() == SecurityTokenRequestType.Issue
+            && secureChannel.getChannelSecurity() != null) {
+          // An established channel can only be renewed, never re-issued. A second Issue would be
+          // chained off the current input key material on the renewal derivation path while the
+          // peer believes it performed a fresh issue, and would re-bind the channel
+          // thumbprint/security-mode contrary to the first-response-only binding of Part 6 6.7.5.
+          // Reject here, before any such mutation, so the original binding stays effective.
+          throw new UaException(
+              StatusCodes.Bad_SecurityChecksFailed,
+              "secure channel issue for an already-established channel");
         }
 
-        try {
-          OpenSecureChannelRequest request =
-              (OpenSecureChannelRequest) binaryDecoder.setBuffer(message).decodeMessage(null);
+        sendOpenSecureChannelResponse(ctx, requestId, header, request, requestSignature);
+      } catch (Throwable t) {
+        logger.error("Error decoding OpenSecureChannelRequest", t);
 
-          logger.debug(
-              "Received OpenSecureChannelRequest ({}, id={}).",
-              request.getRequestType(),
-              secureChannelId);
-
-          if (request.getRequestType() == SecurityTokenRequestType.Renew) {
-            if (secureChannelId == 0L) {
-              throw new UaException(
-                  StatusCodes.Bad_SecurityChecksFailed,
-                  "secure channel renewal for secureChannelId=0");
-            }
-          } else if (request.getRequestType() == SecurityTokenRequestType.Issue
-              && secureChannel.getChannelSecurity() != null) {
-            // An established channel can only be renewed, never re-issued. A second Issue would be
-            // chained off the current input key material on the renewal derivation path while the
-            // peer believes it performed a fresh issue, and would re-bind the channel
-            // thumbprint/security-mode contrary to the first-response-only binding of Part 6 6.7.5.
-            // Reject here, before any such mutation, so the original binding stays effective.
-            throw new UaException(
-                StatusCodes.Bad_SecurityChecksFailed,
-                "secure channel issue for an already-established channel");
-          }
-
-          sendOpenSecureChannelResponse(ctx, requestId, header, request, requestSignature);
-        } catch (Throwable t) {
-          logger.error("Error decoding OpenSecureChannelRequest", t);
-
-          ctx.close();
-        } finally {
-          message.release();
-          buffersToDecode.clear();
-        }
+        ctx.close();
+      } finally {
+        message.release();
+        buffersToDecode.clear();
       }
     }
   }

--- a/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/server/uasc/UascServerSymmetricHandler.java
+++ b/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/server/uasc/UascServerSymmetricHandler.java
@@ -163,80 +163,76 @@ public class UascServerSymmetricHandler extends ByteToMessageCodec<UascServiceRe
 
     char chunkType = (char) buffer.readByte();
 
-    if (chunkType == 'A') {
-      chunkBuffers.releaseAll();
-    } else {
-      buffer.skipBytes(4); // Skip messageSize
+    buffer.skipBytes(4); // Skip messageSize
 
-      long secureChannelId = buffer.readUnsignedIntLE();
-      if (secureChannelId != secureChannel.getChannelId()) {
-        throw new UaException(
-            StatusCodes.Bad_SecureChannelIdInvalid,
-            "invalid secure channel id: " + secureChannelId);
-      }
+    long secureChannelId = buffer.readUnsignedIntLE();
+    if (secureChannelId != secureChannel.getChannelId()) {
+      throw new UaException(
+          StatusCodes.Bad_SecureChannelIdInvalid, "invalid secure channel id: " + secureChannelId);
+    }
 
-      int chunkSize = buffer.readerIndex(0).readableBytes();
-      if (chunkSize > maxChunkSize) {
-        throw new UaException(
-            StatusCodes.Bad_TcpMessageTooLarge,
-            String.format("max chunk size exceeded (%s)", maxChunkSize));
-      }
+    int chunkSize = buffer.readerIndex(0).readableBytes();
+    if (chunkSize > maxChunkSize) {
+      throw new UaException(
+          StatusCodes.Bad_TcpMessageTooLarge,
+          String.format("max chunk size exceeded (%s)", maxChunkSize));
+    }
 
-      chunkBuffers.add(buffer);
+    chunkBuffers.add(buffer);
 
-      if (maxChunkCount > 0 && chunkBuffers.size() > maxChunkCount) {
-        throw new UaException(
-            StatusCodes.Bad_TcpMessageTooLarge,
-            String.format("max chunk count exceeded (%s)", maxChunkCount));
-      }
+    if (chunkType != 'A' && maxChunkCount > 0 && chunkBuffers.size() > maxChunkCount) {
+      throw new UaException(
+          StatusCodes.Bad_TcpMessageTooLarge,
+          String.format("max chunk count exceeded (%s)", maxChunkCount));
+    }
 
-      if (chunkType == 'F') {
-        final List<ByteBuf> buffersToDecode = chunkBuffers.takeAll();
+    // Abort terminates a message only after all accumulated chunks pass security and sequence
+    // checks. The decoder consumes the Abort sequence number before reporting
+    // MessageAbortException.
+    if (chunkType == 'F' || chunkType == 'A') {
+      final List<ByteBuf> buffersToDecode = chunkBuffers.takeAll();
 
-        ByteBuf message = null;
+      ByteBuf message = null;
 
-        try {
-          DecodedMessage decodedMessage =
-              chunkDecoder.decodeSymmetric(secureChannel, buffersToDecode);
+      try {
+        DecodedMessage decodedMessage =
+            chunkDecoder.decodeSymmetric(secureChannel, buffersToDecode);
 
-          message = decodedMessage.getMessage();
-          long requestId = decodedMessage.getRequestId();
+        message = decodedMessage.getMessage();
+        long requestId = decodedMessage.getRequestId();
 
-          binaryDecoder.setBuffer(message);
-          UaRequestMessageType requestMessage =
-              (UaRequestMessageType) binaryDecoder.decodeMessage(null);
+        binaryDecoder.setBuffer(message);
+        UaRequestMessageType requestMessage =
+            (UaRequestMessageType) binaryDecoder.decodeMessage(null);
 
-          String endpointUrl = ctx.channel().attr(UascServerHelloHandler.ENDPOINT_URL_KEY).get();
+        String endpointUrl = ctx.channel().attr(UascServerHelloHandler.ENDPOINT_URL_KEY).get();
 
-          EndpointDescription endpoint =
-              ctx.channel().attr(UascServerAsymmetricHandler.ENDPOINT_KEY).get();
+        EndpointDescription endpoint =
+            ctx.channel().attr(UascServerAsymmetricHandler.ENDPOINT_KEY).get();
 
-          var serviceRequest =
-              new UascServiceRequest(
-                  endpointUrl,
-                  transportProfile,
-                  ctx.channel(),
-                  secureChannel,
-                  endpoint,
-                  requestMessage,
-                  requestId);
+        var serviceRequest =
+            new UascServiceRequest(
+                endpointUrl,
+                transportProfile,
+                ctx.channel(),
+                secureChannel,
+                endpoint,
+                requestMessage,
+                requestId);
 
-          out.add(serviceRequest);
-        } catch (MessageAbortException e) {
-          logger.warn(
-              "Received message abort chunk; error={}, reason={}",
-              e.getStatusCode(),
-              e.getMessage());
-        } catch (MessageDecodeException e) {
-          logger.error("Error decoding symmetric message", e);
+        out.add(serviceRequest);
+      } catch (MessageAbortException e) {
+        logger.warn(
+            "Received message abort chunk; error={}, reason={}", e.getStatusCode(), e.getMessage());
+      } catch (MessageDecodeException e) {
+        logger.error("Error decoding symmetric message", e);
 
-          ctx.close();
-        } finally {
-          if (message != null) {
-            message.release();
-          }
-          buffersToDecode.clear();
+        ctx.close();
+      } finally {
+        if (message != null) {
+          message.release();
         }
+        buffersToDecode.clear();
       }
     }
   }

--- a/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/server/uasc/package-info.java
+++ b/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/server/uasc/package-info.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/**
+ * Establishes server SecureChannels and translates UASC chunks into service requests and responses.
+ * The asymmetric handler validates OpenSecureChannel messages and installs the symmetric handler
+ * after a token is established. Both handlers share the connection's chunk encoder and decoder, so
+ * asymmetric renewals and symmetric service messages use the same directional sequence streams.
+ *
+ * <p>Handlers retain partial-message buffers until a final or Abort chunk completes the message.
+ * Both terminal chunk types pass through the core decoder, which authenticates the accumulated
+ * chunks and advances sequence state. A valid Abort discards the message while leaving the channel
+ * open; malformed or unauthenticated chunks follow the decoding-error path. An Abort may follow the
+ * maximum allowed number of intermediate chunks, adding at most one size-limited chunk before the
+ * decoder releases the accumulated message.
+ *
+ * <p>Buffer ownership stays on the channel's event loop. Accumulation transfers retained buffers to
+ * the decoder for message completion, and disconnect, handler removal, and exception cleanup
+ * release buffers still owned by the handler. Service dispatch begins only after successful
+ * decoding and uses the executor supplied by the server transport configuration.
+ */
+package org.eclipse.milo.opcua.stack.transport.server.uasc;

--- a/opc-ua-stack/transport/src/test/java/org/eclipse/milo/opcua/stack/transport/client/uasc/UascClientChunkLifecycleTest.java
+++ b/opc-ua-stack/transport/src/test/java/org/eclipse/milo/opcua/stack/transport/client/uasc/UascClientChunkLifecycleTest.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.transport.client.uasc;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ubyte;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.util.HashedWheelTimer;
+import io.netty.util.ReferenceCountUtil;
+import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicLong;
+import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.channel.ChannelParameters;
+import org.eclipse.milo.opcua.stack.core.channel.ChannelSecurity;
+import org.eclipse.milo.opcua.stack.core.channel.ChunkDecoder;
+import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
+import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
+import org.eclipse.milo.opcua.stack.core.encoding.binary.OpcUaBinaryEncoder;
+import org.eclipse.milo.opcua.stack.core.security.CertificateIdentity;
+import org.eclipse.milo.opcua.stack.core.security.CertificateValidator;
+import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
+import org.eclipse.milo.opcua.stack.core.security.SecurityPolicyProfile;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.ApplicationType;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.MessageSecurityMode;
+import org.eclipse.milo.opcua.stack.core.types.structured.ApplicationDescription;
+import org.eclipse.milo.opcua.stack.core.types.structured.ChannelSecurityToken;
+import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
+import org.eclipse.milo.opcua.stack.core.types.structured.GetEndpointsResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.ResponseHeader;
+import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateBuilder;
+import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateGenerator;
+import org.eclipse.milo.opcua.stack.transport.client.ClientApplicationContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+/** Authenticated Abort responses preserve the following response at the chunk-count boundary. */
+class UascClientChunkLifecycleTest {
+
+  // A response Abort may follow every permitted C chunk. It must release the message, report the
+  // request failure, and preserve the authenticated stream for the next response.
+  @ParameterizedTest
+  @EnumSource(
+      value = SecurityPolicy.class,
+      names = {"None", "ECC_nistP256_AesGcm"})
+  void abortAfterChunkCountLimitPreservesTheFollowingResponse(SecurityPolicy policy)
+      throws Exception {
+    var parameters = new ChannelParameters(65535, 8192, 8192, 1, 65535, 8192, 8192, 1);
+    var wheelTimer = new HashedWheelTimer();
+    var channel = new EmbeddedChannel();
+    try {
+      var handler =
+          new UascClientMessageHandler(
+              config(wheelTimer),
+              application(),
+              new AtomicLong(1L)::getAndIncrement,
+              new CompletableFuture<>(),
+              List.of(),
+              parameters);
+      channel.pipeline().addLast(handler);
+      channel.runPendingTasks();
+      Object outbound;
+      while ((outbound = channel.readOutbound()) != null) {
+        ReferenceCountUtil.release(outbound);
+      }
+
+      var keyPair = SelfSignedCertificateGenerator.generateNistP256KeyPair();
+      var certificate =
+          new SelfSignedCertificateBuilder(keyPair)
+              .setCommonName("abort-test")
+              .setApplicationUri("urn:test:client")
+              .build();
+      var secureChannel =
+          new ClientSecureChannel(
+              keyPair,
+              certificate,
+              List.of(certificate),
+              certificate,
+              List.of(certificate),
+              policy,
+              policy == SecurityPolicy.None
+                  ? MessageSecurityMode.None
+                  : MessageSecurityMode.SignAndEncrypt);
+      secureChannel.setChannelId(1);
+      secureChannel.setChannelSecurity(
+          new ChannelSecurity(
+              policy == SecurityPolicy.None
+                  ? null
+                  : ChannelSecurity.createAeadKeyPair(
+                      new byte[16], new byte[12], new byte[16], new byte[12]),
+              new ChannelSecurityToken(uint(1), uint(1), DateTime.now(), uint(60_000))));
+      Field channelField = UascClientMessageHandler.class.getDeclaredField("secureChannel");
+      channelField.setAccessible(true);
+      channelField.set(handler, secureChannel);
+      Field decoderField = UascClientMessageHandler.class.getDeclaredField("chunkDecoder");
+      decoderField.setAccessible(true);
+      Field sequenceField = ChunkDecoder.class.getDeclaredField("lastSequenceNumber");
+      sequenceField.setAccessible(true);
+      sequenceField.setLong(decoderField.get(handler), 0);
+
+      ByteBuf partial = symmetricChunk(policy, 'C', 1, 0, new byte[] {1, 2, 3});
+      byte[] errorBody =
+          ByteBuffer.allocate(8)
+              .order(ByteOrder.LITTLE_ENDIAN)
+              .putInt((int) StatusCodes.Bad_EncodingLimitsExceeded)
+              .putInt(-1)
+              .array();
+      ByteBuf abort = symmetricChunk(policy, 'A', 2, 1, errorBody);
+      channel.writeInbound(partial);
+      assertEquals(1, partial.refCnt());
+      channel.writeInbound(abort);
+      assertTrue(channel.isOpen());
+      assertEquals(0, partial.refCnt());
+      assertEquals(0, abort.refCnt());
+      UascResponse failure = channel.readInbound();
+      assertTrue(failure.isFailure());
+      assertEquals(
+          StatusCodes.Bad_EncodingLimitsExceeded, failure.getException().getStatusCode().value());
+
+      ByteBuf body = Unpooled.buffer();
+      try {
+        var response =
+            new GetEndpointsResponse(
+                new ResponseHeader(DateTime.now(), uint(1), StatusCode.GOOD, null, null, null),
+                new EndpointDescription[0]);
+        new OpcUaBinaryEncoder(DefaultEncodingContext.INSTANCE)
+            .setBuffer(body)
+            .encodeMessage(null, response);
+        byte[] bytes = new byte[body.readableBytes()];
+        body.readBytes(bytes);
+        ByteBuf following = symmetricChunk(policy, 'F', 3, 2, bytes);
+        channel.writeInbound(following);
+        UascResponse success = channel.readInbound();
+        assertInstanceOf(GetEndpointsResponse.class, success.getResponseMessage());
+        assertEquals(0, following.refCnt());
+        assertTrue(channel.isOpen());
+      } finally {
+        body.release();
+      }
+    } finally {
+      channel.finishAndReleaseAll();
+      wheelTimer.stop();
+    }
+  }
+
+  // Independent wire construction covers the Abort type, which the production encoder does not
+  // emit.
+  private static ByteBuf symmetricChunk(
+      SecurityPolicy policy, char type, int sequence, int last, byte[] body) throws Exception {
+    boolean encrypted = policy != SecurityPolicy.None;
+    ByteBuf chunk = PooledByteBufAllocator.DEFAULT.directBuffer();
+    chunk.writeBytes(new byte[] {'M', 'S', 'G', (byte) type});
+    chunk.writeIntLE(24 + body.length + (encrypted ? 16 : 0)).writeIntLE(1).writeIntLE(1);
+    byte[] plaintext =
+        ByteBuffer.allocate(8 + body.length)
+            .order(ByteOrder.LITTLE_ENDIAN)
+            .putInt(sequence)
+            .putInt(1)
+            .put(body)
+            .array();
+    if (encrypted) {
+      byte[] nonce =
+          ByteBuffer.allocate(12)
+              .order(ByteOrder.LITTLE_ENDIAN)
+              .putInt(1)
+              .putInt(last)
+              .putInt(0)
+              .array();
+      Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+      cipher.init(
+          Cipher.ENCRYPT_MODE,
+          new SecretKeySpec(new byte[16], "AES"),
+          new GCMParameterSpec(128, nonce));
+      byte[] aad = new byte[16];
+      chunk.getBytes(0, aad);
+      cipher.updateAAD(aad);
+      chunk.writeBytes(cipher.doFinal(plaintext));
+    } else {
+      chunk.writeBytes(plaintext);
+    }
+    return chunk;
+  }
+
+  static UascClientConfig config(HashedWheelTimer wheelTimer) {
+    return new UascClientConfig() {
+      public UInteger getAcknowledgeTimeout() {
+        return uint(60000);
+      }
+
+      public UInteger getChannelLifetime() {
+        return uint(3600000);
+      }
+
+      public HashedWheelTimer getWheelTimer() {
+        return wheelTimer;
+      }
+    };
+  }
+
+  static ClientApplicationContext application() {
+    EndpointDescription endpoint =
+        new EndpointDescription(
+            "opc.tcp://localhost:0/test",
+            new ApplicationDescription(
+                "urn:eclipse:milo:test",
+                "urn:eclipse:milo:test",
+                LocalizedText.english("test"),
+                ApplicationType.Client,
+                null,
+                null,
+                null),
+            ByteString.NULL_VALUE,
+            MessageSecurityMode.None,
+            SecurityPolicy.None.getUri(),
+            null,
+            null,
+            ubyte(0));
+    return new ClientApplicationContext() {
+      public EndpointDescription getEndpoint() {
+        return endpoint;
+      }
+
+      public Optional<CertificateIdentity> getCertificateIdentity(SecurityPolicyProfile p) {
+        return Optional.empty();
+      }
+
+      public CertificateValidator getCertificateValidator() {
+        return (chain, uri, hosts) -> {};
+      }
+
+      public EncodingContext getEncodingContext() {
+        return new DefaultEncodingContext();
+      }
+
+      public UInteger getRequestTimeout() {
+        return uint(60000);
+      }
+    };
+  }
+}

--- a/opc-ua-stack/transport/src/test/java/org/eclipse/milo/opcua/stack/transport/server/uasc/UascChunkRecoveryTest.java
+++ b/opc-ua-stack/transport/src/test/java/org/eclipse/milo/opcua/stack/transport/server/uasc/UascChunkRecoveryTest.java
@@ -13,17 +13,28 @@ package org.eclipse.milo.opcua.stack.transport.server.uasc;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ubyte;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.embedded.EmbeddedChannel;
 import java.lang.reflect.Field;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.security.KeyPair;
+import java.security.Signature;
 import java.security.cert.X509Certificate;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import javax.crypto.Cipher;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.channel.ChannelParameters;
 import org.eclipse.milo.opcua.stack.core.channel.ChannelSecurity;
@@ -31,9 +42,12 @@ import org.eclipse.milo.opcua.stack.core.channel.ChunkDecoder;
 import org.eclipse.milo.opcua.stack.core.channel.ChunkEncoder;
 import org.eclipse.milo.opcua.stack.core.channel.EncodingLimits;
 import org.eclipse.milo.opcua.stack.core.channel.ServerSecureChannel;
+import org.eclipse.milo.opcua.stack.core.channel.headers.AsymmetricSecurityHeader;
+import org.eclipse.milo.opcua.stack.core.channel.messages.MessageType;
 import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
 import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
 import org.eclipse.milo.opcua.stack.core.encoding.binary.OpcUaBinaryDecoder;
+import org.eclipse.milo.opcua.stack.core.encoding.binary.OpcUaBinaryEncoder;
 import org.eclipse.milo.opcua.stack.core.security.CertificateManager;
 import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
 import org.eclipse.milo.opcua.stack.core.transport.TransportProfile;
@@ -41,18 +55,26 @@ import org.eclipse.milo.opcua.stack.core.types.UaRequestMessageType;
 import org.eclipse.milo.opcua.stack.core.types.UaResponseMessageType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.MessageSecurityMode;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.SecurityTokenRequestType;
 import org.eclipse.milo.opcua.stack.core.types.structured.ChannelSecurityToken;
 import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
+import org.eclipse.milo.opcua.stack.core.types.structured.GetEndpointsRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.OpenSecureChannelRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.OpenSecureChannelResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.RequestHeader;
 import org.eclipse.milo.opcua.stack.core.types.structured.ResponseHeader;
 import org.eclipse.milo.opcua.stack.core.types.structured.ServiceFault;
+import org.eclipse.milo.opcua.stack.core.util.DigestUtil;
 import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateBuilder;
 import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateGenerator;
 import org.eclipse.milo.opcua.stack.transport.client.uasc.ClientSecureChannel;
 import org.eclipse.milo.opcua.stack.transport.server.ServerApplicationContext;
 import org.eclipse.milo.opcua.stack.transport.server.ServiceRequestContext;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
@@ -62,6 +84,8 @@ class UascChunkRecoveryTest {
   private static final String ENDPOINT_URL = "opc.tcp://localhost:4840";
   private static final ChannelParameters PARAMETERS =
       new ChannelParameters(100_000, 8192, 8192, 20, 0, 8192, 8192, 1);
+  private static final ChannelParameters ABORT_PARAMETERS =
+      new ChannelParameters(100_000, 8192, 8192, 1, 0, 8192, 8192, 1);
 
   // A peer may advertise unlimited message size but limit the number of chunks. The fallback
   // ServiceFault must use the next sequence number the peer expects, including its AEAD nonce.
@@ -103,6 +127,203 @@ class UascChunkRecoveryTest {
     }
   }
 
+  // The peer may discover overflow after sending the permitted C chunks. Abort must still pass
+  // security checks, discard those chunks and leave the SecureChannel open (Part 6 §6.7.3).
+  @ParameterizedTest
+  @EnumSource(
+      value = SecurityPolicy.class,
+      names = {"None", "ECC_nistP256_AesGcm"})
+  void authenticatedSymmetricAbortPreservesTheFollowingRequest(SecurityPolicy policy)
+      throws Exception {
+    var fixture = new Fixture(policy);
+    var encoder = new ChunkEncoder(PARAMETERS);
+    var decoder = new ChunkDecoder(PARAMETERS, EncodingLimits.DEFAULT);
+    startAfterOpen(encoder, decoder, policy);
+    EmbeddedChannel channel =
+        fixture.symmetricChannel(new ChunkEncoder(PARAMETERS), decoder, ABORT_PARAMETERS);
+    try {
+      channel.writeInbound(encodeRequest(encoder, fixture.client));
+      assertInstanceOf(UascServiceRequest.class, channel.readInbound());
+      ByteBuf partial = symmetricChunk(policy, 'C', 2, 1, new byte[] {1, 2, 3});
+      ByteBuf abort = symmetricChunk(policy, 'A', 3, 2, abortBody());
+      channel.writeInbound(partial);
+      assertEquals(1, partial.refCnt());
+      channel.writeInbound(abort);
+      assertEquals(0, partial.refCnt());
+      assertEquals(0, abort.refCnt());
+      assertTrue(channel.isOpen());
+
+      if (policy == SecurityPolicy.None) {
+        encodeRequest(encoder, fixture.client).release();
+        encodeRequest(encoder, fixture.client).release();
+      } else {
+        setLong(encoder, "nonLegacyNextSequenceNumber", 4);
+        setLong(encoder, "nonLegacyLastSequenceNumber", 3);
+      }
+      channel.writeInbound(encodeRequest(encoder, fixture.client));
+      assertInstanceOf(UascServiceRequest.class, channel.readInbound());
+      assertTrue(channel.isOpen());
+    } finally {
+      channel.finishAndReleaseAll();
+    }
+  }
+
+  @Test
+  void tamperedSymmetricAbortFailsAuthentication() throws Exception {
+    var fixture = new Fixture(SecurityPolicy.ECC_nistP256_AesGcm);
+    var decoder = new ChunkDecoder(PARAMETERS, EncodingLimits.DEFAULT);
+    setLong(decoder, "lastSequenceNumber", 1);
+    EmbeddedChannel channel =
+        fixture.symmetricChannel(new ChunkEncoder(PARAMETERS), decoder, ABORT_PARAMETERS);
+    try {
+      ByteBuf partial = symmetricChunk(fixture.policy, 'C', 2, 1, new byte[] {1, 2, 3});
+      ByteBuf abort = symmetricChunk(fixture.policy, 'A', 3, 2, abortBody());
+      abort.setByte(abort.writerIndex() - 1, abort.getByte(abort.writerIndex() - 1) ^ 1);
+      channel.writeInbound(partial);
+      channel.writeInbound(abort);
+      assertFalse(channel.isOpen(), "an invalid tag must not be accepted as an Abort");
+      assertEquals(0, partial.refCnt());
+      assertEquals(0, abort.refCnt());
+    } finally {
+      channel.finishAndReleaseAll();
+    }
+  }
+
+  @Test
+  void headerOnlySymmetricAbortCannotDiscardAnAccumulatingMessage() throws Exception {
+    var fixture = new Fixture(SecurityPolicy.None);
+    EmbeddedChannel channel =
+        fixture.symmetricChannel(
+            new ChunkEncoder(PARAMETERS), new ChunkDecoder(PARAMETERS, EncodingLimits.DEFAULT));
+    try {
+      channel
+          .pipeline()
+          .addLast(
+              new ChannelInboundHandlerAdapter() {
+                @Override
+                public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+                  ctx.close();
+                }
+              });
+      ByteBuf partial = symmetricChunk(SecurityPolicy.None, 'C', 1, 0, new byte[] {1});
+      ByteBuf abort =
+          Unpooled.buffer()
+              .writeBytes(new byte[] {'M', 'S', 'G', 'A'})
+              .writeIntLE(12)
+              .writeIntLE(1);
+      channel.writeInbound(partial);
+      channel.writeInbound(abort);
+      assertFalse(channel.isOpen(), "a header without security or sequence fields is not an Abort");
+      assertEquals(0, partial.refCnt());
+      assertEquals(0, abort.refCnt());
+    } finally {
+      channel.finishAndReleaseAll();
+    }
+  }
+
+  @Test
+  void asymmetricAbortPreservesTheFollowingOpenRequest() throws Exception {
+    var fixture = new Fixture(SecurityPolicy.None);
+    var handler =
+        new UascServerAsymmetricHandler(
+            CONFIG, fixture.application(), TransportProfile.TCP_UASC_UABINARY, ABORT_PARAMETERS);
+    EmbeddedChannel channel = new EmbeddedChannel(handler);
+    try {
+      channel.attr(UascServerHelloHandler.ENDPOINT_URL_KEY).set(ENDPOINT_URL);
+      ByteBuf partial = fixture.asymmetricChunk('C', 1, new byte[] {1, 2, 3});
+      ByteBuf abort = fixture.asymmetricChunk('A', 2, abortBody());
+      channel.writeInbound(partial);
+      channel.writeInbound(abort);
+      assertEquals(0, partial.refCnt());
+      assertEquals(0, abort.refCnt());
+      assertTrue(channel.isOpen());
+
+      ByteBuf body = Unpooled.buffer();
+      try {
+        new OpcUaBinaryEncoder(ENCODING)
+            .setBuffer(body)
+            .encodeMessage(
+                null,
+                new OpenSecureChannelRequest(
+                    requestHeader(),
+                    uint(0),
+                    SecurityTokenRequestType.Issue,
+                    MessageSecurityMode.None,
+                    ByteString.NULL_VALUE,
+                    uint(60_000)));
+        byte[] bytes = new byte[body.readableBytes()];
+        body.readBytes(bytes);
+        channel.writeInbound(fixture.asymmetricChunk('F', 3, bytes));
+      } finally {
+        body.release();
+      }
+      ByteBuf response = outbound(channel);
+      try {
+        var decoded =
+            new ChunkDecoder(PARAMETERS, EncodingLimits.DEFAULT)
+                .decodeAsymmetric(fixture.client, List.of(response));
+        try {
+          assertInstanceOf(
+              OpenSecureChannelResponse.class,
+              new OpcUaBinaryDecoder(ENCODING).setBuffer(decoded.getMessage()).decodeMessage(null));
+        } finally {
+          decoded.getMessage().release();
+        }
+      } finally {
+        if (response.refCnt() > 0) {
+          response.release();
+        }
+      }
+      assertTrue(channel.isOpen());
+    } finally {
+      channel.finishAndReleaseAll();
+    }
+  }
+
+  @Test
+  void asymmetricAbortMustHaveAValidSignature() throws Exception {
+    assertAsymmetricAbortAuthentication(true);
+  }
+
+  @Test
+  void authenticatedAsymmetricAbortsKeepTheChannelOpen() throws Exception {
+    assertAsymmetricAbortAuthentication(false);
+  }
+
+  private void assertAsymmetricAbortAuthentication(boolean tamper) throws Exception {
+    var fixture = new Fixture(SecurityPolicy.ECC_nistP256_AesGcm);
+    var handler =
+        new UascServerAsymmetricHandler(
+            CONFIG, fixture.application(), TransportProfile.TCP_UASC_UABINARY, ABORT_PARAMETERS);
+    Field field = UascServerAsymmetricHandler.class.getDeclaredField("secureChannel");
+    field.setAccessible(true);
+    field.set(handler, fixture.server);
+    EmbeddedChannel channel = new EmbeddedChannel(handler);
+    try {
+      channel.attr(UascServerHelloHandler.ENDPOINT_URL_KEY).set(ENDPOINT_URL);
+      ByteBuf partial = fixture.asymmetricChunk('C', 0, new byte[] {1, 2, 3});
+      ByteBuf abort = fixture.asymmetricChunk('A', 1, abortBody());
+      if (tamper) {
+        abort.setByte(abort.writerIndex() - 1, abort.getByte(abort.writerIndex() - 1) ^ 1);
+      }
+      channel.writeInbound(partial);
+      assertEquals(1, partial.refCnt());
+      channel.writeInbound(abort);
+      channel.advanceTimeBy(1, TimeUnit.SECONDS);
+      channel.runScheduledPendingTasks();
+      assertEquals(
+          !tamper, channel.isOpen(), "only an authenticated OPN Abort may leave the channel open");
+      assertEquals(0, partial.refCnt());
+      assertEquals(0, abort.refCnt());
+      if (!tamper) {
+        channel.writeInbound(fixture.asymmetricChunk('A', 2, abortBody()));
+        assertTrue(channel.isOpen());
+      }
+    } finally {
+      channel.finishAndReleaseAll();
+    }
+  }
+
   private static UascServiceResponse response(int textLength) {
     return new UascServiceResponse(
         new ServiceFault(
@@ -136,6 +357,73 @@ class UascChunkRecoveryTest {
       buffer.release();
     }
     throw new AssertionError("no response was sent");
+  }
+
+  private static RequestHeader requestHeader() {
+    return new RequestHeader(
+        NodeId.NULL_VALUE, DateTime.now(), uint(1), uint(0), null, uint(1000), null);
+  }
+
+  private static ByteBuf encodeRequest(ChunkEncoder encoder, ClientSecureChannel channel)
+      throws Exception {
+    ByteBuf body = Unpooled.buffer();
+    try {
+      new OpcUaBinaryEncoder(ENCODING)
+          .setBuffer(body)
+          .encodeMessage(null, new GetEndpointsRequest(requestHeader(), ENDPOINT_URL, null, null));
+      return encoder
+          .encodeSymmetric(channel, 1, body, MessageType.SecureMessage)
+          .getMessageChunks()
+          .get(0);
+    } finally {
+      body.release();
+    }
+  }
+
+  private static byte[] abortBody() {
+    return ByteBuffer.allocate(8)
+        .order(ByteOrder.LITTLE_ENDIAN)
+        .putInt((int) StatusCodes.Bad_EncodingLimitsExceeded)
+        .putInt(-1)
+        .array();
+  }
+
+  // Assemble independently because production encoders only emit C/F chunks. With a zero IV base,
+  // the GCM nonce is token id, previous sequence number, zero, all UInt32 little endian (Part 6).
+  private static ByteBuf symmetricChunk(
+      SecurityPolicy policy, char type, int sequence, int last, byte[] body) throws Exception {
+    boolean encrypted = policy != SecurityPolicy.None;
+    ByteBuf chunk = Unpooled.buffer();
+    chunk.writeBytes(new byte[] {'M', 'S', 'G', (byte) type});
+    chunk.writeIntLE(24 + body.length + (encrypted ? 16 : 0)).writeIntLE(1).writeIntLE(1);
+    byte[] plaintext =
+        ByteBuffer.allocate(8 + body.length)
+            .order(ByteOrder.LITTLE_ENDIAN)
+            .putInt(sequence)
+            .putInt(1)
+            .put(body)
+            .array();
+    if (encrypted) {
+      byte[] nonce =
+          ByteBuffer.allocate(12)
+              .order(ByteOrder.LITTLE_ENDIAN)
+              .putInt(1)
+              .putInt(last)
+              .putInt(0)
+              .array();
+      Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+      cipher.init(
+          Cipher.ENCRYPT_MODE,
+          new SecretKeySpec(new byte[16], "AES"),
+          new GCMParameterSpec(128, nonce));
+      byte[] aad = new byte[16];
+      chunk.getBytes(0, aad);
+      cipher.updateAAD(aad);
+      chunk.writeBytes(cipher.doFinal(plaintext));
+    } else {
+      chunk.writeBytes(plaintext);
+    }
+    return chunk;
   }
 
   private static void startAfterOpen(
@@ -249,6 +537,33 @@ class UascChunkRecoveryTest {
                   server));
       channel.pipeline().remove(UascServiceRequestHandler.class);
       return channel;
+    }
+
+    ByteBuf asymmetricChunk(char type, int sequence, byte[] body) throws Exception {
+      ByteBuf chunk = Unpooled.buffer();
+      chunk
+          .writeBytes(new byte[] {'O', 'P', 'N', (byte) type})
+          .writeIntLE(0)
+          .writeIntLE(policy == SecurityPolicy.None ? 0 : 1);
+      AsymmetricSecurityHeader.encode(
+          new AsymmetricSecurityHeader(
+              policy.getUri(),
+              policy == SecurityPolicy.None
+                  ? ByteString.NULL_VALUE
+                  : ByteString.of(certificate.getEncoded()),
+              policy == SecurityPolicy.None
+                  ? ByteString.NULL_VALUE
+                  : ByteString.of(DigestUtil.sha1(certificate.getEncoded()))),
+          chunk);
+      chunk.writeIntLE(sequence).writeIntLE(1).writeBytes(body);
+      chunk.setIntLE(4, chunk.writerIndex() + (policy == SecurityPolicy.None ? 0 : 64));
+      if (policy != SecurityPolicy.None) {
+        Signature signature = Signature.getInstance("SHA256withECDSAinP1363Format");
+        signature.initSign(keyPair.getPrivate());
+        signature.update(chunk.nioBuffer());
+        chunk.writeBytes(signature.sign());
+      }
+      return chunk;
     }
 
     ServerApplicationContext application() {

--- a/opc-ua-stack/transport/src/test/java/org/eclipse/milo/opcua/stack/transport/server/uasc/UascServerChunkLifecycleTest.java
+++ b/opc-ua-stack/transport/src/test/java/org/eclipse/milo/opcua/stack/transport/server/uasc/UascServerChunkLifecycleTest.java
@@ -22,6 +22,7 @@ import io.netty.channel.embedded.EmbeddedChannel;
 import io.netty.handler.codec.DecoderException;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.channel.ChannelParameters;
 import org.eclipse.milo.opcua.stack.core.channel.ChannelSecurity;
@@ -203,8 +204,8 @@ class UascServerChunkLifecycleTest {
     UascServerSymmetricHandler handler = newSymmetricHandler();
     var channel = new EmbeddedChannel(handler);
 
-    ByteBuf partialChunk = newSymmetricPartialChunk();
-    ByteBuf abortChunk = newSymmetricChunk('A');
+    ByteBuf partialChunk = newValidatedSymmetricChunk('C', 1);
+    ByteBuf abortChunk = newValidatedSymmetricChunk('A', 2);
 
     channel.writeInbound(partialChunk);
     assertEquals(1, partialChunk.refCnt());
@@ -337,6 +338,20 @@ class UascServerChunkLifecycleTest {
       SequenceHeader.encode(new SequenceHeader(1L, 1L), buffer);
     }
     buffer.setIntLE(chunkStart + 4, buffer.writerIndex() - chunkStart);
+  }
+
+  private static ByteBuf newValidatedSymmetricChunk(char chunkType, long sequence) {
+    ByteBuf buffer = PooledByteBufAllocator.DEFAULT.directBuffer();
+    buffer.writeMediumLE(MessageType.toMediumInt(MessageType.SecureMessage));
+    buffer.writeByte(chunkType).writeIntLE(0).writeIntLE(1).writeIntLE(1);
+    SequenceHeader.encode(new SequenceHeader(sequence, 1), buffer);
+    if (chunkType == 'A') {
+      buffer.writeIntLE((int) StatusCodes.Bad_EncodingLimitsExceeded).writeIntLE(-1);
+    } else {
+      buffer.writeByte(0);
+    }
+    buffer.setIntLE(4, buffer.writerIndex());
+    return buffer;
   }
 
   private static ByteBuf newSymmetricPartialChunk() {


### PR DESCRIPTION
Server handlers previously accepted the Abort chunk type before checking its security or sequence number. A forged Abort could discard an accumulating message, while a valid authenticated Abort left the following message's sequence state inconsistent.

Decode Abort chunks with the accumulated message through the existing security and sequence checks. Valid Abort processing releases the message and keeps the channel usable. A terminal Abort may follow the permitted number of intermediate chunks on both server and client paths; per-chunk size, security, and sequence checks still apply.

OPC UA Part 6 §6.7.3 states: "The receiver shall check the security on the abort MessageChunk before processing it." It also says the receiver "shall not close the SecureChannel" after a valid Abort. [Specification](https://reference.opcfoundation.org/specs/OPC-10000-6/6.7.3)

Regressions cover valid and tampered symmetric/asymmetric Abort frames, malformed headers, count-boundary handling under None and GCM, retained buffers, and the following request or response.

## Verification

Formatting and full clean compile passed. The selected regression suites passed (396 tests, no failures or errors).

```sh
mise exec -- mvn -q -pl opc-ua-stack/stack-tests,opc-ua-stack/transport,opc-ua-sdk/integration-tests -am verify '-Dtest=*Chunk*,*Uasc*,SecureChannelStrategiesTest,EccSessionIntegrationTest' -Dsurefire.failIfNoSpecifiedTests=false
```

Based on https://github.com/eclipse-milo/milo/pull/1918 so the diff contains only this fix.
