### PR TITLE
Recover clients after server certificate rotation

### DIFF
--- a/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/ClientExampleRunner.java
+++ b/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/ClientExampleRunner.java
@@ -15,13 +15,19 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.Security;
+import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.eclipse.milo.examples.server.ExampleServer;
+import org.eclipse.milo.opcua.sdk.client.EndpointConfiguration;
+import org.eclipse.milo.opcua.sdk.client.EndpointResolver;
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClientConfig;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClientConfigBuilder;
 import org.eclipse.milo.opcua.stack.core.Stack;
+import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.security.CertificateManager;
 import org.eclipse.milo.opcua.stack.core.security.DefaultClientCertificateValidator;
 import org.eclipse.milo.opcua.stack.core.security.FileBasedTrustListManager;
@@ -84,23 +90,42 @@ public class ClientExampleRunner {
         new DefaultClientCertificateValidator(
             clientTrustListManager, new MemoryCertificateQuarantine());
 
+    // The resolver owns discovery and endpoint selection. It runs once here for the initial
+    // connection, and the client keeps it to rediscover the endpoint if SecureChannel
+    // establishment later fails on a secured endpoint, e.g. after the server's certificate is
+    // replaced. OpcUaClient.create(url, ...) builds and retains an equivalent resolver itself;
+    // this example spells it out to show the pieces involved.
+    EndpointResolver endpointResolver =
+        EndpointResolver.create(
+            clientExample.getEndpointUrl(),
+            endpoints -> endpoints.stream().filter(clientExample.endpointFilter()).findFirst(),
+            transportConfigBuilder -> {},
+            Duration.ofSeconds(10));
+
+    EndpointConfiguration resolved;
+    try {
+      resolved = endpointResolver.resolve().get();
+    } catch (ExecutionException e) {
+      throw new UaException(e.getCause());
+    }
+
     // The example client has one key pair and certificate chain on hand, so it presents them
     // directly. Its trust list lives inside the validator above, which is the only place that
     // reads it. See GdsPullExample for a client that puts the trust list on a CertificateGroup
     // instead, because the pull cycle has to reach it through the group to install into it.
-    return OpcUaClient.create(
-        clientExample.getEndpointUrl(),
-        endpoints -> endpoints.stream().filter(clientExample.endpointFilter()).findFirst(),
-        transportConfigBuilder -> {},
-        clientConfigBuilder -> {
-          clientConfigBuilder
-              .setApplicationName(LocalizedText.english("eclipse milo opc-ua client"))
-              .setApplicationUri("urn:eclipse:milo:examples:client")
-              .setCertificateIdentity(loader.getClientKeyPair(), loader.getClientCertificateChain())
-              .setCertificateValidator(certificateValidator)
-              .setIdentityProvider(clientExample.getIdentityProvider());
-          clientExample.configureClient(clientConfigBuilder);
-        });
+    OpcUaClientConfigBuilder clientConfigBuilder =
+        OpcUaClientConfig.builder()
+            .setEndpoint(resolved.endpoint())
+            .setDiscoveryEndpoints(resolved.discoveryEndpoints())
+            .setEndpointResolver(endpointResolver)
+            .setApplicationName(LocalizedText.english("eclipse milo opc-ua client"))
+            .setApplicationUri("urn:eclipse:milo:examples:client")
+            .setCertificateIdentity(loader.getClientKeyPair(), loader.getClientCertificateChain())
+            .setCertificateValidator(certificateValidator)
+            .setIdentityProvider(clientExample.getIdentityProvider());
+    clientExample.configureClient(clientConfigBuilder);
+
+    return OpcUaClient.create(clientConfigBuilder.build());
   }
 
   public void run() {

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/OpcUaClientConfigTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/OpcUaClientConfigTest.java
@@ -116,6 +116,7 @@ public class OpcUaClientConfigTest {
 
     OpcUaClientConfig copy = OpcUaClientConfig.copy(original).build();
 
+    assertEquals(original.getEndpoint(), copy.getEndpoint());
     assertEquals(original.getSessionName(), copy.getSessionName());
     assertEquals(original.getSessionTimeout(), copy.getSessionTimeout());
     assertEquals(original.getMaxResponseMessageSize(), copy.getMaxResponseMessageSize());

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/session/CreateSessionActionFailureTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/session/CreateSessionActionFailureTest.java
@@ -11,9 +11,11 @@
 package org.eclipse.milo.opcua.sdk.client.session;
 
 import static org.eclipse.milo.opcua.sdk.server.OpcUaServerConfig.USER_TOKEN_POLICY_ANONYMOUS;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -23,12 +25,16 @@ import org.eclipse.milo.opcua.sdk.client.OpcUaClientConfigBuilder;
 import org.eclipse.milo.opcua.sdk.client.OpcUaSession;
 import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
 import org.eclipse.milo.opcua.stack.core.transport.TransportProfile;
+import org.eclipse.milo.opcua.stack.core.types.UaRequestMessageType;
+import org.eclipse.milo.opcua.stack.core.types.UaResponseMessageType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.ApplicationType;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.MessageSecurityMode;
 import org.eclipse.milo.opcua.stack.core.types.structured.ApplicationDescription;
 import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
 import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
+import org.eclipse.milo.opcua.stack.transport.client.tcp.OpcTcpClientTransport;
+import org.eclipse.milo.opcua.stack.transport.client.tcp.OpcTcpClientTransportConfig;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -85,17 +91,54 @@ class CreateSessionActionFailureTest {
     assertOpenSessionFails(config(null), null);
   }
 
+  // A transport can throw before returning its future, for example when its executor rejects
+  // channel acquisition. The FSM still needs a failure event to leave Creating.
+  @Test
+  void synchronousTransportFailureDoesNotStrandSessionCreation() throws Exception {
+    var failure = new IllegalStateException("transport unavailable");
+    var transport =
+        new OpcTcpClientTransport(OpcTcpClientTransportConfig.newBuilder().build()) {
+          @Override
+          public CompletableFuture<UaResponseMessageType> sendRequestMessage(
+              Callable<UaRequestMessageType> requestSupplier, long channelTimeoutMillis) {
+            throw failure;
+          }
+        };
+
+    assertOpenSessionFails(new OpcUaClient(config(null).build(), transport), failure);
+  }
+
   /**
    * Opens a Session against a client that cannot get as far as sending the CreateSessionRequest,
    * and asserts that the failure reaches the caller instead of stranding it.
    *
-   * @param expectedCause the Throwable the caller must be completed with, or {@code null} to accept
-   *     any.
+   * @param expectedCause the Throwable the caller must be completed with, or {@code null} to expect
+   *     a {@link NullPointerException} from the missing server description.
    */
   private static void assertOpenSessionFails(
       OpcUaClientConfigBuilder config, Throwable expectedCause) throws Exception {
 
-    OpcUaClient client = OpcUaClient.create(config.build());
+    // These cases test request construction after channel readiness, without network I/O.
+    var transport =
+        new OpcTcpClientTransport(OpcTcpClientTransportConfig.newBuilder().build()) {
+          @Override
+          public CompletableFuture<UaResponseMessageType> sendRequestMessage(
+              Callable<UaRequestMessageType> requestSupplier, long channelTimeoutMillis) {
+            try {
+              requestSupplier.call();
+              return CompletableFuture.failedFuture(
+                  new AssertionError("request construction should have failed"));
+            } catch (Exception e) {
+              return CompletableFuture.failedFuture(e);
+            }
+          }
+        };
+
+    assertOpenSessionFails(new OpcUaClient(config.build(), transport), expectedCause);
+  }
+
+  private static void assertOpenSessionFails(OpcUaClient client, Throwable expectedCause)
+      throws Exception {
     SessionFsm sessionFsm = client.getSessionFsm();
 
     try {
@@ -110,10 +153,12 @@ class CreateSessionActionFailureTest {
 
       if (expectedCause != null) {
         assertSame(expectedCause, ex.getCause());
+      } else {
+        assertInstanceOf(NullPointerException.class, ex.getCause());
       }
     } finally {
       // Stop the CreatingWait -> Creating retry loop that a failed CreateSession starts.
-      sessionFsm.closeSession();
+      sessionFsm.closeSession().get(TIMEOUT_SECONDS, TimeUnit.SECONDS);
     }
   }
 

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/session/ReactivateSessionEscalationTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/session/ReactivateSessionEscalationTest.java
@@ -176,8 +176,8 @@ public class ReactivateSessionEscalationTest {
     }
 
     @Override
-    public CompletableFuture<UaResponseMessageType> sendRequestMessage(
-        UaRequestMessageType requestMessage) {
+    protected CompletableFuture<UaResponseMessageType> sendRequestMessage(
+        UaRequestMessageType requestMessage, Channel channel) {
 
       if (requestMessage instanceof CreateSessionRequest) {
         createSessionRequests.incrementAndGet();
@@ -195,7 +195,7 @@ public class ReactivateSessionEscalationTest {
         return future;
       }
 
-      return super.sendRequestMessage(requestMessage);
+      return super.sendRequestMessage(requestMessage, channel);
     }
   }
 

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/session/ServerCertificateRotationTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/session/ServerCertificateRotationTest.java
@@ -1,0 +1,962 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.session;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelOutboundHandlerAdapter;
+import io.netty.channel.ChannelPromise;
+import java.math.BigInteger;
+import java.net.InetSocketAddress;
+import java.security.KeyPair;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+import java.time.Duration;
+import java.util.Date;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+import java.util.stream.Stream;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.KeyUsage;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.eclipse.milo.opcua.sdk.client.EndpointConfiguration;
+import org.eclipse.milo.opcua.sdk.client.EndpointResolver;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClientConfig;
+import org.eclipse.milo.opcua.sdk.client.OpcUaSession;
+import org.eclipse.milo.opcua.sdk.client.SessionActivityListener;
+import org.eclipse.milo.opcua.sdk.client.UaSession;
+import org.eclipse.milo.opcua.sdk.client.identity.AnonymousProvider;
+import org.eclipse.milo.opcua.sdk.client.identity.UsernameProvider;
+import org.eclipse.milo.opcua.sdk.client.identity.X509IdentityProvider;
+import org.eclipse.milo.opcua.sdk.client.subscriptions.OpcUaMonitoredItem;
+import org.eclipse.milo.opcua.sdk.client.subscriptions.OpcUaSubscription;
+import org.eclipse.milo.opcua.sdk.server.EndpointCertificateConfig;
+import org.eclipse.milo.opcua.sdk.server.EndpointConfig;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServerConfig;
+import org.eclipse.milo.opcua.sdk.server.identity.AnonymousIdentityValidator;
+import org.eclipse.milo.opcua.sdk.server.identity.CompositeValidator;
+import org.eclipse.milo.opcua.sdk.server.identity.UsernameIdentityValidator;
+import org.eclipse.milo.opcua.sdk.server.identity.X509IdentityValidator;
+import org.eclipse.milo.opcua.sdk.test.TestPortAllocator;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.security.DefaultCertificateGroup;
+import org.eclipse.milo.opcua.stack.core.security.DefaultCertificateManager;
+import org.eclipse.milo.opcua.stack.core.security.DefaultClientCertificateValidator;
+import org.eclipse.milo.opcua.stack.core.security.MemoryCertificateQuarantine;
+import org.eclipse.milo.opcua.stack.core.security.MemoryCertificateStore;
+import org.eclipse.milo.opcua.stack.core.security.MemoryTrustListManager;
+import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
+import org.eclipse.milo.opcua.stack.core.transport.TransportProfile;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.MessageSecurityMode;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.TimestampsToReturn;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.UserTokenType;
+import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
+import org.eclipse.milo.opcua.stack.core.util.CertificateUtil;
+import org.eclipse.milo.opcua.stack.core.util.EndpointUtil;
+import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateBuilder;
+import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateGenerator;
+import org.eclipse.milo.opcua.stack.core.util.validation.ValidationCheck;
+import org.eclipse.milo.opcua.stack.transport.client.ChannelStateObservable;
+import org.eclipse.milo.opcua.stack.transport.client.tcp.OpcTcpClientTransport;
+import org.eclipse.milo.opcua.stack.transport.server.tcp.OpcTcpServerTransport;
+import org.eclipse.milo.opcua.stack.transport.server.tcp.OpcTcpServerTransportConfig;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ServerCertificateRotationTest {
+  private static final String SERVER_URI = "urn:milo:rotation:server";
+  private static final String CLIENT_URI = "urn:milo:rotation:client";
+
+  // Part 4 6.7: keep the Java client and recover sessions/subscriptions after live rotation.
+  @ParameterizedTest(name = "{0}, sameKey={1}, retainedSession={2}, response={3}")
+  @MethodSource("rotations")
+  void recoversAfterLiveRotation(
+      SecurityPolicy policy, boolean sameKey, boolean retainSession, ThumbprintResponse response)
+      throws Exception {
+    try (var fixture = new Fixture(policy, response)) {
+      fixture.connect();
+      OpcUaSession original = fixture.client.getSession();
+      Channel originalChannel = fixture.channel();
+      var boundChannel =
+          ((OpcTcpClientTransport) fixture.client.getTransport()).getSecureChannel().orElseThrow();
+      X509Certificate originalCertificate = boundChannel.getRemoteCertificate();
+      fixture.subscribe();
+      assertNotNull(fixture.notifications.poll(5, TimeUnit.SECONDS));
+      fixture.activeSessions.clear();
+      long started = System.nanoTime();
+      X509Certificate replacement = fixture.rotate(sameKey, true);
+      // The established channel continues using A until it closes, even after B is advertised.
+      fixture.read();
+      assertEquals(originalCertificate, boundChannel.getRemoteCertificate());
+      assertEquals(
+          original.getServerCertificate(), fixture.client.getSession().getServerCertificate());
+      if (!retainSession)
+        fixture.server.getSessionManager().killSession(original.getSessionId(), false);
+      originalChannel.close().sync();
+      OpcUaSession recovered = fixture.activeSessions.poll(25, TimeUnit.SECONDS);
+      assertNotNull(recovered, "same client must recover without an application retry loop");
+      if (retainSession) assertSame(original, recovered);
+      else assertNotEquals(original.getSessionId(), recovered.getSessionId());
+      assertNotSame(originalChannel, fixture.channel());
+      assertEquals(
+          replacement,
+          ((OpcTcpClientTransport) fixture.client.getTransport())
+              .getSecureChannel()
+              .orElseThrow()
+              .getRemoteCertificate());
+      assertEquals(originalCertificate, boundChannel.getRemoteCertificate());
+      if (!retainSession)
+        assertEquals(ByteString.of(replacement.getEncoded()), recovered.getServerCertificate());
+      else
+        assertNotEquals(ByteString.of(replacement.getEncoded()), recovered.getServerCertificate());
+      fixture.read();
+      fixture.notifications.clear();
+      assertNotNull(fixture.notifications.poll(6, TimeUnit.SECONDS), "notifications must resume");
+      assertEquals(2, fixture.discoveries.get(), "initial discovery plus one refresh");
+      assertTrue(
+          fixture.unknownThumbprints.get() >= 1, "must exercise stale-certificate handshake");
+      System.out.printf(
+          "rotation policy=%s sameKey=%s retained=%s response=%s recoveryMs=%d discoveries=%d%n",
+          policy,
+          sameKey,
+          retainSession,
+          response,
+          TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - started),
+          fixture.discoveries.get());
+    }
+  }
+
+  // Recovery must tolerate servers that disguise a stale thumbprint or send no error response.
+  @ParameterizedTest
+  @EnumSource(
+      value = ThumbprintResponse.class,
+      names = {"UNEXPECTED_ERROR", "SILENT_CLOSE", "NO_RESPONSE"})
+  void recoversWithoutCertificateStatus(ThumbprintResponse response) throws Exception {
+    try (var f = new Fixture(SecurityPolicy.Basic256Sha256, response, "anonymous", false, 1000)) {
+      f.connect();
+      var handshakeFailure = new CompletableFuture<Throwable>();
+      ((ChannelStateObservable) f.client.getTransport())
+          .addTransitionListener(
+              new ChannelStateObservable.TransitionListener() {
+                @Override
+                public void onStateTransition(boolean connected) {}
+
+                @Override
+                public void onConnectFailure(Throwable failure) {
+                  handshakeFailure.complete(failure);
+                }
+              });
+      OpcUaSession original = f.client.getSession();
+      f.activeSessions.clear();
+      X509Certificate replacement = f.rotate(false, true);
+      f.channel().close().sync();
+      assertSame(original, f.activeSessions.poll(15, TimeUnit.SECONDS));
+      f.read();
+      assertEquals(
+          replacement,
+          ((OpcTcpClientTransport) f.client.getTransport())
+              .getSecureChannel()
+              .orElseThrow()
+              .getRemoteCertificate());
+      long expectedStatus =
+          switch (response) {
+            case CERTIFICATE_INVALID -> StatusCodes.Bad_CertificateInvalid;
+            case SECURITY_CHECKS_FAILED -> StatusCodes.Bad_SecurityChecksFailed;
+            case UNEXPECTED_ERROR -> StatusCodes.Bad_UnexpectedError;
+            case SILENT_CLOSE -> StatusCodes.Bad_ConnectionClosed;
+            case NO_RESPONSE -> StatusCodes.Bad_Timeout;
+          };
+      assertEquals(
+          expectedStatus,
+          UaException.extractStatusCode(handshakeFailure.get(2, TimeUnit.SECONDS))
+              .orElseThrow()
+              .value());
+      assertTrue(f.unknownThumbprints.get() >= 1);
+      assertEquals(2, f.discoveries.get(), "initial discovery plus one refresh");
+    }
+  }
+
+  enum ThumbprintResponse {
+    CERTIFICATE_INVALID,
+    SECURITY_CHECKS_FAILED,
+    UNEXPECTED_ERROR,
+    SILENT_CLOSE,
+    NO_RESPONSE
+  }
+
+  // Network loss alone does not suggest a changed server certificate.
+  @ParameterizedTest
+  @MethodSource("policies")
+  void ordinaryReconnectDoesNotDiscover(SecurityPolicy policy) throws Exception {
+    try (var f = new Fixture(policy)) {
+      f.connect();
+      OpcUaSession original = f.client.getSession();
+      f.activeSessions.clear();
+      f.channel().close().sync();
+      assertSame(original, f.activeSessions.poll(15, TimeUnit.SECONDS));
+      f.read();
+      assertEquals(1, f.discoveries.get());
+    }
+  }
+
+  // Removing the listener before rotation models a server restart, without external processes.
+  @ParameterizedTest
+  @MethodSource("policies")
+  void recoversAfterServerDownRotation(SecurityPolicy policy) throws Exception {
+    try (var f = new Fixture(policy)) {
+      f.connect();
+      f.activeSessions.clear();
+      f.server.shutdown().get(5, TimeUnit.SECONDS);
+      assertNull(f.activeSessions.poll(2, TimeUnit.SECONDS));
+      assertEquals(1, f.discoveries.get(), "network failure alone must not trigger discovery");
+      f.rotate(false, true);
+      f.server =
+          new OpcUaServer(f.server.getConfig(), profile -> new OpcTcpServerTransport(f.tcpConfig));
+      f.server.startup().get(5, TimeUnit.SECONDS);
+      assertNotNull(f.activeSessions.poll(25, TimeUnit.SECONDS));
+      f.read();
+      assertEquals(2, f.discoveries.get());
+    }
+  }
+
+  // Failed or unchanged discovery must leave later retries eligible without a discovery flood.
+  @ParameterizedTest(name = "{0}, discovery={1}")
+  @MethodSource("discoveryFailures")
+  void recoversAfterTemporaryDiscoveryFailure(SecurityPolicy policy, String failure)
+      throws Exception {
+    try (var f = new Fixture(policy)) {
+      f.connect();
+      EndpointConfiguration cached = f.initial;
+      var attempted = new CompletableFuture<Throwable>();
+      f.noMatchingEndpoint = failure.equals("no-match");
+      f.discoveryUnavailable = failure.equals("outage");
+      f.discoveryBehavior =
+          discovered ->
+              discovered
+                  .<CompletableFuture<EndpointConfiguration>>handle(
+                      (value, error) -> {
+                        attempted.complete(error);
+                        if (error != null)
+                          return CompletableFuture.<EndpointConfiguration>failedFuture(error);
+                        return switch (failure) {
+                          case "unchanged" -> CompletableFuture.completedFuture(cached);
+                          case "no-match" ->
+                              CompletableFuture.failedFuture(
+                                  new UaException(
+                                      StatusCodes.Bad_ConfigurationError, "no endpoint selected"));
+                          default ->
+                              CompletableFuture.failedFuture(
+                                  new UaException(StatusCodes.Bad_Timeout));
+                        };
+                      })
+                  .thenCompose(Function.identity());
+      f.activeSessions.clear();
+      f.rotate(false, true);
+      f.channel().close().sync();
+      Throwable resolutionError = attempted.get(10, TimeUnit.SECONDS);
+      if (!failure.equals("unchanged"))
+        assertNotNull(
+            resolutionError, "resolver must fail at its actual discovery/selection boundary");
+      assertEquals(2, f.discoveries.get());
+      // Restoring discovery must suffice; no new client, reconnect call or refresh event is needed.
+      f.discoveryUnavailable = false;
+      f.noMatchingEndpoint = false;
+      f.discoveryBehavior = discovered -> discovered;
+      OpcUaSession recovered = f.activeSessions.poll(30, TimeUnit.SECONDS);
+      assertNotNull(recovered);
+      f.read();
+      assertEquals(3, f.discoveries.get());
+      assertEquals(policy.getUri(), recovered.getEndpoint().orElseThrow().getSecurityPolicyUri());
+    }
+  }
+
+  // GetEndpoints is unauthenticated metadata. It must never make an untrusted B acceptable.
+  @ParameterizedTest
+  @MethodSource("policies")
+  void rejectsUntrustedReplacement(SecurityPolicy policy) throws Exception {
+    try (var f = new Fixture(policy)) {
+      f.connect();
+      f.activeSessions.clear();
+      X509Certificate replacement = f.rotate(false, false);
+      f.channel().close().sync();
+      assertEquals(replacement, f.rejectedCertificates.poll(12, TimeUnit.SECONDS));
+      assertNull(f.activeSessions.poll(2, TimeUnit.SECONDS));
+      assertTrue(f.discoveries.get() >= 2, "rediscovery must not grant trust in the replacement");
+    }
+  }
+
+  // Disconnecting during a refresh must neither open a Session nor leave a channel behind.
+  @Test
+  void closeDuringRefreshDiscardsLateResult() throws Exception {
+    try (var f = new Fixture(SecurityPolicy.Basic256Sha256)) {
+      f.connect();
+      var entered = new CompletableFuture<EndpointConfiguration>();
+      var late =
+          new CompletableFuture<EndpointConfiguration>() {
+            @Override
+            public boolean cancel(boolean mayInterrupt) {
+              return false;
+            }
+          };
+      f.discoveryBehavior =
+          discovered -> {
+            discovered.thenAccept(entered::complete);
+            return late;
+          };
+      f.activeSessions.clear();
+      f.rotate(false, true);
+      f.channel().close().sync();
+      EndpointConfiguration replacement = entered.get(10, TimeUnit.SECONDS);
+      f.client.disconnectAsync().get(8, TimeUnit.SECONDS);
+      late.complete(replacement);
+      assertNull(f.activeSessions.poll(1, TimeUnit.SECONDS));
+      assertEquals(State.Inactive, f.client.getSessionFsm().getState());
+      assertTrue(((OpcTcpClientTransport) f.client.getTransport()).getSecureChannel().isEmpty());
+    }
+  }
+
+  // Retained sessions keep their credential encryption/signature inputs across channel rotation.
+  @ParameterizedTest(name = "{0}, identity={1}")
+  @MethodSource("credentialPolicies")
+  void reactivatesRetainedSessionWithCredentials(SecurityPolicy policy, String identity)
+      throws Exception {
+    try (var f = new Fixture(policy, identity)) {
+      f.connect();
+      OpcUaSession original = f.client.getSession();
+      f.activeSessions.clear();
+      f.rotate(false, true);
+      f.channel().close().sync();
+      assertSame(original, f.activeSessions.poll(20, TimeUnit.SECONDS));
+      f.read();
+      assertEquals(2, f.discoveries.get());
+    }
+  }
+
+  // Part 6 6.7.4: certificate replacement must not rebind renewal of an established channel.
+  @ParameterizedTest
+  @MethodSource("policies")
+  void renewalKeepsEstablishedCertificateBinding(SecurityPolicy policy) throws Exception {
+    try (var f = new Fixture(policy, "anonymous", true)) {
+      f.connect();
+      var bound =
+          ((OpcTcpClientTransport) f.client.getTransport()).getSecureChannel().orElseThrow();
+      X509Certificate original = bound.getRemoteCertificate();
+      var originalToken = bound.getChannelSecurity().getCurrentToken();
+      // Keep A advertised while observing renewal. The live-rotation matrix invalidates the
+      // endpoint cache and tests recovery on a replacement channel instead.
+      f.rotate(false, true, false);
+      long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(6);
+      while (bound.getChannelSecurity().getCurrentToken().equals(originalToken)
+          && System.nanoTime() < deadline) {
+        f.read();
+        CompletableFuture.runAsync(
+                () -> {}, CompletableFuture.delayedExecutor(100, TimeUnit.MILLISECONDS))
+            .get();
+      }
+      assertNotEquals(originalToken, bound.getChannelSecurity().getCurrentToken());
+      assertSame(
+          bound,
+          ((OpcTcpClientTransport) f.client.getTransport()).getSecureChannel().orElseThrow());
+      assertEquals(original, bound.getRemoteCertificate());
+      assertEquals(1, f.discoveries.get());
+      f.read();
+    }
+  }
+
+  // Part 4 6.7 requires a new Session when the client's application certificate changes.
+  @ParameterizedTest
+  @MethodSource("policies")
+  void reconnectWithNewClientIdentityCreatesNewSession(SecurityPolicy policy) throws Exception {
+    try (var f = new Fixture(policy)) {
+      f.connect();
+      OpcUaSession original = f.client.getSession();
+      var originalChannel =
+          ((OpcTcpClientTransport) f.client.getTransport()).getSecureChannel().orElseThrow();
+      X509Certificate originalCertificate = originalChannel.getLocalCertificate();
+      KeyPair key = f.keyPair();
+      X509Certificate replacement = signedCertificate(key, CLIENT_URI, f.caKey, f.ca);
+      f.client
+          .getConfig()
+          .getCertificateGroup()
+          .orElseThrow()
+          .updateCertificate(f.certificateType, key, new X509Certificate[] {replacement, f.ca});
+      // An explicit connect refreshes the selected local identity without closing the Session.
+      // The established channel remains bound to A until the replacement connection uses B.
+      f.client.connectAsync().get(5, TimeUnit.SECONDS);
+      assertSame(original, f.client.getSession());
+      f.activeSessions.clear();
+      f.channel().close().sync();
+      OpcUaSession recovered = f.activeSessions.poll(15, TimeUnit.SECONDS);
+      assertNotNull(recovered);
+      assertNotEquals(original.getSessionId(), recovered.getSessionId());
+      f.read();
+      assertEquals(originalCertificate, originalChannel.getLocalCertificate());
+      assertEquals(
+          replacement,
+          ((OpcTcpClientTransport) f.client.getTransport())
+              .getSecureChannel()
+              .orElseThrow()
+              .getLocalCertificate());
+      assertEquals(1, f.discoveries.get());
+    }
+  }
+
+  // The URL factory must keep the same selection strategy after its initial discovery.
+  @ParameterizedTest
+  @MethodSource("policies")
+  void urlFactoryRetainsResolverAcrossRotation(SecurityPolicy policy) throws Exception {
+    try (var f = new Fixture(policy)) {
+      var selections = new AtomicInteger();
+      OpcUaClient client =
+          OpcUaClient.create(
+              f.discoveryUrl,
+              endpoints -> {
+                selections.incrementAndGet();
+                return endpoints.stream()
+                    .filter(e -> policy.getUri().equals(e.getSecurityPolicyUri()))
+                    .filter(e -> e.getSecurityMode() == MessageSecurityMode.SignAndEncrypt)
+                    .map(e -> EndpointUtil.updateUrl(e, "localhost"))
+                    .findFirst();
+              },
+              b -> b.setConnectTimeout(uint(1000)),
+              b ->
+                  b.setApplicationUri(CLIENT_URI)
+                      .setCertificateGroup(f.client.getConfig().getCertificateGroup().orElseThrow())
+                      .setSessionEndpointValidationEnabled(true)
+                      .setRequestTimeout(uint(3000)));
+      var active = new LinkedBlockingQueue<UaSession>();
+      client.addSessionActivityListener(
+          new SessionActivityListener() {
+            @Override
+            public void onSessionActive(UaSession session) {
+              active.add(session);
+            }
+
+            @Override
+            public void onSessionInactive(UaSession session) {}
+          });
+      try {
+        client.connectAsync().get(10, TimeUnit.SECONDS);
+        UaSession original = active.poll(5, TimeUnit.SECONDS);
+        assertNotNull(original);
+        X509Certificate replacement = f.rotate(false, true);
+        f.server.getSessionManager().killSession(original.getSessionId(), false);
+        ((OpcTcpClientTransport) client.getTransport())
+            .getChannelFsm()
+            .getChannel()
+            .get()
+            .close()
+            .sync();
+        UaSession recovered = active.poll(20, TimeUnit.SECONDS);
+        assertNotNull(recovered);
+        assertNotEquals(original.getSessionId(), recovered.getSessionId());
+        assertEquals(ByteString.of(replacement.getEncoded()), recovered.getServerCertificate());
+        assertTrue(
+            client
+                .readValuesAsync(
+                    0, TimestampsToReturn.Neither, List.of(NodeIds.Server_ServerStatus_CurrentTime))
+                .get(5, TimeUnit.SECONDS)
+                .get(0)
+                .getStatusCode()
+                .isGood());
+        assertEquals(2, selections.get());
+      } finally {
+        client.disconnectAsync().get(8, TimeUnit.SECONDS);
+      }
+    }
+  }
+
+  static Stream<Arguments> credentialPolicies() {
+    return policies()
+        .flatMap(
+            policy ->
+                Stream.of("username", "certificate")
+                    .map(identity -> Arguments.of(policy, identity)));
+  }
+
+  static Stream<Arguments> discoveryFailures() {
+    return policies()
+        .flatMap(
+            policy ->
+                Stream.of("outage", "unchanged", "no-match")
+                    .map(failure -> Arguments.of(policy, failure)));
+  }
+
+  static Stream<SecurityPolicy> policies() {
+    return Stream.of(SecurityPolicy.Basic256Sha256, SecurityPolicy.ECC_nistP256_AesGcm);
+  }
+
+  static Stream<Arguments> rotations() {
+    return policies()
+        .flatMap(
+            policy ->
+                Stream.of(false, true)
+                    .flatMap(
+                        sameKey ->
+                            Stream.of(false, true)
+                                .flatMap(
+                                    retain ->
+                                        Stream.of(
+                                                ThumbprintResponse.CERTIFICATE_INVALID,
+                                                ThumbprintResponse.SECURITY_CHECKS_FAILED)
+                                            .map(
+                                                response ->
+                                                    Arguments.of(
+                                                        policy, sameKey, retain, response)))));
+  }
+
+  private static final class Fixture implements AutoCloseable {
+    final SecurityPolicy policy;
+    final NodeId certificateType;
+    final KeyPair caKey;
+    final X509Certificate ca;
+    final DefaultCertificateGroup serverGroup;
+    OpcUaServer server;
+    final OpcTcpServerTransportConfig tcpConfig;
+    final OpcUaClient client;
+    final AtomicInteger discoveries = new AtomicInteger();
+    final AtomicInteger unknownThumbprints = new AtomicInteger();
+    final LinkedBlockingQueue<OpcUaSession> activeSessions = new LinkedBlockingQueue<>();
+    final LinkedBlockingQueue<DataValue> notifications = new LinkedBlockingQueue<>();
+    final LinkedBlockingQueue<X509Certificate> rejectedCertificates = new LinkedBlockingQueue<>();
+    final EndpointResolver resolver;
+    final EndpointConfiguration initial;
+    final String discoveryUrl;
+    volatile boolean discoveryUnavailable;
+    volatile boolean noMatchingEndpoint;
+    final Set<Channel> discoveryChannels = ConcurrentHashMap.newKeySet();
+    volatile UnaryOperator<CompletableFuture<EndpointConfiguration>> discoveryBehavior = f -> f;
+    KeyPair serverKey;
+
+    Fixture(SecurityPolicy policy) throws Exception {
+      this(policy, ThumbprintResponse.CERTIFICATE_INVALID);
+    }
+
+    Fixture(SecurityPolicy policy, ThumbprintResponse response) throws Exception {
+      this(policy, response, "anonymous", false, 3000);
+    }
+
+    Fixture(SecurityPolicy policy, String identity) throws Exception {
+      this(policy, identity, false);
+    }
+
+    Fixture(SecurityPolicy policy, String identity, boolean renew) throws Exception {
+      this(policy, ThumbprintResponse.CERTIFICATE_INVALID, identity, renew, 3000);
+    }
+
+    Fixture(
+        SecurityPolicy policy,
+        ThumbprintResponse response,
+        String identity,
+        boolean renew,
+        int requestTimeout)
+        throws Exception {
+      this.policy = policy;
+      certificateType =
+          policy == SecurityPolicy.Basic256Sha256
+              ? NodeIds.RsaSha256ApplicationCertificateType
+              : NodeIds.EccNistP256ApplicationCertificateType;
+      caKey = keyPair();
+      ca = caCertificate(caKey);
+      serverKey = keyPair();
+      serverGroup = group(serverKey, signedCertificate(serverKey, SERVER_URI, caKey, ca));
+      var certificateManager = new DefaultCertificateManager(serverGroup);
+      KeyPair clientKey = keyPair();
+      X509Certificate clientCertificate = signedCertificate(clientKey, CLIENT_URI, caKey, ca);
+      int port = TestPortAllocator.allocatePort();
+      int discoveryPort = TestPortAllocator.allocatePort();
+      UserTokenPolicy anonymous =
+          new UserTokenPolicy("anonymous", UserTokenType.Anonymous, null, null, null);
+      EndpointConfig secure =
+          EndpointConfig.newBuilder()
+              .setBindAddress("localhost")
+              .setHostname("advertised.invalid")
+              .setBindPort(port)
+              .setPath("/rotation")
+              .setEndpointCertificateConfig(
+                  EndpointCertificateConfig.newBuilder()
+                      .setCertificateTypeId(certificateType)
+                      .build())
+              .setSecurityPolicy(policy)
+              .setSecurityMode(MessageSecurityMode.SignAndEncrypt)
+              .setTransportProfile(TransportProfile.TCP_UASC_UABINARY)
+              .addTokenPolicies(
+                  anonymous,
+                  new UserTokenPolicy(
+                      "username", UserTokenType.UserName, null, null, policy.getUri()),
+                  new UserTokenPolicy(
+                      "certificate", UserTokenType.Certificate, null, null, policy.getUri()))
+              .build();
+      EndpointConfig discovery =
+          EndpointConfig.newBuilder()
+              .setBindAddress("localhost")
+              .setHostname("localhost")
+              .setBindPort(discoveryPort)
+              .setPath("/discovery")
+              .setSecurityPolicy(SecurityPolicy.None)
+              .setSecurityMode(MessageSecurityMode.None)
+              .setTransportProfile(TransportProfile.TCP_UASC_UABINARY)
+              .addTokenPolicy(anonymous)
+              .build();
+      var config =
+          OpcUaServerConfig.builder()
+              .setApplicationUri(SERVER_URI)
+              .setApplicationName(LocalizedText.english("Rotation test server"))
+              .setProductUri("urn:milo:rotation")
+              .setEndpoints(Set.of(secure, discovery))
+              .setCertificateManager(certificateManager)
+              .setIdentityValidator(
+                  new CompositeValidator(
+                      AnonymousIdentityValidator.INSTANCE,
+                      new UsernameIdentityValidator(
+                          auth ->
+                              "user".equals(auth.getUsername())
+                                  && "password".equals(auth.getPassword())),
+                      new X509IdentityValidator(clientCertificate::equals)))
+              .build();
+      tcpConfig =
+          OpcTcpServerTransportConfig.newBuilder()
+              .setMinimumSecureChannelLifetime(uint(1000))
+              .setChannelPipelineCustomizer(
+                  p -> {
+                    p.addFirst(
+                        new ChannelInboundHandlerAdapter() {
+                          @Override
+                          public void channelActive(ChannelHandlerContext ctx) throws Exception {
+                            if (((InetSocketAddress) ctx.channel().localAddress()).getPort()
+                                == discoveryPort) {
+                              discoveryChannels.add(ctx.channel());
+                              ctx.channel()
+                                  .closeFuture()
+                                  .addListener(future -> discoveryChannels.remove(ctx.channel()));
+                              if (discoveryUnavailable) {
+                                ctx.close();
+                                return;
+                              }
+                            }
+                            super.channelActive(ctx);
+                          }
+                        });
+                    p.addFirst(
+                        new ChannelOutboundHandlerAdapter() {
+                          @Override
+                          public void write(
+                              ChannelHandlerContext ctx, Object msg, ChannelPromise promise)
+                              throws Exception {
+                            if (msg instanceof ByteBuf buf
+                                && buf.readableBytes() >= 12
+                                && buf.getByte(0) == 'E'
+                                && buf.getByte(1) == 'R'
+                                && buf.getByte(2) == 'R'
+                                && buf.getUnsignedIntLE(8) == StatusCodes.Bad_CertificateInvalid) {
+                              unknownThumbprints.incrementAndGet();
+                              switch (response) {
+                                case CERTIFICATE_INVALID -> {}
+                                case SECURITY_CHECKS_FAILED ->
+                                    buf.setIntLE(8, (int) StatusCodes.Bad_SecurityChecksFailed);
+                                case UNEXPECTED_ERROR ->
+                                    buf.setIntLE(8, (int) StatusCodes.Bad_UnexpectedError);
+                                case SILENT_CLOSE -> {
+                                  buf.release();
+                                  ctx.close();
+                                  promise.setSuccess();
+                                  return;
+                                }
+                                case NO_RESPONSE -> {
+                                  buf.release();
+                                  // Leave the write pending until the client times out and closes.
+                                  ctx.channel()
+                                      .closeFuture()
+                                      .addListener(f -> promise.trySuccess());
+                                  return;
+                                }
+                              }
+                            }
+                            super.write(ctx, msg, promise);
+                          }
+                        });
+                  })
+              .build();
+      server = new OpcUaServer(config, profile -> new OpcTcpServerTransport(tcpConfig));
+      server.startup().get(5, TimeUnit.SECONDS);
+      discoveryUrl = "opc.tcp://localhost:" + discoveryPort + "/discovery";
+      resolver =
+          EndpointResolver.create(
+              discoveryUrl,
+              endpoints ->
+                  endpoints.stream()
+                      .filter(e -> !noMatchingEndpoint)
+                      .filter(e -> policy.getUri().equals(e.getSecurityPolicyUri()))
+                      .filter(e -> e.getSecurityMode() == MessageSecurityMode.SignAndEncrypt)
+                      .filter(e -> secure.getEndpointUrl().equals(e.getEndpointUrl()))
+                      .map(e -> EndpointUtil.updateUrl(e, "localhost"))
+                      .findFirst(),
+              b -> b.setConnectTimeout(uint(1000)).setAcknowledgeTimeout(uint(1000)),
+              Duration.ofSeconds(3));
+      // Counts and scripts every resolution, including the one that seeds the configuration.
+      EndpointResolver refreshing =
+          new EndpointResolver() {
+            @Override
+            public CompletableFuture<EndpointConfiguration> resolve() {
+              discoveries.incrementAndGet();
+              return discoveryBehavior.apply(resolver.resolve());
+            }
+
+            @Override
+            public Duration getTimeout() {
+              return resolver.getTimeout();
+            }
+
+            // Short enough that the discovery-failure cases recover in seconds, long enough that
+            // a refresh cannot start before the test restores discovery.
+            @Override
+            public Duration getRefreshCooldown() {
+              return Duration.ofSeconds(2);
+            }
+          };
+      initial = refreshing.resolve().get(10, TimeUnit.SECONDS);
+      var clientGroup = group(clientKey, clientCertificate);
+      var clientConfig =
+          OpcUaClientConfig.builder()
+              .setApplicationUri(CLIENT_URI)
+              .setEndpoint(initial.endpoint())
+              .setDiscoveryEndpoints(initial.discoveryEndpoints())
+              .setEndpointResolver(refreshing)
+              .setIdentityProvider(
+                  switch (identity) {
+                    case "username" -> new UsernameProvider("user", "password");
+                    case "certificate" ->
+                        new X509IdentityProvider(clientCertificate, clientKey.getPrivate());
+                    default -> new AnonymousProvider();
+                  })
+              .setCertificateGroup(clientGroup)
+              .setRequestTimeout(uint(requestTimeout))
+              .setSessionEndpointValidationEnabled(true)
+              .setKeepAliveInterval(uint(1000))
+              .setKeepAliveTimeout(uint(1000))
+              .build();
+      client =
+          OpcUaClient.create(clientConfig, b -> b.setChannelLifetime(uint(renew ? 2000 : 3600000)));
+      client.addSessionActivityListener(
+          new SessionActivityListener() {
+            @Override
+            public void onSessionActive(UaSession session) {
+              activeSessions.add((OpcUaSession) session);
+            }
+
+            @Override
+            public void onSessionInactive(UaSession session) {}
+          });
+    }
+
+    void connect() throws Exception {
+      client.connectAsync().get(10, TimeUnit.SECONDS);
+      assertNotNull(activeSessions.poll(5, TimeUnit.SECONDS));
+      CompletableFuture<?>[] closed =
+          discoveryChannels.stream()
+              .map(
+                  channel -> {
+                    var result = new CompletableFuture<Void>();
+                    channel.closeFuture().addListener(future -> result.complete(null));
+                    return result;
+                  })
+              .toArray(CompletableFuture[]::new);
+      CompletableFuture.allOf(closed).get(3, TimeUnit.SECONDS);
+      read();
+    }
+
+    Channel channel() throws Exception {
+      return ((OpcTcpClientTransport) client.getTransport())
+          .getChannelFsm()
+          .getChannel()
+          .get(5, TimeUnit.SECONDS);
+    }
+
+    void read() throws Exception {
+      List<DataValue> values =
+          client
+              .readValuesAsync(
+                  0, TimestampsToReturn.Neither, List.of(NodeIds.Server_ServerStatus_CurrentTime))
+              .get(5, TimeUnit.SECONDS);
+      assertTrue(values.get(0).getStatusCode().isGood());
+    }
+
+    void subscribe() throws Exception {
+      var subscription = new OpcUaSubscription(client, 100);
+      subscription.setSubscriptionListener(
+          new OpcUaSubscription.SubscriptionListener() {
+            @Override
+            public void onDataReceived(
+                OpcUaSubscription s, List<OpcUaMonitoredItem> items, List<DataValue> values) {
+              notifications.addAll(values);
+            }
+          });
+      subscription.create();
+      var item = OpcUaMonitoredItem.newDataItem(NodeIds.Server_ServerStatus_CurrentTime);
+      item.setSamplingInterval(100);
+      subscription.addMonitoredItem(item);
+      subscription.synchronizeMonitoredItems();
+    }
+
+    X509Certificate rotate(boolean sameKey, boolean trusted) throws Exception {
+      return rotate(sameKey, trusted, true);
+    }
+
+    X509Certificate rotate(boolean sameKey, boolean trusted, boolean invalidateEndpoints)
+        throws Exception {
+      X509Certificate previous = serverGroup.getCertificateChain(certificateType).orElseThrow()[0];
+      if (!sameKey) serverKey = keyPair();
+      KeyPair issuerKey = trusted ? caKey : keyPair();
+      X509Certificate issuer = trusted ? ca : caCertificate(issuerKey);
+      X509Certificate replacement = signedCertificate(serverKey, SERVER_URI, issuerKey, issuer);
+      serverGroup.updateCertificate(
+          certificateType, serverKey, new X509Certificate[] {replacement, issuer});
+      assertTrue(
+          server
+              .getConfig()
+              .getCertificateManager()
+              .getCertificate(CertificateUtil.thumbprint(previous))
+              .isEmpty());
+      if (invalidateEndpoints) server.resetEndpointDescriptionCache();
+      return replacement;
+    }
+
+    DefaultCertificateGroup group(KeyPair key, X509Certificate certificate) throws Exception {
+      var trust = new MemoryTrustListManager();
+      trust.setTrustedCertificates(List.of(ca));
+      var quarantine =
+          new MemoryCertificateQuarantine() {
+            @Override
+            public void addRejectedCertificate(X509Certificate rejected) {
+              rejectedCertificates.add(rejected);
+              super.addRejectedCertificate(rejected);
+            }
+          };
+      var validator =
+          new DefaultClientCertificateValidator(
+              trust,
+              EnumSet.of(ValidationCheck.APPLICATION_URI, ValidationCheck.HOSTNAME),
+              quarantine);
+      var group =
+          new DefaultCertificateGroup(
+              trust, new MemoryCertificateStore(), quarantine, validator, List.of(certificateType));
+      group.updateCertificate(certificateType, key, new X509Certificate[] {certificate, ca});
+      return group;
+    }
+
+    KeyPair keyPair() throws Exception {
+      return policy == SecurityPolicy.Basic256Sha256
+          ? SelfSignedCertificateGenerator.generateRsaKeyPair(2048)
+          : SelfSignedCertificateGenerator.generateNistP256KeyPair();
+    }
+
+    @Override
+    public void close() throws Exception {
+      try {
+        client.disconnectAsync().get(8, TimeUnit.SECONDS);
+      } finally {
+        server.shutdown().get(5, TimeUnit.SECONDS);
+      }
+    }
+  }
+
+  private static X509Certificate caCertificate(KeyPair key) throws Exception {
+    var name = new X500Name("CN=Rotation test CA");
+    var builder =
+        new JcaX509v3CertificateBuilder(
+            name,
+            serial(),
+            new Date(System.currentTimeMillis() - 60000),
+            new Date(System.currentTimeMillis() + 86400000),
+            name,
+            key.getPublic());
+    builder.addExtension(Extension.basicConstraints, true, new BasicConstraints(true));
+    builder.addExtension(
+        Extension.keyUsage, true, new KeyUsage(KeyUsage.keyCertSign | KeyUsage.cRLSign));
+    return sign(builder, key);
+  }
+
+  private static X509Certificate signedCertificate(
+      KeyPair key, String uri, KeyPair caKey, X509Certificate ca) throws Exception {
+    SelfSignedCertificateBuilder leafBuilder =
+        key.getPublic().getAlgorithm().equals("RSA")
+            ? new SelfSignedCertificateBuilder(key)
+            : SelfSignedCertificateBuilder.forEccApplicationCertificate(key);
+    X509Certificate template =
+        leafBuilder
+            .setCommonName("Rotation application")
+            .setApplicationUri(uri)
+            .addDnsName("localhost")
+            .addDnsName("advertised.invalid")
+            .build();
+    var holder = new X509CertificateHolder(template.getEncoded());
+    var builder =
+        new JcaX509v3CertificateBuilder(
+            ca,
+            serial(),
+            template.getNotBefore(),
+            template.getNotAfter(),
+            template.getSubjectX500Principal(),
+            key.getPublic());
+    for (var oid : holder.getExtensions().getExtensionOIDs())
+      builder.addExtension(holder.getExtension(oid));
+    return sign(builder, caKey);
+  }
+
+  private static X509Certificate sign(X509v3CertificateBuilder builder, KeyPair key)
+      throws Exception {
+    String algorithm =
+        key.getPublic().getAlgorithm().equals("RSA") ? "SHA256withRSA" : "SHA256withECDSA";
+    return new JcaX509CertificateConverter()
+        .getCertificate(
+            builder.build(new JcaContentSignerBuilder(algorithm).build(key.getPrivate())));
+  }
+
+  private static BigInteger serial() {
+    return new BigInteger(120, new SecureRandom());
+  }
+}

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/DiscoveryClient.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/DiscoveryClient.java
@@ -263,33 +263,34 @@ public class DiscoveryClient {
   public static CompletableFuture<List<EndpointDescription>> getEndpoints(
       String endpointUrl, Consumer<OpcTcpClientTransportConfigBuilder> customizer) {
 
-    String scheme = EndpointUtil.getScheme(endpointUrl);
-
     String profileUri;
-
-    switch (Objects.requireNonNullElse(scheme, "").toLowerCase()) {
-      case "opc.tcp":
-        profileUri = Stack.TCP_UASC_UABINARY_TRANSPORT_URI;
-        break;
-
-      case "http":
-      case "https":
-      case "opc.http":
-      case "opc.https":
-        profileUri = Stack.HTTPS_UABINARY_TRANSPORT_URI;
-        break;
-
-      case "opc.ws":
-      case "opc.wss":
-        profileUri = Stack.WSS_UASC_UABINARY_TRANSPORT_URI;
-        break;
-
-      default:
-        return failedFuture(
-            new UaException(StatusCodes.Bad_InternalError, "unsupported protocol: " + scheme));
+    try {
+      profileUri = transportProfileUri(endpointUrl);
+    } catch (UaException e) {
+      return failedFuture(e);
     }
 
     return getEndpoints(endpointUrl, profileUri, customizer);
+  }
+
+  /**
+   * Map the scheme of {@code endpointUrl} to the transport profile URI that GetEndpoints results
+   * are filtered by.
+   *
+   * @param endpointUrl the endpoint URL whose scheme selects the profile.
+   * @return the transport profile URI.
+   * @throws UaException if the scheme is not supported.
+   */
+  static String transportProfileUri(String endpointUrl) throws UaException {
+    String scheme = EndpointUtil.getScheme(endpointUrl);
+
+    return switch (Objects.requireNonNullElse(scheme, "").toLowerCase()) {
+      case "opc.tcp" -> Stack.TCP_UASC_UABINARY_TRANSPORT_URI;
+      case "http", "https", "opc.http", "opc.https" -> Stack.HTTPS_UABINARY_TRANSPORT_URI;
+      case "opc.ws", "opc.wss" -> Stack.WSS_UASC_UABINARY_TRANSPORT_URI;
+      default ->
+          throw new UaException(StatusCodes.Bad_InternalError, "unsupported protocol: " + scheme);
+    };
   }
 
   private static CompletableFuture<List<EndpointDescription>> getEndpoints(

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/EndpointConfiguration.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/EndpointConfiguration.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client;
+
+import java.util.List;
+import java.util.Objects;
+import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
+
+/**
+ * A selected connection endpoint and the discovery response used to validate CreateSession.
+ *
+ * <p>The selected endpoint may have an application-supplied host override. Keep the discovery list
+ * as returned by the server so Session endpoint validation compares the advertised endpoints.
+ *
+ * @param endpoint the selected endpoint, including any host override.
+ * @param discoveryEndpoints the unmodified GetEndpoints result.
+ */
+public record EndpointConfiguration(
+    EndpointDescription endpoint, List<EndpointDescription> discoveryEndpoints) {
+  public EndpointConfiguration {
+    Objects.requireNonNull(endpoint, "endpoint");
+    discoveryEndpoints = List.copyOf(discoveryEndpoints);
+  }
+}

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/EndpointRefresh.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/EndpointRefresh.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.LongSupplier;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.MessageSecurityMode;
+import org.eclipse.milo.opcua.stack.transport.client.SecureChannelHandshakeException;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Holds the endpoint the client currently connects with and refreshes it through the configured
+ * {@link EndpointResolver} after a SecureChannel establishment failure.
+ *
+ * <p>The transport reads {@link #current()} at the start of every connection attempt and keeps
+ * reconnecting on its own schedule. A refresh runs concurrently with that schedule, so the attempt
+ * after a successful refresh connects with the replacement server certificate.
+ *
+ * <p>Refreshes are rate limited by the resolver's cooldown. The cooldown resets each time a channel
+ * becomes ready, so the first failure after a working connection refreshes immediately while a
+ * server that keeps failing the handshake sees a bounded discovery rate.
+ */
+final class EndpointRefresh {
+  private static final Logger LOGGER = LoggerFactory.getLogger(EndpointRefresh.class);
+
+  private final @Nullable EndpointResolver resolver;
+  private final LongSupplier nanoTime;
+  private volatile EndpointConfiguration current;
+  private boolean active;
+  private long generation;
+  private long nextRefresh;
+  private long cooldownNanos;
+  private @Nullable CompletableFuture<EndpointConfiguration> inFlight;
+
+  EndpointRefresh(EndpointConfiguration initial, @Nullable EndpointResolver resolver) {
+    this(initial, resolver, System::nanoTime);
+  }
+
+  EndpointRefresh(
+      EndpointConfiguration initial, @Nullable EndpointResolver resolver, LongSupplier nanoTime) {
+    current = Objects.requireNonNull(initial);
+    this.resolver = resolver;
+    this.nanoTime = nanoTime;
+  }
+
+  EndpointConfiguration current() {
+    return current;
+  }
+
+  /** Enable refreshes for a new connection and allow the first one immediately. */
+  synchronized void start() {
+    if (!active) {
+      active = true;
+      resetCooldown();
+    }
+  }
+
+  /**
+   * Allow the next qualifying failure to refresh immediately.
+   *
+   * <p>Called when a channel becomes ready. Without this, the cooldown doubled by an earlier outage
+   * would delay recovery from a second certificate rotation for the client's whole lifetime, since
+   * the transport reconnects without going through {@link #start()}.
+   */
+  synchronized void onConnected() {
+    if (active) {
+      resetCooldown();
+    }
+  }
+
+  private void resetCooldown() {
+    nextRefresh = nanoTime.getAsLong();
+    cooldownNanos = resolver != null ? resolver.getRefreshCooldown().toNanos() : 0;
+  }
+
+  /** Disable refreshes, cancel any in flight, and discard its result if it completes late. */
+  synchronized void stop() {
+    active = false;
+    generation++;
+    if (inFlight != null) {
+      inFlight.cancel(true);
+      inFlight = null;
+    }
+  }
+
+  /**
+   * Refresh after a failed SecureChannel establishment, which may indicate stale discovery data.
+   *
+   * <p>Unsecured endpoints carry no certificate binding and do not trigger refresh.
+   */
+  void onConnectFailure(Throwable failure) {
+    if (current.endpoint().getSecurityMode() != MessageSecurityMode.None
+        && isRefreshTrigger(failure)) {
+      refresh();
+    }
+  }
+
+  private synchronized void refresh() {
+    if (!active || resolver == null || inFlight != null || nanoTime.getAsLong() - nextRefresh < 0) {
+      return;
+    }
+    nextRefresh = nanoTime.getAsLong() + cooldownNanos;
+    cooldownNanos = 2 * resolver.getRefreshCooldown().toNanos();
+    long epoch = generation;
+    CompletableFuture<EndpointConfiguration> source;
+    try {
+      source = resolver.resolve();
+    } catch (Exception e) {
+      LOGGER.warn("Endpoint refresh failed; retaining cached endpoint", e);
+      return;
+    }
+    inFlight = source;
+    // The deadline applies to a copy so it never completes the resolver's own future.
+    source
+        .copy()
+        .orTimeout(resolver.getTimeout().toMillis(), TimeUnit.MILLISECONDS)
+        .whenComplete((value, error) -> complete(source, epoch, value, error));
+  }
+
+  private synchronized void complete(
+      CompletableFuture<EndpointConfiguration> source,
+      long epoch,
+      @Nullable EndpointConfiguration value,
+      @Nullable Throwable error) {
+
+    if (epoch != generation || !active) return;
+    inFlight = null;
+    if (!source.isDone()) source.cancel(true);
+    try {
+      if (error != null) throw new UaException(error);
+      validateEquivalent(current, value);
+      // Compare the selected endpoint only; a change elsewhere in the discovery list is not a
+      // refresh of the endpoint this client connects with.
+      if (!current.endpoint().equals(value.endpoint())) {
+        LOGGER.info("Endpoint refreshed: {}", value.endpoint().getEndpointUrl());
+      }
+      current = value;
+    } catch (Exception e) {
+      LOGGER.warn("Endpoint refresh failed; retaining cached endpoint", e);
+    }
+  }
+
+  /** Whether the transport identifies a failed SecureChannel establishment. */
+  static boolean isRefreshTrigger(Throwable failure) {
+    boolean handshakeFailure = false;
+    for (Throwable cause = failure; cause != null; cause = cause.getCause()) {
+      if (cause instanceof CancellationException) return false;
+      if (cause instanceof SecureChannelHandshakeException) handshakeFailure = true;
+      if (cause.getCause() == cause) break;
+    }
+    return handshakeFailure;
+  }
+
+  /**
+   * Require the replacement to describe the same endpoint as the one it replaces, so that only the
+   * server certificate can change.
+   *
+   * <p>The user token policies are pinned as well. GetEndpoints is unauthenticated and unsecured,
+   * and a refresh is reachable by anyone able to disrupt the OPN handshake. An attacker who could
+   * swap in a weaker user token policy, such as a {@code None} policy on a Sign-only channel, would
+   * otherwise obtain the user's credentials in the clear on the next ActivateSession.
+   */
+  static void validateEquivalent(EndpointConfiguration previous, EndpointConfiguration replacement)
+      throws UaException {
+    var a = previous.endpoint();
+    var b = replacement.endpoint();
+    if (!Objects.equals(a.getEndpointUrl(), b.getEndpointUrl())
+        || !Objects.equals(a.getServer().getApplicationUri(), b.getServer().getApplicationUri())
+        || !Objects.equals(a.getServer().getGatewayServerUri(), b.getServer().getGatewayServerUri())
+        || !Objects.equals(a.getTransportProfileUri(), b.getTransportProfileUri())
+        || !Objects.equals(a.getSecurityPolicyUri(), b.getSecurityPolicyUri())
+        || a.getSecurityMode() != b.getSecurityMode()
+        || !Arrays.equals(a.getUserIdentityTokens(), b.getUserIdentityTokens())) {
+      throw new UaException(
+          StatusCodes.Bad_ConfigurationError,
+          "discovery did not select an equivalent server endpoint");
+    }
+  }
+}

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/EndpointResolver.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/EndpointResolver.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
+import org.eclipse.milo.opcua.stack.transport.client.tcp.OpcTcpClientTransport;
+import org.eclipse.milo.opcua.stack.transport.client.tcp.OpcTcpClientTransportConfig;
+import org.eclipse.milo.opcua.stack.transport.client.tcp.OpcTcpClientTransportConfigBuilder;
+
+/**
+ * Rediscovers and reselects the client's endpoint after a SecureChannel establishment failure.
+ *
+ * <p>Configure this on {@link OpcUaClientConfigBuilder#setEndpointResolver} alongside the endpoint
+ * it must reselect. The client invokes it after SecureChannel establishment fails on a secured
+ * endpoint, regardless of the status code or whether the server sends an error, subject to {@link
+ * #getRefreshCooldown()}. TCP connection and Hello/Acknowledge failures do not trigger resolution.
+ * The client connects with the result on its next attempt. A refresh must select the same endpoint,
+ * including its user token policies; only the server certificate is expected to differ.
+ * Applications can also call {@link #resolve()} themselves to obtain the initial endpoint.
+ */
+@FunctionalInterface
+public interface EndpointResolver {
+
+  /**
+   * Discover and select an endpoint asynchronously.
+   *
+   * <p>Implementations must return promptly and release their resources on completion or
+   * cancellation. Milo runs at most one resolution at a time and discards results after disconnect.
+   * Discovery never changes certificate trust; the connection still uses the client's configured
+   * validator.
+   *
+   * @return a cancellable future containing the selected endpoint and discovery response.
+   */
+  CompletableFuture<EndpointConfiguration> resolve();
+
+  /**
+   * Get the positive deadline for each resolution, including custom asynchronous callbacks.
+   *
+   * @return the resolution timeout, defaulting to ten seconds.
+   */
+  default Duration getTimeout() {
+    return Duration.ofSeconds(10);
+  }
+
+  /**
+   * Get the minimum interval between refreshes after a qualifying handshake failure.
+   *
+   * <p>The first refresh after {@code connect()}, or after a channel becomes ready, runs
+   * immediately on a qualifying failure; later refreshes wait at least this long, doubling after
+   * the first. The interval limits discovery load while a server keeps rejecting the client or
+   * advertises unchanged information.
+   *
+   * @return the non-negative refresh cooldown, defaulting to thirty seconds.
+   */
+  default Duration getRefreshCooldown() {
+    return Duration.ofSeconds(30);
+  }
+
+  /**
+   * Create a strategy that owns a temporary TCP discovery transport per call.
+   *
+   * @param discoveryUrl the independently configured GetEndpoints URL.
+   * @param selectEndpoint the endpoint selection and optional host-override function.
+   * @param configureTransport configures discovery connect and handshake timeouts and resources.
+   * @param timeout the positive total discovery deadline, including connection and GetEndpoints.
+   * @return the discovery strategy.
+   */
+  static EndpointResolver create(
+      String discoveryUrl,
+      Function<List<EndpointDescription>, Optional<EndpointDescription>> selectEndpoint,
+      Consumer<OpcTcpClientTransportConfigBuilder> configureTransport,
+      Duration timeout) {
+    if (timeout.toMillis() <= 0) {
+      throw new IllegalArgumentException("timeout must be at least one millisecond");
+    }
+    return new EndpointResolver() {
+      @Override
+      public Duration getTimeout() {
+        return timeout;
+      }
+
+      @Override
+      public CompletableFuture<EndpointConfiguration> resolve() {
+        // Filter GetEndpoints by the URL's transport profile, as DiscoveryClient.getEndpoints does,
+        // so selection never sees endpoints this transport cannot connect to.
+        String profileUri;
+        try {
+          profileUri = DiscoveryClient.transportProfileUri(discoveryUrl);
+        } catch (UaException e) {
+          return CompletableFuture.failedFuture(e);
+        }
+        var builder = OpcTcpClientTransportConfig.newBuilder();
+        configureTransport.accept(builder);
+        var transport = new OpcTcpClientTransport(builder.build());
+        var discovery =
+            new DiscoveryClient(
+                DiscoveryClient.newDiscoveryEndpoint(discoveryUrl, profileUri), transport);
+        var result = new CompletableFuture<EndpointConfiguration>();
+        // Timeout/cancellation also closes a transport still connecting or awaiting GetEndpoints.
+        result.whenComplete(
+            (value, error) -> {
+              if (error != null) discovery.disconnectAsync();
+            });
+        CompletableFuture<DiscoveryClient> connection = discovery.connectAsync();
+        result.orTimeout(timeout.toMillis(), TimeUnit.MILLISECONDS);
+        connection
+            .thenCompose(
+                c -> c.getEndpoints(discoveryUrl, new String[0], new String[] {profileUri}))
+            .thenApply(
+                response -> {
+                  List<EndpointDescription> endpoints =
+                      response.getEndpoints() == null
+                          ? List.of()
+                          : List.of(response.getEndpoints());
+                  EndpointDescription selected =
+                      selectEndpoint
+                          .apply(endpoints)
+                          .orElseThrow(
+                              () ->
+                                  new CompletionException(
+                                      new UaException(
+                                          StatusCodes.Bad_ConfigurationError,
+                                          "no endpoint selected")));
+                  return new EndpointConfiguration(selected, endpoints);
+                })
+            .whenComplete(
+                (value, error) ->
+                    discovery
+                        .disconnectAsync()
+                        .whenComplete(
+                            (ignored, closeError) -> {
+                              if (error != null) result.completeExceptionally(error);
+                              else if (closeError != null) result.completeExceptionally(closeError);
+                              else result.complete(value);
+                            }));
+        return result;
+      }
+    };
+  }
+}

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClient.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClient.java
@@ -14,6 +14,7 @@ import static java.util.Objects.requireNonNullElse;
 import static org.eclipse.milo.opcua.sdk.client.session.SessionFsm.SessionInitializer;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -169,6 +170,7 @@ import org.eclipse.milo.opcua.stack.core.util.ManifestUtil;
 import org.eclipse.milo.opcua.stack.core.util.Namespaces;
 import org.eclipse.milo.opcua.stack.core.util.NonBlockingLazy;
 import org.eclipse.milo.opcua.stack.core.util.Unit;
+import org.eclipse.milo.opcua.stack.transport.client.ChannelStateObservable;
 import org.eclipse.milo.opcua.stack.transport.client.ClientApplicationContext;
 import org.eclipse.milo.opcua.stack.transport.client.OpcClientTransport;
 import org.eclipse.milo.opcua.stack.transport.client.tcp.OpcTcpClientTransport;
@@ -424,23 +426,29 @@ public class OpcUaClient {
       throws UaException {
 
     try {
-      List<EndpointDescription> endpoints =
-          DiscoveryClient.getEndpoints(endpointUrl, configureTransport).get();
-
-      EndpointDescription endpoint =
-          selectEndpoint
-              .apply(endpoints)
-              .orElseThrow(
-                  () ->
-                      new UaException(StatusCodes.Bad_ConfigurationError, "no endpoint selected"));
-
       OpcTcpClientTransportConfigBuilder transportConfigBuilder =
           OpcTcpClientTransportConfig.newBuilder();
       configureTransport.accept(transportConfigBuilder);
+      OpcTcpClientTransportConfig transportConfig = transportConfigBuilder.build();
+
+      // Discovery was previously bounded only by the transport's connect and acknowledge timeouts
+      // plus the 60 s GetEndpoints request timeout; keep that budget rather than a fixed deadline.
+      Duration discoveryTimeout =
+          Duration.ofMillis(
+              transportConfig.getConnectTimeout().longValue()
+                  + transportConfig.getAcknowledgeTimeout().longValue()
+                  + 60_000L);
+      EndpointResolver resolver =
+          EndpointResolver.create(
+              endpointUrl, selectEndpoint, configureTransport, discoveryTimeout);
+      EndpointConfiguration resolved = resolver.resolve().get();
+      List<EndpointDescription> endpoints = resolved.discoveryEndpoints();
+      EndpointDescription endpoint = resolved.endpoint();
 
       OpcUaClientConfigBuilder clientConfigBuilder = OpcUaClientConfig.builder();
       clientConfigBuilder.setEndpoint(endpoint);
       clientConfigBuilder.setDiscoveryEndpoints(endpoints);
+      clientConfigBuilder.setEndpointResolver(resolver);
       // Set up the discovery endpoints in case the user enables this, but default to false for
       // backwards compatibility.
       clientConfigBuilder.setSessionEndpointValidationEnabled(false);
@@ -449,7 +457,7 @@ public class OpcUaClient {
 
       OpcUaClientConfig clientConfig = clientConfigBuilder.build();
 
-      var transport = new OpcTcpClientTransport(transportConfigBuilder.build());
+      var transport = new OpcTcpClientTransport(transportConfig);
 
       return new OpcUaClient(clientConfig, transport);
     } catch (ExecutionException e) {
@@ -518,6 +526,7 @@ public class OpcUaClient {
   private final OpcUaClientConfig config;
 
   private final OpcClientTransport transport;
+  private final EndpointRefresh endpointRefresh;
   private final Object certificateIdentityLock = new Object();
   private final Map<SecurityPolicyProfile, Optional<CertificateIdentity>>
       selectedCertificateIdentities = new HashMap<>();
@@ -525,6 +534,10 @@ public class OpcUaClient {
   public OpcUaClient(OpcUaClientConfig config, OpcClientTransport transport) {
     this.config = config;
     this.transport = transport;
+    endpointRefresh =
+        new EndpointRefresh(
+            new EndpointConfiguration(config.getEndpoint(), config.getDiscoveryEndpoints()),
+            config.getEndpointResolver().orElse(null));
 
     staticEncodingContext =
         new EncodingContext() {
@@ -558,7 +571,7 @@ public class OpcUaClient {
         new ClientApplicationContext() {
           @Override
           public EndpointDescription getEndpoint() {
-            return config.getEndpoint();
+            return endpointRefresh.current().endpoint();
           }
 
           @Override
@@ -589,7 +602,25 @@ public class OpcUaClient {
           }
         };
 
-    sessionFsm = SessionFsmFactory.newSessionFsm(this);
+    sessionFsm = SessionFsmFactory.newSessionFsm(this, endpointRefresh::current);
+
+    // Transports that report failed connection attempts let the client refresh its endpoint after
+    // a server certificate rotation; the transport's next attempt then reads the refreshed one.
+    if (config.getEndpointResolver().isPresent()
+        && transport instanceof ChannelStateObservable observable) {
+      observable.addTransitionListener(
+          new ChannelStateObservable.TransitionListener() {
+            @Override
+            public void onStateTransition(boolean connected) {
+              if (connected) endpointRefresh.onConnected();
+            }
+
+            @Override
+            public void onConnectFailure(Throwable failure) {
+              endpointRefresh.onConnectFailure(failure);
+            }
+          });
+    }
 
     sessionFsm.addInitializer(this::initializeNamespaceAndServerTables);
 
@@ -769,6 +800,7 @@ public class OpcUaClient {
    *     or completes exceptionally if an error occurs.
    */
   public CompletableFuture<OpcUaClient> connectAsync() {
+    endpointRefresh.start();
     // Discard any identities cached during a prior connection so a rotated CertificateManager
     // entry is presented on this attempt.
     clearCertificateIdentities();
@@ -810,6 +842,7 @@ public class OpcUaClient {
    *     disconnecting the transport are swallowed.
    */
   public CompletableFuture<OpcUaClient> disconnectAsync() {
+    endpointRefresh.stop();
     CompletableFuture<Unit> closeSession =
         sessionFsm.closeSession().exceptionally(ex -> Unit.VALUE);
 

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClientConfig.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClientConfig.java
@@ -37,6 +37,10 @@ public interface OpcUaClientConfig {
   /**
    * Get the endpoint to connect to.
    *
+   * <p>When an {@link #getEndpointResolver() EndpointResolver} is configured, the client may later
+   * connect with a refreshed description of this same endpoint, for example after the server's
+   * application certificate has been replaced. The configuration itself is immutable.
+   *
    * @return the {@link EndpointDescription} to connect to.
    */
   EndpointDescription getEndpoint();
@@ -52,6 +56,16 @@ public interface OpcUaClientConfig {
    * @see #isSessionEndpointValidationEnabled()
    */
   List<EndpointDescription> getDiscoveryEndpoints();
+
+  /**
+   * Get the resolver used to refresh {@link #getEndpoint()} after SecureChannel establishment fails
+   * on a secured endpoint.
+   *
+   * @return the refresh strategy, or empty to always connect with the configured endpoint.
+   */
+  default Optional<EndpointResolver> getEndpointResolver() {
+    return Optional.empty();
+  }
 
   /**
    * Get the {@link CertificateGroup} holding this client's identity and trust material.
@@ -242,6 +256,7 @@ public interface OpcUaClientConfig {
 
     builder.setEndpoint(config.getEndpoint());
     builder.setDiscoveryEndpoints(new ArrayList<>(config.getDiscoveryEndpoints()));
+    config.getEndpointResolver().ifPresent(builder::setEndpointResolver);
     config.getCertificateGroup().ifPresent(builder::setCertificateGroup);
     builder.setCertificateIdentitySelector(config.getCertificateIdentitySelector());
     builder.setCertificateTypeId(config.getCertificateTypeId().orElse(null));

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClientConfigBuilder.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaClientConfigBuilder.java
@@ -37,7 +37,8 @@ import org.jspecify.annotations.Nullable;
 public class OpcUaClientConfigBuilder {
 
   private EndpointDescription endpoint;
-  private List<EndpointDescription> discoveryEndpoints;
+  private List<EndpointDescription> discoveryEndpoints = List.of();
+  private @Nullable EndpointResolver endpointResolver;
   private @Nullable CertificateGroup certificateGroup;
   private @Nullable KeyPair identityKeyPair;
   private X509Certificate @Nullable [] identityCertificateChain;
@@ -158,6 +159,32 @@ public class OpcUaClientConfigBuilder {
 
   public OpcUaClientConfigBuilder setEndpoint(EndpointDescription endpoint) {
     this.endpoint = endpoint;
+    return this;
+  }
+
+  /**
+   * Refresh the endpoint after SecureChannel establishment fails on a secured endpoint, so the
+   * client can recover when the server's application certificate changes.
+   *
+   * <p>The trigger is any failure between a successful Hello/Acknowledge exchange and a ready
+   * channel, not just certificate errors: a rejected client certificate, an OPN timeout, or a
+   * server that closes the connection all qualify. A client that cannot connect for another reason
+   * therefore issues GetEndpoints on each qualifying failure, immediately after {@code connect()}
+   * or a working connection and then at the resolver's cooldown, which doubles once (about every 60
+   * s by default) while the failures continue. Clients without a resolver never issue discovery
+   * traffic after {@code connect()}.
+   *
+   * <p>The resolver reruns the application's discovery and selection; use {@link
+   * EndpointResolver#create} for bounded TCP discovery. A refresh must select the same endpoint as
+   * {@link #setEndpoint}: same URL (including any host override), server URI, transport, security
+   * policy, mode and user token policies. Only the server certificate is expected to differ; any
+   * other difference is rejected and the client keeps the endpoint it has.
+   *
+   * @param endpointResolver the asynchronous discovery and selection strategy.
+   * @return this builder.
+   */
+  public OpcUaClientConfigBuilder setEndpointResolver(EndpointResolver endpointResolver) {
+    this.endpointResolver = endpointResolver;
     return this;
   }
 
@@ -310,6 +337,7 @@ public class OpcUaClientConfigBuilder {
     return new OpcUaClientConfigImpl(
         endpoint,
         discoveryEndpoints,
+        endpointResolver,
         effectiveCertificateGroup,
         certificateIdentitySelector,
         certificateTypeId,
@@ -336,6 +364,7 @@ public class OpcUaClientConfigBuilder {
 
     private final EndpointDescription endpoint;
     private final List<EndpointDescription> discoveryEndpoints;
+    private final @Nullable EndpointResolver endpointResolver;
     private final @Nullable CertificateGroup certificateGroup;
     private final CertificateIdentitySelector certificateIdentitySelector;
     private final @Nullable NodeId certificateTypeId;
@@ -361,6 +390,7 @@ public class OpcUaClientConfigBuilder {
     OpcUaClientConfigImpl(
         EndpointDescription endpoint,
         List<EndpointDescription> discoveryEndpoints,
+        @Nullable EndpointResolver endpointResolver,
         @Nullable CertificateGroup certificateGroup,
         CertificateIdentitySelector certificateIdentitySelector,
         @Nullable NodeId certificateTypeId,
@@ -384,6 +414,7 @@ public class OpcUaClientConfigBuilder {
 
       this.endpoint = endpoint;
       this.discoveryEndpoints = discoveryEndpoints;
+      this.endpointResolver = endpointResolver;
       this.certificateGroup = certificateGroup;
       this.certificateIdentitySelector = certificateIdentitySelector;
       this.certificateTypeId = certificateTypeId;
@@ -409,6 +440,11 @@ public class OpcUaClientConfigBuilder {
     @Override
     public EndpointDescription getEndpoint() {
       return endpoint;
+    }
+
+    @Override
+    public Optional<EndpointResolver> getEndpointResolver() {
+      return Optional.ofNullable(endpointResolver);
     }
 
     @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaSession.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/OpcUaSession.java
@@ -17,6 +17,7 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
 import org.eclipse.milo.opcua.stack.core.types.structured.SignedSoftwareCertificate;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -34,6 +35,8 @@ public class OpcUaSession extends ConcurrentHashMap<String, Object> implements U
   private final double sessionTimeout;
   private final UInteger maxRequestSize;
   private final ByteString serverCertificate;
+  private final @Nullable EndpointDescription endpoint;
+  private final @Nullable ByteString clientCertificate;
   private final SignedSoftwareCertificate[] serverSoftwareCertificates;
 
   public OpcUaSession(
@@ -45,6 +48,35 @@ public class OpcUaSession extends ConcurrentHashMap<String, Object> implements U
       ByteString serverCertificate,
       SignedSoftwareCertificate[] serverSoftwareCertificates) {
 
+    this(
+        authToken,
+        sessionId,
+        sessionName,
+        sessionTimeout,
+        maxRequestSize,
+        serverCertificate,
+        serverSoftwareCertificates,
+        null,
+        null);
+  }
+
+  /**
+   * Create a Session retaining the endpoint and client certificate used at creation.
+   *
+   * <p>These security inputs remain unchanged when reactivating on a replacement channel.
+   */
+  public OpcUaSession(
+      NodeId authToken,
+      NodeId sessionId,
+      String sessionName,
+      double sessionTimeout,
+      UInteger maxRequestSize,
+      ByteString serverCertificate,
+      SignedSoftwareCertificate[] serverSoftwareCertificates,
+      @Nullable EndpointDescription endpoint,
+      @Nullable ByteString clientCertificate) {
+    this.endpoint = endpoint;
+    this.clientCertificate = clientCertificate;
     this.authToken = authToken;
     this.sessionId = sessionId;
     this.sessionName = sessionName;
@@ -82,6 +114,24 @@ public class OpcUaSession extends ConcurrentHashMap<String, Object> implements U
   @Override
   public SignedSoftwareCertificate[] getServerSoftwareCertificates() {
     return serverSoftwareCertificates;
+  }
+
+  /**
+   * Get the endpoint originally used to create this Session.
+   *
+   * @return the original endpoint, or empty for a manually constructed Session without metadata.
+   */
+  public Optional<EndpointDescription> getEndpoint() {
+    return Optional.ofNullable(endpoint);
+  }
+
+  /**
+   * Get the application certificate originally used by the client for this Session.
+   *
+   * @return the original certificate, or empty for a manually constructed Session without metadata.
+   */
+  public Optional<ByteString> getClientCertificate() {
+    return Optional.ofNullable(clientCertificate);
   }
 
   @Override

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/package-info.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/package-info.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/**
+ * Owns the application-facing client, Session lifecycle, and subscription recovery across
+ * successive protocol connections. The configured endpoint is the one the client connects to; an
+ * optional {@link org.eclipse.milo.opcua.sdk.client.EndpointResolver} lets the client refresh that
+ * endpoint's description after SecureChannel establishment fails on a secured endpoint, as can
+ * happen when the server's application certificate is replaced.
+ *
+ * <p>The resolver returns one {@link org.eclipse.milo.opcua.sdk.client.EndpointConfiguration}
+ * containing the selected endpoint and the unmodified discovery list. Selection can apply an
+ * advertised-host override, while Session endpoint validation still compares the original
+ * advertised list against CreateSession. A refresh must preserve the selected URL, server
+ * application URI, transport, security policy, mode and user token policies, since discovery is
+ * unauthenticated and the token policies decide how credentials are protected. User identity and
+ * certificate validation remain client configuration.
+ *
+ * <p>Refresh sits beside the transport's reconnect loop rather than inside it. Transports that
+ * implement {@code ChannelStateObservable} report each failed attempt; the client classifies the
+ * SecureChannel handshake phase independently of the status code, runs at most one resolution at a
+ * time within the resolver's cooldown and timeout, and swaps in the result. The transport's next
+ * attempt reads the refreshed endpoint. Outstanding resolutions are cancelled on disconnect and
+ * late results are discarded. Applications implementing a resolver must release its resources when
+ * its future is cancelled.
+ *
+ * <p>Connection metadata is separate from established security bindings. SecureChannels retain
+ * their original certificates for their whole lifetime. Sessions retain their creation endpoint,
+ * client certificate and server certificate. Reactivation uses those Session inputs together with
+ * the new channel's certificate and thumbprint; failed reactivation follows normal Session and
+ * subscription recovery. Neither discovery nor a server error grants trust in a new certificate.
+ */
+package org.eclipse.milo.opcua.sdk.client;

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseTcpClientTransport.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseTcpClientTransport.java
@@ -27,9 +27,11 @@ import org.eclipse.milo.opcua.stack.transport.client.AbstractUascClientTransport
 import org.eclipse.milo.opcua.stack.transport.client.ChannelStateObservable;
 import org.eclipse.milo.opcua.stack.transport.client.ClientApplicationContext;
 import org.eclipse.milo.opcua.stack.transport.client.CurrentChannelProvider;
+import org.eclipse.milo.opcua.stack.transport.client.SecureChannelHandshakeException;
 import org.eclipse.milo.opcua.stack.transport.client.tcp.OpcTcpClientChannelInitializer;
 import org.eclipse.milo.opcua.stack.transport.client.tcp.OpcTcpClientTransportConfig;
 import org.eclipse.milo.opcua.stack.transport.client.uasc.ClientSecureChannel;
+import org.eclipse.milo.opcua.stack.transport.client.uasc.UascClientMessageHandler;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -530,10 +532,16 @@ public final class ReverseTcpClientTransport extends AbstractUascClientTransport
         .addListener(
             future -> {
               if (!handshakeFuture.isDone()) {
-                handshakeFuture.completeExceptionally(
+                var failure =
                     new UaException(
                         StatusCodes.Bad_ConnectionClosed,
-                        "reverse-connect channel closed before handshake completed"));
+                        "reverse-connect channel closed before handshake completed");
+                // Netty completes closeFuture before firing channelInactive. If the OPN handler
+                // is installed, preserve its phase marker here before it can report the closure.
+                handshakeFuture.completeExceptionally(
+                    channel.pipeline().get(UascClientMessageHandler.class) != null
+                        ? new SecureChannelHandshakeException(failure)
+                        : failure);
               }
             });
 
@@ -578,6 +586,7 @@ public final class ReverseTcpClientTransport extends AbstractUascClientTransport
 
                   targetFuture.completeExceptionally(failure);
                   channel.close();
+                  notifyConnectFailure(failure);
 
                   if (nextFuture != null) {
                     registerForNextChannel(nextFuture);
@@ -704,6 +713,16 @@ public final class ReverseTcpClientTransport extends AbstractUascClientTransport
     }
 
     channelFuture = CompletableFuture.failedFuture(failure);
+  }
+
+  private void notifyConnectFailure(Throwable failure) {
+    for (ChannelStateObservable.TransitionListener listener : transitionListeners) {
+      try {
+        listener.onConnectFailure(failure);
+      } catch (Throwable t) {
+        logger.warn("Channel connect failure listener failed.", t);
+      }
+    }
   }
 
   private void drainTransitionNotifications() {

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/package-info.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/reverse/package-info.java
@@ -101,6 +101,11 @@
  * consumes one pre-claimed connection directly, installs the standard client UASC pipeline, and
  * then lets the Session FSM create and maintain the Session as it would for outbound TCP.
  *
+ * <p>Failed attempts retain the shared UASC pipeline's handshake phase when reported to channel
+ * observers, including when the peer closes the socket without an error response. SecureChannel
+ * establishment failures can trigger endpoint refresh on secured clients with a resolver; failures
+ * before SecureChannel establishment do not.
+ *
  * <p>Shutdown fences listener installation, including a startup still in application bootstrap
  * customization. A selector owns only its pending claim: cancelling or exceptionally completing the
  * registration future removes the selector, and a claim that races that completion closes its

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmFactory.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmFactory.java
@@ -51,6 +51,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.eclipse.milo.opcua.sdk.client.*;
@@ -147,6 +148,23 @@ public class SessionFsmFactory {
   private SessionFsmFactory() {}
 
   public static SessionFsm newSessionFsm(OpcUaClient client) {
+    return newSessionFsm(
+        client,
+        () ->
+            new EndpointConfiguration(
+                client.getConfig().getEndpoint(), client.getConfig().getDiscoveryEndpoints()));
+  }
+
+  /**
+   * Create a {@link SessionFsm} whose CreateSession reads its endpoint from {@code endpoints}.
+   *
+   * @param client the client the FSM manages a Session for.
+   * @param endpoints supplies the endpoint and discovery list to create Sessions with. It is read
+   *     once the channel is ready, so a description refreshed while reconnecting is used.
+   * @return the new {@link SessionFsm}.
+   */
+  public static SessionFsm newSessionFsm(
+      OpcUaClient client, Supplier<EndpointConfiguration> endpoints) {
     Long instanceId = INSTANCE_ID.incrementAndGet();
 
     FsmBuilder<State, Event> builder =
@@ -156,7 +174,7 @@ public class SessionFsmFactory {
             client.getTransport().getConfig().getExecutor(),
             instanceId);
 
-    configureSessionFsm(builder, client);
+    configureSessionFsm(builder, client, endpoints);
 
     Fsm<State, Event> fsm = builder.build(State.Inactive);
 
@@ -165,10 +183,11 @@ public class SessionFsmFactory {
     return new SessionFsm(fsm, client.getTransport().getConfig().getExecutor());
   }
 
-  private static void configureSessionFsm(FsmBuilder<State, Event> fb, OpcUaClient client) {
+  private static void configureSessionFsm(
+      FsmBuilder<State, Event> fb, OpcUaClient client, Supplier<EndpointConfiguration> endpoints) {
     configureInactiveState(fb, client);
     configureCreatingWaitState(fb, client);
-    configureCreatingState(fb, client);
+    configureCreatingState(fb, client, endpoints);
     configureActivatingState(fb, client);
     configureTransferringState(fb, client);
     configureInitializingState(fb, client);
@@ -303,7 +322,8 @@ public class SessionFsmFactory {
         .execute(SessionFsmFactory::handleOpenSessionEvent);
   }
 
-  private static void configureCreatingState(FsmBuilder<State, Event> fb, OpcUaClient client) {
+  private static void configureCreatingState(
+      FsmBuilder<State, Event> fb, OpcUaClient client, Supplier<EndpointConfiguration> endpoints) {
     /* Transitions */
 
     fb.when(State.Creating).on(Event.CreateSessionSuccess.class).transitionTo(State.Activating);
@@ -331,7 +351,7 @@ public class SessionFsmFactory {
               handleOpenSessionEvent(ctx);
 
               //noinspection Duplicates
-              createSession(ctx, client)
+              createSession(ctx, client, endpoints)
                   .whenComplete(
                       (csr, ex) -> {
                         if (csr != null) {
@@ -359,7 +379,7 @@ public class SessionFsmFactory {
         .execute(
             ctx -> {
               //noinspection Duplicates
-              createSession(ctx, client)
+              createSession(ctx, client, endpoints)
                   .whenComplete(
                       (csr, ex) -> {
                         if (csr != null) {
@@ -1299,7 +1319,7 @@ public class SessionFsmFactory {
 
   /** The inputs of one CreateSession attempt, captured when the request is built. */
   private record CreateSessionAttempt(
-      EndpointDescription endpoint,
+      EndpointConfiguration endpoints,
       SecurityPolicy securityPolicy,
       ByteString clientNonce,
       ByteString clientCertificate,
@@ -1307,10 +1327,10 @@ public class SessionFsmFactory {
 
   @SuppressWarnings("Duplicates")
   private static CompletableFuture<CreateSessionResponse> createSession(
-      FsmContext<State, Event> ctx, OpcUaClient client) {
+      FsmContext<State, Event> ctx, OpcUaClient client, Supplier<EndpointConfiguration> endpoints) {
 
-    // The request is built once the channel is ready, so its inputs are captured together and
-    // verified against the same attempt.
+    // The request is built once the channel is ready, so the endpoint it captures is the one the
+    // channel was established with, even if a refresh replaced it while reconnecting.
     var attempt = new AtomicReference<CreateSessionAttempt>();
 
     try {
@@ -1318,8 +1338,7 @@ public class SessionFsmFactory {
           .getTransport()
           .sendRequestMessage(
               () -> {
-                CreateSessionAttempt built =
-                    buildCreateSession(ctx, client, client.getConfig().getEndpoint());
+                CreateSessionAttempt built = buildCreateSession(ctx, client, endpoints.get());
                 attempt.set(built);
                 return built.request();
               },
@@ -1332,9 +1351,10 @@ public class SessionFsmFactory {
   }
 
   private static CreateSessionAttempt buildCreateSession(
-      FsmContext<State, Event> ctx, OpcUaClient client, EndpointDescription endpoint)
+      FsmContext<State, Event> ctx, OpcUaClient client, EndpointConfiguration endpointConfiguration)
       throws Exception {
 
+    EndpointDescription endpoint = endpointConfiguration.endpoint();
     KEY_CREATE_SESSION_ENDPOINT.set(ctx, endpoint);
     SecurityPolicy securityPolicy = SecurityPolicy.fromUri(endpoint.getSecurityPolicyUri());
     Optional<CertificateIdentity> certificateIdentity =
@@ -1404,13 +1424,14 @@ public class SessionFsmFactory {
     }
 
     return new CreateSessionAttempt(
-        endpoint, securityPolicy, clientNonce, clientCertificate, request);
+        endpointConfiguration, securityPolicy, clientNonce, clientCertificate, request);
   }
 
   private static CompletableFuture<CreateSessionResponse> verifyCreateSessionResponse(
       OpcUaClient client, CreateSessionAttempt attempt, CreateSessionResponse response) {
 
-    EndpointDescription endpoint = attempt.endpoint();
+    EndpointConfiguration endpointConfiguration = attempt.endpoints();
+    EndpointDescription endpoint = endpointConfiguration.endpoint();
     SecurityPolicy securityPolicy = attempt.securityPolicy();
     ByteString clientNonce = attempt.clientNonce();
     ByteString clientCertificate = attempt.clientCertificate();
@@ -1466,7 +1487,7 @@ public class SessionFsmFactory {
       if (client.getConfig().isSessionEndpointValidationEnabled()) {
         validateSessionEndpoints(
             endpoint.getTransportProfileUri(),
-            client.getConfig().getDiscoveryEndpoints(),
+            endpointConfiguration.discoveryEndpoints(),
             List.of(
                 Objects.requireNonNullElse(
                     response.getServerEndpoints(), new EndpointDescription[0])));

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmFactory.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/SessionFsmFactory.java
@@ -49,6 +49,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -118,6 +119,10 @@ public class SessionFsmFactory {
   private static final AtomicLong INSTANCE_ID = new AtomicLong();
 
   private static final int MAX_WAIT_SECONDS = 16;
+  private static final FsmContext.Key<EndpointDescription> KEY_CREATE_SESSION_ENDPOINT =
+      new FsmContext.Key<>("createSessionEndpoint", EndpointDescription.class);
+  private static final FsmContext.Key<ByteString> KEY_CREATE_SESSION_CLIENT_CERTIFICATE =
+      new FsmContext.Key<>("createSessionClientCertificate", ByteString.class);
 
   /**
    * Lower bound, in milliseconds, on the keep-alive interval derived from a revised session
@@ -1292,150 +1297,184 @@ public class SessionFsmFactory {
     }
   }
 
+  /** The inputs of one CreateSession attempt, captured when the request is built. */
+  private record CreateSessionAttempt(
+      EndpointDescription endpoint,
+      SecurityPolicy securityPolicy,
+      ByteString clientNonce,
+      ByteString clientCertificate,
+      CreateSessionRequest request) {}
+
   @SuppressWarnings("Duplicates")
   private static CompletableFuture<CreateSessionResponse> createSession(
       FsmContext<State, Event> ctx, OpcUaClient client) {
 
+    // The request is built once the channel is ready, so its inputs are captured together and
+    // verified against the same attempt.
+    var attempt = new AtomicReference<CreateSessionAttempt>();
+
     try {
-      EndpointDescription endpoint = client.getConfig().getEndpoint();
-      SecurityPolicy securityPolicy = SecurityPolicy.fromUri(endpoint.getSecurityPolicyUri());
-      Optional<CertificateIdentity> certificateIdentity =
-          getRequiredCertificateIdentity(client, securityPolicy);
-
-      String gatewayServerUri = endpoint.getServer().getGatewayServerUri();
-
-      String serverUri;
-      if (gatewayServerUri != null && !gatewayServerUri.isEmpty()) {
-        serverUri = endpoint.getServer().getApplicationUri();
-      } else {
-        serverUri = null;
-      }
-
-      ByteString clientNonce = NonceUtil.generateNonce(32);
-      // ActivateSession signatures keep using the CreateSession client nonce, including later
-      // reactivation on a different SecureChannel.
-      KEY_CREATE_SESSION_CLIENT_NONCE.set(ctx, clientNonce);
-
-      ByteString clientCertificate =
-          certificateIdentity
-              .map(CertificateIdentity::certificate)
-              .map(
-                  c -> {
-                    try {
-                      return ByteString.of(c.getEncoded());
-                    } catch (CertificateEncodingException e) {
-                      return ByteString.NULL_VALUE;
-                    }
-                  })
-              .orElse(ByteString.NULL_VALUE);
-
-      ApplicationDescription clientDescription =
-          new ApplicationDescription(
-              client.resolveApplicationUri(certificateIdentity.orElse(null)),
-              client.getConfig().getProductUri(),
-              client.getConfig().getApplicationName(),
-              ApplicationType.Client,
-              null,
-              null,
-              null);
-
-      RequestHeader requestHeader =
-          withAdditionalHeader(
-              client.newRequestHeader(),
-              buildCreateSessionAdditionalHeader(
-                  client.getConfig().getIdentityProvider(),
-                  client.getStaticEncodingContext(),
-                  endpoint));
-
-      CreateSessionRequest request =
-          new CreateSessionRequest(
-              requestHeader,
-              clientDescription,
-              serverUri,
-              client.getConfig().getEndpoint().getEndpointUrl(),
-              client.getConfig().getSessionName().get(),
-              clientNonce,
-              clientCertificate,
-              client.getConfig().getSessionTimeout().doubleValue(),
-              client.getConfig().getMaxResponseMessageSize());
-
-      try (MDCCloseable ignored = putInstanceId(ctx)) {
-
-        LOGGER.debug("Sending CreateSessionRequest...");
-      }
-
       return client
           .getTransport()
-          .sendRequestMessage(request)
+          .sendRequestMessage(
+              () -> {
+                CreateSessionAttempt built =
+                    buildCreateSession(ctx, client, client.getConfig().getEndpoint());
+                attempt.set(built);
+                return built.request();
+              },
+              client.getConfig().getRequestTimeout().longValue())
           .thenApply(CreateSessionResponse.class::cast)
-          .thenCompose(
-              response -> {
-                try {
-                  if (securityPolicy != SecurityPolicy.None) {
-                    if (response.getServerCertificate().isNullOrEmpty()) {
-                      throw new UaException(
-                          StatusCodes.Bad_SecurityChecksFailed,
-                          "Certificate missing from CreateSessionResponse");
-                    }
+          .thenCompose(response -> verifyCreateSessionResponse(client, attempt.get(), response));
+    } catch (Exception e) {
+      return failedFuture(e);
+    }
+  }
 
-                    List<X509Certificate> serverCertificateChain =
-                        CertificateUtil.decodeCertificates(
-                            response.getServerCertificate().bytesOrEmpty());
+  private static CreateSessionAttempt buildCreateSession(
+      FsmContext<State, Event> ctx, OpcUaClient client, EndpointDescription endpoint)
+      throws Exception {
 
-                    X509Certificate serverCertificate = serverCertificateChain.get(0);
+    KEY_CREATE_SESSION_ENDPOINT.set(ctx, endpoint);
+    SecurityPolicy securityPolicy = SecurityPolicy.fromUri(endpoint.getSecurityPolicyUri());
+    Optional<CertificateIdentity> certificateIdentity =
+        getRequiredCertificateIdentity(client, securityPolicy);
 
-                    X509Certificate certificateFromEndpoint =
-                        CertificateUtil.decodeCertificate(
-                            endpoint.getServerCertificate().bytesOrEmpty());
+    String gatewayServerUri = endpoint.getServer().getGatewayServerUri();
 
-                    if (!serverCertificate.equals(certificateFromEndpoint)) {
-                      throw new UaException(
-                          StatusCodes.Bad_SecurityChecksFailed,
-                          "Certificate from CreateSessionResponse did not "
-                              + "match certificate from EndpointDescription!");
-                    }
+    String serverUri;
+    if (gatewayServerUri != null && !gatewayServerUri.isEmpty()) {
+      serverUri = endpoint.getServer().getApplicationUri();
+    } else {
+      serverUri = null;
+    }
 
-                    client
-                        .getConfig()
-                        .getCertificateValidator()
-                        .validateCertificateChain(
-                            serverCertificateChain,
-                            endpoint.getServer().getApplicationUri(),
-                            new String[] {EndpointUtil.getHost(endpoint.getEndpointUrl())},
-                            securityPolicy.getProfile());
+    ByteString clientNonce = NonceUtil.generateNonce(32);
+    // ActivateSession signatures keep using the CreateSession client nonce, including later
+    // reactivation on a different SecureChannel.
+    KEY_CREATE_SESSION_CLIENT_NONCE.set(ctx, clientNonce);
 
-                    SignatureData serverSignature = response.getServerSignature();
-
-                    byte[] dataBytes =
-                        ChannelBoundSignatureData.serverSignatureData(
-                            securityPolicy.getProfile(),
-                            client.getTransport().getChannelThumbprint(),
-                            clientNonce,
-                            certificateBytes(certificateFromEndpoint),
-                            clientCertificate,
-                            response.getServerNonce(),
-                            clientCertificate);
-
-                    ChannelBoundSignatureData.verify(
-                        securityPolicy, serverCertificate, dataBytes, serverSignature);
+    ByteString clientCertificate =
+        certificateIdentity
+            .map(CertificateIdentity::certificate)
+            .map(
+                c -> {
+                  try {
+                    return ByteString.of(c.getEncoded());
+                  } catch (CertificateEncodingException e) {
+                    return ByteString.NULL_VALUE;
                   }
+                })
+            .orElse(ByteString.NULL_VALUE);
 
-                  if (client.getConfig().isSessionEndpointValidationEnabled()) {
-                    validateSessionEndpoints(
-                        endpoint.getTransportProfileUri(),
-                        client.getConfig().getDiscoveryEndpoints(),
-                        List.of(
-                            Objects.requireNonNullElse(
-                                response.getServerEndpoints(), new EndpointDescription[0])));
-                  }
+    KEY_CREATE_SESSION_CLIENT_CERTIFICATE.set(ctx, clientCertificate);
 
-                  return completedFuture(response);
-                } catch (UaException e) {
-                  return failedFuture(e);
-                }
-              });
-    } catch (Exception ex) {
-      return failedFuture(ex);
+    ApplicationDescription clientDescription =
+        new ApplicationDescription(
+            client.resolveApplicationUri(certificateIdentity.orElse(null)),
+            client.getConfig().getProductUri(),
+            client.getConfig().getApplicationName(),
+            ApplicationType.Client,
+            null,
+            null,
+            null);
+
+    RequestHeader requestHeader =
+        withAdditionalHeader(
+            client.newRequestHeader(),
+            buildCreateSessionAdditionalHeader(
+                client.getConfig().getIdentityProvider(),
+                client.getStaticEncodingContext(),
+                endpoint));
+
+    CreateSessionRequest request =
+        new CreateSessionRequest(
+            requestHeader,
+            clientDescription,
+            serverUri,
+            endpoint.getEndpointUrl(),
+            client.getConfig().getSessionName().get(),
+            clientNonce,
+            clientCertificate,
+            client.getConfig().getSessionTimeout().doubleValue(),
+            client.getConfig().getMaxResponseMessageSize());
+
+    try (MDCCloseable ignored = putInstanceId(ctx)) {
+      LOGGER.debug("Sending CreateSessionRequest...");
+    }
+
+    return new CreateSessionAttempt(
+        endpoint, securityPolicy, clientNonce, clientCertificate, request);
+  }
+
+  private static CompletableFuture<CreateSessionResponse> verifyCreateSessionResponse(
+      OpcUaClient client, CreateSessionAttempt attempt, CreateSessionResponse response) {
+
+    EndpointDescription endpoint = attempt.endpoint();
+    SecurityPolicy securityPolicy = attempt.securityPolicy();
+    ByteString clientNonce = attempt.clientNonce();
+    ByteString clientCertificate = attempt.clientCertificate();
+
+    try {
+      if (securityPolicy != SecurityPolicy.None) {
+        if (response.getServerCertificate().isNullOrEmpty()) {
+          throw new UaException(
+              StatusCodes.Bad_SecurityChecksFailed,
+              "Certificate missing from CreateSessionResponse");
+        }
+
+        List<X509Certificate> serverCertificateChain =
+            CertificateUtil.decodeCertificates(response.getServerCertificate().bytesOrEmpty());
+
+        X509Certificate serverCertificate = serverCertificateChain.get(0);
+
+        X509Certificate certificateFromEndpoint =
+            CertificateUtil.decodeCertificate(endpoint.getServerCertificate().bytesOrEmpty());
+
+        if (!serverCertificate.equals(certificateFromEndpoint)) {
+          throw new UaException(
+              StatusCodes.Bad_SecurityChecksFailed,
+              "Certificate from CreateSessionResponse did not "
+                  + "match certificate from EndpointDescription!");
+        }
+
+        client
+            .getConfig()
+            .getCertificateValidator()
+            .validateCertificateChain(
+                serverCertificateChain,
+                endpoint.getServer().getApplicationUri(),
+                new String[] {EndpointUtil.getHost(endpoint.getEndpointUrl())},
+                securityPolicy.getProfile());
+
+        SignatureData serverSignature = response.getServerSignature();
+
+        byte[] dataBytes =
+            ChannelBoundSignatureData.serverSignatureData(
+                securityPolicy.getProfile(),
+                client.getTransport().getChannelThumbprint(),
+                clientNonce,
+                certificateBytes(certificateFromEndpoint),
+                clientCertificate,
+                response.getServerNonce(),
+                clientCertificate);
+
+        ChannelBoundSignatureData.verify(
+            securityPolicy, serverCertificate, dataBytes, serverSignature);
+      }
+
+      if (client.getConfig().isSessionEndpointValidationEnabled()) {
+        validateSessionEndpoints(
+            endpoint.getTransportProfileUri(),
+            client.getConfig().getDiscoveryEndpoints(),
+            List.of(
+                Objects.requireNonNullElse(
+                    response.getServerEndpoints(), new EndpointDescription[0])));
+      }
+
+      return completedFuture(response);
+    } catch (UaException e) {
+      return failedFuture(e);
     }
   }
 
@@ -1734,7 +1773,7 @@ public class SessionFsmFactory {
     // Resolve the SecureChannel-bound signature inputs the same way buildClientSignature does, so a
     // channel-bound user-token signature (enhanced policies) reconstructs identically on the
     // server.
-    ByteString serverChannelCertificate = resolveServerChannelCertificateBytes(endpoint);
+    ByteString serverChannelCertificate = resolveServerChannelCertificateBytes(client, endpoint);
 
     ChannelSignatureInputs channelSignatureInputs =
         new ChannelSignatureInputs(
@@ -1759,7 +1798,7 @@ public class SessionFsmFactory {
       FsmContext<State, Event> ctx, OpcUaClient client, CreateSessionResponse csr) {
 
     try {
-      EndpointDescription endpoint = client.getConfig().getEndpoint();
+      EndpointDescription endpoint = KEY_CREATE_SESSION_ENDPOINT.get(ctx);
       ByteString clientNonce = KEY_CREATE_SESSION_CLIENT_NONCE.get(ctx);
 
       ByteString csrNonce = csr.getServerNonce();
@@ -1792,7 +1831,8 @@ public class SessionFsmFactory {
                   client.newRequestHeader(csr.getAuthenticationToken()),
                   buildActivateSessionAdditionalHeader(
                       client.getStaticEncodingContext(), userTokenSecurityPolicy)),
-              buildClientSignature(client, csr.getServerCertificate(), csrNonce, clientNonce),
+              buildClientSignature(
+                  client, endpoint, csr.getServerCertificate(), csrNonce, clientNonce),
               new SignedSoftwareCertificate[0],
               client.getConfig().getSessionLocaleIds(),
               ExtensionObject.encode(client.getStaticEncodingContext(), userIdentityToken),
@@ -1823,7 +1863,9 @@ public class SessionFsmFactory {
                           csr.getRevisedSessionTimeout(),
                           csr.getMaxRequestMessageSize(),
                           csr.getServerCertificate(),
-                          csr.getServerSoftwareCertificates());
+                          csr.getServerSoftwareCertificates(),
+                          endpoint,
+                          KEY_CREATE_SESSION_CLIENT_CERTIFICATE.get(ctx));
 
                   session.setLastActivateSessionServiceResult(
                       asr.getResponseHeader().getServiceResult());
@@ -1863,7 +1905,7 @@ public class SessionFsmFactory {
       OpcUaSession session = KEY_SESSION.get(ctx);
       assert session != null;
 
-      EndpointDescription endpoint = client.getConfig().getEndpoint();
+      EndpointDescription endpoint = session.getEndpoint().orElse(client.getConfig().getEndpoint());
 
       ByteString serverNonce = session.getServerNonce();
       Optional<SecurityPolicy> userTokenSecurityPolicy =
@@ -1876,6 +1918,15 @@ public class SessionFsmFactory {
       // because enhanced (ECC or RSA-DH) policies bind it to the same channel thumbprint.
       Callable<UaRequestMessageType> requestSupplier =
           () -> {
+            ByteString originalClientCertificate = session.getClientCertificate().orElse(null);
+            if (originalClientCertificate != null
+                && !originalClientCertificate.equals(
+                    getClientCertificate(
+                        client, SecurityPolicy.fromUri(endpoint.getSecurityPolicyUri())))) {
+              // Part 4 6.7: a different application certificate requires a new Session.
+              throw new UaException(
+                  StatusCodes.Bad_SessionIdInvalid, "client application certificate changed");
+            }
             SignedIdentityToken signedIdentityToken =
                 client
                     .getConfig()
@@ -1896,7 +1947,11 @@ public class SessionFsmFactory {
                     buildActivateSessionAdditionalHeader(
                         client.getStaticEncodingContext(), userTokenSecurityPolicy)),
                 buildClientSignature(
-                    client, session.getServerCertificate(), serverNonce, session.getClientNonce()),
+                    client,
+                    endpoint,
+                    session.getServerCertificate(),
+                    serverNonce,
+                    session.getClientNonce()),
                 new SignedSoftwareCertificate[0],
                 client.getConfig().getSessionLocaleIds(),
                 ExtensionObject.encode(
@@ -1910,7 +1965,10 @@ public class SessionFsmFactory {
         LOGGER.debug("Sending ActivateSessionRequest...");
       }
 
-      return sendWhenChannelReady(client.getTransport(), requestSupplier)
+      return sendWhenChannelReady(
+              client.getTransport(),
+              requestSupplier,
+              client.getConfig().getRequestTimeout().longValue())
           .thenApply(ActivateSessionResponse.class::cast)
           .thenCompose(
               asr -> {
@@ -1942,36 +2000,27 @@ public class SessionFsmFactory {
    * Send a request whose contents may bind to the carrying SecureChannel, building it only once the
    * transport's channel is ready.
    *
-   * <p>{@link OpcClientTransport#sendRequestMessage} awaits an in-progress reconnect internally, so
-   * a channel-bound request built eagerly (e.g. an enhanced-policy ActivateSession signature over
-   * {@link OpcClientTransport#getChannelThumbprint()}) could sign over the dead channel's
-   * thumbprint and be sent on the channel that replaces it. For {@link OpcTcpClientTransport} the
-   * ChannelFsm's channel future completes only after the handshake publishes the new channel's
-   * thumbprint, so awaiting it before invoking {@code requestSupplier} guarantees a fresh read.
-   * Other transports have no channel binding and build immediately.
+   * <p>Delegates to {@link OpcClientTransport#sendRequestMessage(Callable, long)}. A channel-bound
+   * request built eagerly (e.g. an enhanced-policy ActivateSession signature over {@link
+   * OpcClientTransport#getChannelThumbprint()}) could sign over a dead channel's thumbprint during
+   * a reconnect; {@link OpcTcpClientTransport} invokes {@code requestSupplier} only after its
+   * ChannelFsm publishes the new channel. Transports without a channel binding build immediately.
+   * The initial ActivateSession does not use this: it follows a CreateSession response received on
+   * the same channel, so that channel is known to be ready when the request is built.
    *
    * @param transport the {@link OpcClientTransport} to send on.
    * @param requestSupplier supplies the request to send, invoked once the channel is ready; any
    *     exception it throws completes the returned future exceptionally.
+   * @param channelTimeoutMillis the maximum wait for a channel, or zero for no deadline.
    * @return a {@link CompletableFuture} that completes successfully with the {@link
    *     UaResponseMessageType} or completes exceptionally if an error occurred.
    */
   static CompletableFuture<UaResponseMessageType> sendWhenChannelReady(
-      OpcClientTransport transport, Callable<UaRequestMessageType> requestSupplier) {
+      OpcClientTransport transport,
+      Callable<UaRequestMessageType> requestSupplier,
+      long channelTimeoutMillis) {
 
-    CompletableFuture<?> channelReady =
-        transport instanceof OpcTcpClientTransport tcpTransport
-            ? tcpTransport.getChannelFsm().getChannel()
-            : completedFuture(null);
-
-    return channelReady.thenCompose(
-        ignored -> {
-          try {
-            return transport.sendRequestMessage(requestSupplier.call());
-          } catch (Exception e) {
-            return failedFuture(e);
-          }
-        });
+    return transport.sendRequestMessage(requestSupplier, channelTimeoutMillis);
   }
 
   @SuppressWarnings("Duplicates")
@@ -2315,14 +2364,11 @@ public class SessionFsmFactory {
   @SuppressWarnings("Duplicates")
   private static SignatureData buildClientSignature(
       OpcUaClient client,
+      EndpointDescription endpoint,
       ByteString serverCertificate,
       ByteString serverNonce,
       ByteString clientNonce)
       throws Exception {
-
-    OpcUaClientConfig config = client.getConfig();
-
-    EndpointDescription endpoint = config.getEndpoint();
 
     SecurityPolicy securityPolicy = SecurityPolicy.fromUri(endpoint.getSecurityPolicyUri());
 
@@ -2339,7 +2385,7 @@ public class SessionFsmFactory {
                           StatusCodes.Bad_ConfigurationError,
                           "client certificate identity is required for session signature"));
       ByteString clientCertificate = getClientCertificate(client, securityPolicy);
-      ByteString serverChannelCertificate = resolveServerChannelCertificateBytes(endpoint);
+      ByteString serverChannelCertificate = resolveServerChannelCertificateBytes(client, endpoint);
 
       byte[] dataToSign =
           ChannelBoundSignatureData.clientSignatureData(
@@ -2359,10 +2405,20 @@ public class SessionFsmFactory {
 
   /**
    * Resolve the {@code ServerChannelCertificate} bytes for the channel-bound session signatures:
-   * the leaf encoding of the endpoint's server certificate, or {@link ByteString#NULL_VALUE} when
-   * the endpoint advertises no certificate. Shared by {@link #buildIdentityProviderContext} and
-   * {@link #buildClientSignature} so both fill the slot identically.
+   * the established channel's leaf certificate, or {@link ByteString#NULL_VALUE} for an unsecured
+   * channel. Shared by {@link #buildIdentityProviderContext} and {@link #buildClientSignature} so
+   * both fill the slot identically.
    */
+  private static ByteString resolveServerChannelCertificateBytes(
+      OpcUaClient client, EndpointDescription endpoint) throws UaException {
+    if (client.getTransport() instanceof OpcTcpClientTransport tcp) {
+      return tcp.getSecureChannel()
+          .orElseThrow(() -> new UaException(StatusCodes.Bad_SecureChannelClosed))
+          .getRemoteCertificateBytes();
+    }
+    return resolveServerChannelCertificateBytes(endpoint);
+  }
+
   private static ByteString resolveServerChannelCertificateBytes(EndpointDescription endpoint)
       throws UaException {
 

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/package-info.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/package-info.java
@@ -24,5 +24,10 @@
  * <p>Initializers participate in Session activation. They must complete before operations waiting
  * for an active Session can proceed. Cleanup during initialization must therefore avoid waiting on
  * work that itself needs an active Session.
+ *
+ * <p>A Session retains its creation endpoint and application certificates. Reactivation keeps the
+ * Session's original server certificate and client nonce, but uses the replacement channel
+ * certificate and thumbprint for enhanced-policy signature inputs. Channel-bound requests are built
+ * only once the transport's channel is ready, so their signatures never cover a dead channel.
  */
 package org.eclipse.milo.opcua.sdk.client.session;

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/package-info.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/session/package-info.java
@@ -25,9 +25,10 @@
  * for an active Session can proceed. Cleanup during initialization must therefore avoid waiting on
  * work that itself needs an active Session.
  *
- * <p>A Session retains its creation endpoint and application certificates. Reactivation keeps the
- * Session's original server certificate and client nonce, but uses the replacement channel
- * certificate and thumbprint for enhanced-policy signature inputs. Channel-bound requests are built
- * only once the transport's channel is ready, so their signatures never cover a dead channel.
+ * <p>A Session retains its creation endpoint and application certificates. Resolver updates apply
+ * to replacement channels and new Sessions. Reactivation keeps the Session's original server
+ * certificate and client nonce, but uses the replacement channel certificate and thumbprint for
+ * enhanced-policy signature inputs. CreateSession captures the selected endpoint and discovery list
+ * together after channel establishment so endpoint comparisons use one resolution result.
  */
 package org.eclipse.milo.opcua.sdk.client.session;

--- a/opc-ua-sdk/sdk-client/src/test/java/org/eclipse/milo/opcua/sdk/client/EndpointRefreshTest.java
+++ b/opc-ua-sdk/sdk-client/src/test/java/org/eclipse/milo/opcua/sdk/client/EndpointRefreshTest.java
@@ -1,0 +1,446 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.ConnectException;
+import java.net.SocketException;
+import java.security.cert.CertPathBuilderException;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Stream;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.ApplicationType;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.MessageSecurityMode;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.UserTokenType;
+import org.eclipse.milo.opcua.stack.core.types.structured.ApplicationDescription;
+import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
+import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
+import org.eclipse.milo.opcua.stack.transport.client.SecureChannelHandshakeException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class EndpointRefreshTest {
+
+  private static final UaException CERTIFICATE_INVALID =
+      new SecureChannelHandshakeException(new UaException(StatusCodes.Bad_CertificateInvalid));
+
+  // A failed OPN can mean stale discovery even when the peer provides no useful security status.
+  @ParameterizedTest
+  @MethodSource("handshakeFailures")
+  void refreshesAfterHandshakeFailureRegardlessOfCause(Throwable cause) {
+    var refresh =
+        new EndpointRefresh(endpoint(1), () -> CompletableFuture.completedFuture(endpoint(2)));
+    refresh.start();
+    refresh.onConnectFailure(new CompletionException(new SecureChannelHandshakeException(cause)));
+    assertEquals(endpoint(2), refresh.current());
+  }
+
+  static Stream<Throwable> handshakeFailures() {
+    return Stream.of(
+        new UaException(StatusCodes.Bad_CertificateInvalid),
+        new UaException(StatusCodes.Bad_SecurityChecksFailed),
+        new UaException(StatusCodes.Bad_UnexpectedError),
+        new UaException(StatusCodes.Bad_Timeout),
+        new UaException(StatusCodes.Bad_ConnectionClosed),
+        new SocketException("connection reset"),
+        new UaException(
+            StatusCodes.Bad_SecurityChecksFailed, new CertPathBuilderException("untrusted")));
+  }
+
+  // The same status before OPN, including a HEL rejection, must not trigger discovery.
+  @ParameterizedTest
+  @ValueSource(
+      longs = {
+        StatusCodes.Bad_CertificateInvalid, StatusCodes.Bad_SecurityChecksFailed,
+        StatusCodes.Bad_Timeout, StatusCodes.Bad_ConnectionRejected,
+        StatusCodes.Bad_UserAccessDenied, StatusCodes.Bad_IdentityTokenRejected
+      })
+  void ignoresFailuresOutsideSecureChannelEstablishment(long code) {
+    assertFalse(EndpointRefresh.isRefreshTrigger(new CompletionException(new UaException(code))));
+  }
+
+  @Test
+  void ignoresTcpConnectionFailure() {
+    assertFalse(EndpointRefresh.isRefreshTrigger(new ConnectException()));
+  }
+
+  @Test
+  void cancellationDuringHandshakeDoesNotRefresh() {
+    assertFalse(
+        EndpointRefresh.isRefreshTrigger(
+            new SecureChannelHandshakeException(new CancellationException())));
+  }
+
+  // A qualifying failure refreshes at once; the replacement is visible to the next attempt.
+  @Test
+  void qualifyingFailureReplacesEndpoint() throws Exception {
+    var resolved = new CompletableFuture<EndpointConfiguration>();
+    var refresh = new EndpointRefresh(endpoint(1), () -> resolved);
+    refresh.start();
+    refresh.onConnectFailure(CERTIFICATE_INVALID);
+    assertEquals(endpoint(1), refresh.current(), "cached endpoint stays until discovery completes");
+    resolved.complete(endpoint(2));
+    assertEquals(endpoint(2), refresh.current());
+  }
+
+  // An unsecured endpoint has no certificate binding, and unrelated failures are not a reason to
+  // rediscover.
+  @Test
+  void unsecuredEndpointAndUnrelatedFailuresDoNotRefresh() {
+    var calls = new AtomicInteger();
+    EndpointResolver counting =
+        () -> CompletableFuture.completedFuture(endpoint(calls.incrementAndGet() + 1));
+    var secured = new EndpointRefresh(endpoint(1), counting);
+    secured.start();
+    secured.onConnectFailure(new UaException(StatusCodes.Bad_ConnectionRejected));
+    var unsecured = new EndpointRefresh(endpoint(1, MessageSecurityMode.None), counting);
+    unsecured.start();
+    unsecured.onConnectFailure(CERTIFICATE_INVALID);
+    assertEquals(0, calls.get());
+  }
+
+  // Failures reported while a refresh is in flight must share it rather than start another.
+  @Test
+  void concurrentFailuresShareOneResolution() throws Exception {
+    var source = new CompletableFuture<EndpointConfiguration>();
+    var calls = new AtomicInteger();
+    var refresh =
+        new EndpointRefresh(
+            endpoint(1),
+            () -> {
+              calls.incrementAndGet();
+              return source;
+            });
+    refresh.start();
+    CompletableFuture<?>[] reporters = new CompletableFuture[16];
+    for (int i = 0; i < reporters.length; i++) {
+      reporters[i] =
+          CompletableFuture.runAsync(() -> refresh.onConnectFailure(CERTIFICATE_INVALID));
+    }
+    CompletableFuture.allOf(reporters).get(5, TimeUnit.SECONDS);
+    assertEquals(1, calls.get());
+    source.complete(endpoint(2));
+    assertEquals(endpoint(2), refresh.current());
+  }
+
+  // Part 4 6.7: a temporary GetEndpoints failure cannot strand later reconnects, but repeated
+  // failures must not flood discovery.
+  @Test
+  void retriesOutageWithBoundedFrequency() {
+    var calls = new AtomicInteger();
+    var time = new AtomicLong();
+    var refresh =
+        new EndpointRefresh(
+            endpoint(1),
+            () -> {
+              int attempt = calls.incrementAndGet();
+              if (attempt == 1)
+                return CompletableFuture.failedFuture(new UaException(StatusCodes.Bad_Timeout));
+              return CompletableFuture.completedFuture(endpoint(attempt == 2 ? 1 : 2));
+            },
+            time::get);
+    refresh.start();
+    refresh.onConnectFailure(CERTIFICATE_INVALID);
+    assertEquals(endpoint(1), refresh.current());
+    for (int i = 0; i < 100; i++) refresh.onConnectFailure(CERTIFICATE_INVALID);
+    assertEquals(1, calls.get(), "no refresh inside the 30 s cooldown");
+    time.set(TimeUnit.SECONDS.toNanos(30));
+    refresh.onConnectFailure(CERTIFICATE_INVALID);
+    assertEquals(2, calls.get());
+    time.set(TimeUnit.SECONDS.toNanos(89));
+    refresh.onConnectFailure(CERTIFICATE_INVALID);
+    assertEquals(2, calls.get(), "later refreshes wait out the doubled 60 s cooldown");
+    time.set(TimeUnit.SECONDS.toNanos(90));
+    refresh.onConnectFailure(CERTIFICATE_INVALID);
+    assertEquals(3, calls.get());
+    assertEquals(endpoint(2), refresh.current());
+  }
+
+  // The cooldown belongs to the resolver, so a deployment can trade discovery load for recovery
+  // latency without a client-wide setting.
+  @Test
+  void resolverCooldownScalesRefreshSchedule() {
+    var calls = new AtomicInteger();
+    var time = new AtomicLong();
+    EndpointResolver resolver =
+        new EndpointResolver() {
+          @Override
+          public CompletableFuture<EndpointConfiguration> resolve() {
+            return CompletableFuture.completedFuture(endpoint(calls.incrementAndGet() + 1));
+          }
+
+          @Override
+          public Duration getRefreshCooldown() {
+            return Duration.ofSeconds(2);
+          }
+        };
+    var refresh = new EndpointRefresh(endpoint(1), resolver, time::get);
+    refresh.start();
+    refresh.onConnectFailure(CERTIFICATE_INVALID);
+    assertEquals(1, calls.get());
+    time.set(TimeUnit.SECONDS.toNanos(1));
+    refresh.onConnectFailure(CERTIFICATE_INVALID);
+    assertEquals(1, calls.get(), "second refresh must wait out the 2 s cooldown");
+    time.set(TimeUnit.SECONDS.toNanos(2));
+    refresh.onConnectFailure(CERTIFICATE_INVALID);
+    assertEquals(2, calls.get());
+    time.set(TimeUnit.SECONDS.toNanos(5));
+    refresh.onConnectFailure(CERTIFICATE_INVALID);
+    assertEquals(2, calls.get(), "third refresh must wait out the doubled 4 s cooldown");
+    time.set(TimeUnit.SECONDS.toNanos(6));
+    refresh.onConnectFailure(CERTIFICATE_INVALID);
+    assertEquals(3, calls.get());
+  }
+
+  // A stopped client must neither publish a late result nor keep the resolver running.
+  @Test
+  void stopCancelsRefreshAndDiscardsLateCompletion() {
+    var source =
+        new CompletableFuture<EndpointConfiguration>() {
+          @Override
+          public boolean cancel(boolean mayInterrupt) {
+            return false;
+          }
+        };
+    var cancelled = new CompletableFuture<EndpointConfiguration>();
+    var calls = new AtomicInteger();
+    var refresh =
+        new EndpointRefresh(endpoint(1), () -> calls.incrementAndGet() == 1 ? source : cancelled);
+    refresh.start();
+    refresh.onConnectFailure(CERTIFICATE_INVALID);
+    refresh.stop();
+    source.complete(endpoint(2));
+    assertEquals(endpoint(1), refresh.current());
+    refresh.onConnectFailure(CERTIFICATE_INVALID);
+    assertEquals(1, calls.get(), "no refresh after stop");
+    refresh.start();
+    refresh.onConnectFailure(CERTIFICATE_INVALID);
+    refresh.stop();
+    assertTrue(cancelled.isCancelled());
+  }
+
+  // Security failure is a reason to rediscover, never authorization to select a weaker endpoint.
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("nonEquivalentCandidates")
+  void rejectsNonEquivalentReplacement(String difference, EndpointDescription candidate) {
+    assertThrows(
+        UaException.class,
+        () ->
+            EndpointRefresh.validateEquivalent(
+                endpoint(1), new EndpointConfiguration(candidate, List.of(candidate))),
+        () -> "a replacement with a different " + difference + " must be rejected");
+  }
+
+  static Stream<Arguments> nonEquivalentCandidates() {
+    String url = endpoint(1).endpoint().getEndpointUrl();
+    SecurityPolicy policy = SecurityPolicy.Basic256Sha256;
+    MessageSecurityMode mode = MessageSecurityMode.SignAndEncrypt;
+    return Stream.of(
+        Arguments.of(
+            "endpoint URL", candidate("opc.tcp://other:4840", "urn:server", "tcp", policy, mode)),
+        Arguments.of("server URI", candidate(url, "urn:other", "tcp", policy, mode)),
+        Arguments.of(
+            "transport", candidate(url, "urn:server", "different-transport", policy, mode)),
+        Arguments.of(
+            "security policy", candidate(url, "urn:server", "tcp", SecurityPolicy.None, mode)),
+        Arguments.of(
+            "security mode", candidate(url, "urn:server", "tcp", policy, MessageSecurityMode.None)),
+        // GetEndpoints is unauthenticated; a refreshed None username policy on a Sign channel would
+        // send the password in the clear on the next ActivateSession.
+        Arguments.of(
+            "user token policies",
+            candidate(
+                url,
+                "urn:server",
+                "tcp",
+                policy,
+                mode,
+                new UserTokenPolicy(
+                    "username-none",
+                    UserTokenType.UserName,
+                    null,
+                    null,
+                    SecurityPolicy.None.getUri()))));
+  }
+
+  // A refresh reports the selected endpoint; the discovery list around it may differ harmlessly.
+  @Test
+  void acceptsReplacementWhoseDiscoveryListChangedAroundTheSameEndpoint() throws Exception {
+    EndpointDescription selected = endpoint(1).endpoint();
+    EndpointDescription other =
+        candidate(
+            "opc.tcp://other:4840",
+            "urn:server",
+            "tcp",
+            SecurityPolicy.Basic256Sha256,
+            MessageSecurityMode.SignAndEncrypt);
+    EndpointRefresh.validateEquivalent(
+        endpoint(1), new EndpointConfiguration(selected, List.of(selected, other)));
+  }
+
+  // The transport reconnects without calling start(), so a cooldown doubled by an earlier outage
+  // would otherwise delay recovery from a second rotation for the client's whole lifetime.
+  @Test
+  void successfulConnectionResetsCooldown() {
+    var calls = new AtomicInteger();
+    var time = new AtomicLong();
+    var refresh =
+        new EndpointRefresh(
+            endpoint(1),
+            () -> CompletableFuture.completedFuture(endpoint(calls.incrementAndGet() + 1)),
+            time::get);
+    refresh.start();
+    refresh.onConnectFailure(CERTIFICATE_INVALID);
+    time.set(TimeUnit.SECONDS.toNanos(30));
+    refresh.onConnectFailure(CERTIFICATE_INVALID);
+    assertEquals(2, calls.get());
+    time.set(TimeUnit.SECONDS.toNanos(31));
+    refresh.onConnectFailure(CERTIFICATE_INVALID);
+    assertEquals(2, calls.get(), "baseline: the doubled 60 s cooldown still applies");
+
+    refresh.onConnected();
+    refresh.onConnectFailure(CERTIFICATE_INVALID);
+    assertEquals(3, calls.get(), "first failure after a working connection refreshes at once");
+    time.set(TimeUnit.SECONDS.toNanos(60));
+    refresh.onConnectFailure(CERTIFICATE_INVALID);
+    assertEquals(3, calls.get(), "the cooldown restarts at its base 30 s, not zero");
+    time.set(TimeUnit.SECONDS.toNanos(61));
+    refresh.onConnectFailure(CERTIFICATE_INVALID);
+    assertEquals(4, calls.get());
+  }
+
+  // A stopped refresh must not be reactivated by a late channel-ready notification.
+  @Test
+  void connectedAfterStopDoesNotRefresh() {
+    var calls = new AtomicInteger();
+    var refresh =
+        new EndpointRefresh(
+            endpoint(1),
+            () -> CompletableFuture.completedFuture(endpoint(calls.incrementAndGet() + 1)));
+    refresh.start();
+    refresh.stop();
+    refresh.onConnected();
+    refresh.onConnectFailure(CERTIFICATE_INVALID);
+    assertEquals(0, calls.get());
+  }
+
+  // A no-match selection or a resolver that throws retains the old endpoint and stays retryable.
+  @Test
+  void noMatchAndSynchronousResolverFailureRemainRetryable() {
+    var time = new AtomicLong();
+    var calls = new AtomicInteger();
+    var refresh =
+        new EndpointRefresh(
+            endpoint(1),
+            () -> {
+              if (calls.incrementAndGet() == 1)
+                throw new IllegalStateException("resolver unavailable");
+              if (calls.get() == 2)
+                return CompletableFuture.failedFuture(
+                    new UaException(StatusCodes.Bad_ConfigurationError));
+              return CompletableFuture.completedFuture(endpoint(2));
+            },
+            time::get);
+    refresh.start();
+    refresh.onConnectFailure(CERTIFICATE_INVALID);
+    time.set(TimeUnit.SECONDS.toNanos(30));
+    refresh.onConnectFailure(CERTIFICATE_INVALID);
+    assertEquals(endpoint(1), refresh.current());
+    time.set(TimeUnit.SECONDS.toNanos(90));
+    refresh.onConnectFailure(CERTIFICATE_INVALID);
+    assertEquals(endpoint(2), refresh.current());
+  }
+
+  // A custom resolver that never finishes must be cancelled and must not block later refreshes.
+  @Test
+  void timeoutCancelsResolverAndPreservesCachedEndpoint() throws Exception {
+    var source = new CompletableFuture<EndpointConfiguration>();
+    EndpointResolver resolver =
+        new EndpointResolver() {
+          @Override
+          public CompletableFuture<EndpointConfiguration> resolve() {
+            return source;
+          }
+
+          @Override
+          public Duration getTimeout() {
+            return Duration.ofMillis(50);
+          }
+        };
+    var refresh = new EndpointRefresh(endpoint(1), resolver);
+    refresh.start();
+    refresh.onConnectFailure(CERTIFICATE_INVALID);
+    source.copy().exceptionally(e -> null).get(2, TimeUnit.SECONDS);
+    assertTrue(source.isCancelled());
+    assertEquals(endpoint(1), refresh.current());
+  }
+
+  private static EndpointDescription candidate(
+      String url,
+      String uri,
+      String transport,
+      SecurityPolicy policy,
+      MessageSecurityMode mode,
+      UserTokenPolicy... userIdentityTokens) {
+    return new EndpointDescription(
+        url,
+        server(uri),
+        ByteString.of(new byte[] {2}),
+        mode,
+        policy.getUri(),
+        userIdentityTokens.length == 0 ? null : userIdentityTokens,
+        transport,
+        null);
+  }
+
+  static EndpointConfiguration endpoint(int certificate) {
+    return endpoint(certificate, MessageSecurityMode.SignAndEncrypt);
+  }
+
+  static EndpointConfiguration endpoint(int certificate, MessageSecurityMode mode) {
+    var endpoint =
+        new EndpointDescription(
+            "opc.tcp://localhost:4840",
+            server("urn:server"),
+            ByteString.of(new byte[] {(byte) certificate}),
+            mode,
+            mode == MessageSecurityMode.None
+                ? SecurityPolicy.None.getUri()
+                : SecurityPolicy.Basic256Sha256.getUri(),
+            null,
+            "tcp",
+            null);
+    return new EndpointConfiguration(endpoint, List.of(endpoint));
+  }
+
+  private static ApplicationDescription server(String uri) {
+    return new ApplicationDescription(
+        uri, "product", LocalizedText.english("server"), ApplicationType.Server, null, null, null);
+  }
+}

--- a/opc-ua-sdk/sdk-client/src/test/java/org/eclipse/milo/opcua/sdk/client/EndpointResolverTest.java
+++ b/opc-ua-sdk/sdk-client/src/test/java/org/eclipse/milo/opcua/sdk/client/EndpointResolverTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketTimeoutException;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class EndpointResolverTest {
+  // A peer that accepts TCP but never answers Hello must not retain a discovery socket or retry
+  // loop.
+  @ParameterizedTest(name = "cancel={0}")
+  @ValueSource(booleans = {false, true})
+  void timeoutAndCancellationCloseTemporaryTransport(boolean cancel) throws Exception {
+    try (var listener = new ServerSocket(0, 1, InetAddress.getLoopbackAddress())) {
+      listener.setSoTimeout(2000);
+      EndpointResolver resolver =
+          EndpointResolver.create(
+              "opc.tcp://localhost:" + listener.getLocalPort() + "/discovery",
+              endpoints -> Optional.empty(),
+              b -> b.setConnectTimeout(uint(2000)).setAcknowledgeTimeout(uint(5000)),
+              Duration.ofSeconds(1));
+      CompletableFuture<EndpointConfiguration> operation = resolver.resolve();
+      try (Socket accepted = listener.accept()) {
+        accepted.setSoTimeout(3000);
+        if (cancel) assertTrue(operation.cancel(true));
+        else assertThrows(ExecutionException.class, () -> operation.get(2, TimeUnit.SECONDS));
+        // Drain the client's Hello. EOF proves timeout/cancellation closed the underlying socket.
+        while (accepted.getInputStream().read() != -1) {}
+      }
+      listener.setSoTimeout(300);
+      assertThrows(
+          SocketTimeoutException.class,
+          listener::accept,
+          "the temporary transport must not reconnect after resolution ends");
+    }
+  }
+}

--- a/opc-ua-sdk/sdk-client/src/test/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseTcpClientTransportTest.java
+++ b/opc-ua-sdk/sdk-client/src/test/java/org/eclipse/milo/opcua/sdk/client/reverse/ReverseTcpClientTransportTest.java
@@ -49,6 +49,8 @@ import org.eclipse.milo.opcua.sdk.client.OpcUaClientConfig;
 import org.eclipse.milo.opcua.stack.core.Stack;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.channel.messages.AcknowledgeMessage;
+import org.eclipse.milo.opcua.stack.core.channel.messages.TcpMessageEncoder;
 import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
@@ -58,12 +60,17 @@ import org.eclipse.milo.opcua.stack.core.types.enumerated.UserTokenType;
 import org.eclipse.milo.opcua.stack.core.types.structured.ApplicationDescription;
 import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
 import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
+import org.eclipse.milo.opcua.stack.transport.client.ChannelStateObservable;
+import org.eclipse.milo.opcua.stack.transport.client.ClientApplicationContext;
+import org.eclipse.milo.opcua.stack.transport.client.SecureChannelHandshakeException;
 import org.eclipse.milo.opcua.stack.transport.client.tcp.OpcTcpClientTransportConfig;
 import org.eclipse.milo.opcua.stack.transport.client.uasc.ClientSecureChannel;
 import org.eclipse.milo.opcua.stack.transport.client.uasc.UascClientAcknowledgeHandler;
 import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 class ReverseTcpClientTransportTest {
 
@@ -422,6 +429,73 @@ class ReverseTcpClientTransportTest {
       channel.finishAndReleaseAll();
       timer.stop();
     }
+  }
+
+  // A socket close must preserve the OPN phase for endpoint refresh, while earlier closes must
+  // still settle connect without suggesting stale discovery data.
+  @ParameterizedTest
+  @EnumSource(HandshakeClosePhase.class)
+  void silentCloseReportsHandshakePhase(HandshakeClosePhase phase) throws Exception {
+    var channel = new EmbeddedChannel();
+    var timer = new HashedWheelTimer();
+    var transport =
+        new ReverseTcpClientTransport(
+            OpcTcpClientTransportConfig.newBuilder()
+                .setExecutor(executor())
+                .setScheduledExecutor(scheduledExecutor())
+                .setWheelTimer(timer)
+                .build(),
+            newConnection(channel));
+    var client = new OpcUaClient(clientConfig(), transport);
+    var reportedFailure = new CompletableFuture<Throwable>();
+    transport.addTransitionListener(
+        new ChannelStateObservable.TransitionListener() {
+          @Override
+          public void onStateTransition(boolean connected) {}
+
+          @Override
+          public void onConnectFailure(Throwable failure) {
+            reportedFailure.complete(failure);
+          }
+        });
+    try {
+      CompletableFuture<?> connected =
+          transport.connect(
+              (ClientApplicationContext)
+                  declaredField(OpcUaClient.class, "applicationContext").get(client));
+      if (phase != HandshakeClosePhase.BEFORE_INITIALIZATION) {
+        channel.runPendingTasks();
+      }
+      if (phase == HandshakeClosePhase.WAITING_FOR_OPEN_SECURE_CHANNEL) {
+        channel.writeInbound(
+            TcpMessageEncoder.encode(new AcknowledgeMessage(0, 65535, 65535, 0, 0)));
+        channel.runPendingTasks();
+      }
+
+      // EmbeddedChannel.close() drains pending tasks first, which would initialize the pipeline
+      // before the BEFORE_INITIALIZATION case can close the socket.
+      channel.pipeline().close();
+      channel.runPendingTasks();
+
+      Throwable failure = reportedFailure.get(5, TimeUnit.SECONDS);
+      assertEquals(
+          phase == HandshakeClosePhase.WAITING_FOR_OPEN_SECURE_CHANNEL,
+          failure instanceof SecureChannelHandshakeException);
+      assertEquals(
+          StatusCodes.Bad_ConnectionClosed,
+          UaException.extractStatusCode(failure).orElseThrow().value());
+      assertTerminalConnectionClosed(connected);
+    } finally {
+      transport.disconnect().get(5, TimeUnit.SECONDS);
+      channel.finishAndReleaseAll();
+      timer.stop();
+    }
+  }
+
+  enum HandshakeClosePhase {
+    BEFORE_INITIALIZATION,
+    WAITING_FOR_ACKNOWLEDGE,
+    WAITING_FOR_OPEN_SECURE_CHANNEL
   }
 
   private OpcTcpClientTransportConfig transportConfig() {

--- a/opc-ua-sdk/sdk-client/src/test/java/org/eclipse/milo/opcua/sdk/client/session/SendWhenChannelReadyTest.java
+++ b/opc-ua-sdk/sdk-client/src/test/java/org/eclipse/milo/opcua/sdk/client/session/SendWhenChannelReadyTest.java
@@ -12,6 +12,7 @@ package org.eclipse.milo.opcua.sdk.client.session;
 
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -93,7 +94,8 @@ class SendWhenChannelReadyTest {
             () -> {
               thumbprintAtBuild.set(transport.getChannelThumbprint());
               return readRequest();
-            });
+            },
+            5000);
 
     // The handshake has not completed, so the request must not have been built or sent yet.
     assertNull(thumbprintAtBuild.get());
@@ -115,7 +117,7 @@ class SendWhenChannelReadyTest {
     ReadRequest request = readRequest();
 
     CompletableFuture<UaResponseMessageType> responseFuture =
-        SessionFsmFactory.sendWhenChannelReady(transport, () -> request);
+        SessionFsmFactory.sendWhenChannelReady(transport, () -> request, 5000);
 
     responseFuture.get(5, TimeUnit.SECONDS);
 
@@ -134,13 +136,99 @@ class SendWhenChannelReadyTest {
             transport,
             () -> {
               throw failure;
-            });
+            },
+            5000);
 
     ExecutionException e =
         assertThrows(ExecutionException.class, () -> responseFuture.get(5, TimeUnit.SECONDS));
 
     assertSame(failure, e.getCause());
     assertEquals(0, transport.sentRequests.size());
+  }
+
+  // A channel-bound signature must fail with its channel if it closes during construction;
+  // looking up another channel after construction would send a stale signature on the replacement.
+  @Test
+  void channelClosingDuringBuildDoesNotSendRequestOnReplacement() throws Exception {
+    var original = new EmbeddedChannel();
+    var replacement = new EmbeddedChannel();
+    var handshakeFuture = new CompletableFuture<Channel>();
+    var connectInvoked = new CountDownLatch(1);
+    ChannelFsm channelFsm = newTcpTransport(handshakeFuture, connectInvoked).getChannelFsm();
+    var transport =
+        new OpcTcpClientTransport(
+            OpcTcpClientTransportConfig.newBuilder().setExecutor(executor).build()) {
+          @Override
+          public ChannelFsm getChannelFsm() {
+            return channelFsm;
+          }
+
+          @Override
+          protected CompletableFuture<Channel> getChannel() {
+            return CompletableFuture.completedFuture(replacement);
+          }
+        };
+
+    try {
+      channelFsm.connect();
+      assertTrue(connectInvoked.await(5, TimeUnit.SECONDS));
+      handshakeFuture.complete(original);
+
+      CompletableFuture<UaResponseMessageType> response =
+          SessionFsmFactory.sendWhenChannelReady(
+              transport,
+              () -> {
+                original.close();
+                return readRequest();
+              },
+              5000);
+
+      assertThrows(ExecutionException.class, () -> response.get(5, TimeUnit.SECONDS));
+      assertNull(replacement.readOutbound(), "the replacement must not carry the old signature");
+    } finally {
+      original.finishAndReleaseAll();
+      replacement.finishAndReleaseAll();
+    }
+  }
+
+  // Waiting for a reconnect must remain bounded, and an expired operation must not create a
+  // Session later when the channel finally arrives. The shared channel future must stay usable.
+  @Test
+  void channelTimeoutPreventsLateRequestWithoutFailingSharedChannel() throws Exception {
+    var channelReady = new CompletableFuture<Channel>();
+    var connectInvoked = new CountDownLatch(1);
+    TestTcpTransport transport = newTcpTransport(channelReady, connectInvoked);
+    CompletableFuture<Channel> connection = transport.getChannelFsm().connect();
+    assertTrue(connectInvoked.await(5, TimeUnit.SECONDS));
+    var built = new CompletableFuture<Void>();
+
+    CompletableFuture<UaResponseMessageType> response =
+        SessionFsmFactory.sendWhenChannelReady(
+            transport,
+            () -> {
+              built.complete(null);
+              return readRequest();
+            },
+            50);
+
+    ExecutionException failure =
+        assertThrows(ExecutionException.class, () -> response.get(5, TimeUnit.SECONDS));
+    assertEquals(
+        StatusCodes.Bad_Timeout,
+        UaException.extract(failure).orElseThrow().getStatusCode().value());
+    assertFalse(channelReady.isDone(), "a request timeout must not fail the shared channel future");
+
+    var channel = new EmbeddedChannel();
+    try {
+      channelReady.complete(channel);
+      assertSame(channel, connection.get(5, TimeUnit.SECONDS));
+      // Drain the executor so any channel-ready continuation has had a chance to run.
+      executor.submit(() -> {}).get(5, TimeUnit.SECONDS);
+      assertFalse(built.isDone(), "the expired request must not be built when the channel arrives");
+      assertEquals(0, transport.sentRequests.size());
+    } finally {
+      channel.finishAndReleaseAll();
+    }
   }
 
   private TestTcpTransport newTcpTransport(
@@ -221,8 +309,8 @@ class SendWhenChannelReadyTest {
     }
 
     @Override
-    public CompletableFuture<UaResponseMessageType> sendRequestMessage(
-        UaRequestMessageType requestMessage) {
+    protected CompletableFuture<UaResponseMessageType> sendRequestMessage(
+        UaRequestMessageType requestMessage, Channel channel) {
 
       sentRequests.add(requestMessage);
       return CompletableFuture.completedFuture(new ReadResponse(null, null, null));

--- a/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/client/ChannelStateObservable.java
+++ b/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/client/ChannelStateObservable.java
@@ -39,7 +39,10 @@ public interface ChannelStateObservable {
    */
   void removeTransitionListener(TransitionListener listener);
 
-  /** Callback notified when a client transport gains or loses a usable channel. */
+  /**
+   * Callback notified when a client transport gains or loses a usable channel, and when an attempt
+   * to establish one fails.
+   */
   @FunctionalInterface
   interface TransitionListener {
 
@@ -50,5 +53,21 @@ public interface ChannelStateObservable {
      *     the current channel leaves service.
      */
     void onStateTransition(boolean connected);
+
+    /**
+     * Invoked when a connection attempt fails before a channel becomes ready for service.
+     *
+     * <p>The transport keeps reconnecting on its own schedule; this callback lets the application
+     * react to the cause, for example by refreshing cached discovery information after a security
+     * failure, before the next attempt reads {@link ClientApplicationContext#getEndpoint()}.
+     *
+     * <p>Failures during SecureChannel establishment must include a {@link
+     * SecureChannelHandshakeException} in the cause chain. Transport connection and
+     * Hello/Acknowledge failures must not use that marker. This lets callers refresh discovery
+     * without depending on particular server status codes.
+     *
+     * @param failure the cause of the failed attempt, including the server status when available.
+     */
+    default void onConnectFailure(Throwable failure) {}
   }
 }

--- a/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/client/OpcClientTransport.java
+++ b/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/client/OpcClientTransport.java
@@ -10,6 +10,7 @@
 
 package org.eclipse.milo.opcua.stack.transport.client;
 
+import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import org.eclipse.milo.opcua.stack.core.types.UaRequestMessageType;
 import org.eclipse.milo.opcua.stack.core.types.UaResponseMessageType;
@@ -63,4 +64,26 @@ public interface OpcClientTransport {
    *     UaResponseMessageType} or completes exceptionally if an error occurred.
    */
   CompletableFuture<UaResponseMessageType> sendRequestMessage(UaRequestMessageType requestMessage);
+
+  /**
+   * Build a channel-bound request once the channel is available and send it.
+   *
+   * <p>Transports with a channel binding invoke {@code requestSupplier} only after their channel is
+   * established, so security inputs read while building (e.g. {@link #getChannelThumbprint()}) are
+   * fresh. The default builds immediately and sends via {@link
+   * #sendRequestMessage(UaRequestMessageType)}, retaining that method's request timeout.
+   *
+   * @param requestSupplier builds the request using the established channel's security inputs.
+   * @param channelTimeoutMillis the maximum wait for a channel, or zero for no deadline. Once the
+   *     request is built, its header supplies the response timeout.
+   * @return the response future.
+   */
+  default CompletableFuture<UaResponseMessageType> sendRequestMessage(
+      Callable<UaRequestMessageType> requestSupplier, long channelTimeoutMillis) {
+    try {
+      return sendRequestMessage(requestSupplier.call());
+    } catch (Exception e) {
+      return CompletableFuture.failedFuture(e);
+    }
+  }
 }

--- a/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/client/SecureChannelHandshakeException.java
+++ b/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/client/SecureChannelHandshakeException.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.transport.client;
+
+import org.eclipse.milo.opcua.stack.core.UaException;
+
+/**
+ * A failure while establishing a SecureChannel after transport negotiation has succeeded.
+ *
+ * <p>This identifies the failed handshake phase independently of the server's status code or
+ * whether the server sent an error at all. The original cause and its status code are preserved. It
+ * does not describe TCP connection failures, Hello/Acknowledge failures, or failures of an already
+ * established channel.
+ */
+public final class SecureChannelHandshakeException extends UaException {
+
+  /**
+   * Creates a SecureChannel establishment failure with the original cause.
+   *
+   * @param cause the failure encountered while establishing the SecureChannel.
+   */
+  public SecureChannelHandshakeException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/client/package-info.java
+++ b/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/client/package-info.java
@@ -50,5 +50,14 @@
  * response or failure has been consumed. Caller continuations should return promptly because this
  * fallback may run on an I/O or timer thread. Publish responses pass through a dedicated {@code
  * ExecutionQueue} that preserves their order across normal dispatch and rejection fallback.
+ *
+ * <p>Each connection attempt reads {@link ClientApplicationContext#getEndpoint()} afresh, and
+ * transports that implement {@link ChannelStateObservable} report failed attempts through {@link
+ * ChannelStateObservable.TransitionListener#onConnectFailure}. Failures during SecureChannel
+ * establishment carry a {@link SecureChannelHandshakeException}, including local validation errors,
+ * server errors, timeouts, and connection closure during that phase. TCP and Hello/Acknowledge
+ * failures do not carry this marker. The SDK uses this boundary to refresh discovery without
+ * relying on server status codes; the next attempt reads the updated endpoint. Transports have no
+ * dependency on SDK discovery, and an established channel's certificate binding never changes.
  */
 package org.eclipse.milo.opcua.stack.transport.client;

--- a/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/client/tcp/OpcTcpClientTransport.java
+++ b/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/client/tcp/OpcTcpClientTransport.java
@@ -38,9 +38,11 @@ import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
@@ -85,6 +87,13 @@ public class OpcTcpClientTransport extends AbstractUascClientTransport
   private final OpcTcpClientTransportConfig config;
   private volatile ClientSecureChannel secureChannel;
 
+  // The ChannelFsm shelves Disconnect while an attempt is in progress, so disconnect() aborts the
+  // in-flight socket and handshake itself rather than waiting for a peer or a handshake timeout.
+  private volatile boolean connectionRequested;
+  private final AtomicReference<Channel> connectingChannel = new AtomicReference<>();
+  private final AtomicReference<CompletableFuture<ClientSecureChannel>> pendingHandshake =
+      new AtomicReference<>();
+
   private final List<ChannelStateObservable.TransitionListener> transitionListeners =
       new CopyOnWriteArrayList<>();
 
@@ -122,6 +131,9 @@ public class OpcTcpClientTransport extends AbstractUascClientTransport
 
     channelFsm.addTransitionListener(
         (from, to, via) -> {
+          if (via instanceof Event.ConnectFailure connectFailure) {
+            notifyConnectFailure(connectFailure.failure);
+          }
           if (from != State.Connected && to == State.Connected) {
             notifyTransitionListeners(true);
           } else if (from == State.Connected && to != State.Connected) {
@@ -137,6 +149,7 @@ public class OpcTcpClientTransport extends AbstractUascClientTransport
 
   @Override
   public CompletableFuture<Unit> connect(ClientApplicationContext applicationContext) {
+    connectionRequested = true;
     channelFsm.getFsm().withContext(ctx -> ctx.set(KEY_CLIENT_APPLICATION, applicationContext));
 
     return channelFsm.connect().thenApply(c -> Unit.VALUE);
@@ -144,6 +157,13 @@ public class OpcTcpClientTransport extends AbstractUascClientTransport
 
   @Override
   public CompletableFuture<Unit> disconnect() {
+    connectionRequested = false;
+    Channel connecting = connectingChannel.getAndSet(null);
+    if (connecting != null) connecting.close();
+    CompletableFuture<ClientSecureChannel> handshake = pendingHandshake.getAndSet(null);
+    if (handshake != null) {
+      handshake.completeExceptionally(new UaException(StatusCodes.Bad_ConnectionClosed));
+    }
     return channelFsm
         .disconnect()
         .thenApply(
@@ -187,6 +207,16 @@ public class OpcTcpClientTransport extends AbstractUascClientTransport
     }
   }
 
+  private void notifyConnectFailure(Throwable failure) {
+    for (ChannelStateObservable.TransitionListener listener : transitionListeners) {
+      try {
+        listener.onConnectFailure(failure);
+      } catch (Throwable t) {
+        logger.warn("Channel connect failure listener failed.", t);
+      }
+    }
+  }
+
   private void notifyTransitionListeners(boolean connected) {
     for (ChannelStateObservable.TransitionListener listener : transitionListeners) {
       try {
@@ -206,7 +236,11 @@ public class OpcTcpClientTransport extends AbstractUascClientTransport
       ClientApplicationContext application =
           (ClientApplicationContext) ctx.get(KEY_CLIENT_APPLICATION);
 
+      // The ChannelFsm runs one connect attempt at a time, so a plain set cannot overwrite another
+      // attempt's future. The compareAndSet on completion guards against disconnect(), which may
+      // have already cleared this reference concurrently.
       var handshakeFuture = new CompletableFuture<ClientSecureChannel>();
+      pendingHandshake.set(handshakeFuture);
 
       var bootstrap = new Bootstrap();
 
@@ -241,27 +275,42 @@ public class OpcTcpClientTransport extends AbstractUascClientTransport
 
       int port = EndpointUtil.getPort(endpointUrl);
 
-      bootstrap
-          .connect(new InetSocketAddress(host, port))
-          .addListener(
-              (ChannelFuture f) -> {
-                if (!f.isSuccess()) {
-                  Throwable cause = f.cause();
+      ChannelFuture connection = bootstrap.connect(new InetSocketAddress(host, port));
+      connectingChannel.set(connection.channel());
+      // disconnect() may have run between the ChannelFsm dispatching this attempt and the socket
+      // being published above.
+      if (!connectionRequested) {
+        connection.channel().close();
+        handshakeFuture.completeExceptionally(new UaException(StatusCodes.Bad_ConnectionClosed));
+      }
+      connection.addListener(
+          (ChannelFuture f) -> {
+            if (!f.isSuccess()) {
+              Throwable cause = f.cause();
 
-                  if (cause instanceof ConnectTimeoutException) {
-                    handshakeFuture.completeExceptionally(
-                        new UaException(StatusCodes.Bad_Timeout, f.cause()));
-                  } else if (cause instanceof ConnectException) {
-                    handshakeFuture.completeExceptionally(
-                        new UaException(StatusCodes.Bad_ConnectionRejected, f.cause()));
-                  } else {
-                    handshakeFuture.completeExceptionally(cause);
-                  }
-                }
-              });
+              if (cause instanceof ConnectTimeoutException) {
+                handshakeFuture.completeExceptionally(
+                    new UaException(StatusCodes.Bad_Timeout, f.cause()));
+              } else if (cause instanceof ConnectException) {
+                handshakeFuture.completeExceptionally(
+                    new UaException(StatusCodes.Bad_ConnectionRejected, f.cause()));
+              } else {
+                handshakeFuture.completeExceptionally(cause);
+              }
+            }
+          });
 
-      return handshakeFuture.thenApply(
-          secureChannel -> {
+      // One completion step clears the in-flight references before the channel is published, so
+      // disconnect() cannot close a channel the ChannelFsm is about to own.
+      return handshakeFuture.handle(
+          (secureChannel, error) -> {
+            connectingChannel.compareAndSet(connection.channel(), null);
+            pendingHandshake.compareAndSet(handshakeFuture, null);
+            if (error != null) throw new CompletionException(error);
+            if (!connectionRequested) {
+              secureChannel.getChannel().close();
+              throw new CompletionException(new UaException(StatusCodes.Bad_ConnectionClosed));
+            }
             OpcTcpClientTransport.this.secureChannel = secureChannel;
             return secureChannel.getChannel();
           });

--- a/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/client/tcp/OpcTcpClientTransport.java
+++ b/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/client/tcp/OpcTcpClientTransport.java
@@ -37,14 +37,19 @@ import java.net.ConnectException;
 import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.UaRequestMessageType;
+import org.eclipse.milo.opcua.stack.core.types.UaResponseMessageType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
@@ -186,6 +191,46 @@ public class OpcTcpClientTransport extends AbstractUascClientTransport
 
   public ChannelFsm getChannelFsm() {
     return channelFsm;
+  }
+
+  /**
+   * Get the most recently established SecureChannel, including its immutable certificate bindings.
+   *
+   * @return the established channel, or empty before the first handshake or after disconnect.
+   */
+  public Optional<ClientSecureChannel> getSecureChannel() {
+    return Optional.ofNullable(secureChannel);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The request is built only after the ChannelFsm's channel future completes, which happens
+   * after the handshake publishes the new channel's certificate and thumbprint, so a channel-bound
+   * signature never covers a dead channel during a reconnect.
+   */
+  @Override
+  public CompletableFuture<UaResponseMessageType> sendRequestMessage(
+      Callable<UaRequestMessageType> requestSupplier, long channelTimeoutMillis) {
+    CompletableFuture<Channel> channelReady = getChannelFsm().getChannel().copy();
+    if (channelTimeoutMillis > 0) {
+      channelReady.orTimeout(channelTimeoutMillis, TimeUnit.MILLISECONDS);
+    }
+    return channelReady
+        .exceptionallyCompose(
+            error ->
+                CompletableFuture.failedFuture(
+                    error instanceof TimeoutException
+                        ? new UaException(StatusCodes.Bad_Timeout, "timed out waiting for channel")
+                        : error))
+        .thenCompose(
+            channel -> {
+              try {
+                return sendRequestMessage(requestSupplier.call(), channel);
+              } catch (Exception e) {
+                return CompletableFuture.failedFuture(e);
+              }
+            });
   }
 
   @Override

--- a/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/client/uasc/UascClientAcknowledgeHandler.java
+++ b/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/client/uasc/UascClientAcknowledgeHandler.java
@@ -35,6 +35,7 @@ import org.eclipse.milo.opcua.stack.core.channel.messages.TcpMessageEncoder;
 import org.eclipse.milo.opcua.stack.core.types.UaRequestMessageType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.transport.client.ClientApplicationContext;
+import org.eclipse.milo.opcua.stack.transport.client.SecureChannelHandshakeException;
 import org.eclipse.milo.opcua.stack.transport.client.uasc.InboundUascResponseHandler.DelegatingUascResponseHandler;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
@@ -67,6 +68,7 @@ public class UascClientAcknowledgeHandler extends ByteToMessageCodec<UaRequestMe
   private final Supplier<String> endpointUrlSupplier;
   private final Supplier<Long> requestIdSupplier;
   private final CompletableFuture<ClientSecureChannel> handshakeFuture;
+  private boolean secureChannelHandshakeStarted;
   private final boolean sendHelloWhenAddedToActiveChannel;
 
   private @Nullable ChannelHandlerContext handlerContext;
@@ -200,6 +202,13 @@ public class UascClientAcknowledgeHandler extends ByteToMessageCodec<UaRequestMe
     }
   }
 
+  private void failHandshake(Throwable cause) {
+    // This handler remains in the pipeline until OPN succeeds, so it can still receive ERRs and
+    // decoding failures after handing off to the SecureChannel handler.
+    handshakeFuture.completeExceptionally(
+        secureChannelHandshakeStarted ? new SecureChannelHandshakeException(cause) : cause);
+  }
+
   @Override
   public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
     logger.error(
@@ -211,7 +220,7 @@ public class UascClientAcknowledgeHandler extends ByteToMessageCodec<UaRequestMe
     // If the handshake hasn't completed yet this cause will be more
     // accurate than the generic "connection closed" exception that
     // channelInactive() will use.
-    handshakeFuture.completeExceptionally(cause);
+    failHandshake(cause);
 
     ctx.close();
   }
@@ -253,7 +262,7 @@ public class UascClientAcknowledgeHandler extends ByteToMessageCodec<UaRequestMe
         .newTimeout(
             timeout -> {
               if (!timeout.isCancelled()) {
-                handshakeFuture.completeExceptionally(
+                failHandshake(
                     new UaException(StatusCodes.Bad_Timeout, "timed out waiting for acknowledge"));
                 ctx.close();
               }
@@ -299,8 +308,7 @@ public class UascClientAcknowledgeHandler extends ByteToMessageCodec<UaRequestMe
   private void onAcknowledge(ChannelHandlerContext ctx, ByteBuf buffer) {
     if (helloTimeout != null && !helloTimeout.cancel()) {
       helloTimeout = null;
-      handshakeFuture.completeExceptionally(
-          new UaException(StatusCodes.Bad_Timeout, "timed out waiting for acknowledge"));
+      failHandshake(new UaException(StatusCodes.Bad_Timeout, "timed out waiting for acknowledge"));
       ctx.close();
       return;
     }
@@ -352,6 +360,7 @@ public class UascClientAcknowledgeHandler extends ByteToMessageCodec<UaRequestMe
     ctx.executor()
         .execute(
             () -> {
+              secureChannelHandshakeStarted = true;
               var messageHandler =
                   new UascClientMessageHandler(
                       config,
@@ -382,7 +391,7 @@ public class UascClientAcknowledgeHandler extends ByteToMessageCodec<UaRequestMe
       logger.error(
           "[remote={}] received error message: {}", ctx.channel().remoteAddress(), errorMessage);
 
-      handshakeFuture.completeExceptionally(new UaException(statusCode, errorMessage.getReason()));
+      failHandshake(new UaException(statusCode, errorMessage.getReason()));
 
       ctx.fireUserEventTriggered(errorMessage);
     } catch (UaException e) {
@@ -392,7 +401,7 @@ public class UascClientAcknowledgeHandler extends ByteToMessageCodec<UaRequestMe
           e.getMessage(),
           e);
 
-      handshakeFuture.completeExceptionally(e);
+      failHandshake(e);
     } finally {
       ctx.close();
     }

--- a/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/client/uasc/UascClientMessageHandler.java
+++ b/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/client/uasc/UascClientMessageHandler.java
@@ -74,6 +74,7 @@ import org.eclipse.milo.opcua.stack.core.util.BufferUtil;
 import org.eclipse.milo.opcua.stack.core.util.CertificateUtil;
 import org.eclipse.milo.opcua.stack.core.util.NonceUtil;
 import org.eclipse.milo.opcua.stack.transport.client.ClientApplicationContext;
+import org.eclipse.milo.opcua.stack.transport.client.SecureChannelHandshakeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -153,6 +154,10 @@ public class UascClientMessageHandler extends ByteToMessageCodec<UascRequest> {
         });
   }
 
+  private void failHandshake(Throwable cause) {
+    handshakeFuture.completeExceptionally(new SecureChannelHandshakeException(cause));
+  }
+
   @Override
   public void channelInactive(ChannelHandlerContext ctx) throws Exception {
     releaseChunkBuffers();
@@ -163,7 +168,7 @@ public class UascClientMessageHandler extends ByteToMessageCodec<UascRequest> {
 
     UaException exception = new UaException(StatusCodes.Bad_ConnectionClosed, "connection closed");
 
-    handshakeFuture.completeExceptionally(exception);
+    failHandshake(exception);
 
     super.channelInactive(ctx);
   }
@@ -181,7 +186,7 @@ public class UascClientMessageHandler extends ByteToMessageCodec<UascRequest> {
     // If the handshake hasn't completed yet this cause will be more
     // accurate than the generic "connection closed" exception that
     // channelInactive() will use.
-    handshakeFuture.completeExceptionally(cause);
+    failHandshake(cause);
 
     ctx.close();
   }
@@ -213,7 +218,7 @@ public class UascClientMessageHandler extends ByteToMessageCodec<UascRequest> {
             .newTimeout(
                 timeout -> {
                   if (!timeout.isCancelled()) {
-                    handshakeFuture.completeExceptionally(
+                    failHandshake(
                         new UaException(
                             StatusCodes.Bad_Timeout, "timed out waiting for secure channel"));
                     ctx.close();
@@ -381,7 +386,7 @@ public class UascClientMessageHandler extends ByteToMessageCodec<UascRequest> {
       } else {
         logger.warn("timed out waiting for secure channel");
 
-        handshakeFuture.completeExceptionally(
+        failHandshake(
             new UaException(StatusCodes.Bad_Timeout, "timed out waiting for secure channel"));
         ctx.close();
         return;
@@ -467,7 +472,7 @@ public class UascClientMessageHandler extends ByteToMessageCodec<UascRequest> {
                   ? (ServiceFault) responseMessage
                   : new ServiceFault(responseMessage.getResponseHeader());
 
-          handshakeFuture.completeExceptionally(new UaServiceFaultException(serviceFault));
+          failHandshake(new UaServiceFaultException(serviceFault));
           ctx.close();
         }
       } catch (MessageAbortException e) {
@@ -475,13 +480,13 @@ public class UascClientMessageHandler extends ByteToMessageCodec<UascRequest> {
       } catch (MessageDecodeException e) {
         logger.error("Error decoding asymmetric message", e);
 
-        handshakeFuture.completeExceptionally(e);
+        failHandshake(e);
 
         ctx.close();
       } catch (Exception e) {
         logger.error("Error decoding OpenSecureChannelResponse", e);
 
-        handshakeFuture.completeExceptionally(e);
+        failHandshake(e);
 
         ctx.close();
       } finally {
@@ -607,7 +612,7 @@ public class UascClientMessageHandler extends ByteToMessageCodec<UascRequest> {
 
       logger.error("[remote={}] errorMessage={}", ctx.channel().remoteAddress(), errorMessage);
 
-      handshakeFuture.completeExceptionally(new UaException(statusCode, errorMessage.getReason()));
+      failHandshake(new UaException(statusCode, errorMessage.getReason()));
 
       ctx.fireUserEventTriggered(errorMessage);
     } catch (UaException e) {
@@ -617,7 +622,7 @@ public class UascClientMessageHandler extends ByteToMessageCodec<UascRequest> {
           e.getMessage(),
           e);
 
-      handshakeFuture.completeExceptionally(e);
+      failHandshake(e);
     } finally {
       ctx.close();
     }
@@ -733,7 +738,7 @@ public class UascClientMessageHandler extends ByteToMessageCodec<UascRequest> {
     } catch (UaException e) {
       logger.error("Error preparing OpenSecureChannelRequest: {}", e.getStatusCode(), e);
 
-      handshakeFuture.completeExceptionally(e);
+      failHandshake(e);
       ctx.close();
     } finally {
       messageBuffer.release();
@@ -823,11 +828,11 @@ public class UascClientMessageHandler extends ByteToMessageCodec<UascRequest> {
       secureChannel.setChannelId(0);
     } catch (MessageEncodeException e) {
       logger.error("Error encoding {}: {}", request, e.getMessage(), e);
-      handshakeFuture.completeExceptionally(e);
+      failHandshake(e);
       ctx.close();
     } catch (UaSerializationException e) {
       logger.error("Error serializing {}: {}", request, e.getMessage(), e);
-      handshakeFuture.completeExceptionally(e);
+      failHandshake(e);
       ctx.close();
     } finally {
       messageBuffer.release();

--- a/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/server/uasc/UascServerAsymmetricHandler.java
+++ b/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/server/uasc/UascServerAsymmetricHandler.java
@@ -301,7 +301,7 @@ public class UascServerAsymmetricHandler extends ByteToMessageDecoder implements
           secureChannel.setKeyPair(keyPair.get());
         } else {
           throw new UaException(
-              StatusCodes.Bad_SecurityChecksFailed, "no certificate for provided thumbprint");
+              StatusCodes.Bad_CertificateInvalid, "no certificate for provided thumbprint");
         }
       }
     }

--- a/opc-ua-stack/transport/src/test/java/org/eclipse/milo/opcua/stack/transport/client/tcp/OpcTcpClientChannelInitializerTest.java
+++ b/opc-ua-stack/transport/src/test/java/org/eclipse/milo/opcua/stack/transport/client/tcp/OpcTcpClientChannelInitializerTest.java
@@ -35,13 +35,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.channel.messages.AcknowledgeMessage;
+import org.eclipse.milo.opcua.stack.core.channel.messages.ErrorMessage;
 import org.eclipse.milo.opcua.stack.core.channel.messages.HelloMessage;
 import org.eclipse.milo.opcua.stack.core.channel.messages.MessageType;
 import org.eclipse.milo.opcua.stack.core.channel.messages.TcpMessageDecoder;
+import org.eclipse.milo.opcua.stack.core.channel.messages.TcpMessageEncoder;
 import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
 import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
 import org.eclipse.milo.opcua.stack.core.security.CertificateIdentity;
@@ -59,12 +64,50 @@ import org.eclipse.milo.opcua.stack.core.types.structured.ApplicationDescription
 import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
 import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
 import org.eclipse.milo.opcua.stack.transport.client.ClientApplicationContext;
+import org.eclipse.milo.opcua.stack.transport.client.SecureChannelHandshakeException;
+import org.eclipse.milo.opcua.stack.transport.client.uasc.ClientSecureChannel;
 import org.eclipse.milo.opcua.stack.transport.client.uasc.InboundUascResponseHandler.DelegatingUascResponseHandler;
 import org.eclipse.milo.opcua.stack.transport.client.uasc.UascClientAcknowledgeHandler;
 import org.eclipse.milo.opcua.stack.transport.client.uasc.UascResponseHandler;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class OpcTcpClientChannelInitializerTest {
+
+  // Identical wire errors must retain the handshake phase so only OPN failures prompt discovery.
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void marksErrorOnlyAfterAcknowledge(boolean acknowledged) throws Exception {
+    var channel = new EmbeddedChannel();
+    var wheelTimer = new HashedWheelTimer();
+    var handshake = new CompletableFuture<ClientSecureChannel>();
+    try {
+      OpcTcpClientChannelInitializer.initializeOutboundChannel(
+          channel,
+          newClientConfig(wheelTimer),
+          newClientApplicationContext("opc.tcp://localhost:12685/milo"),
+          NoopResponseHandler.INSTANCE,
+          new AtomicLong(1)::getAndIncrement,
+          handshake);
+      if (acknowledged) {
+        channel.writeInbound(
+            TcpMessageEncoder.encode(new AcknowledgeMessage(0, 65535, 65535, 0, 0)));
+        channel.runPendingTasks();
+      }
+      channel.writeInbound(
+          TcpMessageEncoder.encode(new ErrorMessage(StatusCodes.Bad_UnexpectedError, "rejected")));
+      ExecutionException failure =
+          assertThrows(ExecutionException.class, () -> handshake.get(2, TimeUnit.SECONDS));
+      assertEquals(acknowledged, failure.getCause() instanceof SecureChannelHandshakeException);
+      assertEquals(
+          StatusCodes.Bad_UnexpectedError,
+          UaException.extractStatusCode(failure).orElseThrow().value());
+    } finally {
+      channel.finishAndReleaseAll();
+      wheelTimer.stop();
+    }
+  }
 
   @Test
   void outboundInitializerUsesApplicationEndpointUrl() throws Exception {


### PR DESCRIPTION
Stacked on #1955, which carries the server half. Merge #1955 first; this PR's base will then move to integration/1.2.

Clients can recover after a server application certificate changes without replacing the client instance. An EndpointResolver repeats discovery and endpoint selection after SecureChannel establishment failures on a secured endpoint. URL-based client factories configure it automatically; directly constructed clients can supply their own resolver.

Refresh preserves the endpoint's URL, server identity, transport, security policy, security mode, and user token policies. Replacement certificates still pass the configured validator. Retained Sessions keep their original certificate inputs while reactivation uses the replacement channel's security bindings; the server side of that contract is in #1955.

Deferred requests have bounded channel waits and stay on the channel used to build their signatures. The refresh cooldown resets when a channel becomes ready, so a second rotation is not delayed by an earlier outage. The change includes rotation and recovery tests, a configuration example, and feature documentation.
