### PR TITLE
Release partial client responses when handlers terminate

### DIFF
--- a/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/client/uasc/UascClientMessageHandler.java
+++ b/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/client/uasc/UascClientMessageHandler.java
@@ -155,6 +155,8 @@ public class UascClientMessageHandler extends ByteToMessageCodec<UascRequest> {
 
   @Override
   public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+    releaseChunkBuffers();
+
     if (renewFuture != null) {
       renewFuture.cancel(false);
     }
@@ -174,8 +176,7 @@ public class UascClientMessageHandler extends ByteToMessageCodec<UascRequest> {
         cause.getMessage(),
         cause);
 
-    chunkBuffers.forEach(ReferenceCountUtil::safeRelease);
-    chunkBuffers.clear();
+    releaseChunkBuffers();
 
     // If the handshake hasn't completed yet this cause will be more
     // accurate than the generic "connection closed" exception that
@@ -183,6 +184,17 @@ public class UascClientMessageHandler extends ByteToMessageCodec<UascRequest> {
     handshakeFuture.completeExceptionally(cause);
 
     ctx.close();
+  }
+
+  @Override
+  public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
+    releaseChunkBuffers();
+    super.handlerRemoved(ctx);
+  }
+
+  private void releaseChunkBuffers() {
+    chunkBuffers.forEach(ReferenceCountUtil::safeRelease);
+    chunkBuffers.clear();
   }
 
   @Override

--- a/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/client/uasc/package-info.java
+++ b/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/client/uasc/package-info.java
@@ -18,7 +18,8 @@
  * decoder then validates security and sequence state and takes ownership of those buffers. An
  * authenticated Abort fails the affected request without invalidating the channel's sequence
  * stream. An Abort may follow the maximum allowed number of intermediate chunks; its size and
- * security checks still apply, and the decoder releases the accumulated message.
+ * security checks still apply, and the decoder releases the accumulated message. Disconnect,
+ * handler removal, and exception cleanup release any partial message that can no longer complete.
  *
  * <p>Channel state and buffer ownership follow the Netty event loop. The transport receives decoded
  * responses and owns their request-future completion; this package handles framing, cryptographic

--- a/opc-ua-stack/transport/src/test/java/org/eclipse/milo/opcua/stack/transport/client/uasc/UascClientChunkLifecycleTest.java
+++ b/opc-ua-stack/transport/src/test/java/org/eclipse/milo/opcua/stack/transport/client/uasc/UascClientChunkLifecycleTest.java
@@ -36,6 +36,7 @@ import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.channel.ChannelParameters;
 import org.eclipse.milo.opcua.stack.core.channel.ChannelSecurity;
 import org.eclipse.milo.opcua.stack.core.channel.ChunkDecoder;
+import org.eclipse.milo.opcua.stack.core.channel.messages.MessageType;
 import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
 import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
 import org.eclipse.milo.opcua.stack.core.encoding.binary.OpcUaBinaryEncoder;
@@ -61,8 +62,58 @@ import org.eclipse.milo.opcua.stack.transport.client.ClientApplicationContext;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
-/** Authenticated Abort responses preserve the following response at the chunk-count boundary. */
+/**
+ * Retained partial responses must be released when their owning handler can no longer finish them.
+ */
 class UascClientChunkLifecycleTest {
+
+  private static final ChannelParameters CHANNEL_PARAMETERS =
+      new ChannelParameters(65535, 65535, 8196, 0, 65535, 65535, 8196, 0);
+
+  @ParameterizedTest
+  @EnumSource(Cleanup.class)
+  void partialResponseIsReleasedAtEveryTerminationBoundary(Cleanup cleanup) throws Exception {
+    var wheelTimer = new HashedWheelTimer();
+    var channel = new EmbeddedChannel();
+    ByteBuf chunk = PooledByteBufAllocator.DEFAULT.directBuffer();
+    try {
+      var handler =
+          new UascClientMessageHandler(
+              config(wheelTimer),
+              application(),
+              new AtomicLong(1L)::getAndIncrement,
+              new CompletableFuture<>(),
+              List.of(),
+              CHANNEL_PARAMETERS);
+      channel.pipeline().addLast(handler);
+      channel.runPendingTasks();
+      Object outbound;
+      while ((outbound = channel.readOutbound()) != null) {
+        ReferenceCountUtil.release(outbound);
+      }
+
+      chunk.writeMediumLE(MessageType.toMediumInt(MessageType.SecureMessage));
+      chunk.writeByte('C').writeIntLE(112).writeIntLE(0).writeZero(100);
+      channel.writeInbound(chunk);
+      assertEquals(1, chunk.refCnt(), "the partial response must be retained before termination");
+      switch (cleanup) {
+        case CLOSE -> channel.close().syncUninterruptibly();
+        case REMOVE -> channel.pipeline().remove(handler);
+        case EXCEPTION ->
+            channel.pipeline().fireExceptionCaught(new RuntimeException("test failure"));
+      }
+      channel.runPendingTasks();
+      assertEquals(0, chunk.refCnt(), "termination must release the retained pooled response");
+      channel.close().syncUninterruptibly();
+      assertEquals(0, chunk.refCnt(), "a second cleanup boundary must not double-release");
+    } finally {
+      channel.finishAndReleaseAll();
+      if (chunk.refCnt() > 0) {
+        chunk.release();
+      }
+      wheelTimer.stop();
+    }
+  }
 
   // A response Abort may follow every permitted C chunk. It must release the message, report the
   // request failure, and preserve the authenticated stream for the next response.
@@ -206,6 +257,12 @@ class UascClientChunkLifecycleTest {
       chunk.writeBytes(plaintext);
     }
     return chunk;
+  }
+
+  private enum Cleanup {
+    CLOSE,
+    REMOVE,
+    EXCEPTION
   }
 
   static UascClientConfig config(HashedWheelTimer wheelTimer) {


### PR DESCRIPTION
The client message handler retained intermediate response chunks until message completion or an exception. Closing the channel or removing the handler could leave pooled buffers retained indefinitely.

Share idempotent cleanup across exception, channel-inactive, and handler-removal paths. The regression retains a pooled partial response, triggers each termination boundary, and checks that its reference count reaches zero without double release during later cleanup.

## Verification

Formatting and full clean compile passed. The selected regression suites passed (15 tests, no failures or errors).

```sh
mise exec -- mvn -q -pl opc-ua-stack/transport -am verify '-Dtest=UascClientChunkLifecycleTest,UascServerChunkLifecycleTest' -Dsurefire.failIfNoSpecifiedTests=false
```

Based on https://github.com/eclipse-milo/milo/pull/1920 so the diff contains only this fix.
