### PR TITLE
Make Matrix equals and hashCode obey the Object contract

### DIFF
--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/Matrix.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/Matrix.java
@@ -38,6 +38,15 @@ import org.jspecify.annotations.Nullable;
  *   <li>UaEnumeratedType
  *   <li>OptionSetUInteger subclasses
  * </ul>
+ *
+ * <p>Constructors accepting a flat array retain both the elements and dimensions arrays. The
+ * nested-array constructor copies the array structure, but does not copy mutable element values.
+ * {@link #getElements()} and {@link #getDimensions()} return the backing arrays.
+ *
+ * <p>Equality and hashing depend on the current elements, dimensions, and built-in data type. Do
+ * not modify these arrays or mutable elements while this Matrix, or a value containing it, is a map
+ * key or set member. Keep published values unchanged while consumers may retain them for
+ * comparison. Nested values must be acyclic for recursive equality, hashing, and encoding.
  */
 public class Matrix {
 
@@ -91,6 +100,8 @@ public class Matrix {
   /**
    * Get the elements of this Matrix in a flattened array.
    *
+   * <p>The returned array is the backing array, not a copy.
+   *
    * @return the elements of this Matrix in a flattened array.
    */
   public @Nullable Object getElements() {
@@ -100,7 +111,8 @@ public class Matrix {
   /**
    * Get the dimensions of this Matrix.
    *
-   * <p>The returned array is zero length if this Matrix contains a null value.
+   * <p>The returned array is the backing array, not a copy. It is zero length if this Matrix
+   * contains a null value.
    *
    * @return the dimensions of this Matrix.
    */
@@ -314,18 +326,29 @@ public class Matrix {
     return result;
   }
 
-  /**
-   * Hash the elements by value, boxing primitive arrays first so that a Matrix of primitives hashes
-   * the same as an equal Matrix of the boxed type.
-   */
   private int elementsHash() {
-    if (flatArray == null) {
-      return 0;
+    // Primitive array hashes match their boxed equivalents without allocating a boxed array.
+    if (flatArray instanceof Object[] array) {
+      return Arrays.deepHashCode(array);
+    } else if (flatArray instanceof boolean[] array) {
+      return Arrays.hashCode(array);
+    } else if (flatArray instanceof byte[] array) {
+      return Arrays.hashCode(array);
+    } else if (flatArray instanceof short[] array) {
+      return Arrays.hashCode(array);
+    } else if (flatArray instanceof int[] array) {
+      return Arrays.hashCode(array);
+    } else if (flatArray instanceof long[] array) {
+      return Arrays.hashCode(array);
+    } else if (flatArray instanceof float[] array) {
+      return Arrays.hashCode(array);
+    } else if (flatArray instanceof double[] array) {
+      return Arrays.hashCode(array);
+    } else if (flatArray instanceof char[] array) {
+      return Arrays.hashCode(array);
+    } else {
+      return Objects.hashCode(flatArray);
     }
-
-    Object boxed = ArrayUtil.box(flatArray);
-
-    return boxed instanceof Object[] array ? Arrays.deepHashCode(array) : Objects.hashCode(boxed);
   }
 
   @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/Matrix.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/Matrix.java
@@ -280,6 +280,10 @@ public class Matrix {
     if (o == null || getClass() != o.getClass()) return false;
     Matrix matrix = (Matrix) o;
 
+    if (!Arrays.equals(dimensions, matrix.dimensions) || dataType != matrix.dataType) {
+      return false;
+    }
+
     final Object thisArray = flatArray;
     final Object thatArray = matrix.flatArray;
 
@@ -295,22 +299,33 @@ public class Matrix {
         Object thisBoxed = ArrayUtil.box(thisArray);
         Object thatBoxed = ArrayUtil.box(thatArray);
 
-        return Objects.deepEquals(thisBoxed, thatBoxed)
-            && Arrays.equals(dimensions, matrix.dimensions)
-            && dataType == matrix.dataType;
+        return Objects.deepEquals(thisBoxed, thatBoxed);
       } else {
-        return Objects.deepEquals(thisArray, thatArray)
-            && Arrays.equals(dimensions, matrix.dimensions)
-            && dataType == matrix.dataType;
+        return Objects.deepEquals(thisArray, thatArray);
       }
     }
   }
 
   @Override
   public int hashCode() {
-    int result = Objects.hash(flatArray, dataType);
+    int result = elementsHash();
     result = 31 * result + Arrays.hashCode(dimensions);
+    result = 31 * result + Objects.hashCode(dataType);
     return result;
+  }
+
+  /**
+   * Hash the elements by value, boxing primitive arrays first so that a Matrix of primitives hashes
+   * the same as an equal Matrix of the boxed type.
+   */
+  private int elementsHash() {
+    if (flatArray == null) {
+      return 0;
+    }
+
+    Object boxed = ArrayUtil.box(flatArray);
+
+    return boxed instanceof Object[] array ? Arrays.deepHashCode(array) : Objects.hashCode(boxed);
   }
 
   @Override

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/package-info.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/package-info.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/**
+ * OPC UA values shared by the protocol encoders and the client and server SDKs. A {@link
+ * org.eclipse.milo.opcua.stack.core.types.builtin.Variant} carries a scalar, array, or {@link
+ * org.eclipse.milo.opcua.stack.core.types.builtin.Matrix}. A {@link
+ * org.eclipse.milo.opcua.stack.core.types.builtin.DataValue} adds status and timestamps for reads,
+ * writes, and subscription notifications. Matrix preserves the dimensions of a multidimensional
+ * value alongside its flattened elements so encoders and SDK operations can use the same value.
+ *
+ * <p>These containers do not establish exclusive ownership of their contents. Wrapping an array or
+ * mutable element does not make it immutable. Callers sharing values with the SDK should keep them
+ * unchanged while consumers retain them, including for change detection or use in hash collections.
+ * Create an independent value before updating shared contents; copying an array alone does not
+ * isolate mutable objects inside it. See the individual types for their copying and accessor
+ * contracts.
+ */
+package org.eclipse.milo.opcua.stack.core.types.builtin;

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/types/builtin/MatrixTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/types/builtin/MatrixTest.java
@@ -17,12 +17,18 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Array;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.ApplicationType;
 import org.eclipse.milo.opcua.stack.core.types.structured.ThreeDVector;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class MatrixTest {
   private final int[][] primitiveInt2d = {{1, 2}, {3, 4}};
@@ -136,23 +142,109 @@ class MatrixTest {
     assertEquals(new Matrix(boxed), new Matrix(primitive));
   }
 
-  @Test
-  void equalMatricesHashTheSame() {
-    Matrix m1 = new Matrix(new int[][] {{1, 2}, {3, 4}});
-    Matrix m2 = new Matrix(new int[][] {{1, 2}, {3, 4}});
-
+  // Independently created values must remain interchangeable in hash collections, including
+  // when wrapped in the Variant and DataValue containers used by the SDK.
+  @ParameterizedTest
+  @MethodSource("equalMatrixValues")
+  void equalMatricesHashTheSame(Matrix m1, Matrix m2) {
     assertEquals(m1, m2);
+    assertEquals(m2, m1);
     assertEquals(m1.hashCode(), m2.hashCode());
 
     Set<Matrix> set = new HashSet<>();
     set.add(m1);
     assertTrue(set.contains(m2));
+
+    Map<Variant, String> variants = new HashMap<>();
+    variants.put(new Variant(m1), "found");
+    assertEquals("found", variants.get(new Variant(m2)));
+
+    Set<DataValue> values = new HashSet<>();
+    values.add(new DataValue(new Variant(m1), StatusCode.GOOD, null, null));
+    assertTrue(values.contains(new DataValue(new Variant(m2), StatusCode.GOOD, null, null)));
   }
 
-  // equals() boxes before comparing, so the hash has to be taken over boxed elements too.
+  private static Stream<Arguments> equalMatrixValues() {
+    return Stream.of(
+        Arguments.of(
+            new Matrix(new int[][] {{1, 2}, {3, 4}}), new Matrix(new int[][] {{1, 2}, {3, 4}})),
+        Arguments.of(Matrix.ofNull(), Matrix.ofNull()),
+        Arguments.of(
+            new Matrix(new int[0], new int[] {0, 2}), new Matrix(new Integer[0], new int[] {0, 2})),
+        Arguments.of(
+            Matrix.ofString(new String[][] {{"value", null}}),
+            Matrix.ofString(new String[][] {{"value", null}})),
+        Arguments.of(
+            Matrix.ofByteString(new ByteString[][] {{ByteString.of(new byte[] {1, 2})}}),
+            Matrix.ofByteString(new ByteString[][] {{ByteString.of(new byte[] {1, 2})}})),
+        Arguments.of(
+            Matrix.ofStruct(new ThreeDVector[][] {{new ThreeDVector(1.0, 2.0, 3.0)}}),
+            Matrix.ofStruct(new ThreeDVector[][] {{new ThreeDVector(1.0, 2.0, 3.0)}})),
+        Arguments.of(
+            Matrix.ofVariant(new Variant[][] {{new Variant(Matrix.ofInt32(new int[][] {{1, 2}}))}}),
+            Matrix.ofVariant(
+                new Variant[][] {{new Variant(Matrix.ofInt32(new Integer[][] {{1, 2}}))}})));
+  }
+
+  // Primitive hashing must preserve the existing mixed primitive/boxed equality contract,
+  // including distinct NaN representations and both signs of zero.
+  @ParameterizedTest
+  @MethodSource("primitiveAndBoxedArrays")
+  void primitiveBoxedHashEquality(Object primitive, Object boxed) {
+    Matrix primitiveMatrix = new Matrix(primitive);
+    Matrix boxedMatrix = new Matrix(boxed);
+
+    assertEquals(primitiveMatrix, boxedMatrix);
+    assertEquals(boxedMatrix, primitiveMatrix);
+    assertEquals(primitiveMatrix.hashCode(), boxedMatrix.hashCode());
+  }
+
+  private static Stream<Arguments> primitiveAndBoxedArrays() {
+    return Stream.of(
+        Arguments.of(new boolean[][] {{true, false}}, new Boolean[][] {{true, false}}),
+        Arguments.of(new byte[][] {{-128, 127}}, new Byte[][] {{-128, 127}}),
+        Arguments.of(new short[][] {{-32768, 32767}}, new Short[][] {{-32768, 32767}}),
+        Arguments.of(
+            new int[][] {{Integer.MIN_VALUE, Integer.MAX_VALUE}},
+            new Integer[][] {{Integer.MIN_VALUE, Integer.MAX_VALUE}}),
+        Arguments.of(
+            new long[][] {{Long.MIN_VALUE, Long.MAX_VALUE}},
+            new Long[][] {{Long.MIN_VALUE, Long.MAX_VALUE}}),
+        Arguments.of(
+            new float[][] {
+              {
+                Float.intBitsToFloat(0x7fc00001),
+                -0.0f,
+                0.0f,
+                Float.NEGATIVE_INFINITY,
+                Float.POSITIVE_INFINITY
+              }
+            },
+            new Float[][] {
+              {Float.NaN, -0.0f, 0.0f, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY}
+            }),
+        Arguments.of(
+            new double[][] {
+              {
+                Double.longBitsToDouble(0x7ff8000000000001L),
+                -0.0,
+                0.0,
+                Double.NEGATIVE_INFINITY,
+                Double.POSITIVE_INFINITY
+              }
+            },
+            new Double[][] {
+              {Double.NaN, -0.0, 0.0, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY}
+            }));
+  }
+
+  // Floating-point equality distinguishes signed zero even across primitive/boxed arrays.
   @Test
-  void primitiveBoxedHashEquality() {
-    assertEquals(new Matrix(primitiveInt2d).hashCode(), new Matrix(boxedInt2d).hashCode());
+  void signedZerosRemainUnequal() {
+    assertNotEquals(
+        Matrix.ofFloat(new float[][] {{-0.0f}}), Matrix.ofFloat(new Float[][] {{0.0f}}));
+    assertNotEquals(
+        Matrix.ofDouble(new double[][] {{-0.0}}), Matrix.ofDouble(new Double[][] {{0.0}}));
   }
 
   // Matrix does not copy the elements it is given, so two Matrices can share a backing array and

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/types/builtin/MatrixTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/types/builtin/MatrixTest.java
@@ -12,10 +12,13 @@ package org.eclipse.milo.opcua.stack.core.types.builtin;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Array;
 import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.ApplicationType;
 import org.eclipse.milo.opcua.stack.core.types.structured.ThreeDVector;
@@ -131,6 +134,43 @@ class MatrixTest {
 
     assertEquals(new Matrix(primitive), new Matrix(boxed));
     assertEquals(new Matrix(boxed), new Matrix(primitive));
+  }
+
+  @Test
+  void equalMatricesHashTheSame() {
+    Matrix m1 = new Matrix(new int[][] {{1, 2}, {3, 4}});
+    Matrix m2 = new Matrix(new int[][] {{1, 2}, {3, 4}});
+
+    assertEquals(m1, m2);
+    assertEquals(m1.hashCode(), m2.hashCode());
+
+    Set<Matrix> set = new HashSet<>();
+    set.add(m1);
+    assertTrue(set.contains(m2));
+  }
+
+  // equals() boxes before comparing, so the hash has to be taken over boxed elements too.
+  @Test
+  void primitiveBoxedHashEquality() {
+    assertEquals(new Matrix(primitiveInt2d).hashCode(), new Matrix(boxedInt2d).hashCode());
+  }
+
+  // Matrix does not copy the elements it is given, so two Matrices can share a backing array and
+  // still describe different values.
+  @Test
+  void sharedElementsWithDifferentDimensionsAreNotEqual() {
+    int[] elements = {1, 2, 3, 4};
+
+    assertNotEquals(new Matrix(elements, new int[] {2, 2}), new Matrix(elements, new int[] {4, 1}));
+  }
+
+  @Test
+  void sharedElementsWithDifferentDataTypesAreNotEqual() {
+    int[] elements = {1, 2, 3, 4};
+
+    assertNotEquals(
+        new Matrix(elements, new int[] {2, 2}, OpcUaDataType.Int32),
+        new Matrix(elements, new int[] {2, 2}, OpcUaDataType.UInt32));
   }
 
   @Test


### PR DESCRIPTION
`Matrix` violates the `Object.equals`/`Object.hashCode` contract in two ways, so an equal
`Matrix` is not found in a `HashSet` and cannot be used as a `HashMap` key. `Variant` and
`DataValue` carrying a `Matrix` inherit it, because `Variant.valueHash()` falls through to the
value's own `hashCode()` for anything that is not an array.

### 1. `hashCode()` hashes the array identity, not its contents

`Objects.hash(flatArray, dataType)` calls `flatArray.hashCode()`, and `flatArray` is declared
`Object`, so for a primitive or object array that is the identity hash:

```java
Matrix m1 = new Matrix(new int[][] {{1, 2}, {3, 4}});
Matrix m2 = new Matrix(new int[][] {{1, 2}, {3, 4}});

m1.equals(m2);                    // true
m1.hashCode() == m2.hashCode();   // false
Set.of(m1).contains(m2);          // false
```

`equals()` boxes primitive arrays before comparing, so `new Matrix(int[][])` and
`new Matrix(Integer[][])` are equal (pinned by the existing `primitiveBoxedEquality` test) but
also hash differently today.

### 2. `equals()` shortcuts past `dimensions` and `dataType`

The `thisArray == thatArray` shortcut returns `true` before either is compared, while
`hashCode()` does account for both — the same contract violation from the other side:

```java
int[] elements = {1, 2, 3, 4};

new Matrix(elements, new int[] {2, 2})
    .equals(new Matrix(elements, new int[] {4, 1}));              // true

new Matrix(elements, new int[] {2, 2}, OpcUaDataType.Int32)
    .equals(new Matrix(elements, new int[] {2, 2}, OpcUaDataType.UInt32));  // true
```

`Matrix` does not copy the elements it is given and `getElements()` hands the backing array out
directly, so a shared backing array is reachable through the public `Matrix(Object, int[])`
constructors.

The two are entangled: fixing only `hashCode()` leaves case 2 violating the contract, and fixing
only `equals()` leaves case 1. Neither half restores it on its own, so both are here.

### Change

- Hash the elements by value, boxing primitive arrays first so a `Matrix` of primitives hashes the
  same as the equal `Matrix` of the boxed type, matching how `equals()` compares them.
  `Arrays.deepHashCode(box(prim[]))` equals `Arrays.hashCode(prim[])` for all eight primitive
  types, so this is consistent in both directions.
- Include `dataType` in the hash alongside `dimensions`, both of which `equals()` compares.
- Compare `dimensions` and `dataType` up front in `equals()`, which also removes the duplicated
  comparison from its two branches.

No behaviour change for unequal matrices, and no in-tree caller relies on the old behaviour.

### Tests

Four tests added to `MatrixTest`. All four fail before the change and pass after:

```
MatrixTest.equalMatricesHashTheSame                       expected: <679162395> but was: <-1506169415>
MatrixTest.primitiveBoxedHashEquality                     expected: <-1070723957> but was: <-1468407034>
MatrixTest.sharedElementsWithDifferentDimensionsAreNotEqual  expected: not equal but was: dimensions=[4, 1]
MatrixTest.sharedElementsWithDifferentDataTypesAreNotEqual   expected: not equal but was: dataType=UInt32
```

Verified on JDK 17 with `mvn -pl opc-ua-sdk/integration-tests -am test`: stack-core, transport,
sdk-core, sdk-client, dtd-core, dtd-reader, sdk-server, encoding-json, encoding-xml and the
integration tests all pass — 2283 tests, 0 failures, 0 errors. `mvn -pl opc-ua-stack/stack-core
verify` passes, including `spotless:check`.

---

- [x] You have signed an Eclipse Contributor Agreement and are committing using the same email address
- [x] Your code contains any tests relevant to the problem you are solving
- [x] All new and existing tests passed
- [x] Code follows the style guidelines and Checkstyle passes
