### PR TITLE
Select the CRL signed by the path's issuer when CAs share a subject name

### DIFF
--- a/opc-ua-stack/stack-core/pom.xml
+++ b/opc-ua-stack/stack-core/pom.xml
@@ -108,7 +108,10 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
-          <argLine>-Dio.netty.noReflectiveAccessible=false</argLine>
+          <argLine>
+            -Dio.netty.noReflectiveAccessible=false
+            --add-opens java.base/sun.security.provider.certpath=ALL-UNNAMED
+          </argLine>
         </configuration>
       </plugin>
       <plugin>

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/validation/CertificateValidationUtil.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/validation/CertificateValidationUtil.java
@@ -267,9 +267,13 @@ public class CertificateValidationUtil {
 
           parameters.setRevocationEnabled(true);
 
-          if (!crls.isEmpty()) {
+          Collection<X509CRL> applicableCrls =
+              selectApplicableCrls(crls, pathCertificates, anchorCert);
+
+          if (!applicableCrls.isEmpty()) {
             parameters.addCertStore(
-                CertStore.getInstance("Collection", new CollectionCertStoreParameters(crls)));
+                CertStore.getInstance(
+                    "Collection", new CollectionCertStoreParameters(applicableCrls)));
           }
 
           parameters.addCertPathChecker(
@@ -349,6 +353,63 @@ public class CertificateValidationUtil {
       } catch (GeneralSecurityException e) {
         throw new UaException(StatusCodes.Bad_SecurityChecksFailed, e);
       }
+    }
+  }
+
+  /**
+   * Removes CRLs that share an issuer name with a certificate in the path but were signed by a
+   * different key.
+   *
+   * <p>PKIX selects a CRL by issuer name alone. That is ambiguous whenever a trust list holds
+   * several CA certificates with the same subject name, which a Global Discovery Server produces as
+   * a matter of course: a certificate group that offers more than one certificate type issues one
+   * CA per type, all under the group's single configured subject name, and publishes a CRL for
+   * each. Handed more than one candidate, PKIX reports {@link
+   * BasicReason#UNDETERMINED_REVOCATION_STATUS} instead of trying each in turn, so the whole path
+   * fails even though the right CRL was present.
+   *
+   * <p>A CRL whose issuer name matches nothing in the path is left alone; it belongs to some other
+   * path and is not ours to judge.
+   *
+   * @param crls the CRLs from the trust list.
+   * @param pathCertificates the certificates of the path being validated.
+   * @param anchorCert the trust anchor certificate.
+   * @return the CRLs that PKIX can unambiguously attribute to an issuer in the path.
+   */
+  private static Collection<X509CRL> selectApplicableCrls(
+      Collection<X509CRL> crls,
+      List<X509Certificate> pathCertificates,
+      X509Certificate anchorCert) {
+
+    var issuers = new ArrayList<X509Certificate>(pathCertificates);
+    issuers.add(anchorCert);
+
+    var applicable = new ArrayList<X509CRL>(crls.size());
+
+    for (X509CRL crl : crls) {
+      List<X509Certificate> candidates =
+          issuers.stream()
+              .filter(c -> c.getSubjectX500Principal().equals(crl.getIssuerX500Principal()))
+              .collect(Collectors.toList());
+
+      if (candidates.isEmpty() || candidates.stream().anyMatch(c -> verifies(crl, c))) {
+        applicable.add(crl);
+      } else {
+        LOGGER.debug(
+            "Discarding CRL from issuer={} that no same-named certificate in the path signed.",
+            crl.getIssuerX500Principal().getName());
+      }
+    }
+
+    return applicable;
+  }
+
+  private static boolean verifies(X509CRL crl, X509Certificate issuer) {
+    try {
+      crl.verify(issuer.getPublicKey());
+      return true;
+    } catch (GeneralSecurityException e) {
+      return false;
     }
   }
 

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/validation/CertificateValidationUtil.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/validation/CertificateValidationUtil.java
@@ -292,6 +292,11 @@ public class CertificateValidationUtil {
                     PKIXRevocationChecker.Option.NO_FALLBACK,
                     PKIXRevocationChecker.Option.PREFER_CRLS,
                     PKIXRevocationChecker.Option.SOFT_FAIL));
