### PR TITLE
Compare certificate IP addresses by address rather than by text

### DIFF
--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/validation/CertificateValidationUtil.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/validation/CertificateValidationUtil.java
@@ -12,6 +12,8 @@ package org.eclipse.milo.opcua.stack.core.util.validation;
 
 import com.google.common.base.Preconditions;
 import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.security.GeneralSecurityException;
 import java.security.InvalidKeyException;
 import java.security.PublicKey;
@@ -44,6 +46,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.asn1.x509.GeneralName;
@@ -66,6 +69,11 @@ public class CertificateValidationUtil {
   private static final int SUBJECT_ALT_NAME_URI = 6;
   private static final int SUBJECT_ALT_NAME_DNS_NAME = 2;
   private static final int SUBJECT_ALT_NAME_IP_ADDRESS = 7;
+
+  /** Matches a dotted-quad IPv4 literal, rejecting any octet outside 0-255. */
+  private static final Pattern IPV4_LITERAL =
+      Pattern.compile(
+          "(?:(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)\\.){3}(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)");
 
   /**
    * Given a possibly partial certificate chain with at least one certificate in it, builds a path
@@ -478,8 +486,13 @@ public class CertificateValidationUtil {
    * Validate that one of {@code hostNames} matches a SubjectAltName DNSName or IPAddress entry in
    * the certificate.
    *
+   * <p>DNSName entries are compared case-insensitively. IPAddress entries are compared by address
+   * rather than by text, so that the same address written in different forms still matches; an
+   * entry that is not an IP address literal never matches.
+   *
    * @param certificate the certificate to validate against.
-   * @param hostNames the host names or ip addresses to look for.
+   * @param hostNames the host names or ip addresses to look for. IPv6 addresses may be given in
+   *     either the bare or the bracketed URI form.
    * @throws UaException if there is no matching DNSName or IPAddress entry.
    */
   public static void checkHostnameOrIpAddress(X509Certificate certificate, String... hostNames)
@@ -504,9 +517,19 @@ public class CertificateValidationUtil {
         Arrays.stream(hostNames)
             .anyMatch(
                 n -> {
+                  byte[] address = parseIpAddress(n);
+
+                  if (address == null) {
+                    return false;
+                  }
+
                   try {
                     return checkSubjectAltNameField(
-                        certificate, SUBJECT_ALT_NAME_IP_ADDRESS, n::equals);
+                        certificate,
+                        SUBJECT_ALT_NAME_IP_ADDRESS,
+                        fieldValue ->
+                            (fieldValue instanceof String s)
+                                && Arrays.equals(address, parseIpAddress(s)));
                   } catch (Throwable t) {
                     return false;
                   }
@@ -627,6 +650,36 @@ public class CertificateValidationUtil {
       } catch (IOException | CertificateEncodingException e) {
         throw new UaException(StatusCodes.Bad_CertificateUriInvalid, e);
       }
+    }
+  }
+
+  /**
+   * Parse a textual IP address into its raw address bytes.
+   *
+   * <p>No name resolution is attempted: an argument that is not an IP address literal returns
+   * {@code null} rather than being looked up.
+   *
+   * @param address an IPv4 or IPv6 address literal. IPv6 literals may be bracketed, as they appear
+   *     in the host component of a URL (RFC 3986, section 3.2.2).
+   * @return the raw address bytes, or {@code null} if {@code address} is not an IP address literal.
+   */
+  private static byte[] parseIpAddress(String address) {
+    String literal = address;
+
+    if (literal.length() > 2 && literal.startsWith("[") && literal.endsWith("]")) {
+      literal = literal.substring(1, literal.length() - 1);
+    }
+
+    // A DNS name can contain neither ':' nor the strict dotted-quad form, so getByName() resolves
+    // both of these as literals and never performs a lookup.
+    if (literal.indexOf(':') < 0 && !IPV4_LITERAL.matcher(literal).matches()) {
+      return null;
+    }
+
+    try {
+      return InetAddress.getByName(literal).getAddress();
+    } catch (UnknownHostException e) {
+      return null;
     }
   }
 

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/validation/CertificateValidationUtil.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/validation/CertificateValidationUtil.java
@@ -54,6 +54,7 @@ import org.bouncycastle.asn1.x509.GeneralNames;
 import org.bouncycastle.cert.X509CertificateHolder;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -663,21 +664,29 @@ public class CertificateValidationUtil {
    *     in the host component of a URL (RFC 3986, section 3.2.2).
    * @return the raw address bytes, or {@code null} if {@code address} is not an IP address literal.
    */
-  private static byte[] parseIpAddress(String address) {
+  private static byte @Nullable [] parseIpAddress(String address) {
     String literal = address;
 
     if (literal.length() > 2 && literal.startsWith("[") && literal.endsWith("]")) {
       literal = literal.substring(1, literal.length() - 1);
     }
 
-    // A DNS name can contain neither ':' nor the strict dotted-quad form, so getByName() resolves
-    // both of these as literals and never performs a lookup.
-    if (literal.indexOf(':') < 0 && !IPV4_LITERAL.matcher(literal).matches()) {
+    // InetAddress.getByName() hands anything it cannot parse as a literal to the system resolver,
+    // including some strings that contain ':'. Only call it with the two forms it always treats as
+    // a literal: a strict dotted-quad, or a bracketed RFC 2732 IPv6 literal. A bracketed argument
+    // that is not a valid IPv6 address is rejected outright rather than looked up.
+    String candidate;
+
+    if (IPV4_LITERAL.matcher(literal).matches()) {
+      candidate = literal;
+    } else if (literal.indexOf(':') >= 0) {
+      candidate = "[" + literal + "]";
+    } else {
       return null;
     }
 
     try {
-      return InetAddress.getByName(literal).getAddress();
+      return InetAddress.getByName(candidate).getAddress();
     } catch (UnknownHostException e) {
       return null;
     }

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/util/validation/CertificateValidationUtilTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/util/validation/CertificateValidationUtilTest.java
@@ -420,6 +420,51 @@ public class CertificateValidationUtilTest {
     checkHostnameOrIpAddress(createSelfSignedCertificate("DigitalPetri.com"), hostname);
   }
 
+  @Test
+  public void testIpv4Address() throws Exception {
+    X509Certificate certificate = createSelfSignedCertificateWithIpAddress("192.168.0.1");
+
+    checkHostnameOrIpAddress(certificate, "192.168.0.1");
+  }
+
+  // EndpointUtil.getHost() returns IPv6 hosts in the bracketed form they have in the endpoint URL,
+  // and that value is what the client passes here (SessionFsmFactory, UsernameProvider). The
+  // certificate stores the address unbracketed.
+  @Test
+  public void testIpv6AddressInBracketedUriForm() throws Exception {
+    X509Certificate certificate = createSelfSignedCertificateWithIpAddress("2001:db8::1");
+
+    checkHostnameOrIpAddress(certificate, "[2001:db8::1]");
+  }
+
+  // The JDK renders a SubjectAltName IPAddress entry from its raw bytes, so the text in the
+  // certificate need not use the same notation the caller does.
+  @Test
+  public void testIpv6AddressNotationDiffers() throws Exception {
+    X509Certificate certificate = createSelfSignedCertificateWithIpAddress("2001:db8::1");
+
+    checkHostnameOrIpAddress(certificate, "2001:db8::1");
+    checkHostnameOrIpAddress(certificate, "2001:0db8:0000:0000:0000:0000:0000:0001");
+    checkHostnameOrIpAddress(certificate, "2001:DB8::1");
+  }
+
+  @Test
+  public void testNonMatchingIpAddressIsRejected() throws Exception {
+    X509Certificate certificate = createSelfSignedCertificateWithIpAddress("2001:db8::1");
+
+    assertThrows(UaException.class, () -> checkHostnameOrIpAddress(certificate, "[2001:db8::2]"));
+    assertThrows(UaException.class, () -> checkHostnameOrIpAddress(certificate, "192.168.0.1"));
+  }
+
+  // A host name is matched against DNSName entries only; it must never be resolved to an address
+  // and compared against IPAddress entries.
+  @Test
+  public void testHostNameIsNotResolvedToIpAddress() throws Exception {
+    X509Certificate certificate = createSelfSignedCertificateWithIpAddress("127.0.0.1");
+
+    assertThrows(UaException.class, () -> checkHostnameOrIpAddress(certificate, "localhost"));
+  }
+
   private X509CRL generateCrl(
       X509Certificate ca, PrivateKey caPrivateKey, X509Certificate... revoked) throws Exception {
     X509v2CRLBuilder builder =
@@ -456,6 +501,19 @@ public class CertificateValidationUtilTest {
         new SelfSignedCertificateBuilder(keyPair)
             .setApplicationUri("urn:eclipse:milo:test")
             .addDnsName(dnsName);
+
+    return builder.build();
+  }
+
+  private static X509Certificate createSelfSignedCertificateWithIpAddress(String ipAddress)
+      throws Exception {
+
+    KeyPair keyPair = SelfSignedCertificateGenerator.generateRsaKeyPair(2048);
+
+    SelfSignedCertificateBuilder builder =
+        new SelfSignedCertificateBuilder(keyPair)
+            .setApplicationUri("urn:eclipse:milo:test")
+            .addIpAddress(ipAddress);
 
     return builder.build();
   }

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/util/validation/CertificateValidationUtilTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/util/validation/CertificateValidationUtilTest.java
@@ -457,12 +457,15 @@ public class CertificateValidationUtilTest {
   }
 
   // A host name is matched against DNSName entries only; it must never be resolved to an address
-  // and compared against IPAddress entries.
+  // and compared against IPAddress entries. Names containing ':' are included because
+  // InetAddress.getByName() would hand those to the system resolver.
   @Test
   public void testHostNameIsNotResolvedToIpAddress() throws Exception {
     X509Certificate certificate = createSelfSignedCertificateWithIpAddress("127.0.0.1");
 
     assertThrows(UaException.class, () -> checkHostnameOrIpAddress(certificate, "localhost"));
+    assertThrows(UaException.class, () -> checkHostnameOrIpAddress(certificate, "[not:an:ip]"));
+    assertThrows(UaException.class, () -> checkHostnameOrIpAddress(certificate, "not:an:ip"));
   }
 
   private X509CRL generateCrl(


### PR DESCRIPTION
## Problem

`checkHostnameOrIpAddress` matched host names against SubjectAltName `IPAddress`
entries with `String.equals`. The JDK renders those entries from the raw bytes
stored in the certificate, while `EndpointUtil.getHost()` returns IPv6 hosts in
the bracketed form used by the endpoint URL, so two spellings of the same address
did not compare equal and validation failed with `Bad_CertificateHostNameInvalid`.

## Fix

Parse both sides into their raw address bytes before comparing, accepting the
bracketed URI form ([RFC 3986, §3.2.2](https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2)).
Parsing is restricted to address literals: a value that is not an IP address
literal yields `null` and never matches, so a host name is never resolved.

Javadoc updated to state how DNSName and IPAddress entries are compared and that
IPv6 hosts may be passed in either the bare or the bracketed form.

## Tests

Added coverage for:

- IPv4
- bracketed and alternately spelled IPv6
- a non-matching address
- a host name that must not be resolved

---

Before you submit a pull request please acknowledge the following:

- [x] You have signed an Eclipse Contributor Agreement and are committing using the same email address
- [x] Your code contains any tests relevant to the problem you are solving
- [x] All new and existing tests passed
- [x] Code follows the style guidelines and Checkstyle passes

See [CONTRIBUTING](https://github.com/eclipse-milo/milo/blob/master/CONTRIBUTING.md) for more information.