### PR TITLE
Merge main into integration/1.2

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/OperationLimitsTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/OperationLimitsTest.java
@@ -10,24 +10,51 @@
 
 package org.eclipse.milo.opcua.sdk.client;
 
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
 import org.eclipse.milo.opcua.sdk.test.AbstractClientServerTest;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UShort;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.TimestampsToReturn;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 public class OperationLimitsTest extends AbstractClientServerTest {
+
+  private static final List<NodeId> OPERATION_LIMIT_NODES =
+      List.of(
+          NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerRead,
+          NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerWrite,
+          NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerMethodCall,
+          NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerBrowse,
+          NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerRegisterNodes,
+          NodeIds
+              .Server_ServerCapabilities_OperationLimits_MaxNodesPerTranslateBrowsePathsToNodeIds,
+          NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerNodeManagement,
+          NodeIds.Server_ServerCapabilities_OperationLimits_MaxMonitoredItemsPerCall,
+          NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerHistoryReadData,
+          NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerHistoryReadEvents,
+          NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerHistoryUpdateData,
+          NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerHistoryUpdateEvents);
 
   @Test
   void readOperationLimits() throws UaException {
@@ -117,5 +144,142 @@ public class OperationLimitsTest extends AbstractClientServerTest {
 
     assertTrue(operationLimits.maxNodesPerHistoryUpdateEvents().isPresent());
     assertEquals(1200, operationLimits.maxNodesPerHistoryUpdateEvents().get().intValue());
+  }
+
+  // A server may enforce a hidden Read limit of one, while every OperationLimits property remains
+  // individually readable. Discovery must preserve the declared property mapping in this case.
+  @Test
+  void bulkTooManyOperationsReadsEveryLimitIndividuallyInPropertyOrder() throws UaException {
+    OpcUaClient mockClient = mock(OpcUaClient.class);
+    List<DataValue> values = operationLimitValues();
+
+    when(mockClient.readValues(anyDouble(), any(), anyList()))
+        .thenThrow(new UaException(StatusCodes.Bad_TooManyOperations));
+    when(mockClient.readValue(anyDouble(), any(), any(NodeId.class)))
+        .thenAnswer(
+            invocation -> {
+              NodeId nodeId = invocation.getArgument(2);
+              return values.get(OPERATION_LIMIT_NODES.indexOf(nodeId));
+            });
+
+    OperationLimits operationLimits = OperationLimits.read(mockClient);
+
+    assertEquals(
+        List.of(
+            uint(1), uint(2), uint(3), uint(4), uint(5), uint(6), uint(7), uint(8), uint(9),
+            uint(10), uint(11), uint(12)),
+        presentValues(operationLimits));
+
+    ArgumentCaptor<NodeId> nodeIds = ArgumentCaptor.forClass(NodeId.class);
+    verify(mockClient, times(OPERATION_LIMIT_NODES.size()))
+        .readValue(eq(0.0), eq(TimestampsToReturn.Neither), nodeIds.capture());
+    assertEquals(OPERATION_LIMIT_NODES, nodeIds.getAllValues());
+  }
+
+  // Only Bad_TooManyOperations says that reducing the number of operations can make the same
+  // request safe to replay. Other service failures must remain visible to the caller.
+  @Test
+  void nonTooManyBulkServiceFailurePropagatesWithoutSingletonReads() throws UaException {
+    OpcUaClient mockClient = mock(OpcUaClient.class);
+    when(mockClient.readValues(anyDouble(), any(), anyList()))
+        .thenThrow(new UaException(StatusCodes.Bad_Timeout));
+
+    UaException exception = assertThrows(UaException.class, () -> OperationLimits.read(mockClient));
+
+    assertEquals(StatusCodes.Bad_Timeout, exception.getStatusCode().value());
+    verify(mockClient, never()).readValue(anyDouble(), any(), any(NodeId.class));
+  }
+
+  // A singleton service failure does not prove that an optional node is absent. Propagating it
+  // leaves the lazy cache retryable instead of caching a partial set of limits.
+  @Test
+  void singletonServiceFailureAbortsDiscovery() throws UaException {
+    OpcUaClient mockClient = mock(OpcUaClient.class);
+    when(mockClient.readValues(anyDouble(), any(), anyList()))
+        .thenThrow(new UaException(StatusCodes.Bad_TooManyOperations));
+    when(mockClient.readValue(anyDouble(), any(), any(NodeId.class)))
+        .thenReturn(operationLimitValues().get(0))
+        .thenThrow(new UaException(StatusCodes.Bad_Timeout));
+
+    UaException exception = assertThrows(UaException.class, () -> OperationLimits.read(mockClient));
+
+    assertEquals(StatusCodes.Bad_Timeout, exception.getStatusCode().value());
+    verify(mockClient, times(2)).readValue(anyDouble(), any(), any(NodeId.class));
+  }
+
+  // Optional OperationLimits nodes report absence through per-operation data, so bad and null
+  // singleton values must not turn an otherwise valid discovery into a service failure.
+  @Test
+  void badAndNullSingletonValuesRemainAbsent() throws UaException {
+    OpcUaClient mockClient = mock(OpcUaClient.class);
+    List<DataValue> values = operationLimitValues();
+
+    when(mockClient.readValues(anyDouble(), any(), anyList()))
+        .thenThrow(new UaException(StatusCodes.Bad_TooManyOperations));
+    when(mockClient.readValue(anyDouble(), any(), any(NodeId.class)))
+        .thenAnswer(
+            invocation -> {
+              NodeId nodeId = invocation.getArgument(2);
+              int index = OPERATION_LIMIT_NODES.indexOf(nodeId);
+              return switch (index) {
+                case 0 -> new DataValue(StatusCodes.Bad_NodeIdUnknown);
+                case 1 -> null;
+                default -> values.get(index);
+              };
+            });
+
+    OperationLimits operationLimits = OperationLimits.read(mockClient);
+
+    assertTrue(operationLimits.maxNodesPerRead().isEmpty());
+    assertTrue(operationLimits.maxNodesPerWrite().isEmpty());
+    assertEquals(uint(3), operationLimits.maxNodesPerMethodCall().orElseThrow());
+    verify(mockClient, times(OPERATION_LIMIT_NODES.size()))
+        .readValue(anyDouble(), any(), any(NodeId.class));
+  }
+
+  // A successful service response with the wrong number of per-operation results is malformed and
+  // must fail deterministically before any property is indexed or a fallback is attempted.
+  @Test
+  void bulkResponseWithWrongResultCountThrowsBadUnexpectedError() throws UaException {
+    OpcUaClient mockClient = mock(OpcUaClient.class);
+    when(mockClient.readValues(anyDouble(), any(), anyList()))
+        .thenReturn(operationLimitValues().subList(0, OPERATION_LIMIT_NODES.size() - 1));
+
+    UaException exception = assertThrows(UaException.class, () -> OperationLimits.read(mockClient));
+
+    assertEquals(StatusCodes.Bad_UnexpectedError, exception.getStatusCode().value());
+    verify(mockClient, never()).readValue(anyDouble(), any(), any(NodeId.class));
+  }
+
+  private static List<DataValue> operationLimitValues() {
+    return List.of(
+        new DataValue(new Variant(uint(1))),
+        new DataValue(new Variant(uint(2))),
+        new DataValue(new Variant(uint(3))),
+        new DataValue(new Variant(uint(4))),
+        new DataValue(new Variant(uint(5))),
+        new DataValue(new Variant(uint(6))),
+        new DataValue(new Variant(uint(7))),
+        new DataValue(new Variant(uint(8))),
+        new DataValue(new Variant(uint(9))),
+        new DataValue(new Variant(uint(10))),
+        new DataValue(new Variant(uint(11))),
+        new DataValue(new Variant(uint(12))));
+  }
+
+  private static List<UInteger> presentValues(OperationLimits limits) {
+    return List.of(
+        limits.maxNodesPerRead().orElseThrow(),
+        limits.maxNodesPerWrite().orElseThrow(),
+        limits.maxNodesPerMethodCall().orElseThrow(),
+        limits.maxNodesPerBrowse().orElseThrow(),
+        limits.maxNodesPerRegisterNodes().orElseThrow(),
+        limits.maxNodesPerTranslateBrowsePathsToNodeIds().orElseThrow(),
+        limits.maxNodesPerNodeManagement().orElseThrow(),
+        limits.maxMonitoredItemsPerCall().orElseThrow(),
+        limits.maxNodesPerHistoryReadData().orElseThrow(),
+        limits.maxNodesPerHistoryReadEvents().orElseThrow(),
+        limits.maxNodesPerHistoryUpdateData().orElseThrow(),
+        limits.maxNodesPerHistoryUpdateEvents().orElseThrow());
   }
 }

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/SessionInitializerOperationLimitTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/SessionInitializerOperationLimitTest.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import org.eclipse.milo.opcua.sdk.server.EndpointConfig;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaVariableNode;
+import org.eclipse.milo.opcua.sdk.server.servicesets.AttributeServiceSet;
+import org.eclipse.milo.opcua.sdk.server.servicesets.impl.DefaultAttributeServiceSet;
+import org.eclipse.milo.opcua.sdk.test.TestClient;
+import org.eclipse.milo.opcua.sdk.test.TestServer;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.structured.HistoryReadRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.HistoryReadResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.HistoryUpdateRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.HistoryUpdateResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.ReadRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.ReadResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.ReadValueId;
+import org.eclipse.milo.opcua.stack.core.types.structured.WriteRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.WriteResponse;
+import org.eclipse.milo.opcua.stack.transport.server.ServiceRequestContext;
+import org.junit.jupiter.api.Test;
+
+class SessionInitializerOperationLimitTest {
+
+  private static final long AWAIT_TIMEOUT_SECONDS = 10;
+
+  private static final List<NodeId> TABLE_NODES =
+      List.of(NodeIds.Server_NamespaceArray, NodeIds.Server_ServerArray);
+
+  // NamespaceArray and ServerArray are independent values. A server whose hidden Read limit is
+  // one must still populate both client tables after rejecting the optimistic two-node request.
+  @Test
+  void tooManyOperationsRetriesNamespaceAndServerArraysIndividually() throws Exception {
+    try (Fixture fixture = new Fixture(StatusCodes.Bad_TooManyOperations)) {
+      assertArrayEquals(
+          fixture.server.getNamespaceTable().toArray(),
+          fixture.client.getNamespaceTable().toArray());
+      assertArrayEquals(
+          fixture.server.getServerTable().toArray(), fixture.client.getServerTable().toArray());
+
+      assertEquals(TABLE_NODES, fixture.attributeServiceSet.tableReads.get(0));
+      assertEquals(
+          1, fixture.attributeServiceSet.countReadsOf(List.of(NodeIds.Server_NamespaceArray)));
+      assertEquals(
+          1, fixture.attributeServiceSet.countReadsOf(List.of(NodeIds.Server_ServerArray)));
+      assertEquals(3, fixture.attributeServiceSet.tableReads.size());
+    }
+  }
+
+  // A failure unrelated to request cardinality gives no assurance that replaying the Read is safe.
+  // The best-effort initializer must leave it alone and let session establishment continue.
+  @Test
+  void nonTooManyOperationsFailureDoesNotRetryTableReads() throws Exception {
+    try (Fixture fixture = new Fixture(StatusCodes.Bad_Timeout)) {
+      assertEquals(List.of(TABLE_NODES), fixture.attributeServiceSet.tableReads);
+    }
+  }
+
+  // The two fallback Reads are independent. Failure to read one optional local table must not
+  // discard the other table's successful result or fail session establishment.
+  @Test
+  void oneFailedSingletonDoesNotDiscardTheOtherTable() throws Exception {
+    try (Fixture fixture =
+        new Fixture(StatusCodes.Bad_TooManyOperations, NodeIds.Server_ServerArray)) {
+
+      assertArrayEquals(
+          fixture.server.getNamespaceTable().toArray(),
+          fixture.client.getNamespaceTable().toArray());
+      assertArrayEquals(new String[0], fixture.client.getServerTable().toArray());
+      assertEquals(3, fixture.attributeServiceSet.tableReads.size());
+    }
+  }
+
+  // OperationLimits describe the active server Session. Reusing the previous Session's lazy value
+  // after a reconnect can make every SDK-owned partition use a stale limit.
+  @Test
+  void newSessionInvalidatesCachedOperationLimits() throws Exception {
+    try (Fixture fixture = new Fixture(StatusCodes.Good)) {
+      OperationLimits initialLimits = fixture.client.getOperationLimits();
+      assertEquals(uint(10_000), initialLimits.maxNodesPerRead().orElseThrow());
+
+      UaVariableNode maxNodesPerRead =
+          (UaVariableNode)
+              fixture
+                  .server
+                  .getAddressSpaceManager()
+                  .getManagedNode(NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerRead)
+                  .orElseThrow();
+      maxNodesPerRead.setValue(new DataValue(new Variant(uint(17))));
+
+      assertEquals(
+          uint(10_000),
+          fixture.client.getOperationLimits().maxNodesPerRead().orElseThrow(),
+          "precondition: the first Session's OperationLimits were not cached");
+
+      fixture.client.disconnect();
+      fixture.client.connect();
+
+      assertEquals(uint(17), fixture.client.getOperationLimits().maxNodesPerRead().orElseThrow());
+    }
+  }
+
+  private static final class Fixture implements AutoCloseable {
+
+    final OpcUaServer server;
+    final OpcUaClient client;
+    final TableReadAttributeServiceSet attributeServiceSet;
+
+    Fixture(long bootstrapFailure) throws Exception {
+      this(bootstrapFailure, NodeId.NULL_VALUE);
+    }
+
+    Fixture(long bootstrapFailure, NodeId singletonFailureNode) throws Exception {
+      server = TestServer.create().getServer();
+      attributeServiceSet =
+          new TableReadAttributeServiceSet(server, bootstrapFailure, singletonFailureNode);
+
+      for (EndpointConfig endpoint : server.getConfig().getEndpoints()) {
+        server.addServiceSet(endpoint.getPath(), attributeServiceSet);
+      }
+
+      server.startup().get(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+      client =
+          TestClient.create(
+              server, config -> config.setKeepAliveInterval(uint(TimeUnit.MINUTES.toMillis(1))));
+      client.connect();
+    }
+
+    @Override
+    public void close() throws Exception {
+      try {
+        client.disconnectAsync().get(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+      } finally {
+        server.shutdown().get(AWAIT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+      }
+    }
+  }
+
+  /** Records table Reads and scripts the service result of the optimistic two-node request. */
+  private static final class TableReadAttributeServiceSet implements AttributeServiceSet {
+
+    private final AttributeServiceSet delegate;
+    private final long bootstrapFailure;
+    private final NodeId singletonFailureNode;
+
+    final List<List<NodeId>> tableReads = new CopyOnWriteArrayList<>();
+
+    TableReadAttributeServiceSet(
+        OpcUaServer server, long bootstrapFailure, NodeId singletonFailureNode) {
+      this.delegate = new DefaultAttributeServiceSet(Objects.requireNonNull(server, "server"));
+      this.bootstrapFailure = bootstrapFailure;
+      this.singletonFailureNode = singletonFailureNode;
+    }
+
+    @Override
+    public ReadResponse onRead(ServiceRequestContext context, ReadRequest request)
+        throws UaException {
+
+      List<NodeId> nodeIds = tableNodeIds(request);
+      if (!nodeIds.isEmpty()) {
+        tableReads.add(nodeIds);
+
+        if (nodeIds.equals(TABLE_NODES) && bootstrapFailure != StatusCodes.Good) {
+          throw new UaException(bootstrapFailure);
+        }
+        if (nodeIds.equals(List.of(singletonFailureNode))) {
+          throw new UaException(StatusCodes.Bad_Timeout);
+        }
+      }
+
+      return delegate.onRead(context, request);
+    }
+
+    @Override
+    public HistoryReadResponse onHistoryRead(
+        ServiceRequestContext context, HistoryReadRequest request) throws UaException {
+      return delegate.onHistoryRead(context, request);
+    }
+
+    @Override
+    public WriteResponse onWrite(ServiceRequestContext context, WriteRequest request)
+        throws UaException {
+      return delegate.onWrite(context, request);
+    }
+
+    @Override
+    public HistoryUpdateResponse onHistoryUpdate(
+        ServiceRequestContext context, HistoryUpdateRequest request) throws UaException {
+      return delegate.onHistoryUpdate(context, request);
+    }
+
+    int countReadsOf(List<NodeId> expected) {
+      return (int) tableReads.stream().filter(expected::equals).count();
+    }
+
+    private static List<NodeId> tableNodeIds(ReadRequest request) {
+      ReadValueId[] nodesToRead = request.getNodesToRead();
+      if (nodesToRead == null || nodesToRead.length == 0) {
+        return List.of();
+      }
+
+      List<NodeId> nodeIds = Arrays.stream(nodesToRead).map(ReadValueId::getNodeId).toList();
+
+      return nodeIds.stream().allMatch(TABLE_NODES::contains) ? nodeIds : List.of();
+    }
+  }
+}

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/session/SessionActivityOrderingTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/session/SessionActivityOrderingTest.java
@@ -1,0 +1,271 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.session;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ubyte;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import com.digitalpetri.fsm.Fsm;
+import io.netty.util.HashedWheelTimer;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClientConfig;
+import org.eclipse.milo.opcua.sdk.client.SessionActivityListener;
+import org.eclipse.milo.opcua.sdk.client.UaSession;
+import org.eclipse.milo.opcua.sdk.client.subscriptions.OpcUaSubscription;
+import org.eclipse.milo.opcua.sdk.client.subscriptions.PublishingManager;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
+import org.eclipse.milo.opcua.stack.core.types.UaRequestMessageType;
+import org.eclipse.milo.opcua.stack.core.types.UaResponseMessageType;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.ApplicationType;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.MessageSecurityMode;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.UserTokenType;
+import org.eclipse.milo.opcua.stack.core.types.structured.ActivateSessionRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.ActivateSessionResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.ApplicationDescription;
+import org.eclipse.milo.opcua.stack.core.types.structured.CloseSessionRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.CloseSessionResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.CreateSessionRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.CreateSessionResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.CreateSubscriptionRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.CreateSubscriptionResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
+import org.eclipse.milo.opcua.stack.core.types.structured.PublishRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.ReadRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.ReadResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.ResponseHeader;
+import org.eclipse.milo.opcua.stack.core.types.structured.SignatureData;
+import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
+import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.transport.client.ClientApplicationContext;
+import org.eclipse.milo.opcua.stack.transport.client.OpcClientTransport;
+import org.eclipse.milo.opcua.stack.transport.client.OpcClientTransportConfig;
+import org.eclipse.milo.opcua.stack.transport.client.tcp.OpcTcpClientTransportConfig;
+import org.junit.jupiter.api.Test;
+
+/** Session listener ordering across reactivation of the same Session object. */
+class SessionActivityOrderingTest {
+  private static class QueueExecutor extends AbstractExecutorService {
+    public void shutdown() {}
+
+    public List<Runnable> shutdownNow() {
+      return List.of();
+    }
+
+    public boolean isShutdown() {
+      return false;
+    }
+
+    public boolean isTerminated() {
+      return false;
+    }
+
+    public boolean awaitTermination(long timeout, TimeUnit unit) {
+      return false;
+    }
+
+    final Deque<Runnable> q = new ArrayDeque<>();
+
+    public void execute(Runnable r) {
+      q.addLast(r);
+    }
+
+    void drain() {
+      int count = 0;
+      while (!q.isEmpty()) {
+        if (++count > 1000) throw new AssertionError("loop");
+        q.removeFirst().run();
+      }
+    }
+  }
+
+  private static class Transport implements OpcClientTransport {
+    final QueueExecutor executor = new QueueExecutor();
+    final HashedWheelTimer timer = new HashedWheelTimer();
+    final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+    final OpcClientTransportConfig config =
+        OpcTcpClientTransportConfig.newBuilder()
+            .setExecutor(executor)
+            .setWheelTimer(timer)
+            .setScheduledExecutor(scheduler)
+            .build();
+    int publishes;
+
+    public OpcClientTransportConfig getConfig() {
+      return config;
+    }
+
+    public CompletableFuture<Unit> connect(ClientApplicationContext context) {
+      return CompletableFuture.completedFuture(Unit.VALUE);
+    }
+
+    public CompletableFuture<Unit> disconnect() {
+      return CompletableFuture.completedFuture(Unit.VALUE);
+    }
+
+    public CompletableFuture<UaResponseMessageType> sendRequestMessage(UaRequestMessageType req) {
+      ResponseHeader h =
+          new ResponseHeader(
+              DateTime.now(),
+              req.getRequestHeader().getRequestHandle(),
+              StatusCode.GOOD,
+              null,
+              null,
+              null);
+      UaResponseMessageType resp;
+      if (req instanceof CreateSessionRequest)
+        resp =
+            new CreateSessionResponse(
+                h,
+                new NodeId(1, 1),
+                new NodeId(1, 2),
+                120000.0,
+                ByteString.NULL_VALUE,
+                ByteString.NULL_VALUE,
+                null,
+                null,
+                new SignatureData(null, null),
+                uint(0));
+      else if (req instanceof ActivateSessionRequest)
+        resp = new ActivateSessionResponse(h, ByteString.NULL_VALUE, null, null);
+      else if (req instanceof ReadRequest)
+        resp =
+            new ReadResponse(
+                h,
+                new DataValue[] {
+                  new DataValue(new Variant(new String[] {"http://opcfoundation.org/UA/"})),
+                  new DataValue(new Variant(new String[] {"urn:test:server"}))
+                },
+                null);
+      else if (req instanceof CreateSubscriptionRequest)
+        resp = new CreateSubscriptionResponse(h, uint(1), 1000.0, uint(50), uint(10));
+      else if (req instanceof PublishRequest) {
+        publishes++;
+        return new CompletableFuture<>();
+      } else if (req instanceof CloseSessionRequest) resp = new CloseSessionResponse(h);
+      else throw new AssertionError(req.getClass());
+      return CompletableFuture.completedFuture(resp);
+    }
+  }
+
+  private static EndpointDescription endpoint() {
+    var app =
+        new ApplicationDescription(
+            "urn:test:server",
+            "urn:test",
+            LocalizedText.english("test"),
+            ApplicationType.Server,
+            null,
+            null,
+            null);
+    return new EndpointDescription(
+        "opc.tcp://localhost:12685",
+        app,
+        ByteString.NULL_VALUE,
+        MessageSecurityMode.None,
+        SecurityPolicy.None.getUri(),
+        new UserTokenPolicy[] {
+          new UserTokenPolicy("anon", UserTokenType.Anonymous, null, null, null)
+        },
+        org.eclipse.milo.opcua.stack.core.Stack.TCP_UASC_UABINARY_TRANSPORT_URI,
+        ubyte(0));
+  }
+
+  @Test
+  void delayedInactiveNotificationCannotOvertakeReactivation() throws Exception {
+    var transport = new Transport();
+    try {
+      var client =
+          new OpcUaClient(
+              OpcUaClientConfig.builder()
+                  .setEndpoint(endpoint())
+                  .setDiscoveryEndpoints(List.of())
+                  .setKeepAliveInterval(uint(1000000))
+                  .build(),
+              transport);
+      var notifications = new ArrayList<String>();
+      client.addSessionActivityListener(
+          new SessionActivityListener() {
+            @Override
+            public void onSessionActive(UaSession session) {
+              notifications.add("active");
+            }
+
+            @Override
+            public void onSessionInactive(UaSession session) {
+              notifications.add("inactive");
+            }
+          });
+      var connected = client.connectAsync();
+      transport.executor.drain();
+      if (!connected.isDone() || connected.isCompletedExceptionally())
+        throw new AssertionError("connect failed");
+      var sf = client.getSessionFsm();
+      Field f = SessionFsm.class.getDeclaredField("fsm");
+      f.setAccessible(true);
+      @SuppressWarnings("unchecked")
+      Fsm<State, Event> fsm = (Fsm<State, Event>) f.get(sf);
+      var pm = client.getPublishingManager();
+      Method suspended = PublishingManager.class.getDeclaredMethod("isPublishingSuspended");
+      suspended.setAccessible(true);
+      if ((boolean) suspended.invoke(pm)) throw new AssertionError("initial gate shut");
+      var session = sf.getSession().join();
+      // Run the FSM's inactive transition while deferring the separate listener-dispatch runnable.
+      fsm.fireEvent(new Event.ServiceFault(new StatusCode(StatusCodes.Bad_SessionIdInvalid)));
+      while (sf.getState() != State.ReactivatingWait) transport.executor.q.removeFirst().run();
+      if (transport.executor.q.size() != 1)
+        throw new AssertionError("unexpected queued tasks " + transport.executor.q.size());
+      Runnable delayedInactive = transport.executor.q.removeFirst();
+
+      // The FSM executor continues on another worker while its inactive callback is delayed.
+      fsm.fireEvent(new Event.ReactivatingWaitExpired());
+      transport.executor.drain();
+      if (sf.getState() != State.Active || sf.getSession().join() != session)
+        throw new AssertionError("reactivation failed");
+      delayedInactive.run();
+      transport.executor.drain();
+      assertFalse(
+          (boolean) suspended.invoke(pm),
+          "an inactive callback from before reactivation must not leave publishing suspended");
+      var subscription = new OpcUaSubscription(client);
+      var created = subscription.createAsync().toCompletableFuture();
+      transport.executor.drain();
+      if (!created.isDone() || created.isCompletedExceptionally())
+        throw new AssertionError("subscription failed");
+      assertEquals(List.of("active", "inactive", "active"), notifications);
+      assertEquals(
+          2, transport.publishes, "the recovered Session must resume its Publish pipeline");
+    } finally {
+      transport.scheduler.shutdownNow();
+      transport.timer.stop();
+    }
+  }
+}

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/MonitoredItemOperationLimitFallbackTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/MonitoredItemOperationLimitFallbackTest.java
@@ -1,0 +1,677 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.subscriptions;
+
+import static java.util.Objects.requireNonNull;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.server.EndpointConfig;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.sdk.test.DelegatingMonitoredItemServiceSet;
+import org.eclipse.milo.opcua.sdk.test.TestClient;
+import org.eclipse.milo.opcua.sdk.test.TestServer;
+import org.eclipse.milo.opcua.stack.core.AttributeId;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.MonitoringMode;
+import org.eclipse.milo.opcua.stack.core.types.structured.CreateMonitoredItemsRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.CreateMonitoredItemsResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.DeleteMonitoredItemsRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.DeleteMonitoredItemsResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.ModifyMonitoredItemsRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.ModifyMonitoredItemsResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.ReadValueId;
+import org.eclipse.milo.opcua.stack.core.types.structured.SetMonitoringModeRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.SetMonitoringModeResponse;
+import org.eclipse.milo.opcua.stack.transport.server.ServiceRequestContext;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies recovery when a Server enforces a lower MaxMonitoredItemsPerCall than it advertises.
+ *
+ * <p>The service set records the actual wire operations and delegates accepted singleton requests
+ * to the real Server. This lets each test verify both the retry shape and the client-side state
+ * produced by successful responses.
+ */
+public class MonitoredItemOperationLimitFallbackTest {
+
+  /**
+   * A rejected Create partition must be replayed in order, and the learned singleton limit must
+   * immediately apply to every monitored-item service owned by the Subscription.
+   */
+  @Test
+  void createFallbackPreservesOrderAndTheLearnedLimitIsShared() throws Exception {
+    try (var fixture = new Fixture()) {
+      var subscription = new OpcUaSubscription(fixture.client);
+      subscription.setMaxMonitoredItemsPerCall(uint(2));
+      subscription.create();
+
+      try {
+        addItems(subscription, 5);
+
+        List<MonitoredItemServiceOperationResult> createResults =
+            subscription.createMonitoredItems();
+
+        assertGood(createResults, 5);
+        assertEquals(
+            List.of(2, 1, 1, 1, 1, 1),
+            fixture.serviceSet.requestSizes(Operation.CREATE),
+            "the failed pair must be retried as singletons and all later work must stay singleton");
+
+        List<UInteger> createOrder =
+            fixture.serviceSet.requests(Operation.CREATE).stream()
+                .skip(1)
+                .flatMap(List::stream)
+                .toList();
+        assertEquals(
+            createOrder,
+            createResults.stream()
+                .map(result -> result.monitoredItem().getClientHandle().orElseThrow())
+                .toList(),
+            "the result list must retain the wire-operation order after the retry");
+
+        List<OpcUaMonitoredItem> items =
+            createResults.stream().map(MonitoredItemServiceOperationResult::monitoredItem).toList();
+
+        fixture.serviceSet.clearRequests();
+        for (int i = 0; i < items.size(); i++) {
+          items.get(i).setSamplingInterval(100.0 + i);
+        }
+
+        List<MonitoredItemServiceOperationResult> modifyResults =
+            subscription.modifyMonitoredItems();
+
+        assertGood(modifyResults, 5);
+        assertEquals(
+            List.of(1, 1, 1, 1, 1),
+            fixture.serviceSet.requestSizes(Operation.MODIFY),
+            "Modify must immediately reuse the limit learned by Create");
+        assertEquals(
+            fixture.serviceSet.requests(Operation.MODIFY).stream().flatMap(List::stream).toList(),
+            monitoredItemIds(modifyResults));
+
+        fixture.serviceSet.clearRequests();
+        List<MonitoredItemServiceOperationResult> modeResults =
+            subscription.setMonitoringMode(MonitoringMode.Disabled, items);
+
+        assertGood(modeResults, 5);
+        assertEquals(
+            List.of(1, 1, 1, 1, 1),
+            fixture.serviceSet.requestSizes(Operation.SET_MONITORING_MODE),
+            "SetMonitoringMode must immediately reuse the limit learned by Create");
+        assertEquals(items, resultItems(modeResults));
+
+        Map<UInteger, OpcUaMonitoredItem> itemsById = itemsByMonitoredItemId(items);
+        fixture.serviceSet.clearRequests();
+        subscription.removeMonitoredItems(items);
+
+        List<MonitoredItemServiceOperationResult> deleteResults =
+            subscription.deleteMonitoredItems();
+
+        assertGood(deleteResults, 5);
+        assertEquals(
+            List.of(1, 1, 1, 1, 1),
+            fixture.serviceSet.requestSizes(Operation.DELETE),
+            "Delete must immediately reuse the limit learned by Create");
+        assertEquals(
+            fixture.serviceSet.requests(Operation.DELETE).stream()
+                .flatMap(List::stream)
+                .map(itemsById::get)
+                .toList(),
+            resultItems(deleteResults),
+            "Delete results must retain request order even though successful deletion clears ids");
+      } finally {
+        subscription.delete();
+      }
+    }
+  }
+
+  // A subscription may first encounter the hidden limit while modifying existing items.
+  @Test
+  void modifyIndependentlyFallsBackToSingletonRequests() throws Exception {
+    try (var fixture = new Fixture()) {
+      var subscription = new OpcUaSubscription(fixture.client);
+      subscription.create();
+
+      try {
+        List<OpcUaMonitoredItem> items = prepareCreatedItems(subscription, 3);
+        for (int i = 0; i < items.size(); i++) {
+          items.get(i).setSamplingInterval(200.0 + i);
+        }
+        fixture.serviceSet.clearRequests();
+
+        List<MonitoredItemServiceOperationResult> results = subscription.modifyMonitoredItems();
+
+        assertGood(results, 3);
+        assertEquals(List.of(2, 1, 1, 1), fixture.serviceSet.requestSizes(Operation.MODIFY));
+        assertEquals(
+            fixture.serviceSet.requests(Operation.MODIFY).stream()
+                .skip(1)
+                .flatMap(List::stream)
+                .toList(),
+            monitoredItemIds(results));
+      } finally {
+        subscription.delete();
+      }
+    }
+  }
+
+  // A subscription may first encounter the hidden limit while deleting existing items.
+  @Test
+  void deleteIndependentlyFallsBackToSingletonRequests() throws Exception {
+    try (var fixture = new Fixture()) {
+      var subscription = new OpcUaSubscription(fixture.client);
+      subscription.create();
+
+      try {
+        List<OpcUaMonitoredItem> items = prepareCreatedItems(subscription, 3);
+        Map<UInteger, OpcUaMonitoredItem> itemsById = itemsByMonitoredItemId(items);
+        subscription.removeMonitoredItems(items);
+        fixture.serviceSet.clearRequests();
+
+        List<MonitoredItemServiceOperationResult> results = subscription.deleteMonitoredItems();
+
+        assertGood(results, 3);
+        assertEquals(List.of(2, 1, 1, 1), fixture.serviceSet.requestSizes(Operation.DELETE));
+        assertEquals(
+            fixture.serviceSet.requests(Operation.DELETE).stream()
+                .skip(1)
+                .flatMap(List::stream)
+                .map(itemsById::get)
+                .toList(),
+            resultItems(results));
+      } finally {
+        subscription.delete();
+      }
+    }
+  }
+
+  // A subscription may first encounter the hidden limit while changing MonitoringMode.
+  @Test
+  void setMonitoringModeIndependentlyFallsBackToSingletonRequests() throws Exception {
+    try (var fixture = new Fixture()) {
+      var subscription = new OpcUaSubscription(fixture.client);
+      subscription.create();
+
+      try {
+        List<OpcUaMonitoredItem> items = prepareCreatedItems(subscription, 3);
+        fixture.serviceSet.clearRequests();
+
+        List<MonitoredItemServiceOperationResult> results =
+            subscription.setMonitoringMode(MonitoringMode.Disabled, items);
+
+        assertGood(results, 3);
+        assertEquals(
+            List.of(2, 1, 1, 1), fixture.serviceSet.requestSizes(Operation.SET_MONITORING_MODE));
+        assertEquals(items, resultItems(results));
+        assertTrue(
+            items.stream().allMatch(item -> item.getMonitoringMode() == MonitoringMode.Disabled));
+      } finally {
+        subscription.delete();
+      }
+    }
+  }
+
+  // Ambiguous service failures must remain visible; replaying Create could duplicate server state.
+  @Test
+  void timeoutDoesNotTriggerSingletonRetries() throws Exception {
+    try (var fixture = new Fixture()) {
+      fixture.serviceSet.setRejectionStatus(StatusCodes.Bad_Timeout);
+
+      var subscription = new OpcUaSubscription(fixture.client);
+      subscription.setMaxMonitoredItemsPerCall(uint(2));
+      subscription.create();
+
+      try {
+        List<OpcUaMonitoredItem> items = addItems(subscription, 2);
+
+        List<MonitoredItemServiceOperationResult> results = subscription.createMonitoredItems();
+
+        assertServiceFailure(results, StatusCodes.Bad_Timeout, 2);
+        assertEquals(List.of(2), fixture.serviceSet.requestSizes(Operation.CREATE));
+        assertEquals(itemsByClientHandle(items), itemsByClientHandle(resultItems(results)));
+        assertTrue(
+            items.stream()
+                .allMatch(item -> item.getSyncState() == OpcUaMonitoredItem.SyncState.INITIAL));
+      } finally {
+        subscription.delete();
+      }
+    }
+  }
+
+  // Retrying a rejected singleton cannot reduce the request and would loop forever.
+  @Test
+  void singletonTooManyOperationsIsReportedWithoutRetry() throws Exception {
+    try (var fixture = new Fixture()) {
+      fixture.serviceSet.setMaximumAcceptedOperations(0);
+
+      var subscription = new OpcUaSubscription(fixture.client);
+      subscription.setMaxMonitoredItemsPerCall(uint(2));
+      subscription.create();
+
+      try {
+        addItems(subscription, 1);
+
+        List<MonitoredItemServiceOperationResult> results = subscription.createMonitoredItems();
+
+        assertServiceFailure(results, StatusCodes.Bad_TooManyOperations, 1);
+        assertEquals(List.of(1), fixture.serviceSet.requestSizes(Operation.CREATE));
+      } finally {
+        subscription.delete();
+      }
+    }
+  }
+
+  /**
+   * SetMonitoringMode partitions client items, but its operation limit applies only to ids sent on
+   * the wire. One valid id mixed with an invalid item is still a singleton service request.
+   */
+  @Test
+  void setMonitoringModeUsesTheActualWireOperationCountForTheRetryGuard() throws Exception {
+    try (var fixture = new Fixture()) {
+      var subscription = new OpcUaSubscription(fixture.client);
+      subscription.setMaxMonitoredItemsPerCall(uint(2));
+      subscription.create();
+
+      try {
+        OpcUaMonitoredItem validItem = addItems(subscription, 1).get(0);
+        assertGood(subscription.createMonitoredItems(), 1);
+
+        var invalidItem = OpcUaMonitoredItem.newDataItem(NodeIds.Server_ServerStatus_CurrentTime);
+        fixture.serviceSet.setMaximumAcceptedOperations(0);
+        fixture.serviceSet.clearRequests();
+
+        List<MonitoredItemServiceOperationResult> results =
+            subscription.setMonitoringMode(
+                MonitoringMode.Disabled, List.of(invalidItem, validItem));
+
+        assertEquals(List.of(1), fixture.serviceSet.requestSizes(Operation.SET_MONITORING_MODE));
+        assertEquals(2, results.size());
+        assertEquals(invalidItem, results.get(0).monitoredItem());
+        assertEquals(StatusCodes.Bad_InvalidState, results.get(0).serviceResult().value());
+        assertFalse(results.get(0).operationResult().isPresent());
+        assertEquals(validItem, results.get(1).monitoredItem());
+        assertEquals(StatusCodes.Bad_TooManyOperations, results.get(1).serviceResult().value());
+        assertFalse(results.get(1).operationResult().isPresent());
+        assertEquals(MonitoringMode.Reporting, validItem.getMonitoringMode());
+      } finally {
+        subscription.delete();
+      }
+    }
+  }
+
+  /**
+   * DeleteMonitoredItems also partitions client items while counting only ids sent on the wire. A
+   * concurrent item reset must not turn one transmitted id into a retryable multi-operation call.
+   */
+  @Test
+  void deleteUsesTheActualWireOperationCountForTheRetryGuard() throws Exception {
+    try (var fixture = new Fixture()) {
+      var subscription = new OpcUaSubscription(fixture.client);
+      subscription.setMaxMonitoredItemsPerCall(uint(1));
+      subscription.create();
+
+      try {
+        var validItem = OpcUaMonitoredItem.newDataItem(NodeIds.Server_ServerStatus_CurrentTime);
+        var resetItem = new ResetOnMonitoredItemIdRead();
+        subscription.addMonitoredItems(List.of(validItem, resetItem));
+        assertGood(subscription.createMonitoredItems(), 2);
+
+        subscription.setMaxMonitoredItemsPerCall(uint(2));
+        subscription.removeMonitoredItems(List.of(validItem, resetItem));
+        resetItem.resetOnNextMonitoredItemIdRead();
+        fixture.serviceSet.setMaximumAcceptedOperations(0);
+        fixture.serviceSet.clearRequests();
+
+        List<MonitoredItemServiceOperationResult> results = subscription.deleteMonitoredItems();
+
+        assertEquals(List.of(1), fixture.serviceSet.requestSizes(Operation.DELETE));
+        assertEquals(2, results.size());
+        assertEquals(
+            1,
+            results.stream()
+                .filter(
+                    result -> result.serviceResult().value() == StatusCodes.Bad_TooManyOperations)
+                .count());
+        assertEquals(
+            1,
+            results.stream()
+                .filter(result -> result.serviceResult().value() == StatusCodes.Bad_InvalidState)
+                .count());
+        assertTrue(results.stream().allMatch(result -> result.operationResult().isEmpty()));
+      } finally {
+        subscription.delete();
+      }
+    }
+  }
+
+  // The learned limit belongs to one server-side Subscription incarnation.
+  @Test
+  void recreatingTheSubscriptionClearsTheLearnedLimit() throws Exception {
+    try (var fixture = new Fixture()) {
+      var subscription = new OpcUaSubscription(fixture.client);
+      subscription.setMaxMonitoredItemsPerCall(uint(2));
+      subscription.create();
+
+      try {
+        addItems(subscription, 2);
+        assertGood(subscription.createMonitoredItems(), 2);
+        assertEquals(List.of(2, 1, 1), fixture.serviceSet.requestSizes(Operation.CREATE));
+
+        subscription.delete();
+        subscription.create();
+        fixture.serviceSet.clearRequests();
+
+        List<MonitoredItemServiceOperationResult> results = subscription.createMonitoredItems();
+
+        assertGood(results, 2);
+        assertEquals(
+            List.of(2, 1, 1),
+            fixture.serviceSet.requestSizes(Operation.CREATE),
+            "the replacement Subscription must be allowed one new optimistic attempt");
+      } finally {
+        subscription.delete();
+      }
+    }
+  }
+
+  // Changing the configured cap intentionally starts a new partition-size calculation.
+  @Test
+  void changingTheConfiguredLimitClearsTheLearnedLimit() throws Exception {
+    try (var fixture = new Fixture()) {
+      var subscription = new OpcUaSubscription(fixture.client);
+      subscription.setMaxMonitoredItemsPerCall(uint(2));
+      subscription.create();
+
+      try {
+        addItems(subscription, 2);
+        assertGood(subscription.createMonitoredItems(), 2);
+
+        fixture.serviceSet.clearRequests();
+        addItems(subscription, 2);
+        assertGood(subscription.createMonitoredItems(), 2);
+        assertEquals(
+            List.of(1, 1),
+            fixture.serviceSet.requestSizes(Operation.CREATE),
+            "control: the Subscription must have retained its learned singleton limit");
+
+        addItems(subscription, 2);
+        subscription.setMaxMonitoredItemsPerCall(uint(3));
+        fixture.serviceSet.clearRequests();
+
+        List<MonitoredItemServiceOperationResult> results = subscription.createMonitoredItems();
+
+        assertGood(results, 2);
+        assertEquals(
+            List.of(2, 1, 1),
+            fixture.serviceSet.requestSizes(Operation.CREATE),
+            "changing the configured cap must permit one new optimistic attempt");
+      } finally {
+        subscription.delete();
+      }
+    }
+  }
+
+  private static List<OpcUaMonitoredItem> addItems(OpcUaSubscription subscription, int itemCount) {
+
+    var items = new ArrayList<OpcUaMonitoredItem>(itemCount);
+    for (int i = 0; i < itemCount; i++) {
+      items.add(OpcUaMonitoredItem.newDataItem(NodeIds.Server_ServerStatus_CurrentTime));
+    }
+    subscription.addMonitoredItems(items);
+    return items;
+  }
+
+  private static List<OpcUaMonitoredItem> prepareCreatedItems(
+      OpcUaSubscription subscription, int itemCount) {
+
+    subscription.setMaxMonitoredItemsPerCall(uint(1));
+    addItems(subscription, itemCount);
+
+    List<MonitoredItemServiceOperationResult> results = subscription.createMonitoredItems();
+    assertGood(results, itemCount);
+
+    subscription.setMaxMonitoredItemsPerCall(uint(2));
+    return resultItems(results);
+  }
+
+  private static void assertGood(
+      List<MonitoredItemServiceOperationResult> results, int expectedCount) {
+
+    assertEquals(expectedCount, results.size());
+    assertTrue(results.stream().allMatch(MonitoredItemServiceOperationResult::isGood));
+  }
+
+  private static void assertServiceFailure(
+      List<MonitoredItemServiceOperationResult> results,
+      long expectedStatusCode,
+      int expectedCount) {
+
+    assertEquals(expectedCount, results.size());
+    assertTrue(
+        results.stream().allMatch(result -> result.serviceResult().value() == expectedStatusCode));
+    assertTrue(results.stream().allMatch(result -> result.operationResult().isEmpty()));
+  }
+
+  private static List<OpcUaMonitoredItem> resultItems(
+      List<MonitoredItemServiceOperationResult> results) {
+
+    return results.stream().map(MonitoredItemServiceOperationResult::monitoredItem).toList();
+  }
+
+  private static List<UInteger> monitoredItemIds(
+      List<MonitoredItemServiceOperationResult> results) {
+
+    return results.stream()
+        .map(result -> result.monitoredItem().getMonitoredItemId().orElseThrow())
+        .toList();
+  }
+
+  private static Map<UInteger, OpcUaMonitoredItem> itemsByMonitoredItemId(
+      List<OpcUaMonitoredItem> items) {
+
+    var itemsById = new HashMap<UInteger, OpcUaMonitoredItem>();
+    for (OpcUaMonitoredItem item : items) {
+      itemsById.put(item.getMonitoredItemId().orElseThrow(), item);
+    }
+    return itemsById;
+  }
+
+  private static Map<UInteger, OpcUaMonitoredItem> itemsByClientHandle(
+      List<OpcUaMonitoredItem> items) {
+
+    var itemsByHandle = new HashMap<UInteger, OpcUaMonitoredItem>();
+    for (OpcUaMonitoredItem item : items) {
+      itemsByHandle.put(item.getClientHandle().orElseThrow(), item);
+    }
+    return itemsByHandle;
+  }
+
+  private enum Operation {
+    CREATE,
+    MODIFY,
+    DELETE,
+    SET_MONITORING_MODE
+  }
+
+  /** A real MonitoredItem service set with a scriptable hidden per-request operation limit. */
+  private static final class OperationLimitingMonitoredItemServiceSet
+      extends DelegatingMonitoredItemServiceSet {
+
+    private final Map<Operation, List<List<UInteger>>> requests = new EnumMap<>(Operation.class);
+
+    private volatile int maximumAcceptedOperations = 1;
+    private volatile long rejectionStatus = StatusCodes.Bad_TooManyOperations;
+
+    OperationLimitingMonitoredItemServiceSet(OpcUaServer server) {
+      super(server);
+
+      for (Operation operation : Operation.values()) {
+        requests.put(operation, new ArrayList<>());
+      }
+    }
+
+    void setMaximumAcceptedOperations(int maximumAcceptedOperations) {
+      this.maximumAcceptedOperations = maximumAcceptedOperations;
+    }
+
+    void setRejectionStatus(long rejectionStatus) {
+      this.rejectionStatus = rejectionStatus;
+    }
+
+    synchronized void clearRequests() {
+      requests.values().forEach(List::clear);
+    }
+
+    synchronized List<List<UInteger>> requests(Operation operation) {
+      return requests.get(operation).stream().map(List::copyOf).toList();
+    }
+
+    List<Integer> requestSizes(Operation operation) {
+      return requests(operation).stream().map(List::size).toList();
+    }
+
+    @Override
+    public CreateMonitoredItemsResponse onCreateMonitoredItems(
+        ServiceRequestContext context, CreateMonitoredItemsRequest request) throws UaException {
+
+      List<UInteger> clientHandles =
+          Arrays.stream(requireNonNull(request.getItemsToCreate()))
+              .map(item -> item.getRequestedParameters().getClientHandle())
+              .toList();
+      recordAndRejectIfNecessary(Operation.CREATE, clientHandles);
+
+      return super.onCreateMonitoredItems(context, request);
+    }
+
+    @Override
+    public ModifyMonitoredItemsResponse onModifyMonitoredItems(
+        ServiceRequestContext context, ModifyMonitoredItemsRequest request) throws UaException {
+
+      List<UInteger> monitoredItemIds =
+          Arrays.stream(requireNonNull(request.getItemsToModify()))
+              .map(item -> item.getMonitoredItemId())
+              .toList();
+      recordAndRejectIfNecessary(Operation.MODIFY, monitoredItemIds);
+
+      return super.onModifyMonitoredItems(context, request);
+    }
+
+    @Override
+    public DeleteMonitoredItemsResponse onDeleteMonitoredItems(
+        ServiceRequestContext context, DeleteMonitoredItemsRequest request) throws UaException {
+
+      List<UInteger> monitoredItemIds =
+          Arrays.stream(requireNonNull(request.getMonitoredItemIds())).toList();
+      recordAndRejectIfNecessary(Operation.DELETE, monitoredItemIds);
+
+      return super.onDeleteMonitoredItems(context, request);
+    }
+
+    @Override
+    public SetMonitoringModeResponse onSetMonitoringMode(
+        ServiceRequestContext context, SetMonitoringModeRequest request) throws UaException {
+
+      List<UInteger> monitoredItemIds =
+          Arrays.stream(requireNonNull(request.getMonitoredItemIds())).toList();
+      recordAndRejectIfNecessary(Operation.SET_MONITORING_MODE, monitoredItemIds);
+
+      return super.onSetMonitoringMode(context, request);
+    }
+
+    private synchronized void recordAndRejectIfNecessary(
+        Operation operation, List<UInteger> operationKeys) throws UaException {
+
+      requests.get(operation).add(List.copyOf(operationKeys));
+
+      if (operationKeys.size() > maximumAcceptedOperations) {
+        throw new UaException(
+            rejectionStatus,
+            "scripted " + operation + " rejection for " + operationKeys.size() + " operations");
+      }
+    }
+  }
+
+  private static final class ResetOnMonitoredItemIdRead extends OpcUaMonitoredItem {
+
+    private boolean resetOnNextMonitoredItemIdRead;
+
+    private ResetOnMonitoredItemIdRead() {
+      super(
+          new ReadValueId(
+              NodeIds.Server_ServerStatus_CurrentTime,
+              AttributeId.Value.uid(),
+              null,
+              QualifiedName.NULL_VALUE));
+    }
+
+    void resetOnNextMonitoredItemIdRead() {
+      resetOnNextMonitoredItemIdRead = true;
+    }
+
+    @Override
+    public Optional<UInteger> getMonitoredItemId() {
+      if (resetOnNextMonitoredItemIdRead) {
+        resetOnNextMonitoredItemIdRead = false;
+        reset();
+      }
+
+      return super.getMonitoredItemId();
+    }
+  }
+
+  /** A running Server with the operation-limiting service set and a connected client. */
+  private static final class Fixture implements AutoCloseable {
+
+    private final OpcUaServer server;
+    private final OpcUaClient client;
+    private final OperationLimitingMonitoredItemServiceSet serviceSet;
+
+    Fixture() throws Exception {
+      TestServer testServer = TestServer.create();
+      server = testServer.getServer();
+
+      serviceSet = new OperationLimitingMonitoredItemServiceSet(server);
+      for (EndpointConfig endpoint : server.getConfig().getEndpoints()) {
+        server.addServiceSet(endpoint.getPath(), serviceSet);
+      }
+
+      server.startup().get();
+
+      client = TestClient.create(server, configBuilder -> {});
+      client.connect();
+    }
+
+    @Override
+    public void close() throws Exception {
+      try {
+        client.disconnectAsync().get(5, TimeUnit.SECONDS);
+      } finally {
+        server.shutdown().get(5, TimeUnit.SECONDS);
+      }
+    }
+  }
+}

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/PublishRegistrationReuseTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/PublishRegistrationReuseTest.java
@@ -1,0 +1,332 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.subscriptions;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ubyte;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.netty.util.HashedWheelTimer;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.List;
+import java.util.concurrent.AbstractExecutorService;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClientConfig;
+import org.eclipse.milo.opcua.sdk.client.OpcUaSession;
+import org.eclipse.milo.opcua.stack.core.Stack;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
+import org.eclipse.milo.opcua.stack.core.types.UaRequestMessageType;
+import org.eclipse.milo.opcua.stack.core.types.UaResponseMessageType;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.MessageSecurityMode;
+import org.eclipse.milo.opcua.stack.core.types.structured.CreateSubscriptionResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
+import org.eclipse.milo.opcua.stack.core.types.structured.NotificationMessage;
+import org.eclipse.milo.opcua.stack.core.types.structured.PublishRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.PublishResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.ResponseHeader;
+import org.eclipse.milo.opcua.stack.core.types.structured.SignedSoftwareCertificate;
+import org.eclipse.milo.opcua.stack.core.types.structured.StatusChangeNotification;
+import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
+import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.transport.client.ClientApplicationContext;
+import org.eclipse.milo.opcua.stack.transport.client.OpcClientTransport;
+import org.eclipse.milo.opcua.stack.transport.client.OpcClientTransportConfig;
+import org.eclipse.milo.opcua.stack.transport.client.tcp.OpcTcpClientTransportConfig;
+import org.junit.jupiter.api.Test;
+
+/** A response belongs to the subscription registration that existed when its request was sent. */
+class PublishRegistrationReuseTest {
+  @Test
+  void delayedTimeoutCannotResetRecreatedObjectWithSameId() throws Exception {
+    assertTimeoutOwnership(true, true);
+  }
+
+  @Test
+  void delayedTimeoutCannotResetReplacementObjectWithSameId() throws Exception {
+    assertTimeoutOwnership(true, false);
+  }
+
+  @Test
+  void currentTimeoutStillResetsItsSubscription() throws Exception {
+    assertTimeoutOwnership(false, true);
+  }
+
+  @Test
+  void requestQueuedBeforeFirstRegistrationCanServeThatSubscription() throws Exception {
+    assertRegistrationChurnDoesNotDiscardResponse(false);
+  }
+
+  @Test
+  void unrelatedRegistrationDoesNotDiscardExistingSubscriptionsResponse() throws Exception {
+    assertRegistrationChurnDoesNotDiscardResponse(true);
+  }
+
+  private void assertRegistrationChurnDoesNotDiscardResponse(boolean originalAlreadyRegistered)
+      throws Exception {
+    try (var transport = new Transport()) {
+      var client = new Client(transport);
+      var original = new OpcUaSubscription(client);
+      if (originalAlreadyRegistered)
+        original.createAsync().toCompletableFuture().get(5, TimeUnit.SECONDS);
+      var session =
+          new OpcUaSession(
+              new NodeId(1, "token"),
+              new NodeId(1, "session"),
+              "session",
+              60000,
+              uint(0),
+              ByteString.NULL_VALUE,
+              new SignedSoftwareCertificate[0]);
+      var pendingCount = new AtomicLong(1);
+      client.getPublishingManager().sendPublishRequest(session, pendingCount);
+      var response = client.pending;
+      if (originalAlreadyRegistered) {
+        client.nextSubscriptionId = 8;
+        new OpcUaSubscription(client).createAsync().toCompletableFuture().get(5, TimeUnit.SECONDS);
+      } else {
+        original.createAsync().toCompletableFuture().get(5, TimeUnit.SECONDS);
+      }
+      var status = new StatusChangeNotification(new StatusCode(StatusCodes.Bad_Timeout), null);
+      response.complete(
+          new PublishResponse(
+              header(),
+              uint(7),
+              new UInteger[] {uint(1)},
+              false,
+              new NotificationMessage(
+                  uint(1),
+                  DateTime.now(),
+                  new ExtensionObject[] {
+                    ExtensionObject.encode(client.getStaticEncodingContext(), status)
+                  }),
+              new StatusCode[0],
+              null));
+      transport.executor.drain();
+      assertEquals(0, pendingCount.get());
+      assertTrue(
+          original.getSubscriptionId().isEmpty(),
+          "valid timeout must reach its owner despite a registration after the request was sent");
+    }
+  }
+
+  private void assertTimeoutOwnership(boolean replace, boolean reuseObject) throws Exception {
+    try (var transport = new Transport()) {
+      var client = new Client(transport);
+      var statuses = new ArrayList<StatusCode>();
+      var original = new OpcUaSubscription(client);
+      original.setSubscriptionListener(
+          new OpcUaSubscription.SubscriptionListener() {
+            @Override
+            public void onStatusChanged(OpcUaSubscription s, StatusCode status) {
+              statuses.add(status);
+            }
+          });
+      original.createAsync().toCompletableFuture().get(5, TimeUnit.SECONDS);
+      var session =
+          new OpcUaSession(
+              new NodeId(1, "token"),
+              new NodeId(1, "session"),
+              "session",
+              60000,
+              uint(0),
+              ByteString.NULL_VALUE,
+              new SignedSoftwareCertificate[0]);
+      var pendingCount = new AtomicLong(1);
+      client.getPublishingManager().sendPublishRequest(session, pendingCount);
+      var response = client.pending;
+      OpcUaSubscription current = original;
+      if (replace) {
+        original.reset();
+        if (!reuseObject) {
+          current = new OpcUaSubscription(client);
+          current.setSubscriptionListener(
+              new OpcUaSubscription.SubscriptionListener() {
+                @Override
+                public void onStatusChanged(OpcUaSubscription s, StatusCode status) {
+                  statuses.add(status);
+                }
+              });
+        }
+        current.createAsync().toCompletableFuture().get(5, TimeUnit.SECONDS);
+      }
+      long incarnation = current.getIncarnation();
+      var status = new StatusChangeNotification(new StatusCode(StatusCodes.Bad_Timeout), null);
+      response.complete(
+          new PublishResponse(
+              header(),
+              uint(7),
+              new UInteger[] {uint(1)},
+              false,
+              new NotificationMessage(
+                  uint(1),
+                  DateTime.now(),
+                  new ExtensionObject[] {
+                    ExtensionObject.encode(client.getStaticEncodingContext(), status)
+                  }),
+              new StatusCode[0],
+              null));
+      transport.executor.drain();
+      assertEquals(
+          0, pendingCount.get(), "discarding a response must still release its pipeline slot");
+      if (replace) {
+        assertEquals(uint(7), current.getSubscriptionId().orElseThrow());
+        assertEquals(incarnation, current.getIncarnation());
+        assertTrue(
+            statuses.isEmpty(), "the replacement must not receive its predecessor's timeout");
+      } else {
+        assertTrue(current.getSubscriptionId().isEmpty());
+        assertEquals(List.of(new StatusCode(StatusCodes.Bad_Timeout)), statuses);
+      }
+    }
+  }
+
+  private static ResponseHeader header() {
+    return new ResponseHeader(DateTime.now(), uint(1), StatusCode.GOOD, null, null, null);
+  }
+
+  private static class ManualExecutor extends AbstractExecutorService {
+    final Deque<Runnable> tasks = new ArrayDeque<>();
+
+    @Override
+    public void execute(Runnable command) {
+      tasks.addLast(command);
+    }
+
+    void drain() {
+      int count = 0;
+      while (!tasks.isEmpty()) {
+        assertTrue(++count < 1000, "executor did not quiesce");
+        tasks.removeFirst().run();
+      }
+    }
+
+    @Override
+    public void shutdown() {}
+
+    @Override
+    public List<Runnable> shutdownNow() {
+      return List.of();
+    }
+
+    @Override
+    public boolean isShutdown() {
+      return false;
+    }
+
+    @Override
+    public boolean isTerminated() {
+      return false;
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) {
+      return false;
+    }
+  }
+
+  private static class Transport implements OpcClientTransport, AutoCloseable {
+    final ManualExecutor executor = new ManualExecutor();
+    final HashedWheelTimer timer = new HashedWheelTimer();
+    final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+    final OpcClientTransportConfig config =
+        OpcTcpClientTransportConfig.newBuilder()
+            .setExecutor(executor)
+            .setWheelTimer(timer)
+            .setScheduledExecutor(scheduler)
+            .build();
+
+    @Override
+    public OpcClientTransportConfig getConfig() {
+      return config;
+    }
+
+    @Override
+    public CompletableFuture<Unit> connect(ClientApplicationContext c) {
+      return CompletableFuture.completedFuture(Unit.VALUE);
+    }
+
+    @Override
+    public CompletableFuture<Unit> disconnect() {
+      return CompletableFuture.completedFuture(Unit.VALUE);
+    }
+
+    @Override
+    public CompletableFuture<UaResponseMessageType> sendRequestMessage(UaRequestMessageType r) {
+      throw new AssertionError(r);
+    }
+
+    @Override
+    public void close() {
+      scheduler.shutdownNow();
+      timer.stop();
+    }
+  }
+
+  private static class Client extends OpcUaClient {
+    CompletableFuture<UaResponseMessageType> pending;
+    int nextSubscriptionId = 7;
+
+    Client(Transport transport) {
+      super(
+          OpcUaClientConfig.builder()
+              .setEndpoint(
+                  new EndpointDescription(
+                      "opc.tcp://localhost:4840",
+                      null,
+                      ByteString.NULL_VALUE,
+                      MessageSecurityMode.None,
+                      SecurityPolicy.None.getUri(),
+                      new UserTokenPolicy[0],
+                      Stack.TCP_UASC_UABINARY_TRANSPORT_URI,
+                      ubyte(0)))
+              .setDiscoveryEndpoints(List.of())
+              .build(),
+          transport);
+    }
+
+    // Automatic Publish replenishment waits here. Each test sends exactly one controlled request.
+    @Override
+    public CompletableFuture<OpcUaSession> getSessionAsync() {
+      return new CompletableFuture<>();
+    }
+
+    @Override
+    public CompletableFuture<CreateSubscriptionResponse> createSubscriptionAsync(
+        double p, UInteger l, UInteger k, UInteger n, boolean enabled, UByte priority) {
+      return CompletableFuture.completedFuture(
+          new CreateSubscriptionResponse(header(), uint(nextSubscriptionId), p, l, k));
+    }
+
+    @Override
+    public CompletableFuture<UaResponseMessageType> sendRequestAsync(UaRequestMessageType request) {
+      assertInstanceOf(PublishRequest.class, request);
+      pending = new CompletableFuture<>();
+      return pending;
+    }
+  }
+}

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/PublishingManagerSessionIsolationTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/PublishingManagerSessionIsolationTest.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -202,7 +203,7 @@ public class PublishingManagerSessionIsolationTest {
       subscriptionDetailsClass =
           Class.forName(PublishingManager.class.getName() + "$SubscriptionDetails");
 
-      Map<UInteger, Object> details = subscriptionDetails(manager);
+      var details = new HashMap<UInteger, Object>();
 
       primaryDetails = newSubscriptionDetails(subscriptionId);
 
@@ -210,6 +211,7 @@ public class PublishingManagerSessionIsolationTest {
         UInteger id = uint(i + 1L);
         details.put(id, i == 0 ? primaryDetails : newSubscriptionDetails(id));
       }
+      setSubscriptionDetails(Map.copyOf(details));
     }
 
     UaSession newSession() {
@@ -227,8 +229,7 @@ public class PublishingManagerSessionIsolationTest {
     }
 
     void retainOnlyPrimarySubscription() throws Exception {
-      Map<UInteger, Object> details = subscriptionDetails(manager);
-      details.keySet().removeIf(id -> !id.equals(subscriptionId));
+      setSubscriptionDetails(Map.of(subscriptionId, primaryDetails));
     }
 
     void setResponder(
@@ -327,14 +328,12 @@ public class PublishingManagerSessionIsolationTest {
           subscription, id, (java.util.concurrent.Executor) Runnable::run);
     }
 
-    @SuppressWarnings("unchecked")
-    private static Map<UInteger, Object> subscriptionDetails(PublishingManager manager)
-        throws Exception {
+    private void setSubscriptionDetails(Map<UInteger, Object> details) throws Exception {
 
       Field field = PublishingManager.class.getDeclaredField("subscriptionDetails");
       field.setAccessible(true);
 
-      return (Map<UInteger, Object>) field.get(manager);
+      field.set(manager, details);
     }
   }
 }

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/SubscriptionLifecycleRecoveryTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/SubscriptionLifecycleRecoveryTest.java
@@ -11,6 +11,8 @@
 package org.eclipse.milo.opcua.sdk.client.subscriptions;
 
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -21,22 +23,30 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
 import org.eclipse.milo.opcua.sdk.client.OperationLimits;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.MonitoringMode;
 import org.eclipse.milo.opcua.stack.core.types.structured.CreateMonitoredItemsResponse;
 import org.eclipse.milo.opcua.stack.core.types.structured.CreateSubscriptionResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.DeleteMonitoredItemsResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.ModifyMonitoredItemsResponse;
 import org.eclipse.milo.opcua.stack.core.types.structured.MonitoredItemCreateResult;
+import org.eclipse.milo.opcua.stack.core.types.structured.MonitoredItemModifyResult;
 import org.eclipse.milo.opcua.stack.core.types.structured.ReadValueId;
+import org.eclipse.milo.opcua.stack.core.types.structured.SetMonitoringModeResponse;
 import org.eclipse.milo.opcua.stack.core.types.structured.SetPublishingModeResponse;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -98,6 +108,112 @@ class SubscriptionLifecycleRecoveryTest {
             new CreateMonitoredItemsResponse(
                 null, new MonitoredItemCreateResult[] {createdItem(42)}, null));
     assertTrue(fixture.subscription.createMonitoredItems().get(0).isGood());
+  }
+
+  @Test
+  void delayedCreateCannotPopulateRecreatedSubscription() throws Exception {
+    assertDelayedResponseIgnored(Operation.CREATE);
+  }
+
+  @Test
+  void delayedModifyCannotOverwriteRecreatedItem() throws Exception {
+    assertDelayedResponseIgnored(Operation.MODIFY);
+  }
+
+  @Test
+  void delayedDeleteCannotDetachRecreatedItem() throws Exception {
+    assertDelayedResponseIgnored(Operation.DELETE);
+  }
+
+  @Test
+  void delayedMonitoringModeCannotChangeRecreatedItem() throws Exception {
+    assertDelayedResponseIgnored(Operation.MODE);
+  }
+
+  private void assertDelayedResponseIgnored(Operation operation) throws Exception {
+    var fixture = new Fixture(Runnable::run);
+    fixture.create();
+    var item = fixture.addItem();
+    if (operation != Operation.CREATE) item.applyCreateResult(createdItem(41));
+    if (operation == Operation.MODIFY) item.setSamplingInterval(250.0);
+    if (operation == Operation.DELETE) fixture.subscription.removeMonitoredItem(item);
+    var entered = new CountDownLatch(1);
+    var release = new CountDownLatch(1);
+    var firstCall = new AtomicBoolean(true);
+    org.mockito.stubbing.Answer<Object> gate =
+        invocation -> {
+          if (firstCall.getAndSet(false)) {
+            entered.countDown();
+            assertTrue(release.await(5, TimeUnit.SECONDS));
+          }
+          return switch (operation) {
+            case CREATE ->
+                new CreateMonitoredItemsResponse(
+                    null, new MonitoredItemCreateResult[] {createdItem(41)}, null);
+            case MODIFY ->
+                new ModifyMonitoredItemsResponse(
+                    null,
+                    new MonitoredItemModifyResult[] {
+                      new MonitoredItemModifyResult(StatusCode.GOOD, 250.0, uint(1), null)
+                    },
+                    null);
+            case DELETE ->
+                new DeleteMonitoredItemsResponse(null, new StatusCode[] {StatusCode.GOOD}, null);
+            case MODE ->
+                new SetMonitoringModeResponse(null, new StatusCode[] {StatusCode.GOOD}, null);
+          };
+        };
+    switch (operation) {
+      case CREATE ->
+          when(fixture.client.createMonitoredItems(any(), any(), anyList())).thenAnswer(gate);
+      case MODIFY ->
+          when(fixture.client.modifyMonitoredItems(any(), any(), anyList())).thenAnswer(gate);
+      case DELETE -> when(fixture.client.deleteMonitoredItems(any(), anyList())).thenAnswer(gate);
+      case MODE -> when(fixture.client.setMonitoringMode(any(), any(), anyList())).thenAnswer(gate);
+    }
+    var oldId = fixture.subscription.getSubscriptionId().orElseThrow();
+    var pending =
+        workers.submit(
+            () ->
+                switch (operation) {
+                  case CREATE -> fixture.subscription.createMonitoredItems();
+                  case MODIFY -> fixture.subscription.modifyMonitoredItems();
+                  case DELETE -> fixture.subscription.deleteMonitoredItems();
+                  case MODE ->
+                      fixture.subscription.setMonitoringMode(
+                          MonitoringMode.Disabled, List.of(item));
+                });
+    assertTrue(entered.await(5, TimeUnit.SECONDS));
+    try {
+      fixture.subscription.reset();
+      fixture.create();
+      assertNotEquals(oldId, fixture.subscription.getSubscriptionId().orElseThrow());
+      if (operation == Operation.DELETE) fixture.subscription.addMonitoredItem(item);
+      if (operation != Operation.CREATE) item.applyCreateResult(createdItem(99));
+    } finally {
+      release.countDown();
+    }
+    var results = pending.get(5, TimeUnit.SECONDS);
+    assertEquals(1, results.size());
+    assertEquals(new StatusCode(StatusCodes.Bad_InvalidState), results.get(0).serviceResult());
+    assertTrue(item.getClientHandle().isPresent());
+    if (operation == Operation.CREATE) {
+      assertEquals(OpcUaMonitoredItem.SyncState.INITIAL, item.getSyncState());
+      assertTrue(item.getMonitoredItemId().isEmpty());
+      assertTrue(fixture.subscription.createMonitoredItems().get(0).isGood());
+    } else {
+      assertEquals(OpcUaMonitoredItem.SyncState.SYNCHRONIZED, item.getSyncState());
+      assertEquals(uint(99), item.getMonitoredItemId().orElseThrow());
+      assertEquals(1000.0, item.getRevisedSamplingInterval().orElseThrow());
+      assertEquals(MonitoringMode.Reporting, item.getMonitoringMode());
+    }
+  }
+
+  private enum Operation {
+    CREATE,
+    MODIFY,
+    DELETE,
+    MODE
   }
 
   private static MonitoredItemCreateResult createdItem(int id) {

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/SubscriptionLifecycleRecoveryTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/SubscriptionLifecycleRecoveryTest.java
@@ -45,6 +45,7 @@ import org.eclipse.milo.opcua.stack.core.types.structured.CreateMonitoredItemsRe
 import org.eclipse.milo.opcua.stack.core.types.structured.CreateSubscriptionResponse;
 import org.eclipse.milo.opcua.stack.core.types.structured.DeleteMonitoredItemsResponse;
 import org.eclipse.milo.opcua.stack.core.types.structured.ModifyMonitoredItemsResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.MonitoredItemCreateRequest;
 import org.eclipse.milo.opcua.stack.core.types.structured.MonitoredItemCreateResult;
 import org.eclipse.milo.opcua.stack.core.types.structured.MonitoredItemModifyResult;
 import org.eclipse.milo.opcua.stack.core.types.structured.ReadValueId;
@@ -144,6 +145,67 @@ class SubscriptionLifecycleRecoveryTest {
         .setPublishingModeAsync(false)
         .toCompletableFuture()
         .get(5, TimeUnit.SECONDS);
+  }
+
+  @Test
+  void transferCleanupDoesNotWaitForLimitsThatNeedSessionActivation() throws Exception {
+    var fixture = new Fixture(Runnable::run);
+    fixture.create();
+    fixture.addItem();
+    var limitsEntered = new CountDownLatch(1);
+    var sessionActive = new CompletableFuture<OperationLimits>();
+    when(fixture.client.getOperationLimits())
+        .thenAnswer(
+            invocation -> {
+              limitsEntered.countDown();
+              return sessionActive.get(10, TimeUnit.SECONDS);
+            });
+    var create =
+        workers.submit(
+            () -> {
+              return fixture.subscription.createMonitoredItems();
+            });
+    assertTrue(limitsEntered.await(5, TimeUnit.SECONDS));
+    var cleanup =
+        workers.submit(
+            () -> {
+              fixture.subscription.handleTransferFailure(
+                  new StatusCode(StatusCodes.Bad_SubscriptionIdInvalid));
+              // Session initialization must finish transfer cleanup before publishing its active
+              // Session.
+              sessionActive.complete(Fixture.limits());
+            });
+    try {
+      cleanup.get(5, TimeUnit.SECONDS);
+      assertTrue(sessionActive.isDone());
+      assertEquals(
+          new StatusCode(StatusCodes.Bad_InvalidState),
+          create.get(5, TimeUnit.SECONDS).get(0).serviceResult());
+    } finally {
+      sessionActive.complete(Fixture.limits());
+      cleanup.get(5, TimeUnit.SECONDS);
+      create.get(5, TimeUnit.SECONDS);
+    }
+
+    // Completing the discarded lookup must not restore its old cached partition size.
+    when(fixture.client.getOperationLimits())
+        .thenReturn(
+            new OperationLimits(
+                null, null, null, null, null, null, null, uint(1), null, null, null, null));
+    fixture.create();
+    fixture.addItem();
+    var calls = new AtomicInteger();
+    when(fixture.client.createMonitoredItems(any(), any(), anyList()))
+        .thenAnswer(
+            invocation -> {
+              calls.incrementAndGet();
+              List<MonitoredItemCreateRequest> requests = invocation.getArgument(2);
+              var results = new MonitoredItemCreateResult[requests.size()];
+              for (int i = 0; i < results.length; i++) results[i] = createdItem(100 + i);
+              return new CreateMonitoredItemsResponse(null, results, null);
+            });
+    assertEquals(2, fixture.subscription.createMonitoredItems().size());
+    assertEquals(2, calls.get(), "replacement must discover the current singleton server limit");
   }
 
   @Test

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/SubscriptionLifecycleRecoveryTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/SubscriptionLifecycleRecoveryTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.subscriptions;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.client.OperationLimits;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.structured.CreateMonitoredItemsResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.CreateSubscriptionResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.MonitoredItemCreateResult;
+import org.eclipse.milo.opcua.stack.core.types.structured.ReadValueId;
+import org.eclipse.milo.opcua.stack.core.types.structured.SetPublishingModeResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/** Deterministic response, reset, and executor boundaries in the subscription lifecycle. */
+class SubscriptionLifecycleRecoveryTest {
+  private final ExecutorService workers = Executors.newCachedThreadPool();
+
+  @AfterEach
+  void stopWorkers() throws InterruptedException {
+    workers.shutdownNow();
+    assertTrue(workers.awaitTermination(5, TimeUnit.SECONDS));
+  }
+
+  @Test
+  void resetAndReaddPreserveTheMappedItemsClientHandle() throws Exception {
+    var fixture = new Fixture(Runnable::run);
+    fixture.create();
+    var item = new GatedResetItem();
+    fixture.subscription.addMonitoredItem(item);
+    item.applyCreateResult(createdItem(41));
+    fixture.subscription.removeMonitoredItem(item);
+
+    var reset = workers.submit(fixture.subscription::reset);
+    assertTrue(item.entered.await(5, TimeUnit.SECONDS));
+    var readded = new CompletableFuture<Void>();
+    Thread adding =
+        new Thread(
+            () -> {
+              try {
+                fixture.subscription.addMonitoredItem(item);
+                readded.complete(null);
+              } catch (Throwable t) {
+                readded.completeExceptionally(t);
+              }
+            });
+    adding.start();
+    try {
+      // Wait until add either acquires the collection lock or is blocked on reset's ownership.
+      // Releasing the reset before add reaches this boundary would miss the original interleaving.
+      long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+      while (!readded.isDone()
+          && adding.getState() != Thread.State.BLOCKED
+          && System.nanoTime() < deadline) {
+        Thread.yield();
+      }
+      assertTrue(readded.isDone() || adding.getState() == Thread.State.BLOCKED);
+    } finally {
+      item.release.countDown();
+      adding.join(5000);
+    }
+    reset.get(5, TimeUnit.SECONDS);
+    readded.get(5, TimeUnit.SECONDS);
+    assertTrue(fixture.subscription.getMonitoredItems().contains(item));
+    assertTrue(item.getClientHandle().isPresent(), "mapped items must retain a requestable handle");
+    fixture.create();
+    when(fixture.client.createMonitoredItems(any(), any(), anyList()))
+        .thenReturn(
+            new CreateMonitoredItemsResponse(
+                null, new MonitoredItemCreateResult[] {createdItem(42)}, null));
+    assertTrue(fixture.subscription.createMonitoredItems().get(0).isGood());
+  }
+
+  private static MonitoredItemCreateResult createdItem(int id) {
+    return new MonitoredItemCreateResult(StatusCode.GOOD, uint(id), 1000.0, uint(1), null);
+  }
+
+  private static ReadValueId readValueId() {
+    return new ReadValueId(new NodeId(2, "value"), uint(13), null, QualifiedName.NULL_VALUE);
+  }
+
+  private static class GatedResetItem extends OpcUaMonitoredItem {
+    final CountDownLatch entered = new CountDownLatch(1);
+    final CountDownLatch release = new CountDownLatch(1);
+
+    GatedResetItem() {
+      super(readValueId());
+    }
+
+    @Override
+    void reset() {
+      entered.countDown();
+      try {
+        assertTrue(release.await(5, TimeUnit.SECONDS));
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new AssertionError(e);
+      }
+      super.reset();
+    }
+  }
+
+  private static class Fixture {
+    final OpcUaClient client = mock(OpcUaClient.class, RETURNS_DEEP_STUBS);
+    final AtomicInteger ids = new AtomicInteger(10);
+    final OpcUaSubscription subscription;
+
+    Fixture(Executor executor) throws Exception {
+      var executorService = mock(ExecutorService.class);
+      doAnswer(
+              invocation -> {
+                executor.execute(invocation.getArgument(0));
+                return null;
+              })
+          .when(executorService)
+          .execute(any());
+      when(client.getTransport().getConfig().getExecutor()).thenReturn(executorService);
+      when(client.getPublishingManager().isPublishingSuspended()).thenReturn(true);
+      when(client.getOperationLimits()).thenReturn(limits());
+      when(client.createSubscriptionAsync(anyDouble(), any(), any(), any(), anyBoolean(), any()))
+          .thenAnswer(
+              invocation -> CompletableFuture.completedFuture(created(ids.incrementAndGet())));
+      when(client.setPublishingModeAsync(anyBoolean(), anyList()))
+          .thenReturn(
+              CompletableFuture.completedFuture(
+                  new SetPublishingModeResponse(null, new StatusCode[] {StatusCode.GOOD}, null)));
+      subscription = new OpcUaSubscription(client);
+    }
+
+    static OperationLimits limits() {
+      return new OperationLimits(
+          null, null, null, null, null, null, null, uint(100), null, null, null, null);
+    }
+
+    static CreateSubscriptionResponse created(int id) {
+      return new CreateSubscriptionResponse(null, uint(id), 1000.0, uint(50), uint(10));
+    }
+
+    void create() throws Exception {
+      subscription.createAsync().toCompletableFuture().get(5, TimeUnit.SECONDS);
+    }
+
+    OpcUaMonitoredItem addItem() {
+      var item = new OpcUaMonitoredItem(readValueId());
+      subscription.addMonitoredItem(item);
+      return item;
+    }
+  }
+}

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/SubscriptionLifecycleRecoveryTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/SubscriptionLifecycleRecoveryTest.java
@@ -23,12 +23,14 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -108,6 +110,40 @@ class SubscriptionLifecycleRecoveryTest {
             new CreateMonitoredItemsResponse(
                 null, new MonitoredItemCreateResult[] {createdItem(42)}, null));
     assertTrue(fixture.subscription.createMonitoredItems().get(0).isGood());
+  }
+
+  @Test
+  void rejectedTransitionHandoffPreservesSuccessAndDrainsWaiters() throws Exception {
+    assertHandoffCompletes(
+        command -> {
+          throw new RejectedExecutionException("executor stopped");
+        });
+  }
+
+  @Test
+  void directTransitionHandoffDrainsWithoutRecursion() throws Exception {
+    assertHandoffCompletes(Runnable::run);
+  }
+
+  private void assertHandoffCompletes(Executor executor) throws Exception {
+    var fixture = new Fixture(executor);
+    var response = new CompletableFuture<CreateSubscriptionResponse>();
+    when(fixture.client.createSubscriptionAsync(
+            anyDouble(), any(), any(), any(), anyBoolean(), any()))
+        .thenReturn(response);
+    var create = fixture.subscription.createAsync().toCompletableFuture();
+    var queued = new ArrayList<CompletableFuture<?>>();
+    for (int i = 0; i < 10_000; i++) {
+      queued.add(fixture.subscription.modifyAsync().toCompletableFuture());
+    }
+    response.complete(Fixture.created(21));
+    create.get(5, TimeUnit.SECONDS);
+    CompletableFuture.allOf(queued.toArray(CompletableFuture[]::new)).get(5, TimeUnit.SECONDS);
+    fixture
+        .subscription
+        .setPublishingModeAsync(false)
+        .toCompletableFuture()
+        .get(5, TimeUnit.SECONDS);
   }
 
   @Test

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/typetree/ClientBrowseUtilsTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/typetree/ClientBrowseUtilsTest.java
@@ -10,21 +10,360 @@
 
 package org.eclipse.milo.opcua.sdk.client.typetree;
 
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.IntStream;
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.client.OperationLimits;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.TimestampsToReturn;
+import org.eclipse.milo.opcua.stack.core.types.structured.BrowseDescription;
 import org.eclipse.milo.opcua.stack.core.types.structured.BrowseNextResponse;
 import org.eclipse.milo.opcua.stack.core.types.structured.BrowseResult;
+import org.eclipse.milo.opcua.stack.core.types.structured.ReadResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.ReadValueId;
+import org.eclipse.milo.opcua.stack.core.types.structured.ReferenceDescription;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
 class ClientBrowseUtilsTest {
+
+  @Test
+  void missingReadLimitUsesSingletonRequests() throws UaException {
+    assertReadLimitUsesSingletonRequests(null);
+  }
+
+  @Test
+  void zeroReadLimitUsesSingletonRequests() throws UaException {
+    assertReadLimitUsesSingletonRequests(uint(0));
+  }
+
+  private static void assertReadLimitUsesSingletonRequests(@Nullable UInteger operationLimit)
+      throws UaException {
+
+    var client = mock(OpcUaClient.class);
+    List<ReadValueId> requests = readRequests(3);
+    List<DataValue> values = dataValues(3);
+    var calls = new ArrayList<List<ReadValueId>>();
+
+    when(client.read(eq(0.0), eq(TimestampsToReturn.Neither), anyList()))
+        .thenAnswer(
+            invocation -> {
+              List<ReadValueId> partition = invocation.getArgument(2);
+              calls.add(List.copyOf(partition));
+              return readResponse(partition, requests, values);
+            });
+
+    List<DataValue> result =
+        ClientBrowseUtils.readWithOperationLimits(
+            client, requests, operationLimits(operationLimit, null));
+
+    assertEquals(values, result);
+    assertEquals(singletonPartitions(requests), calls);
+  }
+
+  @Test
+  void missingBrowseLimitUsesSingletonRequests() throws UaException {
+    assertBrowseLimitUsesSingletonRequests(null);
+  }
+
+  @Test
+  void zeroBrowseLimitUsesSingletonRequests() throws UaException {
+    assertBrowseLimitUsesSingletonRequests(uint(0));
+  }
+
+  private static void assertBrowseLimitUsesSingletonRequests(@Nullable UInteger operationLimit)
+      throws UaException {
+
+    var client = mock(OpcUaClient.class);
+    List<BrowseDescription> requests = browseRequests(3);
+    List<ReferenceDescription> references = references(3);
+    var calls = new ArrayList<List<BrowseDescription>>();
+
+    when(client.browse(anyList()))
+        .thenAnswer(
+            invocation -> {
+              List<BrowseDescription> partition = invocation.getArgument(0);
+              calls.add(List.copyOf(partition));
+              return browseResults(partition, requests, references);
+            });
+
+    List<List<ReferenceDescription>> result =
+        ClientBrowseUtils.browseWithOperationLimits(
+            client, requests, operationLimits(null, operationLimit));
+
+    assertEquals(wrapEach(references), result);
+    assertEquals(singletonPartitions(requests), calls);
+  }
+
+  // UInt32 limits above Integer.MAX_VALUE remain valid and must not overflow into an invalid
+  // partition size.
+  @Test
+  void maximumUnsignedReadLimitUsesOnePositivePartition() throws UaException {
+    var client = mock(OpcUaClient.class);
+    List<ReadValueId> requests = readRequests(3);
+    List<DataValue> values = dataValues(3);
+    var calls = new ArrayList<List<ReadValueId>>();
+
+    when(client.read(eq(0.0), eq(TimestampsToReturn.Neither), anyList()))
+        .thenAnswer(
+            invocation -> {
+              List<ReadValueId> partition = invocation.getArgument(2);
+              calls.add(List.copyOf(partition));
+              return readResponse(partition, requests, values);
+            });
+
+    List<DataValue> result =
+        ClientBrowseUtils.readWithOperationLimits(
+            client, requests, operationLimits(UInteger.MAX, null));
+
+    assertEquals(values, result);
+    assertEquals(List.of(requests), calls);
+  }
+
+  // UInt32 limits above Integer.MAX_VALUE remain valid and must not overflow into an invalid
+  // partition size.
+  @Test
+  void maximumUnsignedBrowseLimitUsesOnePositivePartition() throws UaException {
+    var client = mock(OpcUaClient.class);
+    List<BrowseDescription> requests = browseRequests(3);
+    List<ReferenceDescription> references = references(3);
+    var calls = new ArrayList<List<BrowseDescription>>();
+
+    when(client.browse(anyList()))
+        .thenAnswer(
+            invocation -> {
+              List<BrowseDescription> partition = invocation.getArgument(0);
+              calls.add(List.copyOf(partition));
+              return browseResults(partition, requests, references);
+            });
+
+    List<List<ReferenceDescription>> result =
+        ClientBrowseUtils.browseWithOperationLimits(
+            client, requests, operationLimits(null, UInteger.MAX));
+
+    assertEquals(wrapEach(references), result);
+    assertEquals(List.of(requests), calls);
+  }
+
+  // A stale advertised limit may reject one batch, but retrying it and the remaining Reads as
+  // singletons must retain the original result order.
+  @Test
+  void rejectedReadPartitionFallsBackToOrderedSingletonRequests() throws UaException {
+    var client = mock(OpcUaClient.class);
+    List<ReadValueId> requests = readRequests(5);
+    List<DataValue> values = dataValues(5);
+    var calls = new ArrayList<List<ReadValueId>>();
+
+    when(client.read(eq(0.0), eq(TimestampsToReturn.Neither), anyList()))
+        .thenAnswer(
+            invocation -> {
+              List<ReadValueId> partition = invocation.getArgument(2);
+              calls.add(List.copyOf(partition));
+              if (partition.size() > 1) {
+                throw new UaException(StatusCodes.Bad_TooManyOperations);
+              }
+              return readResponse(partition, requests, values);
+            });
+
+    List<DataValue> result =
+        ClientBrowseUtils.readWithOperationLimits(client, requests, operationLimits(uint(3), null));
+
+    var expectedCalls = new ArrayList<List<ReadValueId>>();
+    expectedCalls.add(List.copyOf(requests.subList(0, 3)));
+    expectedCalls.addAll(singletonPartitions(requests));
+
+    assertEquals(values, result);
+    assertEquals(expectedCalls, calls);
+  }
+
+  // A stale advertised limit may reject one batch, but retrying it and the remaining Browses as
+  // singletons must retain the original result order and one result per input.
+  @Test
+  void rejectedBrowsePartitionFallsBackToOrderedSingletonRequests() throws UaException {
+    var client = mock(OpcUaClient.class);
+    List<BrowseDescription> requests = browseRequests(5);
+    List<ReferenceDescription> references = references(5);
+    var calls = new ArrayList<List<BrowseDescription>>();
+
+    when(client.browse(anyList()))
+        .thenAnswer(
+            invocation -> {
+              List<BrowseDescription> partition = invocation.getArgument(0);
+              calls.add(List.copyOf(partition));
+              if (partition.size() > 1) {
+                throw new UaException(StatusCodes.Bad_TooManyOperations);
+              }
+              return browseResults(partition, requests, references);
+            });
+
+    List<List<ReferenceDescription>> result =
+        ClientBrowseUtils.browseWithOperationLimits(
+            client, requests, operationLimits(null, uint(3)));
+
+    var expectedCalls = new ArrayList<List<BrowseDescription>>();
+    expectedCalls.add(List.copyOf(requests.subList(0, 3)));
+    expectedCalls.addAll(singletonPartitions(requests));
+
+    assertEquals(wrapEach(references), result);
+    assertEquals(expectedCalls, calls);
+  }
+
+  // Only Bad_TooManyOperations identifies an oversized request; another Read service failure must
+  // propagate without replaying any operation.
+  @Test
+  void nonRetryableReadFailurePropagatesWithoutRetry() throws UaException {
+    var client = mock(OpcUaClient.class);
+    List<ReadValueId> requests = readRequests(3);
+    var calls = new ArrayList<List<ReadValueId>>();
+    var failure = new UaException(StatusCodes.Bad_Timeout);
+
+    when(client.read(eq(0.0), eq(TimestampsToReturn.Neither), anyList()))
+        .thenAnswer(
+            invocation -> {
+              List<ReadValueId> partition = invocation.getArgument(2);
+              calls.add(List.copyOf(partition));
+              throw failure;
+            });
+
+    UaException thrown =
+        assertThrows(
+            UaException.class,
+            () ->
+                ClientBrowseUtils.readWithOperationLimits(
+                    client, requests, operationLimits(uint(2), null)));
+
+    assertSame(failure, thrown);
+    assertEquals(List.of(requests.subList(0, 2)), calls);
+  }
+
+  // Only Bad_TooManyOperations identifies an oversized request; another Browse service failure
+  // must propagate without replaying any operation.
+  @Test
+  void nonRetryableBrowseFailurePropagatesWithoutRetry() throws UaException {
+    var client = mock(OpcUaClient.class);
+    List<BrowseDescription> requests = browseRequests(3);
+    var calls = new ArrayList<List<BrowseDescription>>();
+    var failure = new UaException(StatusCodes.Bad_Timeout);
+
+    when(client.browse(anyList()))
+        .thenAnswer(
+            invocation -> {
+              List<BrowseDescription> partition = invocation.getArgument(0);
+              calls.add(List.copyOf(partition));
+              throw failure;
+            });
+
+    UaException thrown =
+        assertThrows(
+            UaException.class,
+            () ->
+                ClientBrowseUtils.browseWithOperationLimits(
+                    client, requests, operationLimits(null, uint(2))));
+
+    assertSame(failure, thrown);
+    assertEquals(List.of(requests.subList(0, 2)), calls);
+  }
+
+  // BrowseNext already sends one continuation point per request. Its failure must not replay the
+  // successful multi-node Browse request that produced the continuation point.
+  @Test
+  void browseNextTooManyOperationsDoesNotRetryTheInitialBrowse() throws UaException {
+    var client = mock(OpcUaClient.class);
+    List<BrowseDescription> requests = browseRequests(2);
+    var continuationPoint = ByteString.of(new byte[] {1});
+    var failure = new UaException(StatusCodes.Bad_TooManyOperations);
+
+    when(client.browse(requests))
+        .thenReturn(
+            List.of(
+                new BrowseResult(StatusCode.GOOD, continuationPoint, null),
+                new BrowseResult(StatusCode.GOOD, ByteString.NULL_VALUE, null)));
+    when(client.browseNext(false, List.of(continuationPoint))).thenThrow(failure);
+
+    UaException thrown =
+        assertThrows(
+            UaException.class,
+            () ->
+                ClientBrowseUtils.browseWithOperationLimits(
+                    client, requests, operationLimits(null, uint(2))));
+
+    assertSame(failure, thrown);
+    verify(client).browse(requests);
+  }
+
+  // A singleton Bad_TooManyOperations cannot be reduced further and must not cause an infinite
+  // retry loop.
+  @Test
+  void singletonReadRejectionPropagatesWithoutRetry() throws UaException {
+    var client = mock(OpcUaClient.class);
+    List<ReadValueId> requests = readRequests(2);
+    var calls = new ArrayList<List<ReadValueId>>();
+    var failure = new UaException(StatusCodes.Bad_TooManyOperations);
+
+    when(client.read(eq(0.0), eq(TimestampsToReturn.Neither), anyList()))
+        .thenAnswer(
+            invocation -> {
+              List<ReadValueId> partition = invocation.getArgument(2);
+              calls.add(List.copyOf(partition));
+              throw failure;
+            });
+
+    UaException thrown =
+        assertThrows(
+            UaException.class,
+            () ->
+                ClientBrowseUtils.readWithOperationLimits(
+                    client, requests, operationLimits(null, null)));
+
+    assertSame(failure, thrown);
+    assertEquals(List.of(List.of(requests.get(0))), calls);
+  }
+
+  // A singleton Bad_TooManyOperations cannot be reduced further and must not cause an infinite
+  // retry loop.
+  @Test
+  void singletonBrowseRejectionPropagatesWithoutRetry() throws UaException {
+    var client = mock(OpcUaClient.class);
+    List<BrowseDescription> requests = browseRequests(2);
+    var calls = new ArrayList<List<BrowseDescription>>();
+    var failure = new UaException(StatusCodes.Bad_TooManyOperations);
+
+    when(client.browse(anyList()))
+        .thenAnswer(
+            invocation -> {
+              List<BrowseDescription> partition = invocation.getArgument(0);
+              calls.add(List.copyOf(partition));
+              throw failure;
+            });
+
+    UaException thrown =
+        assertThrows(
+            UaException.class,
+            () ->
+                ClientBrowseUtils.browseWithOperationLimits(
+                    client, requests, operationLimits(null, null)));
+
+    assertSame(failure, thrown);
+    assertEquals(List.of(List.of(requests.get(0))), calls);
+  }
 
   @Test
   void releasesContinuationPointWhenBrowseNextLimitIsReached() throws UaException {
@@ -42,5 +381,77 @@ class ClientBrowseUtilsTest {
 
     verify(client, times(1000)).browseNext(false, List.of(continuationPoint));
     verify(client).browseNext(true, List.of(continuationPoint));
+  }
+
+  private static OperationLimits operationLimits(
+      @Nullable UInteger maxNodesPerRead, @Nullable UInteger maxNodesPerBrowse) {
+
+    return new OperationLimits(
+        maxNodesPerRead,
+        null,
+        null,
+        maxNodesPerBrowse,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null);
+  }
+
+  private static List<ReadValueId> readRequests(int count) {
+    return IntStream.range(0, count).mapToObj(i -> mock(ReadValueId.class, "read-" + i)).toList();
+  }
+
+  private static List<DataValue> dataValues(int count) {
+    return IntStream.range(0, count).mapToObj(i -> DataValue.valueOnly(new Variant(i))).toList();
+  }
+
+  private static ReadResponse readResponse(
+      List<ReadValueId> partition, List<ReadValueId> requests, List<DataValue> values) {
+
+    DataValue[] results =
+        partition.stream()
+            .map(request -> values.get(requests.indexOf(request)))
+            .toArray(DataValue[]::new);
+
+    return new ReadResponse(null, results, null);
+  }
+
+  private static List<BrowseDescription> browseRequests(int count) {
+    return IntStream.range(0, count)
+        .mapToObj(i -> mock(BrowseDescription.class, "browse-" + i))
+        .toList();
+  }
+
+  private static List<ReferenceDescription> references(int count) {
+    return IntStream.range(0, count)
+        .mapToObj(i -> mock(ReferenceDescription.class, "reference-" + i))
+        .toList();
+  }
+
+  private static List<BrowseResult> browseResults(
+      List<BrowseDescription> partition,
+      List<BrowseDescription> requests,
+      List<ReferenceDescription> references) {
+
+    return partition.stream()
+        .map(
+            request ->
+                new BrowseResult(
+                    StatusCode.GOOD,
+                    ByteString.NULL_VALUE,
+                    new ReferenceDescription[] {references.get(requests.indexOf(request))}))
+        .toList();
+  }
+
+  private static <T> List<List<T>> singletonPartitions(List<T> values) {
+    return values.stream().map(List::of).toList();
+  }
+
+  private static <T> List<List<T>> wrapEach(List<T> values) {
+    return singletonPartitions(values);
   }
 }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClient.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClient.java
@@ -437,51 +437,7 @@ public class OpcUaClient {
 
     sessionFsm = SessionFsmFactory.newSessionFsm(this);
 
-    sessionFsm.addInitializer(
-        (client, session) -> {
-          logger.debug("SessionInitializer: NamespaceTable and ServerTable");
-          RequestHeader requestHeader = newRequestHeader(session.getAuthenticationToken());
-
-          ReadRequest readRequest =
-              new ReadRequest(
-                  requestHeader,
-                  0.0,
-                  TimestampsToReturn.Neither,
-                  new ReadValueId[] {
-                    new ReadValueId(
-                        NodeIds.Server_NamespaceArray,
-                        AttributeId.Value.uid(),
-                        null,
-                        QualifiedName.NULL_VALUE),
-                    new ReadValueId(
-                        NodeIds.Server_ServerArray,
-                        AttributeId.Value.uid(),
-                        null,
-                        QualifiedName.NULL_VALUE)
-                  });
-
-          return client
-              .sendRequestAsync(readRequest)
-              .thenApply(ReadResponse.class::cast)
-              .thenApply(response -> Objects.requireNonNull(response.getResults()))
-              .thenApply(
-                  results -> {
-                    String[] namespaceArray = (String[]) results[0].value().value();
-                    String[] serverArray = (String[]) results[1].value().value();
-                    if (namespaceArray != null) {
-                      updateNamespaceTable(namespaceArray);
-                    }
-                    if (serverArray != null) {
-                      updateServerTable(serverArray);
-                    }
-                    return Unit.VALUE;
-                  })
-              .exceptionally(
-                  ex -> {
-                    logger.warn("SessionInitializer: NamespaceTable", ex);
-                    return Unit.VALUE;
-                  });
-        });
+    sessionFsm.addInitializer(this::initializeNamespaceAndServerTables);
 
     addSessionInitializer(
         (client, session) -> {
@@ -502,6 +458,129 @@ public class OpcUaClient {
 
     ObjectTypeInitializer.initialize(namespaceTable, objectTypeManager);
     VariableTypeInitializer.initialize(namespaceTable, variableTypeManager);
+  }
+
+  private CompletableFuture<Unit> initializeNamespaceAndServerTables(
+      OpcUaClient client, OpcUaSession session) {
+
+    logger.debug("SessionInitializer: NamespaceTable and ServerTable");
+
+    return readNamespaceAndServerArrays(client, session.getAuthenticationToken())
+        .handle(
+            (unit, ex) -> {
+              if (ex == null) {
+                return CompletableFuture.completedFuture(unit);
+              }
+
+              boolean tooManyOperations =
+                  UaException.extractStatusCode(ex)
+                      .map(statusCode -> statusCode.value() == StatusCodes.Bad_TooManyOperations)
+                      .orElse(false);
+
+              if (tooManyOperations) {
+                return readNamespaceAndServerArraysIndividually(
+                    client, session.getAuthenticationToken());
+              }
+
+              logger.warn("SessionInitializer: NamespaceTable and ServerTable", ex);
+              return CompletableFuture.completedFuture(Unit.VALUE);
+            })
+        .thenCompose(Function.identity());
+  }
+
+  private CompletableFuture<Unit> readNamespaceAndServerArrays(
+      OpcUaClient client, NodeId authenticationToken) {
+
+    return readValuesDuringSessionInitialization(
+            client, authenticationToken, NodeIds.Server_NamespaceArray, NodeIds.Server_ServerArray)
+        .thenApply(
+            results -> {
+              if (results[0] != null) {
+                updateNamespaceTable(results[0]);
+              }
+              if (results[1] != null) {
+                updateServerTable(results[1]);
+              }
+
+              return Unit.VALUE;
+            });
+  }
+
+  private CompletableFuture<Unit> readNamespaceAndServerArraysIndividually(
+      OpcUaClient client, NodeId authenticationToken) {
+
+    CompletableFuture<Unit> namespaceArray =
+        readValuesDuringSessionInitialization(
+                client, authenticationToken, NodeIds.Server_NamespaceArray)
+            .thenApply(
+                results -> {
+                  if (results[0] != null) {
+                    updateNamespaceTable(results[0]);
+                  }
+                  return Unit.VALUE;
+                })
+            .exceptionally(
+                ex -> {
+                  logger.warn("SessionInitializer: NamespaceTable singleton Read", ex);
+                  return Unit.VALUE;
+                });
+
+    CompletableFuture<Unit> serverArray =
+        readValuesDuringSessionInitialization(
+                client, authenticationToken, NodeIds.Server_ServerArray)
+            .thenApply(
+                results -> {
+                  if (results[0] != null) {
+                    updateServerTable(results[0]);
+                  }
+                  return Unit.VALUE;
+                })
+            .exceptionally(
+                ex -> {
+                  logger.warn("SessionInitializer: ServerTable singleton Read", ex);
+                  return Unit.VALUE;
+                });
+
+    return CompletableFuture.allOf(namespaceArray, serverArray).thenApply(v -> Unit.VALUE);
+  }
+
+  private CompletableFuture<String[][]> readValuesDuringSessionInitialization(
+      OpcUaClient client, NodeId authenticationToken, NodeId... nodeIds) {
+
+    ReadValueId[] nodesToRead =
+        Stream.of(nodeIds)
+            .map(
+                nodeId ->
+                    new ReadValueId(
+                        nodeId, AttributeId.Value.uid(), null, QualifiedName.NULL_VALUE))
+            .toArray(ReadValueId[]::new);
+
+    ReadRequest readRequest =
+        new ReadRequest(
+            newRequestHeader(authenticationToken), 0.0, TimestampsToReturn.Neither, nodesToRead);
+
+    return client
+        .sendRequestAsync(readRequest)
+        .thenApply(ReadResponse.class::cast)
+        .thenCompose(
+            response -> {
+              DataValue[] results = response.getResults();
+
+              if (results == null || results.length != nodeIds.length) {
+                return CompletableFuture.failedFuture(
+                    new UaException(
+                        StatusCodes.Bad_UnexpectedError,
+                        "Read returned %s results, expected %s"
+                            .formatted(results == null ? "null" : results.length, nodeIds.length)));
+              }
+
+              String[][] values = new String[results.length][];
+              for (int i = 0; i < results.length; i++) {
+                values[i] = (String[]) results[i].value().value();
+              }
+
+              return CompletableFuture.completedFuture(values);
+            });
   }
 
   /**

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClient.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClient.java
@@ -489,6 +489,7 @@ public class OpcUaClient {
           // are refreshed (eagerly or lazily, depending on configuration). Resetting the tree
           // also resets the dynamic DataTypeManager and EncodingContext derived from it.
 
+          resetOperationLimits();
           resetDataTypeTree();
 
           return CompletableFuture.completedFuture(Unit.VALUE);

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OperationLimits.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OperationLimits.java
@@ -12,7 +12,6 @@ package org.eclipse.milo.opcua.sdk.client;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.function.Function;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
@@ -200,18 +199,25 @@ public class OperationLimits {
     List<DataValue> values =
         client.readValues(0.0, TimestampsToReturn.Neither, OPERATION_LIMITS_NODES);
 
-    UInteger maxNodesPerRead = toUInteger(values.get(0).value().value());
-    UInteger maxNodesPerWrite = toUInteger(values.get(1).value().value());
-    UInteger maxNodesPerMethodCall = toUInteger(values.get(2).value().value());
-    UInteger maxNodesPerBrowse = toUInteger(values.get(3).value().value());
-    UInteger maxNodesPerRegisterNodes = toUInteger(values.get(4).value().value());
-    UInteger maxNodesPerTranslateBrowsePathsToNodeIds = toUInteger(values.get(5).value().value());
-    UInteger maxNodesPerNodeManagement = toUInteger(values.get(6).value().value());
-    UInteger maxMonitoredItemsPerCall = toUInteger(values.get(7).value().value());
-    UInteger maxNodesPerHistoryReadData = toUInteger(values.get(8).value().value());
-    UInteger maxNodesPerHistoryReadEvents = toUInteger(values.get(9).value().value());
-    UInteger maxNodesPerHistoryUpdateData = toUInteger(values.get(10).value().value());
-    UInteger maxNodesPerHistoryUpdateEvents = toUInteger(values.get(11).value().value());
+    if (values == null || values.size() != OPERATION_LIMITS_NODES.size()) {
+      throw new UaException(
+          StatusCodes.Bad_UnexpectedError,
+          "Read returned %s OperationLimits results, expected %s"
+              .formatted(values == null ? "null" : values.size(), OPERATION_LIMITS_NODES.size()));
+    }
+
+    UInteger maxNodesPerRead = toUInteger(values.get(0));
+    UInteger maxNodesPerWrite = toUInteger(values.get(1));
+    UInteger maxNodesPerMethodCall = toUInteger(values.get(2));
+    UInteger maxNodesPerBrowse = toUInteger(values.get(3));
+    UInteger maxNodesPerRegisterNodes = toUInteger(values.get(4));
+    UInteger maxNodesPerTranslateBrowsePathsToNodeIds = toUInteger(values.get(5));
+    UInteger maxNodesPerNodeManagement = toUInteger(values.get(6));
+    UInteger maxMonitoredItemsPerCall = toUInteger(values.get(7));
+    UInteger maxNodesPerHistoryReadData = toUInteger(values.get(8));
+    UInteger maxNodesPerHistoryReadEvents = toUInteger(values.get(9));
+    UInteger maxNodesPerHistoryUpdateData = toUInteger(values.get(10));
+    UInteger maxNodesPerHistoryUpdateEvents = toUInteger(values.get(11));
 
     return new OperationLimits(
         maxNodesPerRead,
@@ -229,43 +235,41 @@ public class OperationLimits {
   }
 
   private static OperationLimits readIndividualNodes(OpcUaClient client) throws UaException {
-    Function<NodeId, UInteger> read =
-        nodeId -> {
-          try {
-            return toUInteger(
-                client.readValue(0.0, TimestampsToReturn.Neither, nodeId).value().value());
-          } catch (UaException e) {
-            return null;
-          }
-        };
-
     // checkstyle:off
     UInteger maxNodesPerRead =
-        read.apply(NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerRead);
+        readNode(client, NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerRead);
     UInteger maxNodesPerWrite =
-        read.apply(NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerWrite);
+        readNode(client, NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerWrite);
     UInteger maxNodesPerMethodCall =
-        read.apply(NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerMethodCall);
+        readNode(client, NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerMethodCall);
     UInteger maxNodesPerBrowse =
-        read.apply(NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerBrowse);
+        readNode(client, NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerBrowse);
     UInteger maxNodesPerRegisterNodes =
-        read.apply(NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerRegisterNodes);
+        readNode(
+            client, NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerRegisterNodes);
     UInteger maxNodesPerTranslateBrowsePathsToNodeIds =
-        read.apply(
+        readNode(
+            client,
             NodeIds
                 .Server_ServerCapabilities_OperationLimits_MaxNodesPerTranslateBrowsePathsToNodeIds);
     UInteger maxNodesPerNodeManagement =
-        read.apply(NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerNodeManagement);
+        readNode(
+            client, NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerNodeManagement);
     UInteger maxMonitoredItemsPerCall =
-        read.apply(NodeIds.Server_ServerCapabilities_OperationLimits_MaxMonitoredItemsPerCall);
+        readNode(
+            client, NodeIds.Server_ServerCapabilities_OperationLimits_MaxMonitoredItemsPerCall);
     UInteger maxNodesPerHistoryReadData =
-        read.apply(NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerHistoryReadData);
+        readNode(
+            client, NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerHistoryReadData);
     UInteger maxNodesPerHistoryReadEvents =
-        read.apply(NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerHistoryReadEvents);
+        readNode(
+            client, NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerHistoryReadEvents);
     UInteger maxNodesPerHistoryUpdateData =
-        read.apply(NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerHistoryUpdateData);
+        readNode(
+            client, NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerHistoryUpdateData);
     UInteger maxNodesPerHistoryUpdateEvents =
-        read.apply(
+        readNode(
+            client,
             NodeIds.Server_ServerCapabilities_OperationLimits_MaxNodesPerHistoryUpdateEvents);
     // checkstyle:on
 
@@ -282,6 +286,20 @@ public class OperationLimits {
         maxNodesPerHistoryReadEvents,
         maxNodesPerHistoryUpdateData,
         maxNodesPerHistoryUpdateEvents);
+  }
+
+  private static @Nullable UInteger readNode(OpcUaClient client, NodeId nodeId) throws UaException {
+    DataValue value = client.readValue(0.0, TimestampsToReturn.Neither, nodeId);
+
+    return toUInteger(value);
+  }
+
+  private static @Nullable UInteger toUInteger(@Nullable DataValue value) {
+    if (value == null || value.statusCode().isBad()) {
+      return null;
+    }
+
+    return toUInteger(value.value().value());
   }
 
   /**

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsm.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsm.java
@@ -13,9 +13,12 @@ package org.eclipse.milo.opcua.sdk.client.session;
 import com.digitalpetri.fsm.Fsm;
 import com.digitalpetri.fsm.FsmContext;
 import com.digitalpetri.netty.fsm.ChannelFsm;
+import com.google.common.util.concurrent.MoreExecutors;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.atomic.AtomicLong;
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
@@ -33,7 +36,7 @@ public class SessionFsm {
 
   private final Fsm<State, Event> fsm;
 
-  SessionFsm(Fsm<State, Event> fsm) {
+  SessionFsm(Fsm<State, Event> fsm, Executor executor) {
     this.fsm = fsm;
 
     sessionInitializers =
@@ -46,7 +49,7 @@ public class SessionFsm {
     sessionActivityListeners =
         fsm.getFromContext(
             ctx -> {
-              KEY_SESSION_ACTIVITY_LISTENERS.set(ctx, new SessionActivityListeners());
+              KEY_SESSION_ACTIVITY_LISTENERS.set(ctx, new SessionActivityListeners(executor));
               return KEY_SESSION_ACTIVITY_LISTENERS.get(ctx).sessionActivityListeners;
             });
   }
@@ -185,7 +188,21 @@ public class SessionFsm {
   }
 
   static class SessionActivityListeners {
-    private SessionActivityListeners() {}
+    final Executor executor;
+
+    private SessionActivityListeners(Executor delegate) {
+      executor =
+          MoreExecutors.newSequentialExecutor(
+              command -> {
+                try {
+                  delegate.execute(command);
+                } catch (RejectedExecutionException e) {
+                  // Lifecycle notifications must remain ordered even when dispatch falls back
+                  // inline.
+                  command.run();
+                }
+              });
+    }
 
     final List<SessionActivityListener> sessionActivityListeners = new CopyOnWriteArrayList<>();
   }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmFactory.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmFactory.java
@@ -145,7 +145,7 @@ public class SessionFsmFactory {
 
     client.addFaultListener(new SessionFaultListener(fsm));
 
-    return new SessionFsm(fsm);
+    return new SessionFsm(fsm, client.getTransport().getConfig().getExecutor());
   }
 
   private static void configureSessionFsm(FsmBuilder<State, Event> fb, OpcUaClient client) {
@@ -773,14 +773,10 @@ public class SessionFsmFactory {
               SessionFsm.SessionActivityListeners sessionActivityListeners =
                   KEY_SESSION_ACTIVITY_LISTENERS.get(ctx);
 
-              client
-                  .getTransport()
-                  .getConfig()
-                  .getExecutor()
-                  .execute(
-                      () ->
-                          sessionActivityListeners.sessionActivityListeners.forEach(
-                              listener -> listener.onSessionActive(session)));
+              sessionActivityListeners.executor.execute(
+                  () ->
+                      sessionActivityListeners.sessionActivityListeners.forEach(
+                          listener -> listener.onSessionActive(session)));
             });
 
     // onSessionInactive() callbacks
@@ -794,14 +790,10 @@ public class SessionFsmFactory {
               SessionFsm.SessionActivityListeners sessionActivityListeners =
                   KEY_SESSION_ACTIVITY_LISTENERS.get(ctx);
 
-              client
-                  .getTransport()
-                  .getConfig()
-                  .getExecutor()
-                  .execute(
-                      () ->
-                          sessionActivityListeners.sessionActivityListeners.forEach(
-                              listener -> listener.onSessionInactive(session)));
+              sessionActivityListeners.executor.execute(
+                  () ->
+                      sessionActivityListeners.sessionActivityListeners.forEach(
+                          listener -> listener.onSessionInactive(session)));
             });
 
     /* Internal Transition Actions */

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/package-info.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/**
+ * Establishes and recovers the Session used by {@link
+ * org.eclipse.milo.opcua.sdk.client.OpcUaClient}. The state machine creates and activates Sessions,
+ * runs initializers, and monitors connectivity. A reactivation can reuse the same Session object,
+ * so object identity alone does not identify an activation.
+ *
+ * <p>Session activity notifications run in transition order on a serial executor backed by the
+ * transport's caller-owned executor. The state machine can continue while an earlier notification
+ * waits to run. Consumers such as the publishing manager observe inactive before the subsequent
+ * active notification, which lets them suspend and recover their work in that order. Rejected
+ * dispatch runs inline to preserve this lifecycle ordering; the client does not shut down the
+ * caller's executor.
+ *
+ * <p>Initializers participate in Session activation. They must complete before operations waiting
+ * for an active Session can proceed. Cleanup during initialization must therefore avoid waiting on
+ * work that itself needs an active Session.
+ */
+package org.eclipse.milo.opcua.sdk.client.session;

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscription.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscription.java
@@ -66,7 +66,7 @@ import org.eclipse.milo.opcua.stack.core.types.structured.MonitoredItemModifyRes
 import org.eclipse.milo.opcua.stack.core.types.structured.MonitoredItemNotification;
 import org.eclipse.milo.opcua.stack.core.types.structured.SetMonitoringModeResponse;
 import org.eclipse.milo.opcua.stack.core.types.structured.SetPublishingModeResponse;
-import org.eclipse.milo.opcua.stack.core.util.Lazy;
+import org.eclipse.milo.opcua.stack.core.util.NonBlockingLazy;
 import org.eclipse.milo.opcua.stack.core.util.TaskQueue;
 import org.eclipse.milo.opcua.stack.core.util.Unit;
 import org.jspecify.annotations.Nullable;
@@ -233,7 +233,7 @@ public class OpcUaSubscription {
   private volatile double watchdogMultiplier = 1.5;
 
   private volatile UInteger maxMonitoredItemsPerCall = uint(DEFAULT_MAX_MONITORED_ITEMS_PER_CALL);
-  private final Lazy<UInteger> monitoredItemPartitionSize = new Lazy<>();
+  private final NonBlockingLazy<UInteger> monitoredItemPartitionSize = new NonBlockingLazy<>();
   private volatile long monitoredItemPartitionGeneration;
 
   private volatile @Nullable Object userObject;

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscription.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscription.java
@@ -31,6 +31,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -55,13 +56,14 @@ import org.eclipse.milo.opcua.stack.core.types.structured.DeleteSubscriptionsRes
 import org.eclipse.milo.opcua.stack.core.types.structured.EventFieldList;
 import org.eclipse.milo.opcua.stack.core.types.structured.ModifyMonitoredItemsResponse;
 import org.eclipse.milo.opcua.stack.core.types.structured.ModifySubscriptionResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.MonitoredItemCreateRequest;
 import org.eclipse.milo.opcua.stack.core.types.structured.MonitoredItemCreateResult;
+import org.eclipse.milo.opcua.stack.core.types.structured.MonitoredItemModifyRequest;
 import org.eclipse.milo.opcua.stack.core.types.structured.MonitoredItemModifyResult;
 import org.eclipse.milo.opcua.stack.core.types.structured.MonitoredItemNotification;
 import org.eclipse.milo.opcua.stack.core.types.structured.SetMonitoringModeResponse;
 import org.eclipse.milo.opcua.stack.core.types.structured.SetPublishingModeResponse;
 import org.eclipse.milo.opcua.stack.core.util.Lazy;
-import org.eclipse.milo.opcua.stack.core.util.Lists;
 import org.eclipse.milo.opcua.stack.core.util.TaskQueue;
 import org.eclipse.milo.opcua.stack.core.util.Unit;
 import org.jspecify.annotations.Nullable;
@@ -229,6 +231,7 @@ public class OpcUaSubscription {
 
   private volatile UInteger maxMonitoredItemsPerCall = uint(DEFAULT_MAX_MONITORED_ITEMS_PER_CALL);
   private final Lazy<UInteger> monitoredItemPartitionSize = new Lazy<>();
+  private volatile long monitoredItemPartitionGeneration;
 
   private volatile @Nullable Object userObject;
 
@@ -958,13 +961,12 @@ public class OpcUaSubscription {
       return Collections.emptyList();
     }
 
-    var serviceOperationsResults =
-        new ArrayList<MonitoredItemServiceOperationResult>(itemsToCreate.size());
-
-    ServerState serverState = this.serverState;
-    if (serverState == null) {
+    MonitoredItemOperationContext context = getMonitoredItemOperationContext();
+    if (context == null) {
       logger.debug("Bad_InvalidState: subscription not created yet");
 
+      var serviceOperationsResults =
+          new ArrayList<MonitoredItemServiceOperationResult>(itemsToCreate.size());
       for (OpcUaMonitoredItem item : itemsToCreate) {
         serviceOperationsResults.add(
             new MonitoredItemServiceOperationResult(
@@ -974,27 +976,46 @@ public class OpcUaSubscription {
       return serviceOperationsResults;
     }
 
-    UInteger partitionSize = getMonitoredItemPartitionSize();
+    return executeMonitoredItemPartitions(
+        itemsToCreate, context, partition -> createMonitoredItems(context, partition));
+  }
 
-    List<List<OpcUaMonitoredItem>> partitions =
-        Lists.partition(itemsToCreate, partitionSize.intValue()).toList();
+  private MonitoredItemPartitionAttempt createMonitoredItems(
+      MonitoredItemOperationContext context, List<OpcUaMonitoredItem> partition) {
 
-    for (List<OpcUaMonitoredItem> partition : partitions) {
-      try {
-        logger.debug(
-            "id={}, createMonitoredItems partition.size(): {}",
-            serverState.getSubscriptionId(),
-            partition.size());
+    List<MonitoredItemCreateRequest> itemsToCreate;
+    synchronized (lifecycleLock) {
+      if (incarnation != context.incarnation()) {
+        return invalidStateAttempt(partition, partition.size());
+      }
 
-        CreateMonitoredItemsResponse response =
-            client.createMonitoredItems(
-                serverState.getSubscriptionId(),
-                TimestampsToReturn.Both,
-                partition.stream()
-                    .map(OpcUaMonitoredItem::newCreateRequest)
-                    .collect(Collectors.toList()));
+      itemsToCreate =
+          partition.stream().map(OpcUaMonitoredItem::newCreateRequest).collect(Collectors.toList());
+    }
 
-        MonitoredItemCreateResult[] results = requireNonNull(response.getResults());
+    try {
+      logger.debug(
+          "id={}, createMonitoredItems partition.size(): {}",
+          context.serverState().getSubscriptionId(),
+          partition.size());
+
+      CreateMonitoredItemsResponse response =
+          client.createMonitoredItems(
+              context.serverState().getSubscriptionId(), TimestampsToReturn.Both, itemsToCreate);
+
+      MonitoredItemCreateResult[] results = response.getResults();
+      if (results == null || results.length != partition.size()) {
+        throw unexpectedResultCount(
+            "CreateMonitoredItems", results == null ? null : results.length, partition.size());
+      }
+
+      var serviceOperationResults =
+          new ArrayList<MonitoredItemServiceOperationResult>(results.length);
+
+      synchronized (lifecycleLock) {
+        if (incarnation != context.incarnation()) {
+          return invalidStateAttempt(partition, partition.size());
+        }
 
         for (int i = 0; i < results.length; i++) {
           MonitoredItemCreateResult result = results[i];
@@ -1002,19 +1023,31 @@ public class OpcUaSubscription {
 
           monitoredItem.applyCreateResult(result);
 
-          serviceOperationsResults.add(
+          serviceOperationResults.add(
               new MonitoredItemServiceOperationResult(
                   monitoredItem, StatusCode.GOOD, result.getStatusCode()));
         }
-      } catch (UaException e) {
-        for (OpcUaMonitoredItem item : partition) {
-          serviceOperationsResults.add(
-              new MonitoredItemServiceOperationResult(item, e.getStatusCode(), null));
+      }
+
+      return new MonitoredItemPartitionAttempt(serviceOperationResults, null, partition.size());
+    } catch (UaException e) {
+      synchronized (lifecycleLock) {
+        if (incarnation != context.incarnation()) {
+          return invalidStateAttempt(partition, partition.size());
         }
       }
-    }
 
-    return serviceOperationsResults;
+      var serviceOperationResults =
+          new ArrayList<MonitoredItemServiceOperationResult>(partition.size());
+
+      for (OpcUaMonitoredItem item : partition) {
+        serviceOperationResults.add(
+            new MonitoredItemServiceOperationResult(item, e.getStatusCode(), null));
+      }
+
+      return new MonitoredItemPartitionAttempt(
+          serviceOperationResults, e.getStatusCode(), partition.size());
+    }
   }
 
   /**
@@ -1038,11 +1071,10 @@ public class OpcUaSubscription {
   private List<MonitoredItemServiceOperationResult> modifyMonitoredItems(
       List<OpcUaMonitoredItem> itemsToModify) {
 
-    var serviceOperationsResults =
-        new ArrayList<MonitoredItemServiceOperationResult>(itemsToModify.size());
-
-    ServerState serverState = this.serverState;
-    if (serverState == null) {
+    MonitoredItemOperationContext context = getMonitoredItemOperationContext();
+    if (context == null) {
+      var serviceOperationsResults =
+          new ArrayList<MonitoredItemServiceOperationResult>(itemsToModify.size());
       for (OpcUaMonitoredItem item : itemsToModify) {
         serviceOperationsResults.add(
             new MonitoredItemServiceOperationResult(
@@ -1052,27 +1084,46 @@ public class OpcUaSubscription {
       return serviceOperationsResults;
     }
 
-    UInteger partitionSize = getMonitoredItemPartitionSize();
+    return executeMonitoredItemPartitions(
+        itemsToModify, context, partition -> modifyMonitoredItems(context, partition));
+  }
 
-    List<List<OpcUaMonitoredItem>> partitions =
-        Lists.partition(itemsToModify, partitionSize.intValue()).toList();
+  private MonitoredItemPartitionAttempt modifyMonitoredItems(
+      MonitoredItemOperationContext context, List<OpcUaMonitoredItem> partition) {
 
-    for (List<OpcUaMonitoredItem> partition : partitions) {
-      try {
-        logger.debug(
-            "id={}, modifyMonitoredItems partition.size(): {}",
-            serverState.subscriptionId,
-            partition.size());
+    List<MonitoredItemModifyRequest> itemsToModify;
+    synchronized (lifecycleLock) {
+      if (incarnation != context.incarnation()) {
+        return invalidStateAttempt(partition, partition.size());
+      }
 
-        ModifyMonitoredItemsResponse response =
-            client.modifyMonitoredItems(
-                serverState.getSubscriptionId(),
-                TimestampsToReturn.Both,
-                partition.stream()
-                    .map(OpcUaMonitoredItem::newModifyRequest)
-                    .collect(Collectors.toList()));
+      itemsToModify =
+          partition.stream().map(OpcUaMonitoredItem::newModifyRequest).collect(Collectors.toList());
+    }
 
-        MonitoredItemModifyResult[] results = requireNonNull(response.getResults());
+    try {
+      logger.debug(
+          "id={}, modifyMonitoredItems partition.size(): {}",
+          context.serverState().subscriptionId,
+          partition.size());
+
+      ModifyMonitoredItemsResponse response =
+          client.modifyMonitoredItems(
+              context.serverState().getSubscriptionId(), TimestampsToReturn.Both, itemsToModify);
+
+      MonitoredItemModifyResult[] results = response.getResults();
+      if (results == null || results.length != partition.size()) {
+        throw unexpectedResultCount(
+            "ModifyMonitoredItems", results == null ? null : results.length, partition.size());
+      }
+
+      var serviceOperationResults =
+          new ArrayList<MonitoredItemServiceOperationResult>(results.length);
+
+      synchronized (lifecycleLock) {
+        if (incarnation != context.incarnation()) {
+          return invalidStateAttempt(partition, partition.size());
+        }
 
         for (int i = 0; i < results.length; i++) {
           MonitoredItemModifyResult result = results[i];
@@ -1080,19 +1131,31 @@ public class OpcUaSubscription {
 
           monitoredItem.applyModifyResult(result);
 
-          serviceOperationsResults.add(
+          serviceOperationResults.add(
               new MonitoredItemServiceOperationResult(
                   monitoredItem, StatusCode.GOOD, result.getStatusCode()));
         }
-      } catch (UaException e) {
-        for (OpcUaMonitoredItem item : partition) {
-          serviceOperationsResults.add(
-              new MonitoredItemServiceOperationResult(item, e.getStatusCode(), null));
+      }
+
+      return new MonitoredItemPartitionAttempt(serviceOperationResults, null, partition.size());
+    } catch (UaException e) {
+      synchronized (lifecycleLock) {
+        if (incarnation != context.incarnation()) {
+          return invalidStateAttempt(partition, partition.size());
         }
       }
-    }
 
-    return serviceOperationsResults;
+      var serviceOperationResults =
+          new ArrayList<MonitoredItemServiceOperationResult>(partition.size());
+
+      for (OpcUaMonitoredItem item : partition) {
+        serviceOperationResults.add(
+            new MonitoredItemServiceOperationResult(item, e.getStatusCode(), null));
+      }
+
+      return new MonitoredItemPartitionAttempt(
+          serviceOperationResults, e.getStatusCode(), partition.size());
+    }
   }
 
   /**
@@ -1132,11 +1195,10 @@ public class OpcUaSubscription {
   private List<MonitoredItemServiceOperationResult> deleteMonitoredItems(
       List<OpcUaMonitoredItem> itemsToDelete) {
 
-    var serviceOperationsResults =
-        new ArrayList<MonitoredItemServiceOperationResult>(itemsToDelete.size());
-
-    ServerState serverState = this.serverState;
-    if (serverState == null) {
+    MonitoredItemOperationContext context = getMonitoredItemOperationContext();
+    if (context == null) {
+      var serviceOperationsResults =
+          new ArrayList<MonitoredItemServiceOperationResult>(itemsToDelete.size());
       for (OpcUaMonitoredItem item : itemsToDelete) {
         serviceOperationsResults.add(
             new MonitoredItemServiceOperationResult(
@@ -1146,17 +1208,22 @@ public class OpcUaSubscription {
       return serviceOperationsResults;
     }
 
-    UInteger partitionSize = getMonitoredItemPartitionSize();
+    return executeMonitoredItemPartitions(
+        itemsToDelete, context, partition -> deleteMonitoredItems(context, partition));
+  }
 
-    List<List<OpcUaMonitoredItem>> partitions =
-        Lists.partition(itemsToDelete, partitionSize.intValue()).toList();
+  private MonitoredItemPartitionAttempt deleteMonitoredItems(
+      MonitoredItemOperationContext context, List<OpcUaMonitoredItem> partition) {
 
-    for (List<OpcUaMonitoredItem> partition : partitions) {
-      // Server state may be cleared concurrently, so read each item id only once.
-      //noinspection DuplicatedCode
-      var monitoredItemIds = new ArrayList<UInteger>(partition.size());
-      var itemIds = new ArrayList<Optional<UInteger>>(partition.size());
-      var clientHandles = new ArrayList<Optional<UInteger>>(partition.size());
+    // Server state may be cleared concurrently, so read each item id only once.
+    var monitoredItemIds = new ArrayList<UInteger>(partition.size());
+    var itemIds = new ArrayList<Optional<UInteger>>(partition.size());
+    var clientHandles = new ArrayList<Optional<UInteger>>(partition.size());
+
+    synchronized (lifecycleLock) {
+      if (incarnation != context.incarnation()) {
+        return invalidStateAttempt(partition, 0);
+      }
 
       synchronized (monitoredItemsLock) {
         for (OpcUaMonitoredItem item : partition) {
@@ -1167,27 +1234,45 @@ public class OpcUaSubscription {
           itemId.ifPresent(monitoredItemIds::add);
         }
       }
+    }
 
-      if (monitoredItemIds.isEmpty()) {
-        for (OpcUaMonitoredItem item : partition) {
-          serviceOperationsResults.add(
-              new MonitoredItemServiceOperationResult(
-                  item, new StatusCode(StatusCodes.Bad_InvalidState), null));
-        }
+    if (monitoredItemIds.isEmpty()) {
+      var serviceOperationResults =
+          new ArrayList<MonitoredItemServiceOperationResult>(partition.size());
 
-        continue;
+      for (OpcUaMonitoredItem item : partition) {
+        serviceOperationResults.add(
+            new MonitoredItemServiceOperationResult(
+                item, new StatusCode(StatusCodes.Bad_InvalidState), null));
       }
 
-      try {
-        logger.debug(
-            "id={}, deleteMonitoredItems partition.size(): {}",
-            serverState.subscriptionId,
-            partition.size());
+      return new MonitoredItemPartitionAttempt(serviceOperationResults, null, 0);
+    }
 
-        DeleteMonitoredItemsResponse response =
-            client.deleteMonitoredItems(serverState.getSubscriptionId(), monitoredItemIds);
+    try {
+      logger.debug(
+          "id={}, deleteMonitoredItems partition.size(): {}",
+          context.serverState().subscriptionId,
+          partition.size());
 
-        StatusCode[] results = requireNonNull(response.getResults());
+      DeleteMonitoredItemsResponse response =
+          client.deleteMonitoredItems(context.serverState().getSubscriptionId(), monitoredItemIds);
+
+      StatusCode[] results = response.getResults();
+      if (results == null || results.length != monitoredItemIds.size()) {
+        throw unexpectedResultCount(
+            "DeleteMonitoredItems",
+            results == null ? null : results.length,
+            monitoredItemIds.size());
+      }
+
+      var serviceOperationResults =
+          new ArrayList<MonitoredItemServiceOperationResult>(partition.size());
+
+      synchronized (lifecycleLock) {
+        if (incarnation != context.incarnation()) {
+          return invalidStateAttempt(partition, monitoredItemIds.size());
+        }
 
         int resultIndex = 0;
         for (int i = 0; i < partition.size(); i++) {
@@ -1198,31 +1283,44 @@ public class OpcUaSubscription {
 
             applyMonitoredItemDeleteResult(item, clientHandles.get(i), result);
 
-            serviceOperationsResults.add(
+            serviceOperationResults.add(
                 new MonitoredItemServiceOperationResult(item, StatusCode.GOOD, result));
           } else {
-            serviceOperationsResults.add(
-                new MonitoredItemServiceOperationResult(
-                    item, new StatusCode(StatusCodes.Bad_InvalidState), null));
-          }
-        }
-      } catch (UaException e) {
-        for (int i = 0; i < partition.size(); i++) {
-          OpcUaMonitoredItem item = partition.get(i);
-
-          if (itemIds.get(i).isPresent()) {
-            serviceOperationsResults.add(
-                new MonitoredItemServiceOperationResult(item, e.getStatusCode(), null));
-          } else {
-            serviceOperationsResults.add(
+            serviceOperationResults.add(
                 new MonitoredItemServiceOperationResult(
                     item, new StatusCode(StatusCodes.Bad_InvalidState), null));
           }
         }
       }
-    }
 
-    return serviceOperationsResults;
+      return new MonitoredItemPartitionAttempt(
+          serviceOperationResults, null, monitoredItemIds.size());
+    } catch (UaException e) {
+      synchronized (lifecycleLock) {
+        if (incarnation != context.incarnation()) {
+          return invalidStateAttempt(partition, monitoredItemIds.size());
+        }
+      }
+
+      var serviceOperationResults =
+          new ArrayList<MonitoredItemServiceOperationResult>(partition.size());
+
+      for (int i = 0; i < partition.size(); i++) {
+        OpcUaMonitoredItem item = partition.get(i);
+
+        if (itemIds.get(i).isPresent()) {
+          serviceOperationResults.add(
+              new MonitoredItemServiceOperationResult(item, e.getStatusCode(), null));
+        } else {
+          serviceOperationResults.add(
+              new MonitoredItemServiceOperationResult(
+                  item, new StatusCode(StatusCodes.Bad_InvalidState), null));
+        }
+      }
+
+      return new MonitoredItemPartitionAttempt(
+          serviceOperationResults, e.getStatusCode(), monitoredItemIds.size());
+    }
   }
 
   /**
@@ -1257,6 +1355,95 @@ public class OpcUaSubscription {
     }
   }
 
+  private List<MonitoredItemServiceOperationResult> executeMonitoredItemPartitions(
+      List<OpcUaMonitoredItem> items,
+      MonitoredItemOperationContext context,
+      Function<List<OpcUaMonitoredItem>, MonitoredItemPartitionAttempt> operation) {
+
+    var serviceOperationResults = new ArrayList<MonitoredItemServiceOperationResult>(items.size());
+
+    long partitionGeneration = monitoredItemPartitionGeneration;
+    int partitionSize = getMonitoredItemPartitionSize().intValue();
+    if (partitionSize == 0) {
+      throw new IllegalArgumentException("maxMonitoredItemsPerCall must be greater than zero");
+    }
+
+    int partitionStart = 0;
+
+    while (partitionStart < items.size()) {
+      synchronized (lifecycleLock) {
+        if (incarnation != context.incarnation()) {
+          serviceOperationResults.addAll(
+              invalidStateAttempt(items.subList(partitionStart, items.size()), 0).results());
+          break;
+        }
+      }
+
+      int remaining = items.size() - partitionStart;
+      int partitionEnd = partitionStart + Math.min(partitionSize, remaining);
+      List<OpcUaMonitoredItem> partition = items.subList(partitionStart, partitionEnd);
+
+      MonitoredItemPartitionAttempt attempt = operation.apply(partition);
+
+      if (attempt.operationCount() > 1
+          && attempt.serviceResult() != null
+          && attempt.serviceResult().value() == StatusCodes.Bad_TooManyOperations) {
+
+        synchronized (lifecycleLock) {
+          if (incarnation != context.incarnation()) {
+            serviceOperationResults.addAll(
+                invalidStateAttempt(items.subList(partitionStart, items.size()), 0).results());
+            break;
+          }
+
+          synchronized (monitoredItemPartitionSize) {
+            if (monitoredItemPartitionGeneration == partitionGeneration) {
+              monitoredItemPartitionSize.set(uint(1));
+            }
+          }
+        }
+
+        partitionSize = 1;
+      } else {
+        serviceOperationResults.addAll(attempt.results());
+        partitionStart = partitionEnd;
+      }
+    }
+
+    return serviceOperationResults;
+  }
+
+  private @Nullable MonitoredItemOperationContext getMonitoredItemOperationContext() {
+    synchronized (lifecycleLock) {
+      ServerState serverState = this.serverState;
+      return serverState != null
+          ? new MonitoredItemOperationContext(serverState, incarnation)
+          : null;
+    }
+  }
+
+  private static MonitoredItemPartitionAttempt invalidStateAttempt(
+      List<OpcUaMonitoredItem> items, int operationCount) {
+
+    var results = new ArrayList<MonitoredItemServiceOperationResult>(items.size());
+    StatusCode statusCode = new StatusCode(StatusCodes.Bad_InvalidState);
+
+    for (OpcUaMonitoredItem item : items) {
+      results.add(new MonitoredItemServiceOperationResult(item, statusCode, null));
+    }
+
+    return new MonitoredItemPartitionAttempt(results, statusCode, operationCount);
+  }
+
+  private static UaException unexpectedResultCount(
+      String serviceName, @Nullable Integer actual, int expected) {
+
+    return new UaException(
+        StatusCodes.Bad_UnexpectedError,
+        "%s returned %s results, expected %s"
+            .formatted(serviceName, actual == null ? "null" : actual, expected));
+  }
+
   private UInteger getMonitoredItemPartitionSize() {
     return monitoredItemPartitionSize.get(
         () -> {
@@ -1278,6 +1465,13 @@ public class OpcUaSubscription {
           return uint(Math.min(configuredMax, serverMax));
         });
   }
+
+  private record MonitoredItemPartitionAttempt(
+      List<MonitoredItemServiceOperationResult> results,
+      @Nullable StatusCode serviceResult,
+      int operationCount) {}
+
+  private record MonitoredItemOperationContext(ServerState serverState, long incarnation) {}
 
   // endregion
 
@@ -1302,11 +1496,10 @@ public class OpcUaSubscription {
       return Collections.emptyList();
     }
 
-    var serviceOperationResults =
-        new ArrayList<MonitoredItemServiceOperationResult>(monitoredItems.size());
-
-    ServerState serverState = this.serverState;
-    if (serverState == null) {
+    MonitoredItemOperationContext context = getMonitoredItemOperationContext();
+    if (context == null) {
+      var serviceOperationResults =
+          new ArrayList<MonitoredItemServiceOperationResult>(monitoredItems.size());
       for (OpcUaMonitoredItem item : monitoredItems) {
         serviceOperationResults.add(
             new MonitoredItemServiceOperationResult(
@@ -1315,16 +1508,25 @@ public class OpcUaSubscription {
       return serviceOperationResults;
     }
 
-    UInteger partitionSize = getMonitoredItemPartitionSize();
+    return executeMonitoredItemPartitions(
+        monitoredItems,
+        context,
+        partition -> setMonitoringMode(context, monitoringMode, partition));
+  }
 
-    List<List<OpcUaMonitoredItem>> partitions =
-        Lists.partition(monitoredItems, partitionSize.intValue()).toList();
+  private MonitoredItemPartitionAttempt setMonitoringMode(
+      MonitoredItemOperationContext context,
+      MonitoringMode monitoringMode,
+      List<OpcUaMonitoredItem> partition) {
 
-    for (List<OpcUaMonitoredItem> partition : partitions) {
-      // Server state may be cleared concurrently, so read each item id only once.
-      //noinspection DuplicatedCode
-      var monitoredItemIds = new ArrayList<UInteger>(partition.size());
-      var itemIds = new ArrayList<Optional<UInteger>>(partition.size());
+    // Server state may be cleared concurrently, so read each item id only once.
+    var monitoredItemIds = new ArrayList<UInteger>(partition.size());
+    var itemIds = new ArrayList<Optional<UInteger>>(partition.size());
+
+    synchronized (lifecycleLock) {
+      if (incarnation != context.incarnation()) {
+        return invalidStateAttempt(partition, 0);
+      }
 
       for (OpcUaMonitoredItem item : partition) {
         Optional<UInteger> itemId = item.getMonitoredItemId();
@@ -1332,28 +1534,44 @@ public class OpcUaSubscription {
         itemIds.add(itemId);
         itemId.ifPresent(monitoredItemIds::add);
       }
+    }
 
-      if (monitoredItemIds.isEmpty()) {
-        for (OpcUaMonitoredItem item : partition) {
-          serviceOperationResults.add(
-              new MonitoredItemServiceOperationResult(
-                  item, new StatusCode(StatusCodes.Bad_InvalidState), null));
-        }
+    if (monitoredItemIds.isEmpty()) {
+      var serviceOperationResults =
+          new ArrayList<MonitoredItemServiceOperationResult>(partition.size());
 
-        continue;
+      for (OpcUaMonitoredItem item : partition) {
+        serviceOperationResults.add(
+            new MonitoredItemServiceOperationResult(
+                item, new StatusCode(StatusCodes.Bad_InvalidState), null));
       }
 
-      try {
-        logger.debug(
-            "id={}, setMonitoringMode partition.size(): {}",
-            serverState.subscriptionId,
-            partition.size());
+      return new MonitoredItemPartitionAttempt(serviceOperationResults, null, 0);
+    }
 
-        SetMonitoringModeResponse response =
-            client.setMonitoringMode(
-                serverState.getSubscriptionId(), monitoringMode, monitoredItemIds);
+    try {
+      logger.debug(
+          "id={}, setMonitoringMode partition.size(): {}",
+          context.serverState().subscriptionId,
+          partition.size());
 
-        StatusCode[] results = requireNonNull(response.getResults());
+      SetMonitoringModeResponse response =
+          client.setMonitoringMode(
+              context.serverState().getSubscriptionId(), monitoringMode, monitoredItemIds);
+
+      StatusCode[] results = response.getResults();
+      if (results == null || results.length != monitoredItemIds.size()) {
+        throw unexpectedResultCount(
+            "SetMonitoringMode", results == null ? null : results.length, monitoredItemIds.size());
+      }
+
+      var serviceOperationResults =
+          new ArrayList<MonitoredItemServiceOperationResult>(partition.size());
+
+      synchronized (lifecycleLock) {
+        if (incarnation != context.incarnation()) {
+          return invalidStateAttempt(partition, monitoredItemIds.size());
+        }
 
         int resultIndex = 0;
         for (int i = 0; i < partition.size(); i++) {
@@ -1374,12 +1592,27 @@ public class OpcUaSubscription {
                     item, new StatusCode(StatusCodes.Bad_InvalidState), null));
           }
         }
-      } catch (UaException e) {
+      }
+
+      return new MonitoredItemPartitionAttempt(
+          serviceOperationResults, null, monitoredItemIds.size());
+    } catch (UaException e) {
+      var serviceOperationResults =
+          new ArrayList<MonitoredItemServiceOperationResult>(partition.size());
+
+      synchronized (lifecycleLock) {
+        if (incarnation != context.incarnation()) {
+          return invalidStateAttempt(partition, monitoredItemIds.size());
+        }
+
         for (int i = 0; i < partition.size(); i++) {
           OpcUaMonitoredItem item = partition.get(i);
 
           if (itemIds.get(i).isPresent()) {
-            item.applySetMonitoringModeResult(e.getStatusCode());
+            if (monitoredItemIds.size() == 1
+                || e.getStatusCode().value() != StatusCodes.Bad_TooManyOperations) {
+              item.applySetMonitoringModeResult(e.getStatusCode());
+            }
 
             serviceOperationResults.add(
                 new MonitoredItemServiceOperationResult(item, e.getStatusCode(), null));
@@ -1390,9 +1623,10 @@ public class OpcUaSubscription {
           }
         }
       }
-    }
 
-    return serviceOperationResults;
+      return new MonitoredItemPartitionAttempt(
+          serviceOperationResults, e.getStatusCode(), monitoredItemIds.size());
+    }
   }
 
   // endregion
@@ -1911,10 +2145,13 @@ public class OpcUaSubscription {
    *     created/modified/deleted in a single service call.
    */
   public void setMaxMonitoredItemsPerCall(UInteger maxMonitoredItemsPerCall) {
-    this.maxMonitoredItemsPerCall = maxMonitoredItemsPerCall;
+    synchronized (monitoredItemPartitionSize) {
+      this.maxMonitoredItemsPerCall = maxMonitoredItemsPerCall;
+      monitoredItemPartitionGeneration++;
 
-    // next service call will re-calculate the partition size
-    monitoredItemPartitionSize.reset();
+      // next service call will re-calculate the partition size
+      monitoredItemPartitionSize.reset();
+    }
   }
 
   /**

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscription.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscription.java
@@ -2248,17 +2248,21 @@ public class OpcUaSubscription {
         modifications = null;
 
         monitoredItemPartitionSize.reset();
-        monitoredItems.values().forEach(OpcUaMonitoredItem::reset);
+        // Keep reset's handle cleanup atomic with add/remove, in the same lock order used
+        // when applying monitored-item service results.
+        synchronized (monitoredItemsLock) {
+          monitoredItems.values().forEach(OpcUaMonitoredItem::reset);
 
-        // MonitoredItemIds are scoped to the Subscription that no longer exists, so the items
-        // pending deletion are already gone and their ids must never be sent again. Detach them
-        // completely, including the ClientHandle, so they can be added to a Subscription again.
-        itemsToDelete.forEach(
-            item -> {
-              item.reset();
-              item.setClientHandle(null);
-            });
-        itemsToDelete.clear();
+          // MonitoredItemIds are scoped to the Subscription that no longer exists, so the items
+          // pending deletion are already gone and their ids must never be sent again. Detach them
+          // completely, including the ClientHandle, so they can be added to a Subscription again.
+          itemsToDelete.forEach(
+              item -> {
+                item.reset();
+                item.setClientHandle(null);
+              });
+          itemsToDelete.clear();
+        }
 
         syncState = SyncState.INITIAL;
       }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscription.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/OpcUaSubscription.java
@@ -15,6 +15,7 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
 
 import com.google.common.primitives.Ints;
+import com.google.common.util.concurrent.MoreExecutors;
 import java.math.BigInteger;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -29,6 +30,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -238,13 +241,26 @@ public class OpcUaSubscription {
   private volatile @Nullable SubscriptionListener listener;
 
   private final TaskQueue deliveryQueue;
+  private final Executor transitionHandoffExecutor;
 
   private final OpcUaClient client;
 
   public OpcUaSubscription(OpcUaClient client) {
     this.client = client;
 
-    deliveryQueue = new TaskQueue(client.getTransport().getConfig().getExecutor());
+    Executor executor = client.getTransport().getConfig().getExecutor();
+    deliveryQueue = new TaskQueue(executor);
+    transitionHandoffExecutor =
+        MoreExecutors.newSequentialExecutor(
+            command -> {
+              try {
+                executor.execute(command);
+              } catch (RejectedExecutionException e) {
+                // Finishing a transition must release its successor even when the executor shuts
+                // down.
+                command.run();
+              }
+            });
   }
 
   /**
@@ -732,11 +748,9 @@ public class OpcUaSubscription {
     }
 
     if (next != null) {
-      // Completed asynchronously rather than on this stack: a queued transition that completes
-      // synchronously — nothing pending to send, or an immediate Bad_InvalidState — would re-enter
-      // this method inline, one frame per waiter, and enough waiters is a StackOverflowError that
-      // leaves the slot claimed forever.
-      next.completeAsync(() -> Unit.VALUE, client.getTransport().getConfig().getExecutor());
+      // The sequential executor trampolines direct execution and rejected handoffs. A long queue
+      // of synchronous transitions cannot recurse, and no completion runs under lifecycleLock.
+      transitionHandoffExecutor.execute(() -> next.complete(Unit.VALUE));
     }
   }
 

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/PublishingManager.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/PublishingManager.java
@@ -15,6 +15,7 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -139,7 +140,11 @@ public class PublishingManager {
 
   private final ConcurrentMap<NodeId, AtomicLong> pendingCountMap = new ConcurrentHashMap<>();
 
-  private final Map<UInteger, SubscriptionDetails> subscriptionDetails = new ConcurrentHashMap<>();
+  private final Object registrationLock = new Object();
+
+  // Replace the immutable map only when registration changes. Each Publish request can retain
+  // its identity snapshot with one volatile read instead of copying the registry on the hot path.
+  private volatile Map<UInteger, SubscriptionDetails> subscriptionDetails = Map.of();
 
   /**
    * Incremented every time a Subscription is registered with or unregistered from this manager.
@@ -258,18 +263,17 @@ public class PublishingManager {
         .getSubscriptionId()
         .ifPresent(
             id -> {
-              SubscriptionDetails displaced =
-                  subscriptionDetails.put(id, new SubscriptionDetails(subscription, id, executor));
-
-              if (displaced != null) {
-                // The Server has reused this SubscriptionId while an entry was still registered
-                // under it. Displacement removed that entry from the map, so unregister() — which
-                // matches by (key, value) — can never succeed for it again; without this, work
-                // still queued for it would be applied as if its Subscription existed, forever.
-                displaced.registered = false;
+              // Construct outside registrationLock because this reads the subscription lifecycle.
+              var details = new SubscriptionDetails(subscription, id, executor);
+              synchronized (registrationLock) {
+                var updated = new HashMap<>(subscriptionDetails);
+                SubscriptionDetails displaced = updated.put(id, details);
+                if (displaced != null) {
+                  displaced.registered = false;
+                }
+                subscriptionDetails = Map.copyOf(updated);
+                subscriptionGeneration.incrementAndGet();
               }
-
-              subscriptionGeneration.incrementAndGet();
             });
 
     // The client wants a deeper pipeline than it did when any ceiling was learned, and Part 4
@@ -310,15 +314,18 @@ public class PublishingManager {
    *     it; {@code false} if something else unregistered it first.
    */
   private boolean unregister(SubscriptionDetails details) {
-    if (subscriptionDetails.remove(details.subscriptionId, details)) {
+    synchronized (registrationLock) {
+      if (subscriptionDetails.get(details.subscriptionId) != details) {
+        return false;
+      }
+
+      var updated = new HashMap<>(subscriptionDetails);
+      updated.remove(details.subscriptionId);
       details.registered = false;
-
+      subscriptionDetails = Map.copyOf(updated);
       subscriptionGeneration.incrementAndGet();
-
       return true;
     }
-
-    return false;
   }
 
   /**
@@ -876,6 +883,7 @@ public class PublishingManager {
     // Read before the request is built, so that a Subscription registered or unregistered while it
     // is in flight is seen as a change by the failure handler rather than missed.
     long generation = subscriptionGeneration.get();
+    Map<UInteger, SubscriptionDetails> requestRegistrations = subscriptionDetails;
 
     // Read for the same reason: a Session-level failure describes the Session the request was sent
     // on, and once another activation has been counted it no longer describes the client.
@@ -957,7 +965,12 @@ public class PublishingManager {
 
                   boolean queued = false;
 
-                  if (details != null) {
+                  SubscriptionDetails requestedDetails = requestRegistrations.get(subscriptionId);
+                  if (details != null
+                      && (requestedDetails == null || requestedDetails == details)) {
+                    // A queued Publish may serve a subscription created after the request. Only
+                    // reject a known id that now belongs to another registration: its delayed
+                    // response cannot safely be attributed to the replacement incarnation.
                     // Cheap and non-blocking: cancels and re-schedules a timer. The watchdog
                     // watches for the Server going quiet, so it is reset when the response is
                     // received rather than when it is eventually processed.

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/package-info.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/**
+ * Maintains client-side Subscriptions, their desired MonitoredItems, and ordered notification
+ * delivery. {@link org.eclipse.milo.opcua.sdk.client.subscriptions.OpcUaSubscription} owns the
+ * desired configuration and server-assigned state. The publishing manager maintains the Session's
+ * Publish pipeline and routes responses to registered Subscriptions.
+ *
+ * <p>A reset starts a new incarnation of a Subscription object. Service responses captured for an
+ * earlier incarnation cannot update its replacement, and pending Publish responses retain their
+ * registration identities when server-assigned ids are reused. Publish requests may also serve a
+ * Subscription first registered after the request was sent. Registration changes publish an
+ * immutable registry snapshot; retaining it for each Publish request needs no registry lock or map
+ * copy. Per-subscription processing and delivery queues preserve the order received from the
+ * transport.
+ */
+package org.eclipse.milo.opcua.sdk.client.subscriptions;

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/package-info.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/package-info.java
@@ -22,7 +22,10 @@
  * copy. Per-subscription processing and delivery queues preserve the order received from the
  * transport.
  *
- * <p>Reset and item add/remove operations coordinate collection membership and ClientHandle
- * ownership; code requiring both locks takes the lifecycle lock before the item collection lock.
+ * <p>Lifecycle operations claim a serial transition slot without holding a lock across service
+ * calls. Completing a transition hands the slot to the next waiter through a serial executor, with
+ * inline fallback when the caller-owned transport executor rejects dispatch. Reset and item
+ * add/remove operations coordinate collection membership and ClientHandle ownership; code requiring
+ * both locks takes the lifecycle lock before the item collection lock.
  */
 package org.eclipse.milo.opcua.sdk.client.subscriptions;

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/package-info.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/package-info.java
@@ -21,5 +21,8 @@
  * immutable registry snapshot; retaining it for each Publish request needs no registry lock or map
  * copy. Per-subscription processing and delivery queues preserve the order received from the
  * transport.
+ *
+ * <p>Reset and item add/remove operations coordinate collection membership and ClientHandle
+ * ownership; code requiring both locks takes the lifecycle lock before the item collection lock.
  */
 package org.eclipse.milo.opcua.sdk.client.subscriptions;

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/package-info.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/subscriptions/package-info.java
@@ -27,5 +27,9 @@
  * inline fallback when the caller-owned transport executor rejects dispatch. Reset and item
  * add/remove operations coordinate collection membership and ClientHandle ownership; code requiring
  * both locks takes the lifecycle lock before the item collection lock.
+ *
+ * <p>Discovering a monitored-item partition limit may wait for Session activation and server I/O.
+ * Reset invalidates that cache without waiting for an in-progress lookup, because Session recovery
+ * itself may need to reset Subscriptions before activation can finish.
  */
 package org.eclipse.milo.opcua.sdk.client.subscriptions;

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/typetree/ClientBrowseUtils.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/typetree/ClientBrowseUtils.java
@@ -12,9 +12,9 @@ package org.eclipse.milo.opcua.sdk.client.typetree;
 
 import static java.util.Objects.requireNonNullElse;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
-import static org.eclipse.milo.opcua.stack.core.util.Lists.partition;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -113,25 +113,31 @@ final class ClientBrowseUtils {
     int partitionSize =
         limits
             .maxNodesPerRead()
-            .map(UInteger::intValue)
+            .map(ClientBrowseUtils::toPartitionSize)
             .filter(v -> v > 0)
-            .orElse(Integer.MAX_VALUE);
+            .orElse(1);
 
-    var values = new ArrayList<DataValue>();
+    return executeWithOperationLimit(
+        readValueIds,
+        partitionSize,
+        partitionList -> {
+          ReadResponse response;
+          try {
+            response = client.read(0.0, TimestampsToReturn.Neither, partitionList);
+          } catch (UaException e) {
+            throw retryableTooManyOperations(partitionList, e);
+          }
 
-    for (List<ReadValueId> partitionList : partition(readValueIds, partitionSize).toList()) {
-      ReadResponse response = client.read(0.0, TimestampsToReturn.Neither, partitionList);
-      DataValue[] results = response.getResults();
-      if (results == null || results.length != partitionList.size()) {
-        throw new UaException(
-            StatusCodes.Bad_UnexpectedError,
-            "Read returned %s results, expected %s"
-                .formatted(results == null ? "null" : results.length, partitionList.size()));
-      }
-      Collections.addAll(values, results);
-    }
+          DataValue[] results = response.getResults();
+          if (results == null || results.length != partitionList.size()) {
+            throw new UaException(
+                StatusCodes.Bad_UnexpectedError,
+                "Read returned %s results, expected %s"
+                    .formatted(results == null ? "null" : results.length, partitionList.size()));
+          }
 
-    return values;
+          return Arrays.asList(results);
+        });
   }
 
   /**
@@ -156,18 +162,62 @@ final class ClientBrowseUtils {
     int partitionSize =
         limits
             .maxNodesPerBrowse()
-            .map(UInteger::intValue)
+            .map(ClientBrowseUtils::toPartitionSize)
             .filter(v -> v > 0)
-            .orElse(Integer.MAX_VALUE);
+            .orElse(1);
 
-    var references = new ArrayList<List<ReferenceDescription>>();
+    return executeWithOperationLimit(
+        browseDescriptions, partitionSize, partitionList -> browsePartition(client, partitionList));
+  }
 
-    for (List<BrowseDescription> partitionList :
-        partition(browseDescriptions, partitionSize).toList()) {
-      references.addAll(browse(client, partitionList));
+  private static int toPartitionSize(UInteger operationLimit) {
+    return (int) Math.min(operationLimit.longValue(), Integer.MAX_VALUE);
+  }
+
+  private static <T, R> List<R> executeWithOperationLimit(
+      List<T> inputs, int partitionSize, PartitionOperation<T, R> operation) throws UaException {
+
+    var results = new ArrayList<R>(inputs.size());
+
+    int index = 0;
+    int currentPartitionSize = partitionSize;
+
+    while (index < inputs.size()) {
+      int count = Math.min(currentPartitionSize, inputs.size() - index);
+      List<T> partitionList = inputs.subList(index, index + count);
+
+      try {
+        results.addAll(operation.apply(partitionList));
+        index += count;
+      } catch (RetryableTooManyOperationsException e) {
+        currentPartitionSize = 1;
+      }
     }
 
-    return references;
+    return results;
+  }
+
+  @FunctionalInterface
+  private interface PartitionOperation<T, R> {
+
+    List<R> apply(List<T> partitionList) throws UaException;
+  }
+
+  private static UaException retryableTooManyOperations(List<?> partition, UaException failure) {
+    if (partition.size() > 1
+        && failure.getStatusCode().value() == StatusCodes.Bad_TooManyOperations) {
+
+      return new RetryableTooManyOperationsException(failure);
+    }
+
+    return failure;
+  }
+
+  private static final class RetryableTooManyOperationsException extends UaException {
+
+    private RetryableTooManyOperationsException(UaException cause) {
+      super(cause);
+    }
   }
 
   /**
@@ -185,15 +235,38 @@ final class ClientBrowseUtils {
       return List.of();
     }
 
-    final var referenceDescriptionLists = new ArrayList<List<ReferenceDescription>>();
-
     List<BrowseResult> browseResults = client.browse(browseDescriptions);
+
+    return collectBrowseResults(client, browseDescriptions, browseResults);
+  }
+
+  private static List<List<ReferenceDescription>> browsePartition(
+      OpcUaClient client, List<BrowseDescription> browseDescriptions) throws UaException {
+
+    List<BrowseResult> browseResults;
+    try {
+      browseResults = client.browse(browseDescriptions);
+    } catch (UaException e) {
+      throw retryableTooManyOperations(browseDescriptions, e);
+    }
+
+    return collectBrowseResults(client, browseDescriptions, browseResults);
+  }
+
+  private static List<List<ReferenceDescription>> collectBrowseResults(
+      OpcUaClient client,
+      List<BrowseDescription> browseDescriptions,
+      List<BrowseResult> browseResults)
+      throws UaException {
+
     if (browseResults.size() != browseDescriptions.size()) {
       throw new UaException(
           StatusCodes.Bad_UnexpectedError,
           "Browse returned %d results, expected %d"
               .formatted(browseResults.size(), browseDescriptions.size()));
     }
+
+    final var referenceDescriptionLists = new ArrayList<List<ReferenceDescription>>();
 
     for (BrowseResult result : browseResults) {
       if (result.getStatusCode().isGood()) {


### PR DESCRIPTION
Merge `main` into `integration/1.2` to bring in the client operation-limit fallback and session/subscription lifecycle recovery fixes.

Resolve merge conflicts while preserving the 1.2 transport abstraction, namespace/server table updates, and empty Browse continuation-point handling. The merge retains both branches' Browse regression tests.

Verified with `mise exec -- mvn -q spotless:apply`, `mise exec -- mvn -q clean compile`, and the eight targeted client regression test classes in `integration-tests` with `-am`. All 56 tests passed with no failures, errors, or skips.