+
+            // Configuring the checker is not enough; it only takes effect once it's part of the
+            // parameters. Without this the default revocation checker runs instead, and its
+            // stricter options fail the whole path when a CRL can't be located.
+            parameters.addCertPathChecker(pkixRevocationChecker);
           } else {
             parameters.setRevocationEnabled(false);
           }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/validation/CertificateValidationUtil.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/validation/CertificateValidationUtil.java
@@ -406,7 +406,13 @@ public class CertificateValidationUtil {
 
   private static boolean verifies(X509CRL crl, X509Certificate issuer) {
     try {
-      crl.verify(issuer.getPublicKey());
+      // Use the same provider routing as path validation so unsupported SunEC curves do not
+      // cause a valid CRL to be discarded before the revocation checker sees it.
+      if (usesUnsupportedCurve(issuer)) {
+        crl.verify(issuer.getPublicKey(), bouncyCastleProvider());
+      } else {
+        crl.verify(issuer.getPublicKey());
+      }
       return true;
     } catch (GeneralSecurityException e) {
       return false;

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/validation/package-info.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/validation/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/**
+ * Builds trusted certificate paths and applies OPC UA certificate validation rules for the default
+ * client and server certificate validators.
+ *
+ * <p>{@link org.eclipse.milo.opcua.stack.core.util.validation.CertificateValidationUtil} first
+ * builds a path from the presented chain and trust-list certificates, then validates that path
+ * against the supplied CRLs and validation checks. Path construction establishes trust and
+ * signature chaining; the usage and revocation checkers enforce the remaining certificate rules.
+ * CRLs are matched to signing keys in the selected path so same-named CAs can coexist in a trust
+ * list.
+ *
+ * <p>Signature verification uses Bouncy Castle for Brainpool keys that the default JCA providers
+ * cannot handle. CRL selection and path validation must use compatible providers so a provider
+ * limitation cannot discard revocation information. The validation checks distinguish enforcing
+ * revocation from requiring available CRLs; when CRLs are optional, a missing CRL can be tolerated
+ * while a revoked certificate is still rejected.
+ */
+package org.eclipse.milo.opcua.stack.core.util.validation;

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/util/CrlTestUtil.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/util/CrlTestUtil.java
@@ -10,15 +10,22 @@
 
 package org.eclipse.milo.opcua.stack.core.util;
 
+import java.math.BigInteger;
 import java.security.PrivateKey;
 import java.security.cert.X509CRL;
 import java.security.cert.X509Certificate;
 import java.util.Date;
 import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.AuthorityKeyIdentifier;
+import org.bouncycastle.asn1.x509.CRLNumber;
 import org.bouncycastle.asn1.x509.CRLReason;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
 import org.bouncycastle.cert.X509CRLHolder;
 import org.bouncycastle.cert.X509v2CRLBuilder;
 import org.bouncycastle.cert.jcajce.JcaX509CRLConverter;
+import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils;
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 
 /** Builds X.509 CRLs for tests that need real, decodable CRL bytes. */
@@ -44,6 +51,20 @@ public final class CrlTestUtil {
 
     builder.setNextUpdate(new Date(System.currentTimeMillis() + 60_000));
 
+    // Real CAs identify their signing key on the CRL, and PKIX uses it to choose a signer when
+    // more than one certificate carries the issuer name.
+    var issuerName =
+        new GeneralNames(
+            new GeneralName(X500Name.getInstance(issuer.getSubjectX500Principal().getEncoded())));
+    builder.addExtension(
+        Extension.authorityKeyIdentifier,
+        false,
+        new AuthorityKeyIdentifier(
+            new JcaX509ExtensionUtils().createAuthorityKeyIdentifier(issuer).getKeyIdentifier(),
+            issuerName,
+            issuer.getSerialNumber()));
+    builder.addExtension(Extension.cRLNumber, false, new CRLNumber(BigInteger.ONE));
+
     for (X509Certificate certificate : revoked) {
       builder.addCRLEntry(
           certificate.getSerialNumber(),
@@ -51,8 +72,11 @@ public final class CrlTestUtil {
           CRLReason.privilegeWithdrawn);
     }
 
+    String signatureAlgorithm =
+        "EC".equals(issuerKey.getAlgorithm()) ? "SHA256withECDSA" : "SHA256WithRSAEncryption";
+
     X509CRLHolder holder =
-        builder.build(new JcaContentSignerBuilder("SHA256WithRSAEncryption").build(issuerKey));
+        builder.build(new JcaContentSignerBuilder(signatureAlgorithm).build(issuerKey));
 
     return new JcaX509CRLConverter().getCRL(holder);
   }

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/util/validation/BrainpoolCertificateValidationTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/util/validation/BrainpoolCertificateValidationTest.java
@@ -11,30 +11,50 @@
 package org.eclipse.milo.opcua.stack.core.util.validation;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.security.KeyPair;
+import java.security.PrivateKey;
 import java.security.Security;
 import java.security.cert.CertificateFactory;
+import java.security.cert.PKIXCertPathBuilderResult;
+import java.security.cert.X509CRL;
 import java.security.cert.X509Certificate;
+import java.util.Date;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
+import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.CRLReason;
 import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.asn1.x509.KeyUsage;
 import org.bouncycastle.cert.CertIOException;
+import org.bouncycastle.cert.X509v2CRLBuilder;
 import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.security.DefaultServerCertificateValidator;
 import org.eclipse.milo.opcua.stack.core.security.MemoryCertificateQuarantine;
 import org.eclipse.milo.opcua.stack.core.security.MemoryTrustListManager;
 import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
 import org.eclipse.milo.opcua.stack.core.security.SecurityPolicyProfile;
+import org.eclipse.milo.opcua.stack.core.util.CertificateUtil;
 import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateBuilder;
 import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateGenerator;
 import org.jspecify.annotations.NullMarked;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Brainpool certificates cannot be signature-verified by the JDK's default JCA providers (SunEC
@@ -125,6 +145,81 @@ class BrainpoolCertificateValidationTest {
                     List.of(chain.leaf()), null, null, BRAINPOOL_P384_PROFILE));
   }
 
+  // A valid CRL must reach the revocation checker even when missing CRLs are allowed. Otherwise
+  // provider failures during CRL selection silently turn a revoked certificate into an accepted
+  // one.
+  @ParameterizedTest
+  @CsvSource({"256, false", "256, true", "384, false", "384, true"})
+  void revokedBrainpoolLeafIsRejected(int keySize, boolean requireCrl) throws Exception {
+    startWithBouncyCastleRemoved();
+
+    BrainpoolChain chain = generateCaSignedBrainpoolChain(keySize);
+    X509CRL crl = generateCrl(chain, chain.leaf());
+    EnumSet<ValidationCheck> checks = EnumSet.of(ValidationCheck.REVOCATION);
+    if (requireCrl) {
+      checks.add(ValidationCheck.REVOCATION_LISTS);
+    }
+
+    UaException e = assertThrows(UaException.class, () -> validateChain(chain, crl, checks));
+
+    assertEquals(StatusCodes.Bad_CertificateRevoked, e.getStatusCode().value());
+  }
+
+  // Requiring a CRL also protects legitimate connections: an unsupported default provider must not
+  // make a valid, empty Brainpool CRL appear to be missing.
+  @ParameterizedTest
+  @ValueSource(ints = {256, 384})
+  void unrevokedBrainpoolLeafIsAcceptedWithRequiredCrl(int keySize) throws Exception {
+    startWithBouncyCastleRemoved();
+
+    BrainpoolChain chain = generateCaSignedBrainpoolChain(keySize);
+    X509CRL crl = generateCrl(chain);
+
+    assertDoesNotThrow(
+        () ->
+            validateChain(
+                chain,
+                crl,
+                EnumSet.of(ValidationCheck.REVOCATION, ValidationCheck.REVOCATION_LISTS)));
+  }
+
+  private static void validateChain(BrainpoolChain chain, X509CRL crl, Set<ValidationCheck> checks)
+      throws UaException {
+    PKIXCertPathBuilderResult path =
+        CertificateValidationUtil.buildTrustedCertPath(
+            List.of(chain.leaf()), Set.of(chain.root()), Set.of());
+
+    CertificateValidationUtil.validateTrustedCertPath(
+        path.getCertPath(), path.getTrustAnchor(), List.of(crl), checks, true, chain.profile());
+  }
+
+  private static X509CRL generateCrl(BrainpoolChain chain, X509Certificate... revoked)
+      throws Exception {
+    var builder =
+        new X509v2CRLBuilder(
+            X500Name.getInstance(chain.root().getSubjectX500Principal().getEncoded()),
+            new Date(System.currentTimeMillis() - 60_000));
+    builder.setNextUpdate(new Date(System.currentTimeMillis() + 600_000));
+    builder.addExtension(
+        Extension.authorityKeyIdentifier,
+        false,
+        new JcaX509ExtensionUtils().createAuthorityKeyIdentifier(chain.root()));
+    for (X509Certificate certificate : revoked) {
+      builder.addCRLEntry(
+          certificate.getSerialNumber(),
+          new Date(System.currentTimeMillis() - 60_000),
+          CRLReason.privilegeWithdrawn);
+    }
+
+    ContentSigner signer =
+        new JcaContentSignerBuilder("SHA384withECDSA")
+            .setProvider(new BouncyCastleProvider())
+            .build(chain.rootKey());
+
+    // Use the same decoder as trust-list ingestion, rather than a BC CRL object.
+    return CertificateUtil.decodeCrl(builder.build(signer).getEncoded());
+  }
+
   private void startWithBouncyCastleRemoved() {
     bcWasRegistered = Security.getProvider("BC") != null;
     Security.removeProvider("BC");
@@ -157,7 +252,11 @@ class BrainpoolCertificateValidationTest {
   }
 
   private static BrainpoolChain generateCaSignedBrainpoolP384Chain() throws Exception {
-    KeyPair rootKeyPair = SelfSignedCertificateGenerator.generateBrainpoolP384r1KeyPair();
+    return generateCaSignedBrainpoolChain(384);
+  }
+
+  private static BrainpoolChain generateCaSignedBrainpoolChain(int keySize) throws Exception {
+    KeyPair rootKeyPair = generateBrainpoolKeyPair(keySize);
     X509Certificate root =
         new SelfSignedCertificateBuilder(rootKeyPair, new BrainpoolCaGenerator())
             .setCommonName("Brainpool Root CA")
@@ -166,7 +265,7 @@ class BrainpoolCertificateValidationTest {
             .setSignatureAlgorithm(SelfSignedCertificateBuilder.SA_SHA384_ECDSA)
             .build();
 
-    KeyPair leafKeyPair = SelfSignedCertificateGenerator.generateBrainpoolP384r1KeyPair();
+    KeyPair leafKeyPair = generateBrainpoolKeyPair(keySize);
     X509Certificate leaf =
         new CaSignedCertificateBuilder(leafKeyPair, root, rootKeyPair.getPrivate())
             .setCommonName("Brainpool Leaf")
@@ -180,7 +279,17 @@ class BrainpoolCertificateValidationTest {
 
     // Trust-list and wire certificates are decoded by the default (Sun) CertificateFactory in
     // production, so both ends of the chain are Sun objects here.
-    return new BrainpoolChain(sunDecode(root), sunDecode(leaf));
+    SecurityPolicyProfile profile =
+        keySize == 256
+            ? SecurityPolicy.ECC_brainpoolP256r1_AesGcm.getProfile()
+            : BRAINPOOL_P384_PROFILE;
+    return new BrainpoolChain(sunDecode(root), sunDecode(leaf), rootKeyPair.getPrivate(), profile);
+  }
+
+  private static KeyPair generateBrainpoolKeyPair(int keySize) throws Exception {
+    return keySize == 256
+        ? SelfSignedCertificateGenerator.generateBrainpoolP256r1KeyPair()
+        : SelfSignedCertificateGenerator.generateBrainpoolP384r1KeyPair();
   }
 
   /** Re-decode a certificate via the default (Sun) {@link CertificateFactory}, as on the wire. */
@@ -213,5 +322,9 @@ class BrainpoolCertificateValidationTest {
     protected void addExtendedKeyUsage(X509v3CertificateBuilder certificateBuilder) {}
   }
 
-  private record BrainpoolChain(X509Certificate root, X509Certificate leaf) {}
+  private record BrainpoolChain(
+      X509Certificate root,
+      X509Certificate leaf,
+      PrivateKey rootKey,
+      SecurityPolicyProfile profile) {}
 }

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/util/validation/CertificateValidationUtilTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/util/validation/CertificateValidationUtilTest.java
@@ -42,7 +42,9 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.BasicConstraints;
 import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.KeyPurposeId;
 import org.bouncycastle.asn1.x509.KeyUsage;
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
 import org.bouncycastle.cert.CertIOException;
@@ -494,6 +496,121 @@ public class CertificateValidationUtilTest {
     checkHostnameOrIpAddress(createSelfSignedCertificate("DigitalPetri.com"), hostname);
   }
 
+  /**
+   * A Global Discovery Server certificate group that offers more than one certificate type issues
+   * one CA per type, all under the group's single configured subject name, and publishes a CRL for
+   * each. The trust list a client pulls then holds several same-named CAs, and PKIX selects a CRL
+   * by issuer name alone.
+   */
+  @Test
+  void revocationResolvesWhenSeveralCasShareASubjectName() throws Exception {
+    String sharedSubject = "Plant Default CA";
+
+    KeyPair issuingCaKeyPair = SelfSignedCertificateGenerator.generateRsaKeyPair(2048);
+    X509Certificate issuingCa = createSharedNameCa(issuingCaKeyPair, sharedSubject);
+
+    // The second CA of the group is ECC, as it would be for a group that offers an ECC certificate
+    // type alongside RSA.
+    KeyPair sameNameCaKeyPair = SelfSignedCertificateGenerator.generateNistP256KeyPair();
+    X509Certificate sameNameCa = createSharedNameCa(sameNameCaKeyPair, sharedSubject);
+
+    KeyPair leafKeyPair = SelfSignedCertificateGenerator.generateRsaKeyPair(2048);
+    X509Certificate leaf =
+        new CaSignedCertificateBuilder(leafKeyPair, issuingCa, issuingCaKeyPair.getPrivate())
+            .setCommonName("Ignition OPC UA Client")
+            .setOrganization("Eclipse Milo")
+            .setApplicationUri("urn:eclipse:milo:test:shared-name-ca-client")
+            .addDnsName("localhost")
+            .setIsCa(false)
+            .setKeyUsage(
+                KeyUsage.digitalSignature
+                    | KeyUsage.nonRepudiation
+                    | KeyUsage.keyEncipherment
+                    | KeyUsage.dataEncipherment)
+            .setExtendedKeyUsage(
+                List.of(KeyPurposeId.id_kp_serverAuth, KeyPurposeId.id_kp_clientAuth))
+            .build();
+
+    Set<X509CRL> crls =
+        Set.of(
+            CrlTestUtil.generateCrl(issuingCa, issuingCaKeyPair.getPrivate()),
+            CrlTestUtil.generateCrl(sameNameCa, sameNameCaKeyPair.getPrivate()));
+
+    PKIXCertPathBuilderResult pathBuilderResult =
+        buildTrustedCertPath(List.of(leaf), Set.of(issuingCa, sameNameCa), emptySet());
+
+    // Both CRLs are candidates by issuer name and only one of them verifies. Passing both to PKIX
+    // unfiltered yields Bad_CertificateRevocationUnknown instead of a successful validation.
+    validateTrustedCertPath(
+        pathBuilderResult.getCertPath(),
+        pathBuilderResult.getTrustAnchor(),
+        crls,
+        EnumSet.of(ValidationCheck.REVOCATION, ValidationCheck.REVOCATION_LISTS),
+        true);
+  }
+
+  /** The revoking CRL must still be honored when a same-named CA's CRL is alongside it. */
+  @Test
+  void revocationIsDetectedWhenSeveralCasShareASubjectName() throws Exception {
+    String sharedSubject = "Plant Default CA";
+
+    KeyPair issuingCaKeyPair = SelfSignedCertificateGenerator.generateRsaKeyPair(2048);
+    X509Certificate issuingCa = createSharedNameCa(issuingCaKeyPair, sharedSubject);
+
+    // The second CA of the group is ECC, as it would be for a group that offers an ECC certificate
+    // type alongside RSA.
+    KeyPair sameNameCaKeyPair = SelfSignedCertificateGenerator.generateNistP256KeyPair();
+    X509Certificate sameNameCa = createSharedNameCa(sameNameCaKeyPair, sharedSubject);
+
+    KeyPair leafKeyPair = SelfSignedCertificateGenerator.generateRsaKeyPair(2048);
+    X509Certificate leaf =
+        new CaSignedCertificateBuilder(leafKeyPair, issuingCa, issuingCaKeyPair.getPrivate())
+            .setCommonName("Ignition OPC UA Client")
+            .setOrganization("Eclipse Milo")
+            .setApplicationUri("urn:eclipse:milo:test:shared-name-ca-client-revoked")
+            .addDnsName("localhost")
+            .setIsCa(false)
+            .setKeyUsage(
+                KeyUsage.digitalSignature
+                    | KeyUsage.nonRepudiation
+                    | KeyUsage.keyEncipherment
+                    | KeyUsage.dataEncipherment)
+            .setExtendedKeyUsage(
+                List.of(KeyPurposeId.id_kp_serverAuth, KeyPurposeId.id_kp_clientAuth))
+            .build();
+
+    Set<X509CRL> crls =
+        Set.of(
+            CrlTestUtil.generateCrl(issuingCa, issuingCaKeyPair.getPrivate(), leaf),
+            CrlTestUtil.generateCrl(sameNameCa, sameNameCaKeyPair.getPrivate()));
+
+    PKIXCertPathBuilderResult pathBuilderResult =
+        buildTrustedCertPath(List.of(leaf), Set.of(issuingCa, sameNameCa), emptySet());
+
+    UaException e =
+        assertThrows(
+            UaException.class,
+            () ->
+                validateTrustedCertPath(
+                    pathBuilderResult.getCertPath(),
+                    pathBuilderResult.getTrustAnchor(),
+                    crls,
+                    EnumSet.of(ValidationCheck.REVOCATION, ValidationCheck.REVOCATION_LISTS),
+                    true));
+
+    assertEquals(new StatusCode(StatusCodes.Bad_CertificateRevoked), e.getStatusCode());
+  }
+
+  private static X509Certificate createSharedNameCa(KeyPair keyPair, String commonName)
+      throws Exception {
+
+    return new SelfSignedCertificateBuilder(keyPair, new CaCertificateGenerator())
+        .setCommonName(commonName)
+        .setOrganization("Ignition QA")
+        .setApplicationUri("urn:eclipse:milo:test:" + commonName.toLowerCase().replace(" ", "-"))
+        .build();
+  }
+
   private static X509Certificate createSelfSignedCertificate(String dnsName) throws Exception {
     KeyPair keyPair = SelfSignedCertificateGenerator.generateRsaKeyPair(2048);
 
@@ -526,6 +643,27 @@ public class CertificateValidationUtilTest {
     JcaX509CertificateConverter converter = new JcaX509CertificateConverter();
     converter.setProvider("BC");
     return converter.getCertificate(certBuilder.build(signer));
+  }
+
+  /** Generates a self-signed CA certificate that can sign certificates and CRLs. */
+  private static final class CaCertificateGenerator extends SelfSignedCertificateGenerator {
+
+    @Override
+    protected void addExtendedKeyUsage(X509v3CertificateBuilder certificateBuilder) {}
+
+    @Override
+    protected void addKeyUsage(X509v3CertificateBuilder certificateBuilder) throws CertIOException {
+      certificateBuilder.addExtension(
+          Extension.keyUsage, true, new KeyUsage(KeyUsage.keyCertSign | KeyUsage.cRLSign));
+    }
+
+    @Override
+    protected void addBasicConstraints(
+        X509v3CertificateBuilder certificateBuilder, BasicConstraints basicConstraints)
+        throws CertIOException {
+
+      certificateBuilder.addExtension(Extension.basicConstraints, true, new BasicConstraints(true));
+    }
   }
 
   private static final class KeyUsageCertificateGenerator extends SelfSignedCertificateGenerator {


### PR DESCRIPTION
A client cannot validate any peer certified by a Global Discovery Server certificate group that offers more than one certificate type.

Such a group issues one CA per certificate type, all under the group's single configured subject name, and publishes a CRL for each. The OPC Foundation .NET reference GDS does this by design, so it is what real trust lists look like: several same-DN CA certificates and several same-DN CRLs.

PKIX selects a CRL by issuer name alone. Given more than one candidate it does not try each in turn — it takes the indirect-CRL route through `DistributionPointFetcher.verifyCRL`, fails to build a path to the CRL signer, and reports `UNDETERMINED_REVOCATION_STATUS`. `validateTrustedCertPath` turns that into `Bad_CertificateRevocationUnknown` and the handshake dies, even though the correct CRL was in the collection and verifies cleanly. The outcome does not depend on CRL order, and two same-named CAs are enough.

I hit this against a real GDS: an Ignition Gateway pulling from a group carrying RSA, NIST P-256 and P-384 was rejected by a Milo server on every connection. Each connection came up as soon as all but its own CA was removed from the server's trust list.

## What changed

**`selectApplicableCrls` filters the collection before it reaches PKIX.** A CRL is dropped when the path holds a same-named certificate and none of them signed it. A CRL whose issuer name matches nothing in the path belongs to some other path and is left alone, so this only removes candidates that were going to be ambiguous.

**The fallback now registers the revocation checker it configures.** When the custom checker cannot be installed, the fallback built a `PKIXRevocationChecker`, set `NO_FALLBACK`, `PREFER_CRLS` and `SOFT_FAIL` on it, and never called `addCertPathChecker`. Only `setRevocationEnabled(true)` took effect, so the default checker ran with default options and a CRL that could not be located failed the whole path — the opposite of what the warning logged beside it promises.

**stack-core's surefire run opens `sun.security.provider.certpath`.** `OpcUaCertificateRevocationChecker` reaches into that package by reflection and bails in its constructor when access is denied, so without the option every validation silently falls back. No test in the project had ever run the custom checker. The two paths differ on whether `ValidationCheck.REVOCATION_LISTS` is honored, and this bug is only visible on the custom one — with the fallback's `SOFT_FAIL` now correctly applied, the symptom is suppressed rather than fixed.

## Notes for review

The new tests only discriminate because `CrlTestUtil` now emits the AuthorityKeyIdentifier and CRL number a real CA writes. With a key-id-only AKI the JDK resolves the right CRL and the failure does not reproduce at all, so a test built on `JcaX509ExtensionUtils.createAuthorityKeyIdentifier` alone passes with or without the fix. I verified the discrimination by reverting each change in turn.

I also checked the fix against the bytes from the live failure — the issued leaf, the three same-DN CAs and their three CRLs — outside this test harness: unfiltered gives `UNDETERMINED_REVOCATION_STATUS`, filtered gives a valid path.

`stack-core` 1244 tests and the `sdk-server` / `integration-tests` run (1288) pass. Each commit builds and tests green on its own. Unrelated and pre-existing: `BinaryDataTypeDictionaryReaderTest` in `dtd-reader` fails with `NoClassDefFoundError: com/google/common/io/ByteStreams` on a clean tree as well.