### PR TITLE
Run reverse-connect attempts and retry policies on the server executor

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/reverse/ReverseConnectTargetManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/reverse/ReverseConnectTargetManager.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
@@ -31,6 +32,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
@@ -78,6 +80,18 @@ import org.slf4j.LoggerFactory;
  * and the next {@code startup()}, structure-changing operations ({@link #addTarget}, {@code
  * update}, and the channel- and attempt-side event handlers) throw {@link IllegalStateException};
  * configure or remove targets while the manager is running or before the first startup.
+ *
+ * <p>The manager uses two caller-owned execution resources. The scheduler only fires attempt
+ * timers; its callbacks check whether the timer is still current and hand the work to the server
+ * executor. The executor runs attempt startup (including client listener hostname resolution and
+ * transport startup), custom {@link ReverseConnectRetryPolicy} evaluation, and, through a separate
+ * serialized queue, listener callbacks. Work handed to the executor revalidates target ownership,
+ * generation, and lifecycle state when it starts, so a timer that fired before a pause, update,
+ * removal, or shutdown cannot start a stale attempt. If the executor rejects attempt startup or
+ * retry evaluation, the manager records the rejection as a failed attempt or skipped retry
+ * evaluation, emits the usual listener notifications, and reschedules the target after its
+ * registration period without consulting the custom retry policy. The manager never shuts down the
+ * executor or the scheduler.
  */
 public final class ReverseConnectTargetManager {
 
@@ -91,6 +105,7 @@ public final class ReverseConnectTargetManager {
   private final Supplier<List<EndpointDescription>> endpointDescriptions;
   private final Function<TransportProfile, OpcServerTransport> transportSupplier;
   private final String serverUri;
+  private final Executor executor;
   private final ExecutionQueue listenerQueue;
   private final ScheduledExecutorService scheduler;
 
@@ -100,12 +115,15 @@ public final class ReverseConnectTargetManager {
   /**
    * Construct a target manager for one server instance.
    *
+   * <p>The manager does not take ownership of {@code executor} or {@code scheduler}; the caller
+   * remains responsible for shutting them down.
+   *
    * @param applicationContext the server application context used by reverse-opened channels.
    * @param endpointDescriptions supplies current endpoint descriptions for target validation.
    * @param transportSupplier supplies the server transport for a transport profile.
    * @param serverUri the server application URI advertised in {@code ReverseHello}.
-   * @param listenerExecutor dispatches target and attempt listener callbacks.
-   * @param scheduler schedules initial, retry, and reconnect attempts.
+   * @param executor runs attempt startup, retry-policy evaluation, and listener callbacks.
+   * @param scheduler fires timers for initial, retry, and reconnect attempts.
    * @param initialTargets the targets registered when the server is constructed.
    */
   public ReverseConnectTargetManager(
@@ -113,7 +131,7 @@ public final class ReverseConnectTargetManager {
       Supplier<List<EndpointDescription>> endpointDescriptions,
       Function<TransportProfile, OpcServerTransport> transportSupplier,
       String serverUri,
-      ExecutorService listenerExecutor,
+      ExecutorService executor,
       ScheduledExecutorService scheduler,
       Collection<ReverseConnectTarget> initialTargets) {
 
@@ -121,7 +139,8 @@ public final class ReverseConnectTargetManager {
     this.endpointDescriptions = requireNonNull(endpointDescriptions, "endpointDescriptions");
     this.transportSupplier = requireNonNull(transportSupplier, "transportSupplier");
     this.serverUri = requireNonNull(serverUri, "serverUri");
-    this.listenerQueue = new ExecutionQueue(requireNonNull(listenerExecutor, "listenerExecutor"));
+    this.executor = requireNonNull(executor, "executor");
+    this.listenerQueue = new ExecutionQueue(executor);
     this.scheduler = requireNonNull(scheduler, "scheduler");
 
     requireNonNull(initialTargets, "initialTargets");
@@ -588,7 +607,7 @@ public final class ReverseConnectTargetManager {
     record.nextAttemptTime = Instant.now().plusMillis(normalizedDelayMillis);
     record.scheduledFuture =
         scheduler.schedule(
-            () -> runScheduledAttempt(record, generation),
+            () -> dispatchScheduledAttempt(record, generation),
             normalizedDelayMillis,
             TimeUnit.MILLISECONDS);
   }
@@ -608,31 +627,102 @@ public final class ReverseConnectTargetManager {
         && !record.hasPendingAttempt();
   }
 
+  /**
+   * Scheduler timer callback. Only checks that the timer is still current and hands the attempt to
+   * the executor; the executor task revalidates before it mutates any state.
+   */
+  private void dispatchScheduledAttempt(TargetRecord owner, long generation) {
+    synchronized (lock) {
+      if (!isScheduledAttemptCurrentLocked(owner, generation)) {
+        return;
+      }
+    }
+
+    try {
+      executor.execute(() -> runScheduledAttempt(owner, generation));
+    } catch (RejectedExecutionException e) {
+      onAttemptDispatchRejected(owner, generation, e);
+    }
+  }
+
   private void runScheduledAttempt(TargetRecord owner, long generation) {
     AttemptStart start;
     synchronized (lock) {
-      TargetRecord record = records.get(owner.target.getId());
-      if (record != owner
-          || generation != record.generation
-          || !running
-          || shutdown
-          || !record.isSchedulable()
-          || record.hasPendingAttempt()) {
+      if (!isScheduledAttemptCurrentLocked(owner, generation)) {
         return;
       }
 
-      record.scheduledFuture = null;
-      record.nextAttemptTime = null;
-      record.attemptInProgress = true;
-      record.lastAttemptTime = Instant.now();
+      owner.scheduledFuture = null;
+      owner.nextAttemptTime = null;
+      owner.attemptInProgress = true;
+      owner.lastAttemptTime = Instant.now();
 
       start =
           new AttemptStart(
-              record, record.target, ++record.attemptCounter, generation, record.snapshot());
+              owner, owner.target, ++owner.attemptCounter, generation, owner.snapshot());
     }
 
     notifyTargetUpdated(start.snapshot());
     startTransportAttempt(start);
+  }
+
+  private boolean isScheduledAttemptCurrentLocked(TargetRecord owner, long generation) {
+    TargetRecord record = records.get(owner.target.getId());
+    return record == owner
+        && generation == record.generation
+        && running
+        && !shutdown
+        && record.isSchedulable()
+        && !record.hasPendingAttempt();
+  }
+
+  /**
+   * The executor refused the attempt before it started. The attempt number is consumed and reported
+   * as FAILED so listeners observe the outcome, and the target is rescheduled after its
+   * registration period; the custom retry policy is not consulted because it would need the same
+   * executor.
+   */
+  private void onAttemptDispatchRejected(
+      TargetRecord owner, long generation, RejectedExecutionException cause) {
+
+    ReverseConnectAttemptEvent event;
+    ReverseConnectTargetSnapshot snapshot;
+    synchronized (lock) {
+      if (!isScheduledAttemptCurrentLocked(owner, generation)) {
+        return;
+      }
+
+      Instant now = Instant.now();
+      StatusCode statusCode = new StatusCode(StatusCodes.Bad_ResourceUnavailable);
+
+      owner.scheduledFuture = null;
+      owner.nextAttemptTime = null;
+      owner.lastAttemptTime = now;
+      owner.lastStatusCode = statusCode;
+      owner.lastError = ReverseConnectTargetSnapshot.copyThrowable(cause);
+
+      event =
+          new ReverseConnectAttemptEvent(
+              owner.target.getId(),
+              ++owner.attemptCounter,
+              ReverseConnectAttemptState.FAILED,
+              now,
+              statusCode,
+              cause,
+              "reverse-connect attempt rejected by server executor");
+
+      scheduleLocked(owner, fallbackRetryDelayMillis(owner.target));
+      snapshot = owner.snapshot();
+    }
+
+    logger.warn(
+        "Server executor rejected Reverse Connect attempt for target {}; retrying after the"
+            + " registration period.",
+        owner.target.getId(),
+        cause);
+
+    notifyAttemptEvent(event);
+    notifyTargetUpdated(snapshot);
   }
 
   private void startTransportAttempt(AttemptStart start) {
@@ -898,13 +988,15 @@ public final class ReverseConnectTargetManager {
       RetryContext retryContext, @Nullable ReverseConnectTargetSnapshot terminalSnapshot) {
 
     try {
-      scheduler.execute(() -> evaluateRetry(retryContext));
+      executor.execute(() -> evaluateRetry(retryContext));
     } catch (RejectedExecutionException e) {
-      logger.warn("Unable to evaluate Reverse Connect retry policy.", e);
-      notifyAttemptEvent(retryContext.event());
-      if (terminalSnapshot != null) {
-        notifyTargetUpdated(terminalSnapshot);
-      }
+      onRetryEvaluationRejected(
+          retryContext.targetId(),
+          retryContext.target(),
+          retryContext.event(),
+          record -> isRetryCurrent(record, retryContext),
+          terminalSnapshot,
+          e);
     }
   }
 
@@ -912,11 +1004,49 @@ public final class ReverseConnectTargetManager {
       PostCloseRetryContext retryContext, ReverseConnectTargetSnapshot closedSnapshot) {
 
     try {
-      scheduler.execute(() -> evaluatePostCloseRetry(retryContext));
+      executor.execute(() -> evaluatePostCloseRetry(retryContext));
     } catch (RejectedExecutionException e) {
-      logger.warn("Unable to evaluate Reverse Connect retry policy.", e);
-      notifyAttemptEvent(retryContext.event());
-      notifyTargetUpdated(closedSnapshot);
+      onRetryEvaluationRejected(
+          retryContext.targetId(),
+          retryContext.target(),
+          retryContext.event(),
+          record -> isPostCloseRetryCurrent(record, retryContext),
+          closedSnapshot,
+          e);
+    }
+  }
+
+  /**
+   * The executor refused to run the retry policy. The target is rescheduled after its registration
+   * period when the retry is still current, so a saturated executor cannot strand a target, and the
+   * terminal notifications are still delivered.
+   */
+  private void onRetryEvaluationRejected(
+      UUID targetId,
+      ReverseConnectTarget target,
+      ReverseConnectAttemptEvent event,
+      Predicate<TargetRecord> isCurrent,
+      @Nullable ReverseConnectTargetSnapshot terminalSnapshot,
+      RejectedExecutionException cause) {
+
+    logger.warn(
+        "Server executor rejected Reverse Connect retry evaluation for target {}; retrying after"
+            + " the registration period.",
+        targetId,
+        cause);
+
+    ReverseConnectTargetSnapshot snapshot = terminalSnapshot;
+    synchronized (lock) {
+      TargetRecord record = records.get(targetId);
+      if (record != null && isCurrent.test(record)) {
+        scheduleLocked(record, fallbackRetryDelayMillis(target));
+        snapshot = record.snapshot();
+      }
+    }
+
+    notifyAttemptEvent(event);
+    if (snapshot != null) {
+      notifyTargetUpdated(snapshot);
     }
   }
 
@@ -1006,8 +1136,12 @@ public final class ReverseConnectTargetManager {
           "Reverse Connect retry policy failed for target {}; using registration period.",
           target.getId(),
           t);
-      return target.getRegistrationPeriod().longValue();
+      return fallbackRetryDelayMillis(target);
     }
+  }
+
+  private static long fallbackRetryDelayMillis(ReverseConnectTarget target) {
+    return target.getRegistrationPeriod().longValue();
   }
 
   private void validateTarget(ReverseConnectTarget target) {

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/reverse/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/reverse/package-info.java
@@ -55,6 +55,25 @@
  * removed registration close their channels, and stale timers or retry callbacks cannot change its
  * replacement.
  *
+ * <h2>Runtime boundaries</h2>
+ *
+ * <p>The manager borrows two execution resources from the server configuration and owns neither.
+ * The scheduled executor is a timer only: its callbacks decide whether a fired timer is still
+ * current and hand the work to the server executor. The server executor, the one configured with
+ * {@code OpcUaServerConfigBuilder.setExecutor(...)}, runs everything that can block or that
+ * application code controls: client listener hostname resolution and transport startup for an
+ * attempt, custom retry-policy evaluation, and listener callbacks. Listener callbacks additionally
+ * pass through a serialized queue so they are observed in order; attempt and retry work never runs
+ * through that queue. Transport attempt events and channel-close events arrive on Netty threads and
+ * only update bookkeeping and hand off before returning.
+ *
+ * <p>Because a timer can fire before a pause, update, removal, or shutdown takes effect, cancelling
+ * the timer is not enough to discard work already queued on the executor. Executor tasks therefore
+ * revalidate the owning registration, its generation, and lifecycle state when they begin, and a
+ * transport attempt that outruns one of those operations is closed rather than adopted. Because the
+ * server executor is shared with service dispatch, applications may size it or supply a
+ * virtual-thread-per-task executor without any reverse-connect specific configuration.
+ *
  * <h2>Failure handling</h2>
  *
  * <p>Attempt failures are translated into immutable {@link
@@ -64,6 +83,12 @@
  * policy uses the target registration period. Listener dispatch uses a serial execution queue;
  * executor rejection runs callbacks on the submitting thread so notification failures cannot
  * abandon an attempt transition. Callbacks should return promptly even during executor overload.
+ *
+ * <p>If the server executor rejects attempt startup, the attempt is reported as {@code FAILED} with
+ * {@code Bad_ResourceUnavailable} and the rejection as its cause. If it rejects retry-policy
+ * evaluation, the terminal event is still delivered. In both cases the target is rescheduled after
+ * its registration period without consulting the custom retry policy, so a saturated executor
+ * delays reconnection but never leaves a target stranded, marked in progress, or silently dropped.
  *
  * <p>Successful outbound UA-TCP connections are handed back to the normal server SecureChannel and
  * Session paths after the stack transport installs the standard server Hello handler. Client-side

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/reverse/ReverseConnectTargetManagerTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/reverse/ReverseConnectTargetManagerTest.java
@@ -18,40 +18,50 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.netty.channel.Channel;
 import io.netty.channel.embedded.EmbeddedChannel;
 import java.lang.reflect.Field;
+import java.time.Duration;
 import java.time.Instant;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.transport.TransportProfile;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
 import org.eclipse.milo.opcua.stack.transport.server.ServerApplicationContext;
 import org.eclipse.milo.opcua.stack.transport.server.tcp.OpcTcpServerReverseConnectAttempt;
@@ -60,8 +70,13 @@ import org.eclipse.milo.opcua.stack.transport.server.tcp.OpcTcpServerReverseConn
 import org.eclipse.milo.opcua.stack.transport.server.tcp.OpcTcpServerReverseConnectParameters;
 import org.eclipse.milo.opcua.stack.transport.server.tcp.OpcTcpServerTransport;
 import org.eclipse.milo.opcua.stack.transport.server.tcp.OpcTcpServerTransportConfig;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class ReverseConnectTargetManagerTest {
 
@@ -351,7 +366,8 @@ class ReverseConnectTargetManagerTest {
     releaseAdded.countDown();
 
     assertTrue(updatedEntered.await(3, TimeUnit.SECONDS));
-    assertEquals(List.of("added", "updated"), events);
+    // The failed attempt's retry evaluation may append a further "updated" on the executor.
+    assertEquals(List.of("added", "updated"), List.copyOf(events).subList(0, 2));
   }
 
   @Test
@@ -388,33 +404,17 @@ class ReverseConnectTargetManagerTest {
     assertUnknownTargetFailure(handle::remove, target.getId());
   }
 
-  // State observers must not prevent an attempt from acquiring a transport when dispatch rejects.
-  @Test
-  void listenerExecutorRejectionDoesNotStrandScheduledAttempt() throws Exception {
-    try (ControlledAttempts fixture = new ControlledAttempts()) {
-      fixture.manager.addListener(new ReverseConnectTargetListener() {});
-      fixture.manager.startup();
-      fixture.rejectNotifications.set(true);
-      fixture.scheduled.remove().run();
-      assertEquals(1, fixture.transport.attempts.size());
-      fixture.rejectNotifications.set(false);
-      fixture.manager.trigger(fixture.target.getId()).get(5, TimeUnit.SECONDS);
-      assertEquals(
-          1, fixture.transport.attempts.size(), "the original attempt remains in progress");
-    }
-  }
-
   // UUIDs identify public targets, but a removed registration must never own a replacement's
   // channel.
   @Test
   void oldHandoffCannotAttachChannelToReplacementWithSameTargetId() throws Exception {
-    try (ControlledAttempts fixture = new ControlledAttempts()) {
+    try (ControlledExecution fixture = new ControlledExecution()) {
       fixture.manager.startup();
-      fixture.scheduled.remove().run();
+      fixture.runScheduledAttempt();
       fixture.transport.handoff(0);
       fixture.manager.remove(fixture.target.getId()).get(5, TimeUnit.SECONDS);
       fixture.manager.addTarget(fixture.target);
-      fixture.scheduled.remove().run();
+      fixture.runScheduledAttempt();
       EmbeddedChannel oldChannel = new EmbeddedChannel();
       EmbeddedChannel newChannel = new EmbeddedChannel();
       try {
@@ -435,9 +435,9 @@ class ReverseConnectTargetManagerTest {
   // Removing in the HANDOFF/future-completion interval must still close the later channel.
   @Test
   void removalClosesChannelDeliveredAfterHandoffEvent() throws Exception {
-    try (ControlledAttempts fixture = new ControlledAttempts()) {
+    try (ControlledExecution fixture = new ControlledExecution()) {
       fixture.manager.startup();
-      fixture.scheduled.remove().run();
+      fixture.runScheduledAttempt();
       fixture.transport.handoff(0);
       fixture.manager.remove(fixture.target.getId()).get(5, TimeUnit.SECONDS);
       EmbeddedChannel channel = new EmbeddedChannel();
@@ -450,54 +450,471 @@ class ReverseConnectTargetManagerTest {
     }
   }
 
-  private static final class ControlledAttempts implements AutoCloseable {
-    final Queue<Runnable> scheduled = new ArrayDeque<>();
-    final AtomicBoolean rejectNotifications = new AtomicBoolean();
+  /**
+   * Attempt startup and retry-policy evaluation can block (hostname resolution, transport startup,
+   * application-supplied policies). They must run on the server executor so a slow target cannot
+   * delay unrelated timers on the shared scheduler.
+   */
+  @Nested
+  class ExecutionBoundaries {
+
+    @Test
+    void timerCallbackOnlyDispatchesAndAttemptStartsOnExecutor() throws Exception {
+      try (ControlledExecution fixture = new ControlledExecution()) {
+        fixture.manager.startup();
+        fixture.drainExecutor();
+
+        fixture.fireTimer();
+
+        assertTrue(fixture.transport.attempts.isEmpty(), "timer callback must not start attempt");
+        assertEquals(1, fixture.executorTasks.size(), "attempt must be handed to the executor");
+
+        fixture.drainExecutor();
+
+        assertEquals(1, fixture.transport.attempts.size());
+        assertEquals(List.of("executor"), fixture.transport.runners);
+      }
+    }
+
+    @Test
+    void retryPolicyEvaluatesOnExecutorAndSchedulesPolicyDelay() throws Exception {
+      RecordingRetryPolicy policy = new RecordingRetryPolicy(5_000L);
+      try (ControlledExecution fixture = new ControlledExecution(target(policy))) {
+        fixture.manager.startup();
+        fixture.runScheduledAttempt();
+        fixture.listener.drain();
+
+        fixture.transport.fail(0);
+
+        assertTrue(policy.runners.isEmpty(), "policy must not run on the transport thread");
+        assertEquals(1, fixture.scheduledDelays.size(), "retry must not be scheduled yet");
+
+        fixture.drainExecutor();
+
+        assertEquals(List.of("executor"), policy.runners);
+        assertEquals(List.of(0L, 5_000L), fixture.scheduledDelays);
+        assertEquals(List.of("attempt:FAILED", "updated"), fixture.listener.drain());
+      }
+    }
+
+    @Test
+    void activeChannelCloseEvaluatesReconnectPolicyOnExecutor() throws Exception {
+      RecordingRetryPolicy policy = new RecordingRetryPolicy(7_000L);
+      try (ControlledExecution fixture = new ControlledExecution(target(policy))) {
+        fixture.manager.startup();
+        fixture.runScheduledAttempt();
+        EmbeddedChannel channel = new EmbeddedChannel();
+        fixture.transport.handoff(0);
+        fixture.transport.channels.get(0).complete(channel);
+        fixture.drainExecutor();
+        fixture.listener.drain();
+
+        channel.close();
+
+        assertTrue(policy.runners.isEmpty(), "policy must not run on the channel thread");
+
+        fixture.drainExecutor();
+
+        assertEquals(List.of("executor"), policy.runners);
+        assertEquals(List.of(0L, 7_000L), fixture.scheduledDelays);
+        assertEquals(List.of("attempt:CLOSED", "updated"), fixture.listener.drain());
+      }
+    }
+
+    @Test
+    void blockedRetryPolicyDoesNotOccupyScheduler() throws Exception {
+      CountDownLatch policyEntered = new CountDownLatch(1);
+      CountDownLatch releasePolicy = new CountDownLatch(1);
+      ReverseConnectTarget blockingTarget =
+          target(
+              (target, event) -> {
+                policyEntered.countDown();
+                await(releasePolicy);
+                return 5_000L;
+              });
+
+      try (ControlledExecution fixture =
+          new ControlledExecution(blockingTarget, Executors.newSingleThreadExecutor())) {
+        fixture.manager.startup();
+        fixture.fireTimer();
+        fixture.listener.awaitNotification("updated");
+        fixture.listener.awaitNotification("updated");
+        assertEquals(1, fixture.transport.attempts.size());
+
+        fixture.transport.fail(0);
+        assertTrue(policyEntered.await(3, TimeUnit.SECONDS));
+        fixture.scheduledSignals.drainPermits();
+
+        // The scheduler keeps servicing other targets while the policy blocks the executor.
+        ReverseConnectTarget other = target(ReverseConnectRetryPolicy.registrationPeriod());
+        fixture.manager.addTarget(other);
+        fixture.scheduledSignals.drainPermits();
+        fixture.fireTimer();
+
+        verify(fixture.scheduler, never()).execute(any(Runnable.class));
+        assertEquals(1, fixture.transport.attempts.size(), "executor is still blocked");
+
+        releasePolicy.countDown();
+
+        assertTrue(fixture.scheduledSignals.tryAcquire(3, TimeUnit.SECONDS), "retry scheduled");
+        assertEquals(5_000L, fixture.scheduledDelays.get(fixture.scheduledDelays.size() - 1));
+        assertTrue(fixture.transport.attemptsStarted.tryAcquire(2, 3, TimeUnit.SECONDS));
+        assertEquals(2, fixture.transport.attempts.size());
+      }
+    }
+
+    @Test
+    void blockedAttemptStartDoesNotOccupySchedulerOrHoldLock() throws Exception {
+      CountDownLatch connectEntered = new CountDownLatch(1);
+      CountDownLatch releaseConnect = new CountDownLatch(1);
+
+      try (ControlledExecution fixture =
+          new ControlledExecution(defaultTarget(), Executors.newSingleThreadExecutor())) {
+        fixture.transport.beforeConnect =
+            () -> {
+              connectEntered.countDown();
+              await(releaseConnect);
+            };
+        fixture.manager.startup();
+
+        fixture.fireTimer();
+
+        assertTrue(connectEntered.await(3, TimeUnit.SECONDS));
+        verify(fixture.scheduler, never()).execute(any(Runnable.class));
+
+        ReverseConnectTargetHandle handle =
+            new ReverseConnectTargetHandle(fixture.manager, fixture.target.getId());
+        ReverseConnectTargetSnapshot paused =
+            assertTimeoutPreemptively(Duration.ofSeconds(3), () -> handle.pause().get());
+        assertTrue(paused.paused());
+
+        releaseConnect.countDown();
+
+        assertTrue(fixture.transport.attemptsStarted.tryAcquire(3, TimeUnit.SECONDS));
+        verify(fixture.transport.attempts.get(0), timeout(3_000)).close();
+        assertEquals(0, handle.snapshot().orElseThrow().activeChannelCount());
+      }
+    }
+  }
+
+  /**
+   * Cancelling a timer cannot recall work already queued on the executor, so queued attempt and
+   * retry tasks must revalidate ownership, generation, and lifecycle state before acting.
+   */
+  @Nested
+  class QueuedWorkAfterLifecycleChange {
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource(
+        "org.eclipse.milo.opcua.sdk.server.reverse.ReverseConnectTargetManagerTest#lifecycleChanges")
+    void queuedAttemptDispatchIsHarmlessAndTargetRecovers(
+        String name, Consumer<ControlledExecution> change, Consumer<ControlledExecution> recover)
+        throws Exception {
+
+      try (ControlledExecution fixture = new ControlledExecution()) {
+        fixture.manager.startup();
+        fixture.drainExecutor();
+        fixture.fireTimer();
+        assertEquals(1, fixture.executorTasks.size(), "attempt dispatch is queued");
+
+        change.accept(fixture);
+        fixture.drainExecutor();
+
+        assertTrue(fixture.transport.attempts.isEmpty(), "stale dispatch must not start attempt");
+
+        recover.accept(fixture);
+        fixture.runScheduledAttempt();
+
+        assertEquals(1, fixture.transport.attempts.size(), "target is not stranded");
+      }
+    }
+
+    @Test
+    void staleRetryEvaluationSkipsPolicyButDeliversTerminalEvent() throws Exception {
+      RecordingRetryPolicy policy = new RecordingRetryPolicy(5_000L);
+      try (ControlledExecution fixture = new ControlledExecution(target(policy))) {
+        fixture.manager.startup();
+        fixture.runScheduledAttempt();
+        fixture.listener.drain();
+
+        fixture.transport.fail(0);
+        new ReverseConnectTargetHandle(fixture.manager, fixture.target.getId())
+            .pause()
+            .get(5, TimeUnit.SECONDS);
+        fixture.drainExecutor();
+
+        assertTrue(policy.runners.isEmpty(), "policy must not run for a paused target");
+        assertEquals(List.of(0L), fixture.scheduledDelays, "no retry may be scheduled");
+        assertEquals(List.of("updated", "attempt:FAILED"), fixture.listener.drain());
+        assertNull(
+            fixture.manager.snapshot(fixture.target.getId()).orElseThrow().nextAttemptTime());
+      }
+    }
+  }
+
+  /**
+   * The server executor may reject work when saturated or shutting down. Rejection must leave the
+   * target in a defined, recoverable state and still deliver the notifications listeners rely on.
+   */
+  @Nested
+  class ExecutorRejection {
+
+    @Test
+    void rejectedAttemptDispatchReportsFailedAttemptAndReschedules() throws Exception {
+      try (ControlledExecution fixture = new ControlledExecution()) {
+        fixture.manager.startup();
+        fixture.drainExecutor();
+        fixture.listener.drain();
+        fixture.rejectExecutor.set(true);
+
+        fixture.fireTimer();
+
+        assertTrue(fixture.transport.attempts.isEmpty());
+        assertEquals(List.of("attempt:FAILED", "updated"), fixture.listener.drain());
+
+        ReverseConnectAttemptEvent event = fixture.listener.events.get(0);
+        assertEquals(1L, event.attemptNumber());
+        assertEquals(new StatusCode(StatusCodes.Bad_ResourceUnavailable), event.statusCode());
+        assertInstanceOf(RejectedExecutionException.class, event.exception());
+
+        ReverseConnectTargetSnapshot snapshot =
+            fixture.manager.snapshot(fixture.target.getId()).orElseThrow();
+        assertEquals(
+            new StatusCode(StatusCodes.Bad_ResourceUnavailable), snapshot.lastStatusCode());
+        assertNotNull(snapshot.lastError());
+        assertNotNull(snapshot.nextAttemptTime(), "target must be rescheduled");
+        assertEquals(
+            List.of(0L, 1_000L), fixture.scheduledDelays, "fallback uses the registration period");
+
+        fixture.rejectExecutor.set(false);
+        fixture.runScheduledAttempt();
+
+        assertEquals(1, fixture.transport.attempts.size());
+        fixture.manager.trigger(fixture.target.getId()).get(5, TimeUnit.SECONDS);
+        assertEquals(1, fixture.transport.attempts.size(), "attempt already in progress");
+        assertTrue(fixture.scheduledTasks.isEmpty());
+
+        fixture.transport.fail(0);
+        fixture.drainExecutor();
+        assertEquals(2L, fixture.listener.events.get(1).attemptNumber());
+      }
+    }
+
+    @Test
+    void rejectedRetryEvaluationReschedulesWithRegistrationPeriod() throws Exception {
+      RecordingRetryPolicy policy = new RecordingRetryPolicy(5_000L);
+      try (ControlledExecution fixture = new ControlledExecution(target(policy))) {
+        fixture.manager.startup();
+        fixture.runScheduledAttempt();
+        fixture.listener.drain();
+        fixture.rejectExecutor.set(true);
+
+        fixture.transport.fail(0);
+
+        assertTrue(policy.runners.isEmpty(), "policy must not run on the rejecting thread");
+        assertEquals(List.of(0L, 1_000L), fixture.scheduledDelays);
+        assertEquals(List.of("attempt:FAILED", "updated"), fixture.listener.drain());
+
+        ReverseConnectTargetSnapshot snapshot = fixture.listener.lastUpdated();
+        assertNotNull(snapshot.nextAttemptTime());
+        assertEquals(new StatusCode(StatusCodes.Bad_ConnectionRejected), snapshot.lastStatusCode());
+      }
+    }
+
+    @Test
+    void rejectedPostCloseEvaluationReschedulesWithRegistrationPeriod() throws Exception {
+      RecordingRetryPolicy policy = new RecordingRetryPolicy(5_000L);
+      try (ControlledExecution fixture = new ControlledExecution(target(policy))) {
+        fixture.manager.startup();
+        fixture.runScheduledAttempt();
+        EmbeddedChannel channel = new EmbeddedChannel();
+        fixture.transport.handoff(0);
+        fixture.transport.channels.get(0).complete(channel);
+        fixture.drainExecutor();
+        fixture.listener.drain();
+        fixture.rejectExecutor.set(true);
+
+        channel.close();
+
+        assertTrue(policy.runners.isEmpty());
+        assertEquals(List.of(0L, 1_000L), fixture.scheduledDelays);
+        assertEquals(List.of("attempt:CLOSED", "updated"), fixture.listener.drain());
+        assertNotNull(fixture.listener.lastUpdated().nextAttemptTime());
+      }
+    }
+  }
+
+  static Stream<Arguments> lifecycleChanges() {
+    return Stream.of(
+        Arguments.of(
+            "pause",
+            (Consumer<ControlledExecution>)
+                fixture ->
+                    join(
+                        new ReverseConnectTargetHandle(fixture.manager, fixture.target.getId())
+                            .pause()),
+            (Consumer<ControlledExecution>)
+                fixture ->
+                    join(
+                        new ReverseConnectTargetHandle(fixture.manager, fixture.target.getId())
+                            .resume())),
+        Arguments.of(
+            "remove",
+            (Consumer<ControlledExecution>)
+                fixture -> join(fixture.manager.remove(fixture.target.getId())),
+            (Consumer<ControlledExecution>) fixture -> fixture.manager.addTarget(fixture.target)),
+        Arguments.of(
+            "update",
+            (Consumer<ControlledExecution>)
+                fixture -> join(fixture.manager.update(replacement(fixture.target))),
+            (Consumer<ControlledExecution>) fixture -> {}),
+        Arguments.of(
+            "shutdown",
+            (Consumer<ControlledExecution>) fixture -> fixture.manager.shutdown(),
+            (Consumer<ControlledExecution>) fixture -> fixture.manager.startup()));
+  }
+
+  private static ReverseConnectTarget replacement(ReverseConnectTarget target) {
+    return ReverseConnectTarget.builder()
+        .setId(target.getId())
+        .setClientListenerUrl("opc.tcp://localhost:12699")
+        .setEndpointUrl(target.getEndpointUrl())
+        .setRegistrationPeriod(target.getRegistrationPeriod())
+        .setConnectTimeout(target.getConnectTimeout())
+        .build();
+  }
+
+  private static <T> T join(CompletableFuture<T> future) {
+    return assertDoesNotThrow(() -> future.get(5, TimeUnit.SECONDS));
+  }
+
+  private static ReverseConnectTarget defaultTarget() {
+    return target("opc.tcp://localhost:12686/reverse-target-test", "opc.tcp://localhost:12687");
+  }
+
+  private static ReverseConnectTarget target(ReverseConnectRetryPolicy retryPolicy) {
+    return ReverseConnectTarget.builder()
+        .setClientListenerUrl("opc.tcp://localhost:12687")
+        .setEndpointUrl("opc.tcp://localhost:12686/reverse-target-test")
+        .setRegistrationPeriod(uint(1_000))
+        .setConnectTimeout(uint(100))
+        .setRetryPolicy(retryPolicy)
+        .build();
+  }
+
+  /**
+   * Manager fixture with a manual scheduler queue and, by default, a manual executor queue. Tests
+   * fire timers and drain the executor explicitly, which makes the handoff between the two visible
+   * and deterministic. A real executor can be supplied for tests that need work to actually block.
+   */
+  private static final class ControlledExecution implements AutoCloseable {
+
+    static final ThreadLocal<String> RUNNER = new ThreadLocal<>();
+
+    final Queue<Runnable> executorTasks = new ConcurrentLinkedQueue<>();
+    final Queue<Runnable> scheduledTasks = new ConcurrentLinkedQueue<>();
+    final List<Long> scheduledDelays = new CopyOnWriteArrayList<>();
+    final Semaphore scheduledSignals = new Semaphore(0);
+    final AtomicBoolean rejectExecutor = new AtomicBoolean();
+    final RecordingListener listener = new RecordingListener();
     final ControlledTransport transport = new ControlledTransport();
-    final ReverseConnectTarget target =
-        target("opc.tcp://localhost:12686/reverse-target-test", "opc.tcp://localhost:12687");
+    final ScheduledExecutorService scheduler = mock(ScheduledExecutorService.class);
+    final ReverseConnectTarget target;
     final ReverseConnectTargetManager manager;
 
-    ControlledAttempts() {
-      ExecutorService executor = mock(ExecutorService.class);
-      doAnswer(
-              invocation -> {
-                if (rejectNotifications.get()) {
-                  throw new RejectedExecutionException("saturated");
-                }
-                invocation.<Runnable>getArgument(0).run();
-                return null;
-              })
-          .when(executor)
-          .execute(any(Runnable.class));
-      ScheduledExecutorService scheduler = mock(ScheduledExecutorService.class);
+    private final @Nullable ExecutorService realExecutor;
+
+    ControlledExecution() {
+      this(defaultTarget(), null);
+    }
+
+    ControlledExecution(ReverseConnectTarget target) {
+      this(target, null);
+    }
+
+    ControlledExecution(ReverseConnectTarget target, @Nullable ExecutorService realExecutor) {
+      this.target = target;
+      this.realExecutor = realExecutor;
+
       when(scheduler.schedule(any(Runnable.class), anyLong(), any(TimeUnit.class)))
           .thenAnswer(
               invocation -> {
-                scheduled.add(invocation.getArgument(0));
+                scheduledTasks.add(invocation.getArgument(0));
+                scheduledDelays.add(invocation.getArgument(1));
+                scheduledSignals.release();
                 return mock(ScheduledFuture.class);
               });
+
       manager =
           new ReverseConnectTargetManager(
               mock(ServerApplicationContext.class),
               () -> List.of(endpointDescription(target.getEndpointUrl())),
               profile -> transport,
               "urn:eclipse:milo:test:server:reverse-targets",
-              executor,
+              realExecutor != null ? realExecutor : manualExecutor(),
               scheduler,
               Set.of(target));
+      manager.addListener(listener);
+    }
+
+    private ExecutorService manualExecutor() {
+      ExecutorService executor = mock(ExecutorService.class);
+      doAnswer(
+              invocation -> {
+                if (rejectExecutor.get()) {
+                  throw new RejectedExecutionException("saturated");
+                }
+                executorTasks.add(invocation.getArgument(0));
+                return null;
+              })
+          .when(executor)
+          .execute(any(Runnable.class));
+      return executor;
+    }
+
+    /** Run the next scheduler timer callback on the calling thread, tagged as the scheduler. */
+    void fireTimer() {
+      runAs("scheduler", scheduledTasks.remove());
+    }
+
+    /** Run every queued executor task on the calling thread, tagged as the executor. */
+    void drainExecutor() {
+      Runnable task;
+      while ((task = executorTasks.poll()) != null) {
+        runAs("executor", task);
+      }
+    }
+
+    void runScheduledAttempt() {
+      fireTimer();
+      drainExecutor();
+    }
+
+    private static void runAs(String runner, Runnable task) {
+      RUNNER.set(runner);
+      try {
+        task.run();
+      } finally {
+        RUNNER.remove();
+      }
     }
 
     @Override
     public void close() {
       manager.shutdown();
+      if (realExecutor != null) {
+        realExecutor.shutdownNow();
+      }
     }
   }
 
   private static final class ControlledTransport extends OpcTcpServerTransport {
-    final List<OpcTcpServerReverseConnectParameters> parameters = new ArrayList<>();
-    final List<OpcTcpServerReverseConnectAttempt> attempts = new ArrayList<>();
-    final List<CompletableFuture<Channel>> channels = new ArrayList<>();
+    final List<OpcTcpServerReverseConnectParameters> parameters = new CopyOnWriteArrayList<>();
+    final List<OpcTcpServerReverseConnectAttempt> attempts = new CopyOnWriteArrayList<>();
+    final List<CompletableFuture<Channel>> channels = new CopyOnWriteArrayList<>();
+    final List<String> runners = new CopyOnWriteArrayList<>();
+    final Semaphore attemptsStarted = new Semaphore(0);
+    volatile Runnable beforeConnect = () -> {};
 
     ControlledTransport() {
       super(OpcTcpServerTransportConfig.newBuilder().build());
@@ -506,6 +923,8 @@ class ReverseConnectTargetManagerTest {
     @Override
     public OpcTcpServerReverseConnectAttempt connectReverse(
         OpcTcpServerReverseConnectParameters parameters) {
+      beforeConnect.run();
+      runners.add(String.valueOf(ControlledExecution.RUNNER.get()));
       OpcTcpServerReverseConnectAttempt attempt = mock(OpcTcpServerReverseConnectAttempt.class);
       CompletableFuture<Channel> channel = new CompletableFuture<>();
       when(attempt.channelFuture()).thenReturn(channel);
@@ -513,22 +932,91 @@ class ReverseConnectTargetManagerTest {
       this.parameters.add(parameters);
       attempts.add(attempt);
       channels.add(channel);
+      attemptsStarted.release();
       return attempt;
     }
 
     void handoff(int index) {
       when(attempts.get(index).state()).thenReturn(OpcTcpServerReverseConnectAttemptState.HANDOFF);
+      emit(index, OpcTcpServerReverseConnectAttemptState.HANDOFF, null);
+    }
+
+    void fail(int index) {
+      when(attempts.get(index).state()).thenReturn(OpcTcpServerReverseConnectAttemptState.FAILED);
+      emit(
+          index,
+          OpcTcpServerReverseConnectAttemptState.FAILED,
+          new StatusCode(StatusCodes.Bad_ConnectionRejected));
+    }
+
+    private void emit(
+        int index, OpcTcpServerReverseConnectAttemptState state, @Nullable StatusCode statusCode) {
       parameters
           .get(index)
           .observer()
           .onStateTransition(
               new OpcTcpServerReverseConnectAttemptEvent(
-                  UUID.randomUUID(),
-                  OpcTcpServerReverseConnectAttemptState.HANDOFF,
-                  Instant.now(),
-                  null,
-                  null,
-                  null));
+                  UUID.randomUUID(), state, Instant.now(), statusCode, null, null));
+    }
+  }
+
+  private static final class RecordingRetryPolicy implements ReverseConnectRetryPolicy {
+    final List<String> runners = new CopyOnWriteArrayList<>();
+    private final long delayMillis;
+
+    RecordingRetryPolicy(long delayMillis) {
+      this.delayMillis = delayMillis;
+    }
+
+    @Override
+    public long getRetryDelayMillis(ReverseConnectTarget target, ReverseConnectAttemptEvent event) {
+      runners.add(String.valueOf(ControlledExecution.RUNNER.get()));
+      return delayMillis;
+    }
+  }
+
+  private static final class RecordingListener implements ReverseConnectTargetListener {
+    final BlockingQueue<String> notifications = new LinkedBlockingQueue<>();
+    final List<ReverseConnectAttemptEvent> events = new CopyOnWriteArrayList<>();
+    final List<ReverseConnectTargetSnapshot> updated = new CopyOnWriteArrayList<>();
+
+    @Override
+    public void onTargetAdded(ReverseConnectTargetSnapshot snapshot) {
+      notifications.add("added");
+    }
+
+    @Override
+    public void onTargetUpdated(ReverseConnectTargetSnapshot snapshot) {
+      updated.add(snapshot);
+      notifications.add("updated");
+    }
+
+    @Override
+    public void onTargetRemoved(ReverseConnectTargetSnapshot snapshot) {
+      notifications.add("removed");
+    }
+
+    @Override
+    public void onAttemptEvent(ReverseConnectAttemptEvent event) {
+      events.add(event);
+      notifications.add("attempt:" + event.state());
+    }
+
+    /** Block, with a bound, until the next notification equals {@code expected}. */
+    void awaitNotification(String expected) {
+      String actual = assertDoesNotThrow(() -> notifications.poll(3, TimeUnit.SECONDS));
+      assertEquals(expected, actual);
+    }
+
+    /** Remove and return all notifications recorded so far, in delivery order. */
+    List<String> drain() {
+      List<String> drained = new ArrayList<>();
+      notifications.drainTo(drained);
+      return drained;
+    }
+
+    ReverseConnectTargetSnapshot lastUpdated() {
+      return updated.get(updated.size() - 1);
     }
   }
 


### PR DESCRIPTION
Server-side reverse connect scheduled its attempts with the scheduled executor and then did the substantive work on that same thread. Starting an attempt builds the connection parameters with `OpcTcpServerReverseConnectParameters.fromUrl()`, which resolves the client listener hostname, and retry evaluation calls the application-supplied `ReverseConnectRetryPolicy`. Either can block, and while it did, unrelated timers such as session timeouts and publishing waited behind it. This was the one remaining place in the server where `OpcUaServerConfigBuilder.setExecutor(...)` did not control potentially blocking work, which matters for applications that want to supply a virtual-thread executor on JDK 21 and later while Milo keeps its JDK 17 baseline.

The scheduler is now purely a timer. Its callback checks that the fired timer is still current and hands the attempt to the server executor. Retry evaluation after a failed attempt or a closed reverse-opened channel goes to the executor as well. Because cancelling a timer cannot recall work that is already queued, every executor task repeats the ownership, generation, and lifecycle checks under the registry lock before it mutates state, and hostname resolution, transport startup, and policy calls still happen outside that lock. Listener callbacks keep their own serialized queue on the same executor; attempt and retry work never runs through it, so listener ordering and the at-most-one-attempt guarantee are unchanged. The manager still does not own the executor or scheduler.

Executor rejection is now a defined outcome instead of a stranded target. A rejected attempt start is reported to listeners as a `FAILED` attempt with `Bad_ResourceUnavailable` and the `RejectedExecutionException` as its cause, and the target snapshot records the same. A rejected retry evaluation still delivers the terminal event. In both cases the target is rescheduled after its registration period, the same fallback already used when a custom policy throws, and the custom policy is not consulted because it would need the executor that just refused work.

The manager tests gained a fixture with manual scheduler and executor queues and a thread-local tag that records which resource ran a piece of work. That makes the handoff observable without sleeps: tests fire a timer, assert nothing has started, drain the executor, and assert the attempt or policy ran there. Further tests cover a latch-blocked policy and a latch-blocked `connectReverse` leaving the scheduler untouched and `pause()` completing meanwhile, queued dispatch becoming harmless after pause, update, removal, and shutdown while the target still recovers afterwards, a stale retry evaluation skipping the policy but still delivering the terminal event, and the three rejection paths. One existing ordering test was adjusted because retry evaluation now runs on its real executor rather than a mocked scheduler and can append a further update.

Verified locally with `spotless:apply`, a clean compile of the whole project, the reverse-connect test classes in `sdk-server`, and `OpcUaClientReverseConnectTest` in `integration-tests`, all passing on JDK 17. No virtual-thread runtime validation was performed; this change only removes the last scheduler-bound blocking path so that `setExecutor` is sufficient.
