### PR TITLE
Parse the full UInt16 range of namespace indexes in QualifiedName

### DIFF
--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/QualifiedName.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/QualifiedName.java
@@ -148,6 +148,9 @@ public record QualifiedName(UShort namespaceIndex, @Nullable String name) {
   /**
    * Parse a {@link QualifiedName} from its parseable string representation.
    *
+   * <p>A prefix that is not a namespace index in the UInt16 range is ignored, and the namespace
+   * index of the result is 0.
+   *
    * @param s the string to parse.
    * @return the parsed {@link QualifiedName}.
    */
@@ -159,7 +162,13 @@ public record QualifiedName(UShort namespaceIndex, @Nullable String name) {
 
     if (ss.length > 1) {
       try {
-        namespaceIndex = Short.parseShort(ss[0]);
+        // The namespace index is a UInt16, so it is parsed as an int and range checked rather than
+        // parsed as a short, which cannot represent an index above 32767.
+        int parsed = Integer.parseInt(ss[0]);
+
+        if (parsed >= UShort.MIN_VALUE && parsed <= UShort.MAX_VALUE) {
+          namespaceIndex = parsed;
+        }
       } catch (NumberFormatException ignored) {
       }
       name = ss[1];

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/types/builtin/QualifiedNameTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/types/builtin/QualifiedNameTest.java
@@ -10,6 +10,7 @@
 
 package org.eclipse.milo.opcua.stack.core.types.builtin;
 
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
@@ -20,6 +21,40 @@ public class QualifiedNameTest {
   void parseableStringSymmetry() {
     assertSymmetry("0:foo");
     assertSymmetry("0:foo:bar");
+  }
+
+  // The namespace index is a UInt16, so every index up to 65535 must survive a round trip. Parsing
+  // it as a short silently yields index 0 for anything above 32767.
+  @Test
+  void parseableStringSymmetryAcrossNamespaceRange() {
+    assertSymmetry("1:foo");
+    assertSymmetry("32767:foo");
+    assertSymmetry("32768:foo");
+    assertSymmetry("40000:foo");
+    assertSymmetry("65535:foo");
+  }
+
+  @Test
+  void parseNamespaceIndex() {
+    assertEquals(ushort(0), QualifiedName.parse("0:foo").namespaceIndex());
+    assertEquals(ushort(32768), QualifiedName.parse("32768:foo").namespaceIndex());
+    assertEquals(ushort(65535), QualifiedName.parse("65535:foo").namespaceIndex());
+    assertEquals("foo", QualifiedName.parse("65535:foo").name());
+  }
+
+  // A prefix that is not a namespace index in range is ignored and the name after the separator is
+  // kept, which is how an unparseable prefix has always been treated.
+  @Test
+  void parseIgnoresPrefixThatIsNotANamespaceIndex() {
+    assertEquals(new QualifiedName(0, "foo"), QualifiedName.parse("abc:foo"));
+    assertEquals(new QualifiedName(0, "foo"), QualifiedName.parse("65536:foo"));
+    assertEquals(new QualifiedName(0, "foo"), QualifiedName.parse("99999999999:foo"));
+    assertEquals(new QualifiedName(0, "foo"), QualifiedName.parse("-1:foo"));
+  }
+
+  @Test
+  void parseWithoutSeparator() {
+    assertEquals(new QualifiedName(0, "foo"), QualifiedName.parse("foo"));
   }
 
   @Test


### PR DESCRIPTION
## Description

`QualifiedName.parse` read the namespace index with `Short.parseShort`, which cannot
represent an index above 32767.

- For `"40000:foo"` the parse threw, the exception was swallowed, and the result carried
  namespace index `0`, so `QualifiedName.parse(name.toParseableString())` did not round
  trip for an index above 32767.
- A negative prefix threw `NumberFormatException` out of `parse`, from `ushort()`.

## Fix

Parse the index as an `int` and range check it against `UShort`, as `NodeId.parse` already
does. A prefix outside the `UInt16` range is ignored the same way an unparseable prefix has
always been, which also removes the exception the negative case leaked.

## Tests

Adds coverage for:

- the namespace range;
- the preserved handling of a prefix that is not a namespace index;
- a name with no separator.

---

Before you submit a pull request please acknowledge the following:

- [x] You have signed an Eclipse Contributor Agreement and are committing using the same email address
- [x] Your code contains any tests relevant to the problem you are solving
- [x] All new and existing tests passed
- [x] Code follows the style guidelines and Checkstyle passes

See [CONTRIBUTING](https://github.com/eclipse-milo/milo/blob/master/CONTRIBUTING.md) for more information.