### PR TITLE
 Match endpoint URL schemes case-insensitively

### DIFF
--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/EndpointUtil.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/EndpointUtil.java
@@ -18,10 +18,30 @@ import org.jspecify.annotations.Nullable;
 
 public class EndpointUtil {
 
+  /**
+   * Matches an endpoint URL, capturing the scheme, host, port, and path.
+   *
+   * <p>Matched case-insensitively because URL scheme names are case-insensitive (RFC 3986, section
+   * 3.1). Only the scheme alternation is affected; the remaining groups contain no letters. The
+   * scheme is captured verbatim rather than normalized, so callers that compare it must do so
+   * case-insensitively.
+   */
   private static final Pattern ENDPOINT_URL_PATTERN =
       Pattern.compile(
-          "(opc.tcp|http|https|opc.http|opc.https|opc.ws|opc.wss)://([^:/]+|\\[.*])(:\\d+)?(/.*)?");
+          "(opc.tcp|http|https|opc.http|opc.https|opc.ws|opc.wss)://([^:/]+|\\[.*])(:\\d+)?(/.*)?",
+          Pattern.CASE_INSENSITIVE);
 
+  /**
+   * Get the scheme component from an endpoint URL.
+   *
+   * <p>The scheme is returned as it appeared in {@code endpointUrl}; it is not normalized. Since
+   * scheme names are case-insensitive, callers comparing the result against a known scheme must
+   * ignore case.
+   *
+   * @param endpointUrl the endpoint URL.
+   * @return the scheme component from the endpoint URL, or {@code null} if {@code endpointUrl} is
+   *     null or does not name a supported scheme.
+   */
   public static @Nullable String getScheme(String endpointUrl) {
     if (endpointUrl != null) {
       Matcher matcher = ENDPOINT_URL_PATTERN.matcher(endpointUrl);

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/EndpointUtil.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/EndpointUtil.java
@@ -22,9 +22,8 @@ public class EndpointUtil {
    * Matches an endpoint URL, capturing the scheme, host, port, and path.
    *
    * <p>Matched case-insensitively because URL scheme names are case-insensitive (RFC 3986, section
-   * 3.1). Only the scheme alternation is affected; the remaining groups contain no letters. The
-   * scheme is captured verbatim rather than normalized, so callers that compare it must do so
-   * case-insensitively.
+   * 3.1). Only the scheme alternatives contain literal letters, so the flag does not affect host,
+   * port, or path matching. Captured components retain their original spelling.
    */
   private static final Pattern ENDPOINT_URL_PATTERN =
       Pattern.compile(
@@ -40,7 +39,7 @@ public class EndpointUtil {
    *
    * @param endpointUrl the endpoint URL.
    * @return the scheme component from the endpoint URL, or {@code null} if {@code endpointUrl} is
-   *     null or does not name a supported scheme.
+   *     null or does not match the endpoint URL pattern.
    */
   public static @Nullable String getScheme(String endpointUrl) {
     if (endpointUrl != null) {

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/util/EndpointUtilTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/util/EndpointUtilTest.java
@@ -12,8 +12,11 @@ package org.eclipse.milo.opcua.stack.core.util;
 
 import static org.eclipse.milo.opcua.stack.core.util.EndpointUtil.updateUrl;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class EndpointUtilTest {
 
@@ -37,6 +40,67 @@ public class EndpointUtilTest {
   public void testGetPath_Invalid() {
     assertEquals(
         "/no spaces allowed", EndpointUtil.getPath("opc.tcp://localhost:4840/no spaces allowed"));
+  }
+
+  // RFC 3986 section 3.1 makes scheme names case-insensitive, and Part 6 endpoint URLs inherit
+  // that. Consumers already normalize the scheme themselves (DiscoveryClient lowercases it, the
+  // HTTPS and WebSocket transports use equalsIgnoreCase), so parsing must not reject a mixed-case
+  // scheme before they get the chance.
+  @ParameterizedTest
+  @ValueSource(strings = {"opc.tcp", "OPC.TCP", "Opc.Tcp", "opc.wss", "OPC.WSS", "https", "HTTPS"})
+  public void testMixedCaseScheme(String scheme) {
+    String endpointUrl = scheme + "://localhost:4840/foo";
+
+    assertEquals(scheme, EndpointUtil.getScheme(endpointUrl));
+    assertEquals("localhost", EndpointUtil.getHost(endpointUrl));
+    assertEquals(4840, EndpointUtil.getPort(endpointUrl));
+    assertEquals("/foo", EndpointUtil.getPath(endpointUrl));
+  }
+
+  // A server matches an incoming Hello against its configured endpoints by comparing paths
+  // (UascServerHelloHandler, UascServerAsymmetricHandler). An unmatched URL silently yields "/",
+  // which matches the wrong endpoint rather than failing loudly.
+  @Test
+  public void testGetPath_MixedCaseScheme() {
+    assertEquals("/foo", EndpointUtil.getPath("OPC.TCP://localhost:4840/foo"));
+    assertEquals("/foo", EndpointUtil.getPath("OPC.TCP://localhost:4840/foo/"));
+    assertEquals("/foo/bar", EndpointUtil.getPath("Opc.Tcp://localhost:4840/foo/bar"));
+    assertEquals("/", EndpointUtil.getPath("OPC.TCP://localhost:4840"));
+  }
+
+  // Servers behind NAT rewrite the hostname of the endpoints they advertise. A URL the parser
+  // rejects is returned unchanged, leaving the client with an unreachable address.
+  @Test
+  public void testUpdateUrlWithMixedCaseScheme() {
+    assertEquals("OPC.TCP://localhost2:4840", updateUrl("OPC.TCP://localhost:4840", "localhost2"));
+
+    assertEquals(
+        "OPC.TCP://localhost2:4840/foo", updateUrl("OPC.TCP://localhost:4840/foo", "localhost2"));
+
+    assertEquals(
+        "Opc.Tcp://localhost2:12685", updateUrl("Opc.Tcp://localhost:4840", "localhost2", 12685));
+
+    assertEquals("HTTPS://localhost2/foo", updateUrl("HTTPS://localhost/foo", "localhost2"));
+  }
+
+  @Test
+  public void testMixedCaseSchemeWithIpv6Host() {
+    String endpointUrl = "OPC.TCP://[::1]:4840/foo";
+
+    assertEquals("[::1]", EndpointUtil.getHost(endpointUrl));
+    assertEquals(4840, EndpointUtil.getPort(endpointUrl));
+    assertEquals("/foo", EndpointUtil.getPath(endpointUrl));
+    assertEquals("OPC.TCP://[2001:db8::1]:4840/foo", updateUrl(endpointUrl, "[2001:db8::1]"));
+  }
+
+  // An unrecognized scheme must still be rejected; case-insensitivity is not a license to parse
+  // anything.
+  @Test
+  public void testUnknownSchemeIsStillRejected() {
+    assertNull(EndpointUtil.getScheme("ftp://localhost:4840/foo"));
+    assertNull(EndpointUtil.getScheme("FTP://localhost:4840/foo"));
+    assertNull(EndpointUtil.getHost("FTP://localhost:4840/foo"));
+    assertEquals("/", EndpointUtil.getPath("FTP://localhost:4840/foo"));
   }
 
   @Test

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/util/EndpointUtilTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/util/EndpointUtilTest.java
@@ -42,10 +42,8 @@ public class EndpointUtilTest {
         "/no spaces allowed", EndpointUtil.getPath("opc.tcp://localhost:4840/no spaces allowed"));
   }
 
-  // RFC 3986 section 3.1 makes scheme names case-insensitive, and Part 6 endpoint URLs inherit
-  // that. Consumers already normalize the scheme themselves (DiscoveryClient lowercases it, the
-  // HTTPS and WebSocket transports use equalsIgnoreCase), so parsing must not reject a mixed-case
-  // scheme before they get the chance.
+  // RFC 3986 section 3.1 defines scheme names as case-insensitive. Parsing must accept mixed-case
+  // schemes so discovery and transport selection can recognize them.
   @ParameterizedTest
   @ValueSource(strings = {"opc.tcp", "OPC.TCP", "Opc.Tcp", "opc.wss", "OPC.WSS", "https", "HTTPS"})
   public void testMixedCaseScheme(String scheme) {
@@ -57,9 +55,8 @@ public class EndpointUtilTest {
     assertEquals("/foo", EndpointUtil.getPath(endpointUrl));
   }
 
-  // A server matches an incoming Hello against its configured endpoints by comparing paths
-  // (UascServerHelloHandler, UascServerAsymmetricHandler). An unmatched URL silently yields "/",
-  // which matches the wrong endpoint rather than failing loudly.
+  // Server endpoint selection compares paths. Falling back to "/" for a mixed-case scheme can
+  // select a root endpoint instead of the requested path.
   @Test
   public void testGetPath_MixedCaseScheme() {
     assertEquals("/foo", EndpointUtil.getPath("OPC.TCP://localhost:4840/foo"));
@@ -68,8 +65,8 @@ public class EndpointUtilTest {
     assertEquals("/", EndpointUtil.getPath("OPC.TCP://localhost:4840"));
   }
 
-  // Servers behind NAT rewrite the hostname of the endpoints they advertise. A URL the parser
-  // rejects is returned unchanged, leaving the client with an unreachable address.
+  // Hostname overrides must also work with mixed-case schemes, including when clients connect
+  // through NAT and the advertised hostname is unreachable.
   @Test
   public void testUpdateUrlWithMixedCaseScheme() {
     assertEquals("OPC.TCP://localhost2:4840", updateUrl("OPC.TCP://localhost:4840", "localhost2"));
@@ -93,8 +90,7 @@ public class EndpointUtilTest {
     assertEquals("OPC.TCP://[2001:db8::1]:4840/foo", updateUrl(endpointUrl, "[2001:db8::1]"));
   }
 
-  // An unrecognized scheme must still be rejected; case-insensitivity is not a license to parse
-  // anything.
+  // Unsupported schemes such as FTP must remain rejected regardless of case.
   @Test
   public void testUnknownSchemeIsStillRejected() {
     assertNull(EndpointUtil.getScheme("ftp://localhost:4840/foo"));


### PR DESCRIPTION
Endpoint URLs with uppercase or mixed-case schemes fail to parse in `EndpointUtil`. For example, `OpcUaClient.create("OPC.TCP://plc:4840")` fails during discovery with `unsupported protocol: null`. Path extraction falls back to `/`, and hostname rewriting returns the original URL unchanged.

Compile the endpoint URL pattern with `Pattern.CASE_INSENSITIVE` to accept equivalent scheme spellings as described in [RFC 3986 §3.1](https://www.rfc-editor.org/rfc/rfc3986.html#section-3.1). `DiscoveryClient` already lowercases the parsed scheme for dispatch, and the HTTPS and WebSocket transports use case-insensitive comparisons.

Only the scheme alternatives contain literal letters, so the flag does not affect host, port, or path matching. Captured components retain their original spelling, including the scheme returned by `getScheme()`.

`EndpointUtilTest` covers mixed-case schemes across the accessors, path handling, hostname and port rewriting, IPv6 hosts, and continued rejection of `ftp` and `FTP`.

Verification passed with `mise exec -- mvn -q spotless:apply`, `mise exec -- mvn -q clean compile`, and `mise exec -- mvn -q -pl opc-ua-stack/stack-core -am test -Dtest=EndpointUtilTest -Dsurefire.failIfNoSpecifiedTests=false`.
