### PR TITLE
Harden EventFilter validation and event delivery isolation

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/events/EventDeliveryIsolationTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/events/EventDeliveryIsolationTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.events;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import java.util.List;
+import org.eclipse.milo.opcua.sdk.client.subscriptions.OpcUaSubscription;
+import org.eclipse.milo.opcua.sdk.server.EventListener;
+import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
+import org.eclipse.milo.opcua.sdk.test.AbstractClientServerTest;
+import org.eclipse.milo.opcua.sdk.test.EventTestSupport;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.structured.EventFilter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Tests that event delivery to a monitored item is independent of other registered listeners. */
+public class EventDeliveryIsolationTest extends AbstractClientServerTest {
+
+  /** Severity used by all events fired by this test; the where clause matches on it. */
+  private static final int TEST_SEVERITY = 43;
+
+  private final EventListener throwingListener =
+      event -> {
+        throw new IllegalStateException("listener failure");
+      };
+
+  private OpcUaSubscription subscription;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    // Registered before the monitored item so it is notified first.
+    server.getEventNotifier().register(throwingListener);
+
+    subscription = new OpcUaSubscription(client);
+    subscription.create();
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    subscription.delete();
+    server.getEventNotifier().unregister(throwingListener);
+  }
+
+  @Test
+  void eventIsDeliveredToItemRegisteredAfterAThrowingListener() throws Exception {
+    List<Variant[]> events =
+        EventTestSupport.monitorEvents(subscription, NodeIds.Server, eventFilter());
+
+    assertDoesNotThrow(() -> fireEvent("after throwing listener"));
+
+    EventTestSupport.awaitEvent(
+        events,
+        "message \"after throwing listener\"",
+        eventFields ->
+            eventFields[0].value() instanceof LocalizedText text
+                && "after throwing listener".equals(text.text()));
+  }
+
+  private void fireEvent(String message) throws Exception {
+    try (TransientEvent event = server.newEvent(NodeIds.BaseEventType)) {
+      BaseEventTypeNode eventNode = event.getNode();
+      eventNode.setBrowseName(newQualifiedName("EventDeliveryIsolationTest"));
+      eventNode.setDisplayName(LocalizedText.english("EventDeliveryIsolationTest"));
+      eventNode.setSourceNode(NodeIds.Server);
+      eventNode.setSourceName("Server");
+      eventNode.setMessage(LocalizedText.english(message));
+      eventNode.setSeverity(ushort(TEST_SEVERITY));
+      event.fire();
+    }
+  }
+
+  private static EventFilter eventFilter() {
+    return EventTestSupport.severityEventFilter(
+        TEST_SEVERITY, EventTestSupport.eventField(NodeIds.BaseEventType, "Message"));
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServer.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServer.java
@@ -1767,6 +1767,8 @@ public class OpcUaServer extends AbstractServiceHandler {
    */
   private static class ServerEventNotifier implements EventNotifier {
 
+    private static final Logger logger = LoggerFactory.getLogger(ServerEventNotifier.class);
+
     private final Set<EventListener> eventListeners =
         Collections.synchronizedSet(new LinkedHashSet<>());
 
@@ -1802,7 +1804,11 @@ public class OpcUaServer extends AbstractServiceHandler {
 
       for (EventListener eventListener : toNotify) {
         if (isInScope(eventListener, notifierScope)) {
-          eventListener.onEvent(event);
+          try {
+            eventListener.onEvent(event);
+          } catch (Exception e) {
+            logger.error("Error notifying EventListener {}: {}", eventListener, e.getMessage(), e);
+          }
         }
       }
     }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/DefaultConditionManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/conditions/DefaultConditionManager.java
@@ -263,8 +263,12 @@ public class DefaultConditionManager implements ConditionManager {
         // capture and cannot be followed by a stale retained snapshot inside that item's bracket.
         for (MonitoredEventItem eventItem : eventItems) {
           if (eventItem.isSamplingEnabled()) {
-            eventItem.onRefreshMarker(refreshStart);
-            startedItems.add(eventItem);
+            try {
+              eventItem.onRefreshMarker(refreshStart);
+              startedItems.add(eventItem);
+            } catch (Throwable t) {
+              logger.warn("Error delivering RefreshStart to item {}", eventItem.getId(), t);
+            }
           }
         }
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/EventContentFilter.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/EventContentFilter.java
@@ -343,15 +343,32 @@ public class EventContentFilter {
 
   @NonNull
   private static FilterOperand[] decodeOperands(
-      EncodingContext context, ExtensionObject @Nullable [] operandXos) {
+      EncodingContext context, ExtensionObject @Nullable [] operandXos) throws UaException {
 
     if (operandXos == null) {
       return new FilterOperand[0];
-    } else {
-      return Arrays.stream(operandXos)
-          .map(xo -> (FilterOperand) xo.decode(context))
-          .toArray(FilterOperand[]::new);
     }
+
+    var operands = new FilterOperand[operandXos.length];
+
+    for (int i = 0; i < operandXos.length; i++) {
+      Object decoded;
+      try {
+        decoded = operandXos[i].decode(context);
+      } catch (Exception e) {
+        throw new UaException(
+            StatusCodes.Bad_FilterOperandInvalid, "operand " + i + " could not be decoded", e);
+      }
+
+      if (decoded instanceof FilterOperand operand) {
+        operands[i] = operand;
+      } else {
+        throw new UaException(
+            StatusCodes.Bad_FilterOperandInvalid, "operand " + i + " is not a FilterOperand");
+      }
+    }
+
+    return operands;
   }
 
   @NonNull

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/EventContentFilter.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/EventContentFilter.java
@@ -202,16 +202,21 @@ public class EventContentFilter {
       return new ContentFilterResult(new ContentFilterElementResult[0], new DiagnosticInfo[0]);
     }
 
-    ContentFilterElementResult[] elementResults =
-        Arrays.stream(filterElements)
-            .map(e -> validateFilterElement(context, e))
-            .toArray(ContentFilterElementResult[]::new);
+    var elementResults = new ContentFilterElementResult[filterElements.length];
+
+    for (int i = 0; i < filterElements.length; i++) {
+      elementResults[i] =
+          validateFilterElement(context, filterElements[i], i, filterElements.length);
+    }
 
     return new ContentFilterResult(elementResults, new DiagnosticInfo[0]);
   }
 
   private static ContentFilterElementResult validateFilterElement(
-      @NonNull FilterContext context, @NonNull ContentFilterElement filterElement) {
+      @NonNull FilterContext context,
+      @NonNull ContentFilterElement filterElement,
+      int elementIndex,
+      int elementCount) {
 
     FilterOperator filterOperator = filterElement.getFilterOperator();
 
@@ -253,8 +258,9 @@ public class EventContentFilter {
           } catch (ValidationException e) {
             operandStatusCodes[i] = e.getStatusCode();
           }
-        } else if (operand instanceof ElementOperand) {
-          operandStatusCodes[i] = StatusCode.GOOD;
+        } else if (operand instanceof ElementOperand elementOperand) {
+          operandStatusCodes[i] =
+              validateElementOperand(elementOperand, elementIndex, elementCount);
         } else if (operand instanceof LiteralOperand) {
           operandStatusCodes[i] = StatusCode.GOOD;
         } else {
@@ -277,6 +283,22 @@ public class EventContentFilter {
 
     return new ContentFilterElementResult(
         operatorStatus, operandStatusCodes, new DiagnosticInfo[0]);
+  }
+
+  /**
+   * Part 4 §7.7.4.2: an ElementOperand index is valid only if it is greater than the index of the
+   * element it is part of and it does not reference a non-existent element.
+   */
+  private static StatusCode validateElementOperand(
+      ElementOperand operand, int elementIndex, int elementCount) {
+
+    UInteger index = operand.getIndex();
+
+    if (index == null || index.longValue() <= elementIndex || index.longValue() >= elementCount) {
+      return new StatusCode(StatusCodes.Bad_FilterOperandInvalid);
+    }
+
+    return StatusCode.GOOD;
   }
 
   public static Variant[] select(

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/EventContentFilter.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/EventContentFilter.java
@@ -12,8 +12,10 @@ package org.eclipse.milo.opcua.sdk.server.events;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -534,6 +536,11 @@ public class EventContentFilter {
     // Indices of the elements currently being evaluated, used to detect ElementOperand cycles.
     private final Set<Integer> evaluatingElements = new HashSet<>();
 
+    // Results of elements already evaluated for this event. Element evaluation has no side
+    // effects within a single event, so an element referenced from more than one place is
+    // evaluated once and its result (or failure) is reused.
+    private final Map<Integer, ElementResult> elementResults = new HashMap<>();
+
     DefaultOperatorContext(FilterContext filterContext, ContentFilterElement[] elements) {
       this.filterContext = filterContext;
       this.elements = elements;
@@ -569,6 +576,11 @@ public class EventContentFilter {
 
         int elementIndex = index.intValue();
 
+        ElementResult cached = elementResults.get(elementIndex);
+        if (cached != null) {
+          return cached.get();
+        }
+
         // Guard against self- or mutually referential ElementOperands, which would otherwise
         // recurse until a StackOverflowError escaped the per-event handler.
         if (!evaluatingElements.add(elementIndex)) {
@@ -577,11 +589,18 @@ public class EventContentFilter {
               "ElementOperand cycle detected at index: " + elementIndex);
         }
 
+        ElementResult result;
         try {
-          return evaluate(this, eventNode, elements[elementIndex]);
+          result = ElementResult.value(evaluate(this, eventNode, elements[elementIndex]));
+        } catch (UaException e) {
+          result = ElementResult.failure(e);
         } finally {
           evaluatingElements.remove(elementIndex);
         }
+
+        elementResults.put(elementIndex, result);
+
+        return result.get();
       } else if (operand instanceof AttributeOperand ao) {
         return getAttribute(filterContext, ao, eventNode);
       } else if (operand instanceof SimpleAttributeOperand sao) {
@@ -589,6 +608,25 @@ public class EventContentFilter {
       } else {
         throw new UaException(StatusCodes.Bad_FilterOperandInvalid);
       }
+    }
+  }
+
+  /** The outcome of evaluating one ContentFilterElement: a value (possibly null) or a failure. */
+  private record ElementResult(@Nullable Object value, @Nullable UaException failure) {
+
+    static ElementResult value(@Nullable Object value) {
+      return new ElementResult(value, null);
+    }
+
+    static ElementResult failure(UaException failure) {
+      return new ElementResult(null, failure);
+    }
+
+    @Nullable Object get() throws UaException {
+      if (failure != null) {
+        throw failure;
+      }
+      return value;
     }
   }
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/items/MonitoredEventItem.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/items/MonitoredEventItem.java
@@ -310,8 +310,13 @@ public class MonitoredEventItem extends BaseMonitoredItem<Variant[]> implements 
 
       boolean whereClauseGood =
           Stream.of(elementResults)
-              .map(ContentFilterElementResult::getStatusCode)
-              .allMatch(StatusCode::isGood);
+              .allMatch(
+                  elementResult ->
+                      elementResult.getStatusCode().isGood()
+                          && Stream.of(
+                                  requireNonNullElse(
+                                      elementResult.getOperandStatusCodes(), new StatusCode[0]))
+                              .allMatch(StatusCode::isGood));
 
       filterResultGood = selectClauseGood && whereClauseGood;
     } else {

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/items/MonitoredEventItem.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/items/MonitoredEventItem.java
@@ -131,7 +131,7 @@ public class MonitoredEventItem extends BaseMonitoredItem<Variant[]> implements 
           enqueueEvent(selectEventFields(eventNode), eventNode instanceof ConditionTypeNode);
         }
       }
-    } catch (UaException e) {
+    } catch (Exception e) {
       logger.error("Filter evaluation failed: {}", e.getMessage(), e);
     }
   }

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/ServerEventNotifierTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/ServerEventNotifierTest.java
@@ -10,10 +10,25 @@
 
 package org.eclipse.milo.opcua.sdk.server;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Constructor;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.eclipse.milo.opcua.sdk.core.typetree.ReferenceTypeTree;
+import org.eclipse.milo.opcua.sdk.server.items.EventItem;
+import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
+import org.eclipse.milo.opcua.stack.core.AttributeId;
+import org.eclipse.milo.opcua.stack.core.NamespaceTable;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.structured.ReadValueId;
 import org.junit.jupiter.api.Test;
 
 public class ServerEventNotifierTest {
@@ -48,13 +63,76 @@ public class ServerEventNotifierTest {
     assertEquals(0, eventCount.get());
   }
 
+  // Listeners are notified in registration order; an exception from one listener must not stop
+  // delivery to the listeners registered after it, and must not propagate to the caller of fire().
+  @Test
+  public void throwingListenerDoesNotBlockLaterListeners() throws Exception {
+    EventNotifier notifier = newServerEventNotifier();
+    AtomicInteger eventCount = new AtomicInteger();
+
+    notifier.register(
+        event -> {
+          throw new IllegalStateException("listener failure");
+        });
+    notifier.register(event -> eventCount.incrementAndGet());
+
+    assertDoesNotThrow(() -> notifier.fire(null));
+
+    assertEquals(1, eventCount.get());
+  }
+
+  // Notifier-scope filtering is applied per listener after the scope is resolved once per event;
+  // an in-scope listener that throws must neither stop later in-scope listeners nor let an
+  // out-of-scope listener receive the event.
+  @Test
+  public void throwingListenerDoesNotAffectScopeFilteringOfLaterListeners() throws Exception {
+    NodeId sourceNodeId = new NodeId(2, "source");
+    NodeId unrelatedNodeId = new NodeId(2, "unrelated");
+
+    OpcUaServer server = mock(OpcUaServer.class);
+    AddressSpaceManager addressSpaceManager = mock(AddressSpaceManager.class);
+    when(server.getAddressSpaceManager()).thenReturn(addressSpaceManager);
+    when(server.getReferenceTypeTree()).thenReturn(mock(ReferenceTypeTree.class));
+    when(server.getNamespaceTable()).thenReturn(new NamespaceTable());
+    when(addressSpaceManager.getManagedReferences(any(NodeId.class), any())).thenReturn(List.of());
+
+    BaseEventTypeNode event = mock(BaseEventTypeNode.class);
+    when(event.getSourceNode()).thenReturn(sourceNodeId);
+
+    EventItem throwingInScopeItem = eventItem(sourceNodeId);
+    doThrow(new IllegalStateException("listener failure")).when(throwingInScopeItem).onEvent(any());
+    EventItem inScopeItem = eventItem(sourceNodeId);
+    EventItem outOfScopeItem = eventItem(unrelatedNodeId);
+
+    EventNotifier notifier = newServerEventNotifier(server);
+    notifier.register(throwingInScopeItem);
+    notifier.register(inScopeItem);
+    notifier.register(outOfScopeItem);
+
+    assertDoesNotThrow(() -> notifier.fire(event));
+
+    verify(inScopeItem).onEvent(event);
+    verify(outOfScopeItem, never()).onEvent(any());
+  }
+
+  private static EventItem eventItem(NodeId monitoredNodeId) {
+    EventItem item = mock(EventItem.class);
+    when(item.getReadValueId())
+        .thenReturn(new ReadValueId(monitoredNodeId, AttributeId.EventNotifier.uid(), null, null));
+    return item;
+  }
+
   private static EventNotifier newServerEventNotifier() throws Exception {
+    return newServerEventNotifier(null);
+  }
+
+  private static EventNotifier newServerEventNotifier(OpcUaServer server) throws Exception {
     Class<?> notifierClass = Class.forName(OpcUaServer.class.getName() + "$ServerEventNotifier");
     Constructor<?> constructor = notifierClass.getDeclaredConstructor(OpcUaServer.class);
     constructor.setAccessible(true);
 
-    // a null OpcUaServer is sufficient: firing a null event resolves an empty notifier scope
-    // without consulting the server, and non-item listeners are always in scope.
-    return (EventNotifier) constructor.newInstance(new Object[] {null});
+    // a null OpcUaServer is sufficient when firing a null event: it resolves an empty notifier
+    // scope without consulting the server, and non-item listeners are always in scope.
+    return (EventNotifier) constructor.newInstance(new Object[] {server});
   }
 }

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/conditions/DefaultConditionManagerTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/conditions/DefaultConditionManagerTest.java
@@ -10,17 +10,37 @@
 
 package org.eclipse.milo.opcua.sdk.server.conditions;
 
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
+import java.util.Map;
 import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.sdk.server.Session;
+import org.eclipse.milo.opcua.sdk.server.events.TransientEvent;
+import org.eclipse.milo.opcua.sdk.server.items.BaseMonitoredItem;
+import org.eclipse.milo.opcua.sdk.server.items.MonitoredEventItem;
+import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
+import org.eclipse.milo.opcua.sdk.server.subscriptions.Subscription;
+import org.eclipse.milo.opcua.stack.core.AttributeId;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.structured.ReadValueId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
 
-/** Tests runtime-resource ownership in {@link DefaultConditionManager}. */
+/** Tests runtime-resource ownership and refresh delivery in {@link DefaultConditionManager}. */
 public class DefaultConditionManagerTest {
 
   /**
@@ -66,5 +86,108 @@ public class DefaultConditionManagerTest {
     verify(original).shutdown();
     verify(replacement, never()).shutdown();
     assertTrue(manager.findCondition(conditionId).isPresent());
+  }
+
+  /**
+   * ConditionRefresh delivers a RefreshStart marker, every retained Condition snapshot, and a
+   * RefreshEnd marker to each event item of the Subscription. Delivery to one item must be
+   * independent of the others (Part 9 §4.5).
+   */
+  @Nested
+  class RefreshDelivery {
+
+    private static final UInteger SUBSCRIPTION_ID = uint(7);
+
+    private final OpcUaServer server = mock(OpcUaServer.class);
+    private final Session session = mock(Session.class);
+    private final Subscription subscription = mock(Subscription.class);
+
+    private final BaseEventTypeNode refreshStart = mock(BaseEventTypeNode.class);
+    private final BaseEventTypeNode refreshEnd = mock(BaseEventTypeNode.class);
+    private final BaseEventTypeNode snapshotNode = mock(BaseEventTypeNode.class);
+
+    private final MonitoredEventItem itemA = eventItem(1);
+    private final MonitoredEventItem itemB = eventItem(2);
+
+    private DefaultConditionManager manager;
+
+    @BeforeEach
+    void setUp() throws Exception {
+      NodeId sessionId = new NodeId(1, "session");
+      when(session.getSessionId()).thenReturn(sessionId);
+      when(subscription.getSession()).thenReturn(session);
+      Map<UInteger, BaseMonitoredItem<?>> monitoredItems = Map.of(uint(1), itemA, uint(2), itemB);
+      when(subscription.getMonitoredItems()).thenReturn(monitoredItems);
+      when(server.getSubscriptions()).thenReturn(Map.of(SUBSCRIPTION_ID, subscription));
+
+      when(server.newEvent(NodeIds.RefreshStartEventType))
+          .thenReturn(new TransientEvent(server, refreshStart));
+      when(server.newEvent(NodeIds.RefreshEndEventType))
+          .thenReturn(new TransientEvent(server, refreshEnd));
+
+      Condition condition = mock(Condition.class);
+      when(condition.getConditionId()).thenReturn(new NodeId(1, "condition"));
+      when(condition.createRefreshSnapshots())
+          .thenReturn(List.of(new ConditionEventSnapshot(snapshotNode)));
+
+      manager = new DefaultConditionManager(server);
+      manager.register(condition);
+    }
+
+    // An item whose filtered replay delivery throws must still have its bracket closed, and must
+    // not affect the full bracket delivered to the other item.
+    @Test
+    void replayFailureOnOneItemDoesNotAffectOtherItemsOrItsOwnRefreshEnd() throws Exception {
+      doThrow(new IllegalStateException("replay failure")).when(itemA).onEvent(any());
+
+      assertDoesNotThrow(() -> manager.conditionRefresh(session, SUBSCRIPTION_ID));
+
+      assertFullBracket(itemB);
+      InOrder inOrderA = inOrder(itemA);
+      inOrderA.verify(itemA).onRefreshMarker(refreshStart);
+      inOrderA.verify(itemA).onRefreshMarker(refreshEnd);
+    }
+
+    // An item whose RefreshStart delivery throws never opened a bracket, so it receives nothing
+    // further; the other item's bracket is unaffected.
+    @Test
+    void refreshStartFailureOnOneItemDoesNotAffectOtherItems() throws Exception {
+      doThrow(new IllegalStateException("marker failure"))
+          .when(itemA)
+          .onRefreshMarker(refreshStart);
+
+      assertDoesNotThrow(() -> manager.conditionRefresh(session, SUBSCRIPTION_ID));
+
+      assertFullBracket(itemB);
+      verify(itemA, never()).onEvent(any());
+      verify(itemA, never()).onRefreshMarker(refreshEnd);
+    }
+
+    // The per-Subscription refresh guard must be released after a delivery failure, otherwise
+    // every later refresh of the Subscription fails with Bad_RefreshInProgress.
+    @Test
+    void deliveryFailureReleasesRefreshGuard() throws Exception {
+      doThrow(new IllegalStateException("marker failure")).when(itemA).onRefreshMarker(any());
+
+      manager.conditionRefresh(session, SUBSCRIPTION_ID);
+
+      assertDoesNotThrow(() -> manager.conditionRefresh(session, SUBSCRIPTION_ID));
+    }
+
+    private void assertFullBracket(MonitoredEventItem item) {
+      InOrder inOrder = inOrder(item);
+      inOrder.verify(item).onRefreshMarker(refreshStart);
+      inOrder.verify(item).onEvent(snapshotNode);
+      inOrder.verify(item).onRefreshMarker(refreshEnd);
+    }
+
+    private static MonitoredEventItem eventItem(int id) {
+      MonitoredEventItem item = mock(MonitoredEventItem.class);
+      when(item.getId()).thenReturn(uint(id));
+      when(item.isSamplingEnabled()).thenReturn(true);
+      when(item.getReadValueId())
+          .thenReturn(new ReadValueId(NodeIds.Server, AttributeId.EventNotifier.uid(), null, null));
+      return item;
+    }
   }
 }

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/EventContentFilterTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/EventContentFilterTest.java
@@ -14,10 +14,12 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.time.Duration;
 import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
 import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
 import org.eclipse.milo.opcua.stack.core.AttributeId;
@@ -200,6 +202,52 @@ public class EventContentFilterTest {
 
       assertTrue(elementResult.getStatusCode().isGood());
       assertTrue(elementResult.getOperandStatusCodes()[0].isGood());
+    }
+  }
+
+  @Nested
+  class ElementOperandEvaluation {
+
+    // Each element is evaluated at most once per event. A chain in which every element references
+    // the next one twice would otherwise require 2^n evaluations; And only short-circuits on
+    // FALSE, so a TRUE-terminated chain forces both operands at every level.
+    @Test
+    void sharedElementIsEvaluatedOncePerEvent() {
+      int chainLength = 48;
+      ContentFilterElement[] elements = new ContentFilterElement[chainLength];
+
+      for (int i = 0; i < chainLength - 1; i++) {
+        elements[i] = element(FilterOperator.And, elementOperand(i + 1), elementOperand(i + 1));
+      }
+      elements[chainLength - 1] = element(FilterOperator.Equals, literal(1), literal(1));
+
+      boolean result =
+          assertTimeoutPreemptively(
+              Duration.ofSeconds(10),
+              () ->
+                  EventContentFilter.evaluate(
+                      filterContext(), new ContentFilter(elements), mock(BaseEventTypeNode.class)));
+
+      assertTrue(result);
+    }
+
+    // The evaluation result cache must not defeat cycle detection, which happens while the
+    // referenced element is still on the evaluation path and not yet cached.
+    @Test
+    void cyclicElementOperandFailsEvaluationWithBadFilterOperandInvalid() {
+      ContentFilterElement[] elements = {
+        element(FilterOperator.And, elementOperand(1), literal(true)),
+        element(FilterOperator.Not, elementOperand(0))
+      };
+
+      UaException e =
+          assertThrows(
+              UaException.class,
+              () ->
+                  EventContentFilter.evaluate(
+                      filterContext(), new ContentFilter(elements), mock(BaseEventTypeNode.class)));
+
+      assertEquals(StatusCodes.Bad_FilterOperandInvalid, e.getStatusCode().value());
     }
   }
 

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/EventContentFilterTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/EventContentFilterTest.java
@@ -34,6 +34,7 @@ import org.eclipse.milo.opcua.stack.core.types.enumerated.FilterOperator;
 import org.eclipse.milo.opcua.stack.core.types.structured.ContentFilter;
 import org.eclipse.milo.opcua.stack.core.types.structured.ContentFilterElement;
 import org.eclipse.milo.opcua.stack.core.types.structured.ContentFilterElementResult;
+import org.eclipse.milo.opcua.stack.core.types.structured.ElementOperand;
 import org.eclipse.milo.opcua.stack.core.types.structured.EventFilter;
 import org.eclipse.milo.opcua.stack.core.types.structured.EventFilterResult;
 import org.eclipse.milo.opcua.stack.core.types.structured.FilterOperand;
@@ -42,6 +43,8 @@ import org.eclipse.milo.opcua.stack.core.types.structured.ReadValueId;
 import org.eclipse.milo.opcua.stack.core.types.structured.SimpleAttributeOperand;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 public class EventContentFilterTest {
 
@@ -154,6 +157,52 @@ public class EventContentFilterTest {
     }
   }
 
+  @Nested
+  class ElementOperandValidation {
+
+    /**
+     * Part 4 §7.7.4.2: an ElementOperand index is valid only if it is greater than the index of the
+     * element it is part of and it references an existing element.
+     */
+    @ParameterizedTest(name = "element {0} referencing element {1}")
+    @CsvSource({"0, 0", "1, 0", "1, 1", "0, 2", "1, 2"})
+    void backwardSelfOrOutOfRangeElementOperandIsRejected(int elementIndex, int referencedIndex)
+        throws Exception {
+
+      ContentFilterElement[] elements = new ContentFilterElement[2];
+      elements[elementIndex] = element(FilterOperator.Not, elementOperand(referencedIndex));
+      elements[1 - elementIndex] = element(FilterOperator.IsNull, literal(null));
+
+      EventFilterResult result =
+          EventContentFilter.validate(filterContext(), eventFilter(elements));
+
+      ContentFilterElementResult elementResult =
+          result.getWhereClauseResult().getElementResults()[elementIndex];
+
+      assertEquals(
+          StatusCodes.Bad_FilterOperandInvalid,
+          elementResult.getOperandStatusCodes()[0].value(),
+          "operand status code");
+    }
+
+    @Test
+    void forwardElementOperandIsAccepted() throws Exception {
+      ContentFilterElement[] elements = {
+        element(FilterOperator.Not, elementOperand(1)),
+        element(FilterOperator.IsNull, literal(null))
+      };
+
+      EventFilterResult result =
+          EventContentFilter.validate(filterContext(), eventFilter(elements));
+
+      ContentFilterElementResult elementResult =
+          result.getWhereClauseResult().getElementResults()[0];
+
+      assertTrue(elementResult.getStatusCode().isGood());
+      assertTrue(elementResult.getOperandStatusCodes()[0].isGood());
+    }
+  }
+
   private static FilterContext filterContext() {
     OpcUaServer server = mock(OpcUaServer.class);
     when(server.getStaticEncodingContext()).thenReturn(DefaultEncodingContext.INSTANCE);
@@ -188,5 +237,9 @@ public class EventContentFilterTest {
 
   private static LiteralOperand literal(Object value) {
     return new LiteralOperand(new Variant(value));
+  }
+
+  private static ElementOperand elementOperand(int index) {
+    return new ElementOperand(uint(index));
   }
 }

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/EventContentFilterTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/EventContentFilterTest.java
@@ -13,16 +13,21 @@ package org.eclipse.milo.opcua.sdk.server.events;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
 import org.eclipse.milo.opcua.stack.core.AttributeId;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.FilterOperator;
@@ -33,7 +38,9 @@ import org.eclipse.milo.opcua.stack.core.types.structured.EventFilter;
 import org.eclipse.milo.opcua.stack.core.types.structured.EventFilterResult;
 import org.eclipse.milo.opcua.stack.core.types.structured.FilterOperand;
 import org.eclipse.milo.opcua.stack.core.types.structured.LiteralOperand;
+import org.eclipse.milo.opcua.stack.core.types.structured.ReadValueId;
 import org.eclipse.milo.opcua.stack.core.types.structured.SimpleAttributeOperand;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 public class EventContentFilterTest {
@@ -90,6 +97,61 @@ public class EventContentFilterTest {
         StatusCodes.Bad_FilterOperatorUnsupported, elementResults[0].getStatusCode().value());
     assertEquals(
         StatusCodes.Bad_FilterOperatorUnsupported, elementResults[1].getStatusCode().value());
+  }
+
+  @Nested
+  class OperandDecoding {
+
+    // Operands are decoded again on every event. An operand that decodes to a structure other
+    // than a FilterOperand must be reported as a filter error, not as an unchecked
+    // ClassCastException
+    // escaping the event delivery path.
+    @Test
+    void operandThatIsNotAFilterOperandFailsEvaluationWithBadFilterOperandInvalid() {
+      ExtensionObject notAFilterOperand =
+          ExtensionObject.encode(
+              DefaultEncodingContext.INSTANCE,
+              new ReadValueId(NodeIds.Server, AttributeId.Value.uid(), null, null));
+
+      ContentFilter whereClause =
+          new ContentFilter(
+              new ContentFilterElement[] {
+                new ContentFilterElement(
+                    FilterOperator.IsNull, new ExtensionObject[] {notAFilterOperand})
+              });
+
+      UaException e =
+          assertThrows(
+              UaException.class,
+              () ->
+                  EventContentFilter.evaluate(
+                      filterContext(), whereClause, mock(BaseEventTypeNode.class)));
+
+      assertEquals(StatusCodes.Bad_FilterOperandInvalid, e.getStatusCode().value());
+    }
+
+    // An operand with an encoding id the server cannot decode must likewise be reported as a
+    // filter error rather than an unchecked UaSerializationException.
+    @Test
+    void operandThatCannotBeDecodedFailsEvaluationWithBadFilterOperandInvalid() {
+      ExtensionObject undecodable =
+          ExtensionObject.of(ByteString.of(new byte[] {0}), new NodeId(2, 999));
+
+      ContentFilter whereClause =
+          new ContentFilter(
+              new ContentFilterElement[] {
+                new ContentFilterElement(FilterOperator.IsNull, new ExtensionObject[] {undecodable})
+              });
+
+      UaException e =
+          assertThrows(
+              UaException.class,
+              () ->
+                  EventContentFilter.evaluate(
+                      filterContext(), whereClause, mock(BaseEventTypeNode.class)));
+
+      assertEquals(StatusCodes.Bad_FilterOperandInvalid, e.getStatusCode().value());
+    }
   }
 
   private static FilterContext filterContext() {

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/items/MonitoredEventItemTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/items/MonitoredEventItemTest.java
@@ -11,8 +11,10 @@
 package org.eclipse.milo.opcua.sdk.server.items;
 
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -131,6 +133,33 @@ class MonitoredEventItemTest {
 
       item.onRefreshMarker(eventNode);
 
+      assertEquals(0, drainNotifications().size());
+    }
+  }
+
+  @Nested
+  class FilterEvaluation {
+
+    // Event delivery loops call onEvent for every registered item; an unexpected exception from
+    // evaluating one item's filter must be contained in that item.
+    @Test
+    void unexpectedExceptionDuringEvaluationDoesNotPropagate() throws Exception {
+      item.installFilter(
+          eventFilter(
+              where(
+                  element(
+                      FilterOperator.Equals,
+                      new SimpleAttributeOperand(
+                          NodeIds.BaseEventType,
+                          new QualifiedName[] {new QualifiedName(0, "Severity")},
+                          AttributeId.Value.uid(),
+                          null),
+                      literal(1)))));
+
+      when(eventNode.findNode(any(QualifiedName.class), any(), any()))
+          .thenThrow(new IllegalStateException("event node lookup failure"));
+
+      assertDoesNotThrow(() -> item.onEvent(eventNode));
       assertEquals(0, drainNotifications().size());
     }
   }

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/items/MonitoredEventItemTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/items/MonitoredEventItemTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.items;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.eclipse.milo.opcua.sdk.core.typetree.ReferenceTypeTree;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.sdk.server.Session;
+import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNodeContext;
+import org.eclipse.milo.opcua.stack.core.AttributeId;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
+import org.eclipse.milo.opcua.stack.core.types.UaStructuredType;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.FilterOperator;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.MonitoringMode;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.TimestampsToReturn;
+import org.eclipse.milo.opcua.stack.core.types.structured.ContentFilter;
+import org.eclipse.milo.opcua.stack.core.types.structured.ContentFilterElement;
+import org.eclipse.milo.opcua.stack.core.types.structured.ContentFilterElementResult;
+import org.eclipse.milo.opcua.stack.core.types.structured.ElementOperand;
+import org.eclipse.milo.opcua.stack.core.types.structured.EventFilter;
+import org.eclipse.milo.opcua.stack.core.types.structured.EventFilterResult;
+import org.eclipse.milo.opcua.stack.core.types.structured.FilterOperand;
+import org.eclipse.milo.opcua.stack.core.types.structured.LiteralOperand;
+import org.eclipse.milo.opcua.stack.core.types.structured.ReadValueId;
+import org.eclipse.milo.opcua.stack.core.types.structured.SimpleAttributeOperand;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class MonitoredEventItemTest {
+
+  private final OpcUaServer server = mock(OpcUaServer.class);
+  private final BaseEventTypeNode eventNode = mock(BaseEventTypeNode.class);
+
+  private MonitoredEventItem item;
+
+  @BeforeEach
+  void setUp() {
+    when(server.getStaticEncodingContext()).thenReturn(DefaultEncodingContext.INSTANCE);
+    when(server.getReferenceTypeTree()).thenReturn(mock(ReferenceTypeTree.class));
+
+    UaNodeContext nodeContext = mock(UaNodeContext.class);
+    when(nodeContext.getServer()).thenReturn(server);
+    when(eventNode.getNodeContext()).thenReturn(nodeContext);
+
+    item =
+        new MonitoredEventItem(
+            server,
+            mock(Session.class),
+            uint(1),
+            uint(1),
+            new ReadValueId(NodeIds.Server, AttributeId.EventNotifier.uid(), null, null),
+            MonitoringMode.Reporting,
+            TimestampsToReturn.Neither,
+            uint(1),
+            0.0,
+            uint(10),
+            true);
+  }
+
+  @Nested
+  class FilterArming {
+
+    /**
+     * Element 1's operand is a structure that is not a FilterOperand, so validation reports the
+     * element as Good but its operand as Bad_FilterOperandInvalid. Element 0 is Or(true, Element
+     * 1), which never resolves element 1, so the where clause evaluates to true if it is armed.
+     */
+    private final ContentFilter badOperandWhereClause =
+        where(
+            element(FilterOperator.Or, literal(true), elementOperand(1)),
+            element(FilterOperator.IsNull, notAFilterOperand()));
+
+    @Test
+    void filterWithBadOperandStatusIsNotArmed() throws Exception {
+      item.installFilter(eventFilter(badOperandWhereClause));
+
+      EventFilterResult filterResult = decodeFilterResult();
+      ContentFilterElementResult elementResult =
+          filterResult.getWhereClauseResult().getElementResults()[1];
+      assertTrue(elementResult.getStatusCode().isGood(), "element status");
+      assertEquals(
+          StatusCodes.Bad_FilterOperandInvalid,
+          elementResult.getOperandStatusCodes()[0].value(),
+          "operand status");
+
+      item.onEvent(eventNode);
+
+      assertEquals(
+          0, drainNotifications().size(), "event delivered by a filter with a bad operand");
+    }
+
+    // Control for the test above: the same where clause shape with a valid operand is armed.
+    @Test
+    void filterWithGoodOperandStatusIsArmed() throws Exception {
+      item.installFilter(
+          eventFilter(
+              where(
+                  element(FilterOperator.Or, literal(true), elementOperand(1)),
+                  element(FilterOperator.IsNull, literal(null)))));
+
+      item.onEvent(eventNode);
+
+      assertEquals(1, drainNotifications().size());
+    }
+
+    @Test
+    void refreshMarkerIsNotDeliveredByAFilterThatIsNotArmed() throws Exception {
+      item.installFilter(eventFilter(badOperandWhereClause));
+
+      item.onRefreshMarker(eventNode);
+
+      assertEquals(0, drainNotifications().size());
+    }
+  }
+
+  private EventFilterResult decodeFilterResult() {
+    return (EventFilterResult) item.getFilterResult().decode(DefaultEncodingContext.INSTANCE);
+  }
+
+  private List<UaStructuredType> drainNotifications() {
+    var notifications = new ArrayList<UaStructuredType>();
+    item.getNotifications(notifications, Integer.MAX_VALUE);
+    return notifications;
+  }
+
+  private static EventFilter eventFilter(ContentFilter whereClause) {
+    SimpleAttributeOperand selectClause =
+        new SimpleAttributeOperand(
+            NodeIds.BaseEventType,
+            new QualifiedName[] {new QualifiedName(0, "Message")},
+            AttributeId.Value.uid(),
+            null);
+
+    return new EventFilter(new SimpleAttributeOperand[] {selectClause}, whereClause);
+  }
+
+  private static ContentFilter where(ContentFilterElement... elements) {
+    return new ContentFilter(elements);
+  }
+
+  private static ContentFilterElement element(FilterOperator operator, Object... operands) {
+    var encodedOperands = new ExtensionObject[operands.length];
+
+    for (int i = 0; i < operands.length; i++) {
+      encodedOperands[i] =
+          operands[i] instanceof ExtensionObject xo
+              ? xo
+              : ExtensionObject.encode(
+                  DefaultEncodingContext.INSTANCE, (FilterOperand) operands[i]);
+    }
+
+    return new ContentFilterElement(operator, encodedOperands);
+  }
+
+  private static ExtensionObject notAFilterOperand() {
+    return ExtensionObject.encode(
+        DefaultEncodingContext.INSTANCE,
+        new ReadValueId(NodeIds.Server, AttributeId.Value.uid(), null, null));
+  }
+
+  private static LiteralOperand literal(Object value) {
+    return new LiteralOperand(new Variant(value));
+  }
+
+  private static ElementOperand elementOperand(int index) {
+    return new ElementOperand(uint(index));
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/subscriptions/SubscriptionManagerEventItemTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/subscriptions/SubscriptionManagerEventItemTest.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.subscriptions;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ubyte;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicLong;
+import org.eclipse.milo.opcua.sdk.server.AddressSpace.RevisedEventItemParameters;
+import org.eclipse.milo.opcua.sdk.server.AddressSpaceManager;
+import org.eclipse.milo.opcua.sdk.server.EventNotifier;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServerConfig;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServerConfigLimits;
+import org.eclipse.milo.opcua.sdk.server.Session;
+import org.eclipse.milo.opcua.sdk.server.items.BaseMonitoredItem;
+import org.eclipse.milo.opcua.sdk.server.items.MonitoredEventItem;
+import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
+import org.eclipse.milo.opcua.sdk.server.servicesets.impl.AccessController;
+import org.eclipse.milo.opcua.sdk.server.servicesets.impl.AccessController.AccessResult;
+import org.eclipse.milo.opcua.stack.core.AttributeId;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
+import org.eclipse.milo.opcua.stack.core.types.UaStructuredType;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.FilterOperator;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.MonitoringMode;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.TimestampsToReturn;
+import org.eclipse.milo.opcua.stack.core.types.structured.ContentFilter;
+import org.eclipse.milo.opcua.stack.core.types.structured.ContentFilterElement;
+import org.eclipse.milo.opcua.stack.core.types.structured.ContentFilterElementResult;
+import org.eclipse.milo.opcua.stack.core.types.structured.CreateMonitoredItemsRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.CreateMonitoredItemsResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.EventFilter;
+import org.eclipse.milo.opcua.stack.core.types.structured.EventFilterResult;
+import org.eclipse.milo.opcua.stack.core.types.structured.MonitoredItemCreateRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.MonitoredItemCreateResult;
+import org.eclipse.milo.opcua.stack.core.types.structured.MonitoringParameters;
+import org.eclipse.milo.opcua.stack.core.types.structured.ReadValueId;
+import org.eclipse.milo.opcua.stack.core.types.structured.RequestHeader;
+import org.eclipse.milo.opcua.stack.core.types.structured.SetMonitoringModeRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.SimpleAttributeOperand;
+import org.eclipse.milo.opcua.stack.transport.server.ServiceRequestContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the handling of event items whose filter validates with errors, through the
+ * CreateMonitoredItems registration path and the SetMonitoringMode registration toggle.
+ */
+class SubscriptionManagerEventItemTest {
+
+  private static final UInteger SUBSCRIPTION_ID = uint(1);
+
+  private final Map<UInteger, BaseMonitoredItem<?>> ownedMonitoredItems = new HashMap<>();
+
+  private final OpcUaServer server = mock(OpcUaServer.class);
+  private final AccessController accessController = mock(AccessController.class);
+  private final AddressSpaceManager addressSpaceManager = mock(AddressSpaceManager.class);
+  private final EventNotifier eventNotifier = mock(EventNotifier.class);
+  private final Session session = mock(Session.class);
+  private final ServiceRequestContext context = mock(ServiceRequestContext.class);
+
+  private final ReadValueId itemToMonitor =
+      new ReadValueId(
+          NodeIds.Server, AttributeId.EventNotifier.uid(), null, QualifiedName.NULL_VALUE);
+
+  private SubscriptionManager manager;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    OpcUaServerConfigLimits limits =
+        new OpcUaServerConfigLimits() {
+          @Override
+          public UInteger getMaxMonitoredItems() {
+            return uint(100);
+          }
+
+          @Override
+          public UInteger getMaxMonitoredItemsPerSession() {
+            return uint(100);
+          }
+        };
+
+    OpcUaServerConfig config = mock(OpcUaServerConfig.class);
+    when(config.getExecutor()).thenReturn(mock(ExecutorService.class));
+    when(config.getLimits()).thenReturn(limits);
+
+    when(server.getConfig()).thenReturn(config);
+    when(server.getAccessController()).thenReturn(accessController);
+    when(server.getAddressSpaceManager()).thenReturn(addressSpaceManager);
+    when(server.getEventNotifier()).thenReturn(eventNotifier);
+    when(server.getStaticEncodingContext()).thenReturn(DefaultEncodingContext.INSTANCE);
+    when(server.getMonitoredItemCount()).thenReturn(new AtomicLong());
+
+    manager = new SubscriptionManager(session, server);
+
+    Subscription subscription = mock(Subscription.class);
+    when(subscription.getId()).thenReturn(SUBSCRIPTION_ID);
+    when(subscription.getMonitoredItems()).thenReturn(ownedMonitoredItems);
+    when(subscription.nextItemId()).thenReturn(1L);
+    doAnswer(
+            invocation -> {
+              List<BaseMonitoredItem<?>> items = invocation.getArgument(0);
+              items.forEach(item -> ownedMonitoredItems.put(item.getId(), item));
+              return null;
+            })
+        .when(subscription)
+        .addMonitoredItems(anyList());
+    subscriptions(manager).put(SUBSCRIPTION_ID, subscription);
+
+    when(accessController.checkReadAccess(eq(session), anyList()))
+        .thenReturn(Map.of(itemToMonitor, AccessResult.ALLOWED));
+    when(addressSpaceManager.read(any(), eq(0.0), eq(TimestampsToReturn.Neither), anyList()))
+        .thenReturn(
+            List.of(
+                new DataValue(new Variant(NodeClass.Object)),
+                new DataValue(new Variant(ubyte(1))),
+                new DataValue(new Variant(NodeIds.BaseDataType)),
+                new DataValue(new Variant(0.0))));
+    when(addressSpaceManager.onCreateEventItem(itemToMonitor, uint(1)))
+        .thenReturn(new RevisedEventItemParameters(uint(1)));
+  }
+
+  // A filter that validates with an operand error is reported in the EventFilterResult of a Good
+  // item result; the item is registered with the EventNotifier like any other but delivers nothing.
+  @Test
+  void itemWithRejectedFilterOperandIsCreatedRegisteredAndDeliversNothing() throws Exception {
+    CreateMonitoredItemsResponse response =
+        manager.createMonitoredItems(context, createRequest(createItem(badOperandEventFilter())));
+
+    MonitoredItemCreateResult result = response.getResults()[0];
+    assertEquals(StatusCode.GOOD, result.getStatusCode());
+
+    EventFilterResult filterResult =
+        (EventFilterResult) result.getFilterResult().decode(DefaultEncodingContext.INSTANCE);
+    ContentFilterElementResult elementResult =
+        filterResult.getWhereClauseResult().getElementResults()[0];
+    assertEquals(
+        StatusCodes.Bad_FilterOperandInvalid, elementResult.getOperandStatusCodes()[0].value());
+
+    MonitoredEventItem item =
+        assertInstanceOf(
+            MonitoredEventItem.class, ownedMonitoredItems.get(result.getMonitoredItemId()));
+    verify(eventNotifier).register(item);
+
+    item.onEvent(mock(BaseEventTypeNode.class));
+
+    var notifications = new ArrayList<UaStructuredType>();
+    item.getNotifications(notifications, Integer.MAX_VALUE);
+    assertEquals(0, notifications.size());
+  }
+
+  // SetMonitoringMode toggles EventNotifier registration by sampling state regardless of the
+  // filter's validation result.
+  @Test
+  void monitoringModeTogglesRegistrationOfItemWithRejectedFilterOperand() throws Exception {
+    CreateMonitoredItemsResponse response =
+        manager.createMonitoredItems(context, createRequest(createItem(badOperandEventFilter())));
+    UInteger itemId = response.getResults()[0].getMonitoredItemId();
+    MonitoredEventItem item =
+        assertInstanceOf(MonitoredEventItem.class, ownedMonitoredItems.get(itemId));
+
+    manager
+        .setMonitoringMode(context, setMonitoringModeRequest(MonitoringMode.Disabled, itemId))
+        .get();
+    verify(eventNotifier).unregister(item);
+
+    manager
+        .setMonitoringMode(context, setMonitoringModeRequest(MonitoringMode.Reporting, itemId))
+        .get();
+    verify(eventNotifier, times(2)).register(item);
+  }
+
+  private static ExtensionObject badOperandEventFilter() {
+    var selectClause =
+        new SimpleAttributeOperand(
+            NodeIds.BaseEventType,
+            new QualifiedName[] {new QualifiedName(0, "Message")},
+            AttributeId.Value.uid(),
+            null);
+
+    ExtensionObject notAFilterOperand =
+        ExtensionObject.encode(
+            DefaultEncodingContext.INSTANCE,
+            new ReadValueId(NodeIds.Server, AttributeId.Value.uid(), null, null));
+
+    var whereClause =
+        new ContentFilter(
+            new ContentFilterElement[] {
+              new ContentFilterElement(
+                  FilterOperator.IsNull, new ExtensionObject[] {notAFilterOperand})
+            });
+
+    return ExtensionObject.encode(
+        DefaultEncodingContext.INSTANCE,
+        new EventFilter(new SimpleAttributeOperand[] {selectClause}, whereClause));
+  }
+
+  private MonitoredItemCreateRequest createItem(ExtensionObject filter) {
+    return new MonitoredItemCreateRequest(
+        itemToMonitor,
+        MonitoringMode.Reporting,
+        new MonitoringParameters(uint(1), 0.0, filter, uint(1), true));
+  }
+
+  private static CreateMonitoredItemsRequest createRequest(
+      MonitoredItemCreateRequest... itemsToCreate) {
+
+    return new CreateMonitoredItemsRequest(
+        requestHeader(), SUBSCRIPTION_ID, TimestampsToReturn.Both, itemsToCreate);
+  }
+
+  private static SetMonitoringModeRequest setMonitoringModeRequest(
+      MonitoringMode monitoringMode, UInteger... itemIds) {
+
+    return new SetMonitoringModeRequest(requestHeader(), SUBSCRIPTION_ID, monitoringMode, itemIds);
+  }
+
+  private static RequestHeader requestHeader() {
+    return new RequestHeader(
+        NodeId.NULL_VALUE, DateTime.now(), uint(1), uint(0), null, uint(0), null);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<UInteger, Subscription> subscriptions(SubscriptionManager manager)
+      throws ReflectiveOperationException {
+
+    Field field = SubscriptionManager.class.getDeclaredField("subscriptions");
+    field.setAccessible(true);
+    return (Map<UInteger, Subscription>) field.get(manager);
+  }
+}


### PR DESCRIPTION
Several independent defects in the server-side EventFilter delivery path let a single monitored item's filter interfere with event delivery to other items, or let filters that Part 4 says are invalid through validation only to fail on every event afterwards.

`EventContentFilter.decodeOperands` cast each decoded operand to `FilterOperand` unchecked, so an operand that decodes to some other structure raised `ClassCastException` and one with an unknown encoding id raised `UaSerializationException`. Neither is a `UaException`, so both escaped `MonitoredEventItem.onEvent`. Related to that, `installFilter` only looked at select clause and element status codes when deciding whether to arm the filter, so an element whose operand had been reported as `Bad_FilterOperandInvalid` still armed. And `ServerEventNotifier.fire` notified listeners in a plain loop, so an exception from one listener stopped delivery to every listener registered after it and propagated to the caller.

Operands are now decoded explicitly and reported as `Bad_FilterOperandInvalid`, operand status codes participate in the arming decision, `onEvent` contains any exception from evaluation, and `fire` isolates each listener while leaving notifier-scope resolution and per-listener scope filtering unchanged. The item result for a filter that validates with errors is unchanged: the item is created with Good and the `EventFilterResult` carries the per-clause codes, as before.

Two further issues in `ElementOperand` handling are addressed. `validate` recorded Good for every `ElementOperand`; it now enforces Part 4 §7.7.4.2 (the index must be greater than the containing element's index and reference an existing element) so these filters are rejected at CreateMonitoredItems. And the cycle guard added in #1780 tracks only the current evaluation path, so an element referenced from several places in an acyclic filter was evaluated once per path, which is exponential for a chain of `And` elements that each reference the next element twice. `DefaultOperatorContext` now caches each element's result, or the `UaException` it raised, for the lifetime of one event evaluation. This is sound because element evaluation has no side effects within a single event.

On this branch `DefaultConditionManager.deliverRefresh` already isolated snapshot replay and RefreshEnd delivery per item but delivered RefreshStart in an unguarded loop; it now guards RefreshStart the same way, and tests pin the per-item isolation of the whole bracket and the release of the per-Subscription refresh guard. Tests also cover event items whose filter validates with errors through `SubscriptionManager` creation and the SetMonitoringMode registration toggle, and a throwing in-scope listener alongside scope filtering in `ServerEventNotifier.fire`. The `onRefreshMarker`, overflow, and `onConditionEventOverflow` paths were reviewed: they only reach `select`, which converts `UaException` to a null field, and their callers already guard with `catch (Throwable)` or `catch (Exception)`, so no change was needed there.

Verification: `spotless:apply`, `clean compile`, and the full `sdk-server` test suite pass, along with the integration tests for event filter operators, event routing, ConditionRefresh, and the new event delivery isolation test. Each new unit test was also run against the unmodified production code to confirm it fails there.

The same fixes are opened separately against `main`, where the surrounding delivery code has diverged.
