### PR TITLE
Report matrix dimension changes with numeric deadbands

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/util/DataChangeMonitoringFilter.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/util/DataChangeMonitoringFilter.java
@@ -11,6 +11,7 @@
 package org.eclipse.milo.opcua.sdk.server.util;
 
 import java.lang.reflect.Array;
+import java.util.Arrays;
 import java.util.Objects;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Matrix;
@@ -208,6 +209,11 @@ public class DataChangeMonitoringFilter {
     }
 
     if (last instanceof Matrix lastMatrix && current instanceof Matrix currentMatrix) {
+      // Dimension changes must be reported regardless of the numeric deadband.
+      if (!Arrays.equals(lastMatrix.getDimensions(), currentMatrix.getDimensions())) {
+        return true;
+      }
+
       Object lastElements = lastMatrix.getElements();
       Object currentElements = currentMatrix.getElements();
 

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/util/DataChangeMonitoringFilterTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/util/DataChangeMonitoringFilterTest.java
@@ -11,6 +11,7 @@
 package org.eclipse.milo.opcua.sdk.server.util;
 
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -24,6 +25,8 @@ import org.eclipse.milo.opcua.stack.core.types.enumerated.DeadbandType;
 import org.eclipse.milo.opcua.stack.core.types.structured.DataChangeFilter;
 import org.eclipse.milo.opcua.stack.core.types.structured.Range;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 public class DataChangeMonitoringFilterTest {
 
@@ -491,6 +494,76 @@ public class DataChangeMonitoringFilterTest {
   }
 
   // Test Matrix values
+
+  // Part 4 §7.22.2 requires array dimension changes to be reported regardless of deadband.
+  @ParameterizedTest
+  @CsvSource({"Absolute, true", "Absolute, false", "Percent, true", "Percent, false"})
+  void matrixDimensionChangesTriggerNotificationWithNumericDeadband(
+      DeadbandType deadbandType, boolean sharedElements) {
+    var filter =
+        new DataChangeFilter(DataChangeTrigger.StatusValue, uint(deadbandType.getValue()), 5.0);
+    var euRange = new Range(0.0, 100.0);
+
+    int[] lastElements = {1, 2, 3, 4};
+    int[] currentElements = sharedElements ? lastElements : lastElements.clone();
+    var lastValue =
+        new DataValue(
+            new Variant(new Matrix(lastElements, new int[] {2, 2})), StatusCode.GOOD, null, null);
+    var unchangedValue =
+        new DataValue(
+            new Variant(new Matrix(currentElements, new int[] {2, 2})),
+            StatusCode.GOOD,
+            null,
+            null);
+    var reshapedValue =
+        new DataValue(
+            new Variant(new Matrix(currentElements, new int[] {4, 1})),
+            StatusCode.GOOD,
+            null,
+            null);
+
+    assertFalse(
+        DataChangeMonitoringFilter.filter(lastValue, unchangedValue, filter, euRange),
+        "Equal dimensions and elements should not trigger a notification");
+    assertTrue(
+        DataChangeMonitoringFilter.filter(lastValue, reshapedValue, filter, euRange),
+        "Changed dimensions must trigger a notification even when elements are unchanged");
+  }
+
+  // A dimension check must preserve numeric deadband filtering when the shape is unchanged.
+  @ParameterizedTest
+  @CsvSource({
+    "Absolute, 0, false",
+    "Absolute, 4, false",
+    "Absolute, 5, false",
+    "Absolute, 6, true",
+    "Percent, 0, false",
+    "Percent, 4, false",
+    "Percent, 5, false",
+    "Percent, 6, true"
+  })
+  void matrixWithUnchangedDimensionsNotifiesOnlyWhenDeadbandIsExceeded(
+      DeadbandType deadbandType, int change, boolean expectedNotification) {
+    var filter =
+        new DataChangeFilter(DataChangeTrigger.StatusValue, uint(deadbandType.getValue()), 5.0);
+    var euRange = new Range(0.0, 100.0);
+    var lastValue =
+        new DataValue(
+            new Variant(new Matrix(new int[] {1, 2, 3, 4}, new int[] {2, 2})),
+            StatusCode.GOOD,
+            null,
+            null);
+    var currentValue =
+        new DataValue(
+            new Variant(new Matrix(new int[] {1, 2, 3, 4 + change}, new int[] {2, 2})),
+            StatusCode.GOOD,
+            null,
+            null);
+
+    assertEquals(
+        expectedNotification,
+        DataChangeMonitoringFilter.filter(lastValue, currentValue, filter, euRange));
+  }
 
   @Test
   public void testAbsoluteDeadband_PrimitiveDoubleMatrixValue() {


### PR DESCRIPTION
Changing a matrix from dimensions `[2, 2]` to `[4, 1]` with unchanged elements previously produced no notification when an Absolute or Percent deadband was configured, leaving clients with the old shape.

Check dimensions before comparing flattened elements. Shape changes now trigger notifications, while unchanged shapes continue to respect the numeric deadband.

This complements #1945: numeric deadband filtering bypasses `Matrix.equals()`, so it must check dimensions before applying element thresholds.

Regression tests cover both deadband types, shared and independent backing arrays, and unchanged-shape threshold behavior. The reshape cases failed before the fix and pass afterward.

Verified with `spotless:apply`, a full `clean compile`, and `verify -pl opc-ua-sdk/sdk-server -am`.

Fixes #1946
