### PR TITLE
Honor the requested private-key format in the GDS test server

### DIFF
--- a/docs/features/gds-client.md
+++ b/docs/features/gds-client.md
@@ -60,7 +60,10 @@ application-side Pull workflow tests. Tests can control registration and Certifi
 access, pre-register applications, change the advertised application certificate types, delay or
 reject requests, and inspect method counters and TrustList file calls. The artifact is listed in
 `milo-bom` and is separate from `milo-sdk-client-gds` to avoid adding server dependencies to the
-runtime client module.
+runtime client module. Its new-key requests return PKCS#8 PEM or PKCS#12 PFX according to
+`PrivateKeyFormat`, encrypt the private key when `PrivateKeyPassword` is supplied, and reject
+unsupported formats with `Bad_InvalidArgument`. PFX output includes the issued certificate and
+its issuer.
 
 * * *
 

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/GdsEncodingContractsTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/gds/GdsEncodingContractsTest.java
@@ -12,9 +12,23 @@ package org.eclipse.milo.opcua.sdk.client.gds;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ubyte;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.ByteArrayInputStream;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.Signature;
 import java.util.concurrent.TimeUnit;
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
+import org.bouncycastle.openssl.jcajce.JceOpenSSLPKCS8DecryptorProviderBuilder;
+import org.bouncycastle.pkcs.PKCS8EncryptedPrivateKeyInfo;
 import org.eclipse.milo.opcua.sdk.client.gds.model.objects.AuthorizationServiceType;
 import org.eclipse.milo.opcua.sdk.client.gds.model.objects.AuthorizationServiceTypeNode;
 import org.eclipse.milo.opcua.sdk.core.AccessLevel;
