### PR TITLE
Preserve scripted Publish response order in regression tests

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/PublishSequenceRegressionTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/subscriptions/PublishSequenceRegressionTest.java
@@ -127,7 +127,13 @@ public class PublishSequenceRegressionTest {
 
     server.startup().get();
 
-    client = TestClient.create(server, cfg -> cfg.setRequestTimeout(uint(REQUEST_TIMEOUT_MILLIS)));
+    // One outstanding Publish request preserves scripted response order across server dispatch.
+    client =
+        TestClient.create(
+            server,
+            cfg ->
+                cfg.setRequestTimeout(uint(REQUEST_TIMEOUT_MILLIS))
+                    .setMaxPendingPublishRequests(uint(1)));
     client.connect();
 
     subscription = new OpcUaSubscription(client);


### PR DESCRIPTION
The duplicate-window boundary test can fail when concurrent Publish requests cause the scripted responses to arrive out of order. In the failed snapshot build, sequence 101 arrived before 37, moving 37 outside the 64-message duplicate window and triggering resynchronization.

Limit this test fixture to one outstanding Publish request so the client processes responses in scripted order and the test exercises the intended boundary.

Verification passed locally: `spotless:apply`, `clean compile`, and all four `PublishSequenceRegressionTest` tests with reactor dependencies rebuilt.

Observed failure: https://github.com/eclipse-milo/milo/actions/runs/34000984394/job/101399690448
