### PR TITLE
Hash a null ByteString the same as an empty one

### DIFF
--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/ByteString.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/ByteString.java
@@ -22,6 +22,9 @@ public record ByteString(byte @Nullable [] bytes) {
 
   public static final ByteString NULL_VALUE = new ByteString(null);
 
+  /** The hash of an empty array, which is also the hash of a null ByteString. */
+  private static final int NULL_OR_EMPTY_HASH_CODE = Arrays.hashCode(new byte[0]);
+
   public int length() {
     return bytes != null ? bytes.length : 0;
   }
@@ -88,7 +91,9 @@ public record ByteString(byte @Nullable [] bytes) {
 
   @Override
   public int hashCode() {
-    return Arrays.hashCode(bytes);
+    // equals() considers a null and an empty ByteString equal, but Arrays.hashCode() returns 0 for
+    // null and 1 for an empty array, so hash a null ByteString as if it were empty.
+    return bytes != null ? Arrays.hashCode(bytes) : NULL_OR_EMPTY_HASH_CODE;
   }
 
   @Override

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/types/builtin/ByteStringTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/types/builtin/ByteStringTest.java
@@ -12,7 +12,10 @@ package org.eclipse.milo.opcua.stack.core.types.builtin;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.HashSet;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 public class ByteStringTest {
@@ -35,5 +38,31 @@ public class ByteStringTest {
     assertEquals(new ByteString(new byte[0]), new ByteString(new byte[0]));
     assertEquals(new ByteString(null), new ByteString(new byte[0]));
     assertEquals(new ByteString(new byte[0]), new ByteString(null));
+  }
+
+  @Test
+  public void equalByteStringsHashTheSame() {
+    assertEquals(
+        ByteString.of(new byte[] {1, 2, 3, 4}).hashCode(),
+        ByteString.of(new byte[] {1, 2, 3, 4}).hashCode());
+  }
+
+  // nullEquality() pins that a null and an empty ByteString are equal, so they have to hash the
+  // same to be usable in a hash-based collection.
+  @Test
+  public void nullAndEmptyHashTheSame() {
+    ByteString nullValue = new ByteString(null);
+    ByteString empty = new ByteString(new byte[0]);
+
+    assertEquals(nullValue.hashCode(), empty.hashCode());
+
+    Set<ByteString> set = new HashSet<>();
+    set.add(nullValue);
+
+    assertTrue(set.contains(empty));
+
+    set.add(empty);
+
+    assertEquals(1, set.size());
   }
 }

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/types/builtin/NodeIdTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/types/builtin/NodeIdTest.java
@@ -15,6 +15,8 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
 import org.eclipse.milo.opcua.stack.core.NamespaceTable;
@@ -120,6 +122,29 @@ public class NodeIdTest {
         assertEquals(ByteString.of(bs), nodeId.getIdentifier());
       }
     }
+  }
+
+  // An opaque NodeId built on a null ByteString and one built on an empty ByteString are equal,
+  // and toParseableString() renders both as "b=", so a parse round trip has to preserve the hash
+  // as well as equality for the NodeId to survive a hash-based node lookup.
+  @Test
+  public void opaqueIdentifierNullAndEmptyHashTheSame() {
+    NodeId nullId = new NodeId(0, ByteString.NULL_VALUE);
+    NodeId emptyId = new NodeId(0, ByteString.of(new byte[0]));
+
+    assertEquals(nullId, emptyId);
+    assertEquals(nullId.hashCode(), emptyId.hashCode());
+
+    NodeId parsed = NodeId.parse(nullId.toParseableString());
+
+    assertEquals(nullId, parsed);
+    assertEquals(nullId.hashCode(), parsed.hashCode());
+
+    Map<NodeId, String> map = new HashMap<>();
+    map.put(nullId, "value");
+
+    assertEquals("value", map.get(emptyId));
+    assertEquals("value", map.get(parsed));
   }
 
   @Test


### PR DESCRIPTION
`ByteString.equals` deliberately treats a null and an empty ByteString as equal:

```java
return Arrays.equals(bytes, that.bytes) || (isNullOrEmpty() && that.isNullOrEmpty());
```

and the existing `ByteStringTest.nullEquality` pins that intent. `hashCode()` was plain
`Arrays.hashCode(bytes)`, which returns `0` for `null` and `1` for an empty array, so the two are
equal with different hashes and a `ByteString` stored under one form is not found under the other:

```java
ByteString nullValue = ByteString.NULL_VALUE;
ByteString empty = ByteString.of(new byte[0]);

nullValue.equals(empty);                   // true
nullValue.hashCode();                      // 0
empty.hashCode();                          // 1
Set.of(nullValue).contains(empty);         // false
```

### Knock-on: opaque NodeIds

`NodeId` hashes its identifier, so an opaque `NodeId` inherits the inconsistency:

```java
NodeId a = new NodeId(0, ByteString.NULL_VALUE);
NodeId b = new NodeId(0, ByteString.of(new byte[0]));

a.equals(b);                               // true
a.hashCode() == b.hashCode();              // false

Map<NodeId, String> map = new HashMap<>();
map.put(a, "value");
map.get(b);                                // null
```

`AbstractNodeManager` keys a `ConcurrentHashMap<NodeId, T>` on `NodeId`, so this is the shape of
lookup that misses.

`toParseableString()` renders both forms as `"b="`, so a parse round trip is affected too:
`NodeId.parse(a.toParseableString())` returns a `NodeId` that is equal to `a` but hashes
differently.

### Change

Hash a null ByteString as if it were empty. Nothing else changes: a non-null array still hashes to
`Arrays.hashCode(bytes)`, and an empty array already hashed to that same value, so only the null
case moves (0 to 1). The empty-array hash is held in a constant rather than calling
`Arrays.hashCode(bytesOrEmpty())`, so no array is allocated per hash.

This is the only builtin type affected. `QualifiedName.equals` has the same null/empty leniency but
its record `hashCode` already gives both forms `0`, and `XmlElement` and `LocalizedText` have no
such leniency — checked by running each.

### Tests

`ByteStringTest.nullAndEmptyHashTheSame` and `NodeIdTest.opaqueIdentifierNullAndEmptyHashTheSame`
both fail before the change and pass after:

```
ByteStringTest.nullAndEmptyHashTheSame              expected: <0> but was: <1>
NodeIdTest.opaqueIdentifierNullAndEmptyHashTheSame  expected: <0> but was: <1>
```

`ByteStringTest.equalByteStringsHashTheSame` is added as a plain regression guard and passes either
way.

Verified on JDK 17 with `mvn -pl opc-ua-sdk/integration-tests -am test`: stack-core, transport,
sdk-core, sdk-client, dtd-core, dtd-reader, sdk-server, encoding-json, encoding-xml and the
integration tests all pass — 2311 tests, 0 failures, 0 errors. `mvn -pl opc-ua-stack/stack-core
verify` passes, including `spotless:check`.

---

- [ ] You have signed an Eclipse Contributor Agreement and are committing using the same email address
- [x] Your code contains any tests relevant to the problem you are solving
- [x] All new and existing tests passed
- [x] Code follows the style guidelines and Checkstyle passes
