### PR TITLE
Remove the unused server transport executor

### DIFF
--- a/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/server/OpcServerTransportConfig.java
+++ b/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/server/OpcServerTransportConfig.java
@@ -13,17 +13,9 @@ package org.eclipse.milo.opcua.stack.transport.server;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoopGroup;
-import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 
 public interface OpcServerTransportConfig {
-
-  /**
-   * Get the {@link ExecutorService} to be used by this transport.
-   *
-   * @return the {@link ExecutorService} to be used by this transport.
-   */
-  ExecutorService getExecutor();
 
   /**
    * Get the {@link EventLoopGroup} to be used by this transport.

--- a/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/server/tcp/OpcTcpServerTransportConfigBuilder.java
+++ b/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/server/tcp/OpcTcpServerTransportConfigBuilder.java
@@ -16,14 +16,12 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoopGroup;
-import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 import org.eclipse.milo.opcua.stack.core.Stack;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 
 public class OpcTcpServerTransportConfigBuilder {
 
-  private ExecutorService executor;
   private EventLoopGroup eventLoop;
   private UInteger helloDeadline = uint(10_000);
   private UInteger minimumSecureChannelLifetime = uint(60_000);
@@ -31,11 +29,6 @@ public class OpcTcpServerTransportConfigBuilder {
   private Consumer<ServerBootstrap> bootstrapCustomizer = b -> {};
   private Consumer<Bootstrap> reverseConnectBootstrapCustomizer = b -> {};
   private Consumer<ChannelPipeline> channelPipelineCustomizer = p -> {};
-
-  public OpcTcpServerTransportConfigBuilder setExecutor(ExecutorService executor) {
-    this.executor = executor;
-    return this;
-  }
 
   public OpcTcpServerTransportConfigBuilder setEventLoop(EventLoopGroup eventLoop) {
     this.eventLoop = eventLoop;
@@ -105,15 +98,11 @@ public class OpcTcpServerTransportConfigBuilder {
   }
 
   public OpcTcpServerTransportConfig build() {
-    if (executor == null) {
-      executor = Stack.sharedExecutor();
-    }
     if (eventLoop == null) {
       eventLoop = Stack.sharedEventLoop();
     }
 
     return new OpcTcpServerTransportConfigImpl(
-        executor,
         eventLoop,
         bootstrapCustomizer,
         reverseConnectBootstrapCustomizer,
@@ -125,7 +114,6 @@ public class OpcTcpServerTransportConfigBuilder {
 
   static class OpcTcpServerTransportConfigImpl implements OpcTcpServerTransportConfig {
 
-    private final ExecutorService executor;
     private final EventLoopGroup eventLoop;
     private final UInteger helloDeadline;
     private final UInteger minimumSecureChannelLifetime;
@@ -135,7 +123,6 @@ public class OpcTcpServerTransportConfigBuilder {
     private final Consumer<ChannelPipeline> channelPipelineCustomizer;
 
     public OpcTcpServerTransportConfigImpl(
-        ExecutorService executor,
         EventLoopGroup eventLoop,
         Consumer<ServerBootstrap> bootstrapCustomizer,
         Consumer<Bootstrap> reverseConnectBootstrapCustomizer,
@@ -144,7 +131,6 @@ public class OpcTcpServerTransportConfigBuilder {
         UInteger minimumSecureChannelLifetime,
         UInteger maximumSecureChannelLifetime) {
 
-      this.executor = executor;
       this.eventLoop = eventLoop;
       this.bootstrapCustomizer = bootstrapCustomizer;
       this.reverseConnectBootstrapCustomizer = reverseConnectBootstrapCustomizer;
@@ -152,11 +138,6 @@ public class OpcTcpServerTransportConfigBuilder {
       this.helloDeadline = helloDeadline;
       this.minimumSecureChannelLifetime = minimumSecureChannelLifetime;
       this.maximumSecureChannelLifetime = maximumSecureChannelLifetime;
-    }
-
-    @Override
-    public ExecutorService getExecutor() {
-      return executor;
     }
 
     @Override

--- a/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/server/uasc/UascServerConfig.java
+++ b/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/server/uasc/UascServerConfig.java
@@ -10,19 +10,9 @@
 
 package org.eclipse.milo.opcua.stack.transport.server.uasc;
 
-import java.util.concurrent.ExecutorService;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 
 public interface UascServerConfig {
-
-  /**
-   * Get the {@link ExecutorService} to use when dispatching inbound {@link UascServiceRequest}s
-   * that arrive while on the Netty event loop thread.
-   *
-   * @return the {@link ExecutorService} to use when dispatching inbound {@link
-   *     UascServiceRequest}s.
-   */
-  ExecutorService getExecutor();
 
   /**
    * Get the deadline, in milliseconds, that a "Hello" message must arrive by after the underlying

--- a/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/server/uasc/UascServerSymmetricHandler.java
+++ b/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/server/uasc/UascServerSymmetricHandler.java
@@ -94,7 +94,7 @@ public class UascServerSymmetricHandler extends ByteToMessageCodec<UascServiceRe
 
   @Override
   public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
-    ctx.pipeline().addLast(new UascServiceRequestHandler(config, applicationContext));
+    ctx.pipeline().addLast(new UascServiceRequestHandler(applicationContext));
 
     super.handlerAdded(ctx);
   }

--- a/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/server/uasc/UascServiceRequestHandler.java
+++ b/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/server/uasc/UascServiceRequestHandler.java
@@ -25,12 +25,9 @@ import org.eclipse.milo.opcua.stack.transport.server.ServerApplicationContext;
 
 public class UascServiceRequestHandler extends SimpleChannelInboundHandler<UascServiceRequest> {
 
-  private final UascServerConfig config;
   private final ServerApplicationContext applicationContext;
 
-  public UascServiceRequestHandler(
-      UascServerConfig config, ServerApplicationContext applicationContext) {
-    this.config = config;
+  public UascServiceRequestHandler(ServerApplicationContext applicationContext) {
     this.applicationContext = applicationContext;
   }
 

--- a/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/server/uasc/package-info.java
+++ b/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/server/uasc/package-info.java
@@ -24,6 +24,7 @@
  * <p>Buffer ownership stays on the channel's event loop. Accumulation transfers retained buffers to
  * the decoder for message completion, and disconnect, handler removal, and exception cleanup
  * release buffers still owned by the handler. Service dispatch begins only after successful
- * decoding and uses the executor supplied by the server transport configuration.
+ * decoding and hands the request to the {@code ServerApplicationContext} on the event loop thread;
+ * any handoff to an application executor is the application context's responsibility.
  */
 package org.eclipse.milo.opcua.stack.transport.server.uasc;

--- a/opc-ua-stack/transport/src/test/java/org/eclipse/milo/opcua/stack/transport/server/uasc/UascChunkRecoveryTest.java
+++ b/opc-ua-stack/transport/src/test/java/org/eclipse/milo/opcua/stack/transport/server/uasc/UascChunkRecoveryTest.java
@@ -30,7 +30,6 @@ import java.security.Signature;
 import java.security.cert.X509Certificate;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import javax.crypto.Cipher;
 import javax.crypto.spec.GCMParameterSpec;
@@ -443,11 +442,6 @@ class UascChunkRecoveryTest {
 
   private static final UascServerConfig CONFIG =
       new UascServerConfig() {
-        @Override
-        public ExecutorService getExecutor() {
-          return null;
-        }
-
         @Override
         public UInteger getHelloDeadline() {
           return uint(60_000);

--- a/opc-ua-stack/transport/src/test/java/org/eclipse/milo/opcua/stack/transport/server/uasc/UascServerSymmetricHandlerTest.java
+++ b/opc-ua-stack/transport/src/test/java/org/eclipse/milo/opcua/stack/transport/server/uasc/UascServerSymmetricHandlerTest.java
@@ -22,7 +22,6 @@ import java.security.KeyPair;
 import java.security.cert.X509Certificate;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
 import org.eclipse.milo.opcua.stack.core.channel.ChannelParameters;
 import org.eclipse.milo.opcua.stack.core.channel.ChannelSecurity;
 import org.eclipse.milo.opcua.stack.core.channel.ChunkDecoder;
@@ -183,11 +182,6 @@ class UascServerSymmetricHandlerTest {
 
   private static UascServerConfig stubConfig() {
     return new UascServerConfig() {
-      @Override
-      public ExecutorService getExecutor() {
-        return null;
-      }
-
       @Override
       public UInteger getHelloDeadline() {
         return uint(0);


### PR DESCRIPTION
The OPC TCP server transport has carried an executor setting that nothing uses.

`UascServiceRequestHandler` used to dispatch inbound service requests onto
`config.getExecutor()`. That handoff was removed in #1245, when
`ServerApplicationContext.handleServiceRequest` became the SDK's responsibility. The
configuration surface stayed behind: the builder still accepted an executor and defaulted
it to `Stack.sharedExecutor()`, and both `OpcServerTransportConfig` and
`UascServerConfig` still declared `getExecutor()`, with no reader anywhere in the tree.

### Changes

- Remove `getExecutor()` from `OpcServerTransportConfig` and `UascServerConfig`.
- Remove `setExecutor()`, the field, the default, and the impl getter from
  `OpcTcpServerTransportConfigBuilder`.
- Remove the `UascServerConfig` field and constructor parameter from
  `UascServiceRequestHandler`, which only existed to reach the executor.
- Correct the `server.uasc` package documentation, which claimed service dispatch runs on
  the transport executor.

### Compatibility

This removes public API, hence 1.2. It has no runtime effect, since the removed setting
had none.

Server applications that want service handling off the Netty event loop should use
`OpcUaServerConfigBuilder.setExecutor`, which is the real control point and is unchanged.
The client-side `OpcClientTransportConfig.getExecutor()` is also unchanged and still in
active use.

### Validation

`spotless:apply`, `clean compile`, and a project-wide `test-compile` pass.
`mvn -pl opc-ua-stack/transport -am test -Dtest='Uasc*Test,OpcTcpServer*Test'` runs 52
tests, all passing.