@@ -25,9 +39,80 @@ import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
+import org.eclipse.milo.opcua.stack.core.util.CertificateUtil;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 class GdsEncodingContractsTest extends AbstractGdsClientTest {
+
+  // Part12 §7.9.4 defines PEM/PFX and a password. Parse the returned format and prove its key
+  // belongs to the issued certificate, including password-protected requests.
+  @ParameterizedTest
+  @CsvSource({"PEM,''", "PEM,secret", "PFX,''", "PFX,secret"})
+  void newKeyPairUsesRequestedEncodingAndPassword(String format, String password) throws Exception {
+    NodeId application = registerTestApplication();
+    NodeId request =
+        gdsClient.startNewKeyPairRequest(
+            application, null, null, "CN=Test", new String[0], format, password);
+    var issued = gdsClient.finishRequest(application, request);
+    byte[] bytes = issued.privateKey().bytesOrEmpty();
+    PrivateKey key;
+    if (format.equals("PFX")) {
+      KeyStore pfx = KeyStore.getInstance("PKCS12");
+      pfx.load(new ByteArrayInputStream(bytes), password.toCharArray());
+      String alias = pfx.aliases().nextElement();
+      key = (PrivateKey) pfx.getKey(alias, password.toCharArray());
+      assertEquals(
+          CertificateUtil.decodeCertificate(issued.certificate().bytesOrEmpty()),
+          pfx.getCertificate(alias));
+      if (!password.isEmpty()) {
+        assertThrows(
+            java.io.IOException.class,
+            () ->
+                KeyStore.getInstance("PKCS12")
+                    .load(new ByteArrayInputStream(bytes), "wrong-password".toCharArray()));
+      }
+    } else {
+      try (var parser =
+          new PEMParser(new StringReader(new String(bytes, StandardCharsets.US_ASCII)))) {
+        Object parsed = parser.readObject();
+        PrivateKeyInfo info;
+        if (password.isEmpty()) {
+          info = assertInstanceOf(PrivateKeyInfo.class, parsed);
+        } else {
+          var encrypted = assertInstanceOf(PKCS8EncryptedPrivateKeyInfo.class, parsed);
+          info =
+              encrypted.decryptPrivateKeyInfo(
+                  new JceOpenSSLPKCS8DecryptorProviderBuilder()
+                      .setProvider(new BouncyCastleProvider())
+                      .build(password.toCharArray()));
+        }
+        key = new JcaPEMKeyConverter().getPrivateKey(info);
+      }
+    }
+    var certificate = CertificateUtil.decodeCertificate(issued.certificate().bytesOrEmpty());
+    Signature signature = Signature.getInstance("SHA256withRSA");
+    signature.initSign(key);
+    signature.update(new byte[] {1, 2, 3});
+    byte[] signed = signature.sign();
+    signature.initVerify(certificate);
+    signature.update(new byte[] {1, 2, 3});
+    assertTrue(signature.verify(signed), "returned key must match the issued certificate");
+  }
+
+  // A request for an unsupported format must fail at request creation, not silently return DER.
+  @Test
+  void unsupportedPrivateKeyFormatIsRejected() throws Exception {
+    NodeId application = registerTestApplication();
+    UaException error =
+        assertThrows(
+            UaException.class,
+            () ->
+                gdsClient.startNewKeyPairRequest(
+                    application, null, null, "CN=Test", new String[0], "unsupported", null));
+    assertEquals(StatusCodes.Bad_InvalidArgument, error.getStatusCode().value());
+  }
 
   // A successful Write service can carry Bad_UserAccessDenied for its one operation. Generated
   // blocking

--- a/opc-ua-sdk/sdk-client-gds-testing/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/testing/FakeGdsNamespace.java
+++ b/opc-ua-sdk/sdk-client-gds-testing/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/testing/FakeGdsNamespace.java
@@ -15,8 +15,13 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
+import java.io.ByteArrayOutputStream;
+import java.io.StringWriter;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
+import java.security.KeyStore;
+import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.Date;
@@ -37,8 +42,14 @@ import org.bouncycastle.asn1.x509.GeneralName;
 import org.bouncycastle.asn1.x509.GeneralNames;
 import org.bouncycastle.cert.X509v3CertificateBuilder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.openssl.PKCS8Generator;
+import org.bouncycastle.openssl.jcajce.JcaPKCS8Generator;
+import org.bouncycastle.openssl.jcajce.JceOpenSSLPKCS8EncryptorBuilder;
+import org.bouncycastle.operator.OutputEncryptor;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
+import org.bouncycastle.util.io.pem.PemWriter;
 import org.eclipse.milo.opcua.sdk.client.gds.GdsClient;
 import org.eclipse.milo.opcua.sdk.core.AccessLevel;
 import org.eclipse.milo.opcua.sdk.core.Reference;
@@ -163,7 +174,11 @@ public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
   }
 
   private record SigningRequest(
-      NodeId applicationId, @Nullable PKCS10CertificationRequest csr, AtomicInteger polls) {}
+      NodeId applicationId,
+      @Nullable PKCS10CertificationRequest csr,
+      AtomicInteger polls,
+      @Nullable String privateKeyFormat,
+      @Nullable String privateKeyPassword) {}
 
   private final KeyPair caKeyPair;
   private final X509Certificate caCertificate;
@@ -853,7 +868,8 @@ public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
           }
 
           NodeId requestId = newNodeId("Requests/" + nextId.getAndIncrement());
-          requests.put(requestId, new SigningRequest(applicationId, csr, new AtomicInteger()));
+          requests.put(
+              requestId, new SigningRequest(applicationId, csr, new AtomicInteger(), null, null));
 
           return new Variant[] {Variant.ofNodeId(requestId)};
         });
@@ -879,8 +895,19 @@ public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
 
           requireApplication(applicationId);
 
+          String format = (String) inputs[5].value();
+          if (format == null || format.isEmpty()) {
+            format = "PEM";
+          }
+          if (!format.equals("PEM") && !format.equals("PFX")) {
+            throw new UaException(
+                StatusCodes.Bad_InvalidArgument, "unsupported PrivateKeyFormat: " + format);
+          }
+          String password = (String) inputs[6].value();
           NodeId requestId = newNodeId("Requests/" + nextId.getAndIncrement());
