### PR TITLE
Validate method argument shapes and structure elements

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/methods/MethodArgumentValidationTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/methods/MethodArgumentValidationTest.java
@@ -1,0 +1,446 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.milo.opcua.sdk.server.methods;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.eclipse.milo.opcua.sdk.core.Reference;
+import org.eclipse.milo.opcua.sdk.server.AccessContext;
+import org.eclipse.milo.opcua.sdk.server.Session;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaDataTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaMethodNode;
+import org.eclipse.milo.opcua.sdk.test.AbstractClientServerTest;
+import org.eclipse.milo.opcua.sdk.test.TestNamespace;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaSerializationException;
+import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
+import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
+import org.eclipse.milo.opcua.stack.core.encoding.GenericDataTypeCodec;
+import org.eclipse.milo.opcua.stack.core.encoding.UaDecoder;
+import org.eclipse.milo.opcua.stack.core.encoding.UaEncoder;
+import org.eclipse.milo.opcua.stack.core.encoding.binary.OpcUaBinaryDecoder;
+import org.eclipse.milo.opcua.stack.core.encoding.binary.OpcUaBinaryEncoder;
+import org.eclipse.milo.opcua.stack.core.types.UaStructuredType;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Matrix;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.structured.Argument;
+import org.eclipse.milo.opcua.stack.core.types.structured.CallMethodRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.CallMethodResult;
+import org.eclipse.milo.opcua.stack.core.types.structured.ThreeDVector;
+import org.eclipse.milo.opcua.stack.core.types.structured.Union;
+import org.eclipse.milo.opcua.stack.core.types.structured.XVType;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestFactory;
+
+class MethodArgumentValidationTest extends AbstractClientServerTest {
+
+  record Case(NodeId type, int rank, UInteger[] dimensions, Object value, boolean valid) {
+    @Override
+    public String toString() {
+      return "type=%s rank=%d dimensions=%s value=%s valid=%s"
+          .formatted(
+              type.toParseableString(),
+              rank,
+              Arrays.toString(dimensions),
+              Arrays.deepToString(new Object[] {value}),
+              valid);
+    }
+  }
+
+  @Override
+  protected void configureTestNamespace(TestNamespace namespace) {
+    namespace.configure(
+        (context, nodeManager) -> {
+          NodeId typeId = UnionOfScalar.TYPE_ID;
+          var typeNode =
+              new UaDataTypeNode(
+                  context,
+                  typeId,
+                  newQualifiedName("UnionOfScalar"),
+                  LocalizedText.english("UnionOfScalar"),
+                  LocalizedText.NULL_VALUE,
+                  uint(0),
+                  uint(0),
+                  false);
+          typeNode.addReference(
+              new Reference(
+                  typeId,
+                  NodeIds.HasSubtype,
+                  NodeIds.Union.expanded(),
+                  Reference.Direction.INVERSE));
+          nodeManager.addNode(typeNode);
+          server
+              .getStaticDataTypeManager()
+              .registerType(
+                  typeId, new UnionOfScalar.Codec(), UnionOfScalar.BINARY_ENCODING_ID, null, null);
+        });
+    server.updateDataTypeTree();
+  }
+
+  // Unions are Structure subtypes and must be validated by their concrete decoded type.
+  @TestFactory
+  Stream<DynamicTest> validatesWireDecodedUnions() {
+    NodeId typeId = UnionOfScalar.TYPE_ID;
+    UnionOfScalar union = new UnionOfScalar(true);
+    return Stream.of(
+            new Case(typeId, -1, null, union, true),
+            new Case(NodeIds.Union, -1, null, union, true),
+            new Case(NodeIds.Union, 1, null, new UnionOfScalar[] {union}, true),
+            new Case(
+                NodeIds.Union,
+                2,
+                null,
+                new Matrix(new UnionOfScalar[] {union}, new int[] {1, 1}),
+                true),
+            new Case(
+                typeId, 2, null, new Matrix(new UnionOfScalar[] {union}, new int[] {1, 1}), true),
+            new Case(NodeIds.XVType, -1, null, union, false),
+            new Case(NodeIds.Union, -1, null, new XVType(1.0, 2.0f), false))
+        .map(c -> DynamicTest.dynamicTest(c.toString(), () -> assertValidation(c)));
+  }
+
+  // Part 3 8.6: ranks constrain shape, and dimensions are maxima, not exact lengths.
+  @TestFactory
+  Stream<DynamicTest> validatesWireDecodedShapes() {
+    return shapes().map(c -> DynamicTest.dynamicTest(c.toString(), () -> assertValidation(c)));
+  }
+
+  static Stream<Case> shapes() {
+    return Stream.of(
+        shape(-1, 1, true),
+        shape(-1, new Integer[] {1}, false),
+        shape(1, 1, false),
+        shape(1, new Integer[0], true),
+        shape(1, new Matrix(new Integer[] {1, 2}, new int[] {1, 2}), false),
+        shape(-3, 1, true),
+        shape(-3, new Integer[] {1}, true),
+        shape(-3, new Matrix(new Integer[] {1, 2}, new int[] {1, 2}), false),
+        shape(-2, 1, true),
+        shape(-2, new Integer[] {1}, true),
+        shape(-2, new Matrix(new Integer[] {1, 2}, new int[] {1, 2}), true),
+        shape(0, 1, false),
+        shape(0, new Integer[0], true),
+        shape(0, new Integer[] {1}, true),
+        shape(0, new Matrix(new Integer[] {1, 2}, new int[] {1, 2}), true),
+        shape(2, 1, false),
+        shape(2, new Integer[] {1}, false),
+        shape(2, new Matrix(new Integer[] {1, 2}, new int[] {1, 2}), true),
+        shape(3, new Matrix(new Integer[] {1, 2}, new int[] {1, 2}), false),
+        shape(3, new Matrix(new Integer[] {1, 2}, new int[] {1, 1, 2}), true),
+        shape(2, new Matrix(new Integer[0], new int[] {0, 2}), true),
+        shape(-1, null, true),
+        shape(1, null, true),
+        shape(2, null, true),
+        shape(-3, null, true),
+        shape(-2, null, true),
+        shape(0, null, true),
+        shape(1, new UInteger[] {uint(2)}, new Integer[] {1}, true),
+        shape(1, new UInteger[] {uint(2)}, new Integer[0], true),
+        shape(2, new UInteger[] {uint(1), uint(1)}, null, true),
+        shape(1, new UInteger[] {uint(2)}, new Integer[] {1, 2}, true),
+        shape(1, new UInteger[] {uint(1)}, new Integer[] {1, 2}, false),
+        shape(1, new UInteger[] {UInteger.MAX}, new Integer[] {1, 2}, true),
+        shape(
+            2,
+            new UInteger[] {uint(0), uint(2)},
+            new Matrix(new Integer[6], new int[] {3, 2}),
+            true),
+        shape(
+            2,
+            new UInteger[] {uint(0), uint(1)},
+            new Matrix(new Integer[6], new int[] {3, 2}),
+            false),
+        new Case(NodeIds.ByteString, -1, null, ByteString.of(new byte[] {1, 2}), true),
+        new Case(NodeIds.ByteString, 1, null, ByteString.of(new byte[] {1, 2}), false),
+        new Case(NodeIds.ByteString, -1, null, ByteString.NULL_VALUE, true),
+        new Case(
+            NodeIds.ByteString,
+            1,
+            new UInteger[] {uint(1)},
+            new ByteString[] {ByteString.of(new byte[] {1, 2})},
+            true),
+        new Case(NodeIds.Number, 1, null, new Integer[] {1, 2}, true),
+        new Case(
+            NodeIds.Duration, 2, null, new Matrix(new Double[] {1.0}, new int[] {1, 1}), true));
+  }
+
+  private static Case shape(int rank, Object value, boolean valid) {
+    return shape(rank, null, value, valid);
+  }
+
+  private static Case shape(int rank, UInteger[] dimensions, Object value, boolean valid) {
+    return new Case(NodeIds.Int32, rank, dimensions, value, valid);
+  }
+
+  // Wire decoding loses the concrete structure type of each ExtensionObject, including in matrices.
+  @TestFactory
+  Stream<DynamicTest> validatesEveryWireDecodedStructure() {
+    return structures().map(c -> DynamicTest.dynamicTest(c.toString(), () -> assertValidation(c)));
+  }
+
+  static Stream<Case> structures() {
+    var xv = new XVType(1.0, 2.0f);
+    var vector = new ThreeDVector(1.0, 2.0, 3.0);
+    return Stream.of(
+        new Case(NodeIds.XVType, -1, null, xv, true),
+        new Case(NodeIds.XVType, -1, null, vector, false),
+        new Case(NodeIds.XVType, 1, null, new XVType[] {xv}, true),
+        new Case(NodeIds.XVType, 1, null, new XVType[0], true),
+        new Case(NodeIds.Structure, 1, null, new UaStructuredType[] {xv, vector}, true),
+        new Case(NodeIds.Vector, -1, null, vector, true),
+        new Case(NodeIds.XVType, 2, null, new Matrix(new XVType[] {xv}, new int[] {1, 1}), true),
+        new Case(NodeIds.XVType, 2, null, new Matrix(new XVType[0], new int[] {0, 2}), true),
+        new Case(
+            NodeIds.Structure,
+            2,
+            null,
+            new Matrix(new UaStructuredType[] {xv, vector}, new int[] {1, 2}),
+            true),
+        new Case(
+            NodeIds.XVType,
+            2,
+            null,
+            new Matrix(new UaStructuredType[] {xv, vector}, new int[] {1, 2}),
+            false),
+        new Case(
+            NodeIds.XVType,
+            1,
+            null,
+            new ExtensionObject[] {
+              ExtensionObject.encode(DefaultEncodingContext.INSTANCE, xv),
+              ExtensionObject.of(ByteString.NULL_VALUE, NodeId.NULL_VALUE)
+            },
+            true),
+        new Case(
+            NodeIds.XVType,
+            -1,
+            null,
+            ExtensionObject.of(ByteString.NULL_VALUE, NodeId.NULL_VALUE),
+            true),
+        new Case(
+            NodeIds.XVType,
+            -1,
+            null,
+            ExtensionObject.of(
+                ByteString.of(new byte[] {1}), NodeIds.XVType_Encoding_DefaultBinary),
+            false),
+        new Case(
+            NodeIds.XVType,
+            -1,
+            null,
+            ExtensionObject.of(ByteString.of(new byte[] {1}), new NodeId(2, "unknown")),
+            false),
+        new Case(NodeIds.XVType, -1, null, 1, false),
+        new Case(NodeIds.XVType, 2, null, new Matrix(new Integer[] {1}, new int[] {1, 1}), false),
+        new Case(
+            NodeIds.Vector,
+            2,
+            null,
+            new Matrix(new ThreeDVector[] {vector}, new int[] {1, 1}),
+            true),
+        new Case(
+            NodeIds.XVType,
+            2,
+            null,
+            new Matrix(
+                new ExtensionObject[] {
+                  ExtensionObject.of(ByteString.NULL_VALUE, NodeId.NULL_VALUE)
+                },
+                new int[] {1, 1}),
+            true));
+  }
+
+  private void assertValidation(Case c) {
+    var argument = new Argument("Input", c.type, c.rank, c.dimensions, LocalizedText.NULL_VALUE);
+    var handler = new RecordingHandler(argument);
+    Variant input = wireValue(c.value);
+    CallMethodRequest request = handler.request(input);
+
+    CallMethodResult result = handler.invoke(AccessContext.INTERNAL, request);
+
+    assertEquals(
+        c.valid ? StatusCode.GOOD : StatusCode.of(StatusCodes.Bad_InvalidArgument),
+        result.getStatusCode());
+    assertSame(input, request.getInputArguments()[0], "validation must not mutate the request");
+    if (c.valid) {
+      assertEquals(0, result.getInputArgumentResults().length);
+      if (input.value() instanceof Matrix) {
+        assertSame(input, handler.received[0], "matrix validation must not replace wire values");
+      }
+    } else {
+      assertArrayEquals(
+          new StatusCode[] {StatusCode.of(StatusCodes.Bad_TypeMismatch), StatusCode.GOOD},
+          result.getInputArgumentResults());
+      assertEquals(0, result.getOutputArguments().length);
+    }
+  }
+
+  // Validation must preserve session identity and the object on which the method was called.
+  @Test
+  void preservesSessionContext() {
+    var handler =
+        new RecordingHandler(
+            new Argument("Input", NodeIds.Int32, -1, null, LocalizedText.NULL_VALUE));
+    Session session = mock(Session.class);
+    handler.expectedSession = Optional.of(session);
+
+    CallMethodResult result =
+        handler.invoke(() -> Optional.of(session), handler.request(wireValue(1)));
+
+    assertEquals(StatusCode.GOOD, result.getStatusCode());
+  }
+
+  // Local callers can supply primitive arrays without wire decoding.
+  @Test
+  void acceptsLocalPrimitiveMatrix() {
+    var handler =
+        new RecordingHandler(
+            new Argument("Input", NodeIds.Duration, 2, null, LocalizedText.NULL_VALUE));
+    CallMethodRequest request =
+        handler.request(new Variant(new Matrix(new double[] {1.0}, new int[] {1, 1})));
+
+    assertEquals(StatusCode.GOOD, handler.invoke(AccessContext.INTERNAL, request).getStatusCode());
+  }
+
+  // A null Matrix carries no value or shape, so it is accepted for any rank and delivered as null.
+  @TestFactory
+  Stream<DynamicTest> deliversNullMatrixAsNull() {
+    return Stream.of(-1, 1, 2)
+        .map(
+            rank ->
+                DynamicTest.dynamicTest(
+                    "rank=" + rank,
+                    () -> {
+                      var handler =
+                          new RecordingHandler(
+                              new Argument(
+                                  "Input", NodeIds.Int32, rank, null, LocalizedText.NULL_VALUE));
+                      CallMethodRequest request = handler.request(new Variant(Matrix.ofNull()));
+
+                      CallMethodResult result = handler.invoke(AccessContext.INTERNAL, request);
+
+                      assertEquals(StatusCode.GOOD, result.getStatusCode());
+                      assertEquals(Variant.NULL_VALUE, handler.received[0]);
+                    }));
+  }
+
+  private Variant wireValue(Object value) {
+    ByteBuf buffer = Unpooled.buffer();
+    try {
+      EncodingContext context = server.getStaticEncodingContext();
+      new OpcUaBinaryEncoder(context).setBuffer(buffer).encodeVariant(new Variant(value));
+      return new OpcUaBinaryDecoder(context).setBuffer(buffer).decodeVariant();
+    } finally {
+      buffer.release();
+    }
+  }
+
+  private static class UnionOfScalar extends Union {
+    static final NodeId TYPE_ID = new NodeId(2, "ValidationUnion");
+    static final NodeId BINARY_ENCODING_ID = new NodeId(2, "ValidationUnion.Binary");
+    private final boolean value;
+
+    UnionOfScalar(boolean value) {
+      this.value = value;
+    }
+
+    @Override
+    public ExpandedNodeId getTypeId() {
+      return TYPE_ID.expanded();
+    }
+
+    @Override
+    public ExpandedNodeId getBinaryEncodingId() {
+      return BINARY_ENCODING_ID.expanded();
+    }
+
+    private static class Codec extends GenericDataTypeCodec<UnionOfScalar> {
+      @Override
+      public Class<UnionOfScalar> getType() {
+        return UnionOfScalar.class;
+      }
+
+      @Override
+      public UnionOfScalar decodeType(EncodingContext context, UaDecoder decoder) {
+        if (decoder.decodeUInt32("SwitchField").intValue() != 1) {
+          throw new UaSerializationException(StatusCodes.Bad_DecodingError, "invalid union switch");
+        }
+        return new UnionOfScalar(decoder.decodeBoolean("Value"));
+      }
+
+      @Override
+      public void encodeType(EncodingContext context, UaEncoder encoder, UnionOfScalar union) {
+        encoder.encodeUInt32("SwitchField", uint(1));
+        encoder.encodeBoolean("Value", union.value);
+      }
+    }
+  }
+
+  private class RecordingHandler extends AbstractMethodInvocationHandler {
+    private final Argument argument;
+    private Optional<Session> expectedSession = Optional.empty();
+    private Variant[] received;
+
+    RecordingHandler(Argument argument) {
+      super(
+          UaMethodNode.builder(testNamespace.getNodeContext())
+              .setNodeId(newNodeId("validation"))
+              .setBrowseName(newQualifiedName("validation"))
+              .setDisplayName(LocalizedText.english("validation"))
+              .build());
+      this.argument = argument;
+    }
+
+    @Override
+    public Argument[] getInputArguments() {
+      return new Argument[] {
+        argument, new Argument("Control", NodeIds.Int32, -1, null, LocalizedText.NULL_VALUE)
+      };
+    }
+
+    @Override
+    public Argument[] getOutputArguments() {
+      return new Argument[0];
+    }
+
+    CallMethodRequest request(Variant input) {
+      return new CallMethodRequest(
+          NodeIds.ObjectsFolder, getNode().getNodeId(), new Variant[] {input, Variant.ofInt32(42)});
+    }
+
+    @Override
+    protected Variant[] invoke(InvocationContext context, Variant[] values) {
+      assertSame(server, context.getServer());
+      assertSame(getNode(), context.getMethodNode());
+      assertEquals(NodeIds.ObjectsFolder, context.getObjectId());
+      assertEquals(expectedSession, context.getSession());
+      received = values;
+      return new Variant[0];
+    }
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/methods/AbstractMethodInvocationHandler.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/methods/AbstractMethodInvocationHandler.java
@@ -16,6 +16,7 @@ import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.Optional;
+import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.sdk.core.typetree.DataType;
 import org.eclipse.milo.opcua.sdk.core.typetree.DataTypeTree;
 import org.eclipse.milo.opcua.sdk.server.AccessContext;
@@ -34,9 +35,12 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.Matrix;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.structured.Argument;
 import org.eclipse.milo.opcua.stack.core.types.structured.CallMethodRequest;
 import org.eclipse.milo.opcua.stack.core.types.structured.CallMethodResult;
+import org.eclipse.milo.opcua.stack.core.util.ArrayUtil;
+import org.jspecify.annotations.Nullable;
 
 /**
  * A partial implementation of {@link MethodInvocationHandler} that handles checking the Executable
@@ -81,9 +85,16 @@ public abstract class AbstractMethodInvocationHandler implements MethodInvocatio
         Variant variant = inputArgumentValues[i];
         Object value = variant.value();
 
-        boolean dataTypeMatch = true;
+        if (value instanceof Matrix matrix && matrix.isNull()) {
+          // A null Matrix is just a null value; deliver it as one.
+          inputArgumentValues[i] = Variant.NULL_VALUE;
+          value = null;
+        }
 
-        if (value != null) {
+        // Check the shape first; it is cheap and avoids decoding elements of a mismatched value.
+        boolean dataTypeMatch = shapeMatches(argument, value);
+
+        if (dataTypeMatch && value != null) {
           NodeId argDataTypeId = argument.getDataType();
 
           DataTypeTree dataTypeTree = node.getNodeContext().getServer().getDataTypeTree();
@@ -94,8 +105,7 @@ public abstract class AbstractMethodInvocationHandler implements MethodInvocatio
           if (argIsStructType) {
             try {
               if (value instanceof ExtensionObject xo) {
-                UaStructuredType decoded =
-                    xo.decode(node.getNodeContext().getServer().getStaticEncodingContext());
+                UaStructuredType decoded = decodeStructure(xo);
 
                 dataTypeMatch = structureTypeMatches(dataTypeTree, argDataTypeId, decoded);
 
@@ -105,23 +115,10 @@ public abstract class AbstractMethodInvocationHandler implements MethodInvocatio
                   inputArgumentValues[i] = new Variant(decoded);
                 }
               } else if (value instanceof ExtensionObject[] xos) {
-                var decodedElements = new UaStructuredType[xos.length];
+                UaStructuredType[] decodedElements =
+                    decodeMatchingStructures(dataTypeTree, argDataTypeId, xos);
 
-                for (int j = 0; dataTypeMatch && j < xos.length; j++) {
-                  ExtensionObject xo = xos[j];
-
-                  if (xo == null || xo.isNull()) {
-                    // A struct array with null elements has no typed representation.
-                    dataTypeMatch = false;
-                  } else {
-                    UaStructuredType decoded =
-                        xo.decode(node.getNodeContext().getServer().getStaticEncodingContext());
-
-                    dataTypeMatch = structureTypeMatches(dataTypeTree, argDataTypeId, decoded);
-
-                    decodedElements[j] = decoded;
-                  }
-                }
+                dataTypeMatch = decodedElements != null;
 
                 if (dataTypeMatch) {
                   // Substitute a correctly-typed array of the decoded values, so that e.g. an
@@ -131,26 +128,10 @@ public abstract class AbstractMethodInvocationHandler implements MethodInvocatio
                 }
               } else if (value instanceof UaStructuredType structValue) {
                 dataTypeMatch = structureTypeMatches(dataTypeTree, argDataTypeId, structValue);
-              } else if (value instanceof UaStructuredType[] structValues) {
-                for (int j = 0; dataTypeMatch && j < structValues.length; j++) {
-                  UaStructuredType structValue = structValues[j];
-
-                  dataTypeMatch =
-                      structValue != null
-                          && structureTypeMatches(dataTypeTree, argDataTypeId, structValue);
-                }
-              } else if (value instanceof Matrix) {
-                // TODO decoding a Matrix of ExtensionObject into its struct elements is not
-                //  supported; accept it only if the DataType ids already match exactly.
-                NodeId valueDataTypeId =
-                    variant
-                        .getDataTypeId()
-                        .flatMap(xni -> xni.toNodeId(node.getNodeContext().getNamespaceTable()))
-                        .orElse(NodeId.NULL_VALUE);
-
-                dataTypeMatch = argDataTypeId.equals(valueDataTypeId);
               } else {
-                dataTypeMatch = false;
+                // Validate each element without changing the value passed to subclasses.
+                dataTypeMatch =
+                    structureElementsMatch(dataTypeTree, argDataTypeId, elementsOf(value));
               }
             } catch (UaSerializationException e) {
               dataTypeMatch = false;
@@ -163,32 +144,9 @@ public abstract class AbstractMethodInvocationHandler implements MethodInvocatio
                     .orElse(NodeId.NULL_VALUE);
 
             if (!argDataTypeId.equals(valueDataTypeId)) {
-              dataTypeMatch = dataTypeTree.isAssignable(argDataTypeId, value.getClass());
+              Class<?> elementType = ArrayUtil.getBoxedType(elementsOf(value));
+              dataTypeMatch = dataTypeTree.isAssignable(argDataTypeId, elementType);
             }
-          }
-        }
-
-        int valueRank = argument.getValueRank();
-
-        if (valueRank == -1) {
-          // scalar
-          if (value != null && (value.getClass().isArray() || value instanceof Matrix)) {
-            dataTypeMatch = false;
-          }
-        } else if (valueRank == 1) {
-          // one dimension
-          if (value != null && !value.getClass().isArray()) {
-            dataTypeMatch = false;
-          }
-        } else if (valueRank == 0) {
-          // one or more dimension
-          if (value != null && !(value.getClass().isArray() || value instanceof Matrix)) {
-            dataTypeMatch = false;
-          }
-        } else if (valueRank > 1) {
-          // matrix (2+ dimensions)
-          if (value != null && !(value instanceof Matrix)) {
-            dataTypeMatch = false;
           }
         }
 
@@ -244,6 +202,96 @@ public abstract class AbstractMethodInvocationHandler implements MethodInvocatio
     }
   }
 
+  /** The flat elements of a Matrix, or {@code value} itself for any other value. */
+  private static @Nullable Object elementsOf(@Nullable Object value) {
+    return value instanceof Matrix matrix ? matrix.getElements() : value;
+  }
+
+  // Part 3, 8.6: ArrayDimensions specifies maxima; zero means unknown.
+  private static boolean shapeMatches(Argument argument, @Nullable Object value) {
+    if (value == null) {
+      return true;
+    }
+
+    // ByteString and String have scalar semantics, i.e. rank -1.
+    int rank =
+        value instanceof Matrix matrix ? matrix.getValueRank() : ArrayUtil.getValueRank(value);
+    int valueRank = argument.getValueRank();
+    boolean rankMatches =
+        switch (valueRank) {
+          case ValueRanks.ScalarOrOneDimension -> rank == ValueRanks.Scalar || rank == 1;
+          case ValueRanks.Any -> true;
+          case ValueRanks.Scalar -> rank == ValueRanks.Scalar;
+          case ValueRanks.OneOrMoreDimensions -> rank >= 1;
+          default -> valueRank > 0 && rank == valueRank;
+        };
+    if (!rankMatches) {
+      return false;
+    }
+
+    UInteger[] maxima = argument.getArrayDimensions();
+    if (valueRank > 0 && maxima != null && maxima.length > 0) {
+      int[] dimensions =
+          value instanceof Matrix matrix ? matrix.getDimensions() : ArrayUtil.getDimensions(value);
+      if (maxima.length != dimensions.length) {
+        return false;
+      }
+      for (int i = 0; i < dimensions.length; i++) {
+        long maximum = maxima[i].longValue();
+        if (maximum != 0 && dimensions[i] > maximum) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  private @Nullable UaStructuredType decodeStructure(@Nullable ExtensionObject xo) {
+    if (xo == null || xo.isNull()) {
+      return null;
+    }
+    return xo.decode(node.getNodeContext().getServer().getStaticEncodingContext());
+  }
+
+  /**
+   * Decode each element of {@code xos} and check it against the Argument's DataType, stopping at
+   * the first mismatch.
+   *
+   * @return the decoded elements, or {@code null} if any element does not match.
+   */
+  private UaStructuredType @Nullable [] decodeMatchingStructures(
+      DataTypeTree dataTypeTree, NodeId argDataTypeId, ExtensionObject[] xos) {
+
+    var decodedElements = new UaStructuredType[xos.length];
+
+    for (int j = 0; j < xos.length; j++) {
+      decodedElements[j] = decodeStructure(xos[j]);
+
+      if (!structureTypeMatches(dataTypeTree, argDataTypeId, decodedElements[j])) {
+        return null;
+      }
+    }
+
+    return decodedElements;
+  }
+
+  /**
+   * Check that every element of a structure array matches the Argument's DataType. Null elements
+   * match; {@link ExtensionObject} elements are decoded first. Any other value does not match.
+   */
+  private boolean structureElementsMatch(
+      DataTypeTree dataTypeTree, NodeId argDataTypeId, @Nullable Object elements) {
+
+    if (elements instanceof ExtensionObject[] xos) {
+      return decodeMatchingStructures(dataTypeTree, argDataTypeId, xos) != null;
+    } else if (elements instanceof UaStructuredType[] structs) {
+      return Arrays.stream(structs)
+          .allMatch(s -> structureTypeMatches(dataTypeTree, argDataTypeId, s));
+    } else {
+      return false;
+    }
+  }
+
   /**
    * Check that a structure value's DataType matches the DataType of the {@link Argument} it was
    * supplied for.
@@ -257,7 +305,11 @@ public abstract class AbstractMethodInvocationHandler implements MethodInvocatio
    * @return {@code true} if {@code structValue}'s DataType matches the Argument's DataType.
    */
   private boolean structureTypeMatches(
-      DataTypeTree dataTypeTree, NodeId argDataTypeId, UaStructuredType structValue) {
+      DataTypeTree dataTypeTree, NodeId argDataTypeId, @Nullable UaStructuredType structValue) {
+
+    if (structValue == null) {
+      return true;
+    }
 
     NodeId valueDataTypeId =
         structValue
@@ -333,7 +385,9 @@ public abstract class AbstractMethodInvocationHandler implements MethodInvocatio
    *     verified to be of the type specified by its {@link Argument}. Values for arguments with a
    *     structured DataType carry the decoded {@link UaStructuredType} value (or, for array
    *     arguments, an array of the DataType's registered class, e.g. {@code XVType[]}) rather than
-   *     the raw {@link ExtensionObject}(s) received in the request.
+   *     the raw {@link ExtensionObject}(s) received in the request. A null ExtensionObject, whether
+   *     scalar or an array element, is delivered as {@code null}. Matrix arguments retain their
+   *     original representation; their elements are decoded only for validation.
    * @return this output values matching this Method's output arguments, if any.
    * @throws UaException if invocation has failed for some reason.
    */

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaDefaultBinaryEncoding.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaDefaultBinaryEncoding.java
@@ -97,7 +97,12 @@ public class OpcUaDefaultBinaryEncoding implements DataTypeEncoding {
       OpcUaBinaryDecoder decoder = new OpcUaBinaryDecoder(context);
       decoder.setBuffer(buffer);
 
-      return decoder.decodeStruct(null, codec);
+      try {
+        return decoder.decodeStruct(null, codec);
+      } catch (IndexOutOfBoundsException e) {
+        // A truncated body may fail in a codec's primitive read.
+        throw new UaSerializationException(StatusCodes.Bad_DecodingError, e);
+      }
     } else {
       throw new UaSerializationException(
           StatusCodes.Bad_DecodingError, "not binary encoded: " + encoded);


### PR DESCRIPTION
Method calls could accept arguments with the wrong rank or dimensions and reject valid structured matrices. Validate the argument shape against ValueRank and ArrayDimensions, then check each structure element against the declared DataType. Matrix values retain their original representation, and null structures are accepted consistently.

Truncated binary structure bodies now produce a decoding error that method validation reports as an argument type mismatch. Integration coverage exercises wire-decoded ranks, dimension limits, structures, unions, malformed bodies, and invocation context.

Validation: `spotless:apply`, `clean compile`, and the `MethodArgumentValidationTest` and `AbstractMethodInvocationHandlerTest` integration tests passed.