-          requests.put(requestId, new SigningRequest(applicationId, null, new AtomicInteger()));
+          requests.put(
+              requestId,
+              new SigningRequest(applicationId, null, new AtomicInteger(), format, password));
 
           return new Variant[] {Variant.ofNodeId(requestId)};
         });
@@ -937,7 +964,7 @@ public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
                           List.of(),
                           List.of(),
                           "SHA256withRSA"));
-              privateKey = ByteString.of(keyPair.getPrivate().getEncoded());
+              privateKey = encodePrivateKey(request, keyPair.getPrivate(), certificate);
             }
 
             issued
@@ -1270,6 +1297,36 @@ public class FakeGdsNamespace extends ManagedNamespaceWithLifecycle {
     }
 
     return Extensions.getInstance(attributes[0].getAttrValues().getObjectAt(0));
+  }
+
+  private ByteString encodePrivateKey(
+      SigningRequest request, PrivateKey key, X509Certificate certificate) throws Exception {
+    char[] password =
+        request.privateKeyPassword() != null
+            ? request.privateKeyPassword().toCharArray()
+            : new char[0];
+    if ("PFX".equals(request.privateKeyFormat())) {
+      KeyStore store = KeyStore.getInstance("PKCS12");
+      store.load(null, password);
+      store.setKeyEntry(
+          "application", key, password, new X509Certificate[] {certificate, caCertificate});
+      var output = new ByteArrayOutputStream();
+      store.store(output, password);
+      return ByteString.of(output.toByteArray());
+    }
+
+    OutputEncryptor encryptor =
+        password.length == 0
+            ? null
+            : new JceOpenSSLPKCS8EncryptorBuilder(PKCS8Generator.AES_256_CBC)
+                .setProvider(new BouncyCastleProvider())
+                .setPassword(password)
+                .build();
+    var output = new StringWriter();
+    try (var writer = new PemWriter(output)) {
+      writer.writeObject(new JcaPKCS8Generator(key, encryptor));
+    }
+    return ByteString.of(output.toString().getBytes(StandardCharsets.US_ASCII));
   }
 
   private X509Certificate sign(PKCS10CertificationRequest csr) throws Exception {

--- a/opc-ua-sdk/sdk-client-gds-testing/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/testing/package-info.java
+++ b/opc-ua-sdk/sdk-client-gds-testing/src/main/java/org/eclipse/milo/opcua/sdk/client/gds/testing/package-info.java
@@ -14,7 +14,9 @@
  * <p>{@link org.eclipse.milo.opcua.sdk.client.gds.testing.FakeGdsNamespace} hosts an in-memory GDS
  * namespace on an {@link org.eclipse.milo.opcua.sdk.server.OpcUaServer}. Tests can control access,
  * registration, certificate issuance, and TrustList responses, then inspect recorded calls. The
- * fixture must be started before the server and shut down during test teardown.
+ * fixture returns requested PEM or PFX private keys and applies the supplied password. Pending
+ * requests retain their key format and password until issuance or reset. The fixture must be
+ * started before the server and shut down during test teardown.
  */
 @NullMarked
 package org.eclipse.milo.opcua.sdk.client.gds.testing;


### PR DESCRIPTION
`FakeGdsNamespace` returned raw DER for a PEM private-key request and ignored the requested format and password. Pull-workflow tests could therefore accept output that a client could not decode as requested.

The fixture now returns PKCS#8 PEM or PKCS#12 PFX, applies the requested password, and rejects unsupported formats with `Bad_InvalidArgument`. PFX includes the issued certificate and its issuer.

[Part 12 §7.9.4](https://reference.opcfoundation.org/specs/OPC-10000-12/7.9.4) states: "All CertificateManager implementations shall support "PEM" and "PFX"." It also requires: "If PFX is used the packet shall include the Certificate and the PrivateKey."

Regressions parse both formats with and without passwords, verify that the returned private key matches the issued certificate, and reject an unsupported format.

Formatting, a full clean compile, and the selected regression suites passed for this branch.

Based on https://github.com/eclipse-milo/milo/pull/1919 so the diff contains only this fix.
