### PR TITLE
Harden EventFilter validation and event delivery isolation

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/events/EventDeliveryIsolationTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/events/EventDeliveryIsolationTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.events;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.eclipse.milo.opcua.sdk.client.subscriptions.OpcUaMonitoredItem;
+import org.eclipse.milo.opcua.sdk.client.subscriptions.OpcUaSubscription;
+import org.eclipse.milo.opcua.sdk.server.EventListener;
+import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
+import org.eclipse.milo.opcua.sdk.test.AbstractClientServerTest;
+import org.eclipse.milo.opcua.stack.core.AttributeId;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.structured.ContentFilter;
+import org.eclipse.milo.opcua.stack.core.types.structured.EventFilter;
+import org.eclipse.milo.opcua.stack.core.types.structured.SimpleAttributeOperand;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/** Tests that event delivery to a monitored item is independent of other registered listeners. */
+public class EventDeliveryIsolationTest extends AbstractClientServerTest {
+
+  private final EventListener throwingListener =
+      event -> {
+        throw new IllegalStateException("listener failure");
+      };
+
+  private OpcUaSubscription subscription;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    // Registered before the monitored item so it is notified first.
+    server.getEventNotifier().register(throwingListener);
+
+    subscription = new OpcUaSubscription(client);
+    subscription.create();
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    subscription.delete();
+    server.getEventNotifier().unregister(throwingListener);
+  }
+
+  @Test
+  void eventIsDeliveredToItemRegisteredAfterAThrowingListener() throws Exception {
+    var events = new CopyOnWriteArrayList<Variant[]>();
+    var latch = new CountDownLatch(1);
+
+    OpcUaMonitoredItem item = OpcUaMonitoredItem.newEventItem(NodeIds.Server, eventFilter());
+    item.setQueueSize(uint(100));
+    item.setEventValueListener(
+        (monitoredItem, eventFields) -> {
+          events.add(eventFields);
+          // The test namespace also emits events; wait for this test's message.
+          if (eventFields[0].value() instanceof LocalizedText text
+              && "after throwing listener".equals(text.text())) {
+            latch.countDown();
+          }
+        });
+    subscription.addMonitoredItem(item);
+    subscription.synchronizeMonitoredItems();
+    assertTrue(item.getCreateResult().orElseThrow().isGood());
+
+    assertDoesNotThrow(() -> fireEvent("after throwing listener"));
+
+    assertTrue(latch.await(5, TimeUnit.SECONDS), "event was not delivered");
+    assertTrue(
+        events.stream()
+            .anyMatch(
+                eventFields ->
+                    eventFields[0].value() instanceof LocalizedText text
+                        && "after throwing listener".equals(text.text())));
+  }
+
+  private void fireEvent(String message) throws Exception {
+    BaseEventTypeNode eventNode =
+        server
+            .getEventFactory()
+            .createEvent(new NodeId(1, "EventDeliveryIsolationTest"), NodeIds.BaseEventType);
+
+    try {
+      eventNode.setBrowseName(new QualifiedName(1, "EventDeliveryIsolationTest"));
+      eventNode.setDisplayName(LocalizedText.english("EventDeliveryIsolationTest"));
+      eventNode.setEventId(ByteString.of(new byte[] {1, 2, 3, 4}));
+      eventNode.setEventType(NodeIds.BaseEventType);
+      eventNode.setSourceNode(NodeIds.Server);
+      eventNode.setSourceName("Server");
+      eventNode.setTime(DateTime.now());
+      eventNode.setReceiveTime(DateTime.NULL_VALUE);
+      eventNode.setMessage(LocalizedText.english(message));
+      eventNode.setSeverity(ushort(1));
+
+      server.getEventNotifier().fire(eventNode);
+    } finally {
+      eventNode.delete();
+    }
+  }
+
+  private static EventFilter eventFilter() {
+    SimpleAttributeOperand message =
+        new SimpleAttributeOperand(
+            NodeIds.BaseEventType,
+            new QualifiedName[] {new QualifiedName(0, "Message")},
+            AttributeId.Value.uid(),
+            null);
+
+    return new EventFilter(new SimpleAttributeOperand[] {message}, new ContentFilter(null));
+  }
+}

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/methods/ConditionRefreshMethodTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/methods/ConditionRefreshMethodTest.java
@@ -12,21 +12,101 @@ package org.eclipse.milo.opcua.sdk.server.methods;
 
 import static java.util.Objects.requireNonNull;
 import static org.eclipse.milo.opcua.stack.core.StatusCodes.Bad_SubscriptionIdInvalid;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.eclipse.milo.opcua.sdk.client.subscriptions.OpcUaMonitoredItem;
+import org.eclipse.milo.opcua.sdk.client.subscriptions.OpcUaSubscription;
+import org.eclipse.milo.opcua.sdk.server.EventListener;
 import org.eclipse.milo.opcua.sdk.test.AbstractClientServerTest;
+import org.eclipse.milo.opcua.stack.core.AttributeId;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
 import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 import org.eclipse.milo.opcua.stack.core.types.structured.CallMethodRequest;
 import org.eclipse.milo.opcua.stack.core.types.structured.CallMethodResult;
 import org.eclipse.milo.opcua.stack.core.types.structured.CallResponse;
+import org.eclipse.milo.opcua.stack.core.types.structured.ContentFilter;
+import org.eclipse.milo.opcua.stack.core.types.structured.EventFilter;
+import org.eclipse.milo.opcua.stack.core.types.structured.SimpleAttributeOperand;
 import org.junit.jupiter.api.Test;
 
 public class ConditionRefreshMethodTest extends AbstractClientServerTest {
+
+  /**
+   * ConditionRefresh fires the RefreshStart and RefreshEnd markers through the server's
+   * EventNotifier. A listener registered before the subscription's item that throws must not
+   * prevent either marker from reaching the item, nor fail the method call.
+   */
+  @Test
+  void markersAreDeliveredWhenAnEarlierListenerThrows() throws Exception {
+    EventListener throwingListener =
+        event -> {
+          throw new IllegalStateException("listener failure");
+        };
+    server.getEventNotifier().register(throwingListener);
+
+    var subscription = new OpcUaSubscription(client);
+    subscription.create();
+
+    try {
+      // The test namespace fires its own BaseEventType events; only the markers are collected.
+      var markerTypes = new CopyOnWriteArrayList<NodeId>();
+      var latch = new CountDownLatch(2);
+
+      OpcUaMonitoredItem item = OpcUaMonitoredItem.newEventItem(NodeIds.Server, eventFilter());
+      item.setQueueSize(uint(100));
+      item.setEventValueListener(
+          (monitoredItem, eventFields) -> {
+            if (eventFields[0].value() instanceof NodeId eventType
+                && (NodeIds.RefreshStartEventType.equals(eventType)
+                    || NodeIds.RefreshEndEventType.equals(eventType))) {
+              markerTypes.add(eventType);
+              latch.countDown();
+            }
+          });
+      subscription.addMonitoredItem(item);
+      subscription.synchronizeMonitoredItems();
+      assertTrue(item.getCreateResult().orElseThrow().isGood());
+
+      var request =
+          new CallMethodRequest(
+              NodeIds.ConditionType,
+              NodeIds.ConditionType_ConditionRefresh,
+              new Variant[] {new Variant(subscription.getSubscriptionId().orElseThrow())});
+
+      CallResponse response = client.call(List.of(request));
+      CallMethodResult result = requireNonNull(response.getResults())[0];
+
+      assertTrue(result.getStatusCode().isGood(), () -> "status: " + result.getStatusCode());
+      assertTrue(latch.await(5, TimeUnit.SECONDS), "markers were not delivered");
+      assertEquals(
+          List.of(NodeIds.RefreshStartEventType, NodeIds.RefreshEndEventType), markerTypes);
+    } finally {
+      subscription.delete();
+      server.getEventNotifier().unregister(throwingListener);
+    }
+  }
+
+  private static EventFilter eventFilter() {
+    SimpleAttributeOperand eventType =
+        new SimpleAttributeOperand(
+            NodeIds.BaseEventType,
+            new QualifiedName[] {new QualifiedName(0, "EventType")},
+            AttributeId.Value.uid(),
+            null);
+
+    return new EventFilter(new SimpleAttributeOperand[] {eventType}, new ContentFilter(null));
+  }
 
   @Test
   void subscriptionIdInvalid() throws UaException {

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServer.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/OpcUaServer.java
@@ -943,6 +943,8 @@ public class OpcUaServer extends AbstractServiceHandler {
 
   private static class ServerEventNotifier implements EventNotifier {
 
+    private static final Logger logger = LoggerFactory.getLogger(ServerEventNotifier.class);
+
     private final Set<EventListener> eventListeners =
         Collections.synchronizedSet(new LinkedHashSet<>());
 
@@ -953,7 +955,13 @@ public class OpcUaServer extends AbstractServiceHandler {
         toNotify = List.copyOf(eventListeners);
       }
 
-      toNotify.forEach(eventListener -> eventListener.onEvent(event));
+      for (EventListener eventListener : toNotify) {
+        try {
+          eventListener.onEvent(event);
+        } catch (Exception e) {
+          logger.error("Error notifying EventListener {}: {}", eventListener, e.getMessage(), e);
+        }
+      }
     }
 
     @Override

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/EventContentFilter.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/EventContentFilter.java
@@ -343,15 +343,32 @@ public class EventContentFilter {
 
   @NonNull
   private static FilterOperand[] decodeOperands(
-      EncodingContext context, ExtensionObject @Nullable [] operandXos) {
+      EncodingContext context, ExtensionObject @Nullable [] operandXos) throws UaException {
 
     if (operandXos == null) {
       return new FilterOperand[0];
-    } else {
-      return Arrays.stream(operandXos)
-          .map(xo -> (FilterOperand) xo.decode(context))
-          .toArray(FilterOperand[]::new);
     }
+
+    var operands = new FilterOperand[operandXos.length];
+
+    for (int i = 0; i < operandXos.length; i++) {
+      Object decoded;
+      try {
+        decoded = operandXos[i].decode(context);
+      } catch (Exception e) {
+        throw new UaException(
+            StatusCodes.Bad_FilterOperandInvalid, "operand " + i + " could not be decoded", e);
+      }
+
+      if (decoded instanceof FilterOperand operand) {
+        operands[i] = operand;
+      } else {
+        throw new UaException(
+            StatusCodes.Bad_FilterOperandInvalid, "operand " + i + " is not a FilterOperand");
+      }
+    }
+
+    return operands;
   }
 
   @NonNull

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/EventContentFilter.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/EventContentFilter.java
@@ -202,16 +202,21 @@ public class EventContentFilter {
       return new ContentFilterResult(new ContentFilterElementResult[0], new DiagnosticInfo[0]);
     }
 
-    ContentFilterElementResult[] elementResults =
-        Arrays.stream(filterElements)
-            .map(e -> validateFilterElement(context, e))
-            .toArray(ContentFilterElementResult[]::new);
+    var elementResults = new ContentFilterElementResult[filterElements.length];
+
+    for (int i = 0; i < filterElements.length; i++) {
+      elementResults[i] =
+          validateFilterElement(context, filterElements[i], i, filterElements.length);
+    }
 
     return new ContentFilterResult(elementResults, new DiagnosticInfo[0]);
   }
 
   private static ContentFilterElementResult validateFilterElement(
-      @NonNull FilterContext context, @NonNull ContentFilterElement filterElement) {
+      @NonNull FilterContext context,
+      @NonNull ContentFilterElement filterElement,
+      int elementIndex,
+      int elementCount) {
 
     FilterOperator filterOperator = filterElement.getFilterOperator();
 
@@ -253,8 +258,9 @@ public class EventContentFilter {
           } catch (ValidationException e) {
             operandStatusCodes[i] = e.getStatusCode();
           }
-        } else if (operand instanceof ElementOperand) {
-          operandStatusCodes[i] = StatusCode.GOOD;
+        } else if (operand instanceof ElementOperand elementOperand) {
+          operandStatusCodes[i] =
+              validateElementOperand(elementOperand, elementIndex, elementCount);
         } else if (operand instanceof LiteralOperand) {
           operandStatusCodes[i] = StatusCode.GOOD;
         } else {
@@ -277,6 +283,22 @@ public class EventContentFilter {
 
     return new ContentFilterElementResult(
         operatorStatus, operandStatusCodes, new DiagnosticInfo[0]);
+  }
+
+  /**
+   * Part 4 §7.7.4.2: an ElementOperand index is valid only if it is greater than the index of the
+   * element it is part of and it does not reference a non-existent element.
+   */
+  private static StatusCode validateElementOperand(
+      ElementOperand operand, int elementIndex, int elementCount) {
+
+    UInteger index = operand.getIndex();
+
+    if (index == null || index.longValue() <= elementIndex || index.longValue() >= elementCount) {
+      return new StatusCode(StatusCodes.Bad_FilterOperandInvalid);
+    }
+
+    return StatusCode.GOOD;
   }
 
   public static Variant[] select(

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/EventContentFilter.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/EventContentFilter.java
@@ -12,8 +12,10 @@ package org.eclipse.milo.opcua.sdk.server.events;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -534,6 +536,11 @@ public class EventContentFilter {
     // Indices of the elements currently being evaluated, used to detect ElementOperand cycles.
     private final Set<Integer> evaluatingElements = new HashSet<>();
 
+    // Results of elements already evaluated for this event. Element evaluation has no side
+    // effects within a single event, so an element referenced from more than one place is
+    // evaluated once and its result (or failure) is reused.
+    private final Map<Integer, ElementResult> elementResults = new HashMap<>();
+
     DefaultOperatorContext(FilterContext filterContext, ContentFilterElement[] elements) {
       this.filterContext = filterContext;
       this.elements = elements;
@@ -569,6 +576,11 @@ public class EventContentFilter {
 
         int elementIndex = index.intValue();
 
+        ElementResult cached = elementResults.get(elementIndex);
+        if (cached != null) {
+          return cached.get();
+        }
+
         // Guard against self- or mutually referential ElementOperands, which would otherwise
         // recurse until a StackOverflowError escaped the per-event handler.
         if (!evaluatingElements.add(elementIndex)) {
@@ -577,11 +589,18 @@ public class EventContentFilter {
               "ElementOperand cycle detected at index: " + elementIndex);
         }
 
+        ElementResult result;
         try {
-          return evaluate(this, eventNode, elements[elementIndex]);
+          result = ElementResult.value(evaluate(this, eventNode, elements[elementIndex]));
+        } catch (UaException e) {
+          result = ElementResult.failure(e);
         } finally {
           evaluatingElements.remove(elementIndex);
         }
+
+        elementResults.put(elementIndex, result);
+
+        return result.get();
       } else if (operand instanceof AttributeOperand ao) {
         return getAttribute(filterContext, ao, eventNode);
       } else if (operand instanceof SimpleAttributeOperand sao) {
@@ -589,6 +608,25 @@ public class EventContentFilter {
       } else {
         throw new UaException(StatusCodes.Bad_FilterOperandInvalid);
       }
+    }
+  }
+
+  /** The outcome of evaluating one ContentFilterElement: a value (possibly null) or a failure. */
+  private record ElementResult(@Nullable Object value, @Nullable UaException failure) {
+
+    static ElementResult value(@Nullable Object value) {
+      return new ElementResult(value, null);
+    }
+
+    static ElementResult failure(UaException failure) {
+      return new ElementResult(null, failure);
+    }
+
+    @Nullable Object get() throws UaException {
+      if (failure != null) {
+        throw failure;
+      }
+      return value;
     }
   }
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/items/MonitoredEventItem.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/items/MonitoredEventItem.java
@@ -117,7 +117,7 @@ public class MonitoredEventItem extends BaseMonitoredItem<Variant[]> implements 
           enqueue(selectEventFields(eventNode));
         }
       }
-    } catch (UaException e) {
+    } catch (Exception e) {
       logger.error("Filter evaluation failed: {}", e.getMessage(), e);
     }
   }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/items/MonitoredEventItem.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/items/MonitoredEventItem.java
@@ -243,8 +243,13 @@ public class MonitoredEventItem extends BaseMonitoredItem<Variant[]> implements 
 
       boolean whereClauseGood =
           Stream.of(elementResults)
-              .map(ContentFilterElementResult::getStatusCode)
-              .allMatch(StatusCode::isGood);
+              .allMatch(
+                  elementResult ->
+                      elementResult.getStatusCode().isGood()
+                          && Stream.of(
+                                  requireNonNullElse(
+                                      elementResult.getOperandStatusCodes(), new StatusCode[0]))
+                              .allMatch(StatusCode::isGood));
 
       filterResultGood = selectClauseGood && whereClauseGood;
     } else {

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/ServerEventNotifierTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/ServerEventNotifierTest.java
@@ -10,6 +10,7 @@
 
 package org.eclipse.milo.opcua.sdk.server;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.lang.reflect.Constructor;
@@ -46,6 +47,24 @@ public class ServerEventNotifierTest {
     notifier.fire(null);
 
     assertEquals(0, eventCount.get());
+  }
+
+  // Listeners are notified in registration order; an exception from one listener must not stop
+  // delivery to the listeners registered after it, and must not propagate to the caller of fire().
+  @Test
+  public void throwingListenerDoesNotBlockLaterListeners() throws Exception {
+    EventNotifier notifier = newServerEventNotifier();
+    AtomicInteger eventCount = new AtomicInteger();
+
+    notifier.register(
+        event -> {
+          throw new IllegalStateException("listener failure");
+        });
+    notifier.register(event -> eventCount.incrementAndGet());
+
+    assertDoesNotThrow(() -> notifier.fire(null));
+
+    assertEquals(1, eventCount.get());
   }
 
   private static EventNotifier newServerEventNotifier() throws Exception {

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/EventContentFilterTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/EventContentFilterTest.java
@@ -14,10 +14,12 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import java.time.Duration;
 import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
 import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
 import org.eclipse.milo.opcua.stack.core.AttributeId;
@@ -200,6 +202,52 @@ public class EventContentFilterTest {
 
       assertTrue(elementResult.getStatusCode().isGood());
       assertTrue(elementResult.getOperandStatusCodes()[0].isGood());
+    }
+  }
+
+  @Nested
+  class ElementOperandEvaluation {
+
+    // Each element is evaluated at most once per event. A chain in which every element references
+    // the next one twice would otherwise require 2^n evaluations; And only short-circuits on
+    // FALSE, so a TRUE-terminated chain forces both operands at every level.
+    @Test
+    void sharedElementIsEvaluatedOncePerEvent() {
+      int chainLength = 48;
+      ContentFilterElement[] elements = new ContentFilterElement[chainLength];
+
+      for (int i = 0; i < chainLength - 1; i++) {
+        elements[i] = element(FilterOperator.And, elementOperand(i + 1), elementOperand(i + 1));
+      }
+      elements[chainLength - 1] = element(FilterOperator.Equals, literal(1), literal(1));
+
+      boolean result =
+          assertTimeoutPreemptively(
+              Duration.ofSeconds(10),
+              () ->
+                  EventContentFilter.evaluate(
+                      filterContext(), new ContentFilter(elements), mock(BaseEventTypeNode.class)));
+
+      assertTrue(result);
+    }
+
+    // The evaluation result cache must not defeat cycle detection, which happens while the
+    // referenced element is still on the evaluation path and not yet cached.
+    @Test
+    void cyclicElementOperandFailsEvaluationWithBadFilterOperandInvalid() {
+      ContentFilterElement[] elements = {
+        element(FilterOperator.And, elementOperand(1), literal(true)),
+        element(FilterOperator.Not, elementOperand(0))
+      };
+
+      UaException e =
+          assertThrows(
+              UaException.class,
+              () ->
+                  EventContentFilter.evaluate(
+                      filterContext(), new ContentFilter(elements), mock(BaseEventTypeNode.class)));
+
+      assertEquals(StatusCodes.Bad_FilterOperandInvalid, e.getStatusCode().value());
     }
   }
 

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/EventContentFilterTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/EventContentFilterTest.java
@@ -34,6 +34,7 @@ import org.eclipse.milo.opcua.stack.core.types.enumerated.FilterOperator;
 import org.eclipse.milo.opcua.stack.core.types.structured.ContentFilter;
 import org.eclipse.milo.opcua.stack.core.types.structured.ContentFilterElement;
 import org.eclipse.milo.opcua.stack.core.types.structured.ContentFilterElementResult;
+import org.eclipse.milo.opcua.stack.core.types.structured.ElementOperand;
 import org.eclipse.milo.opcua.stack.core.types.structured.EventFilter;
 import org.eclipse.milo.opcua.stack.core.types.structured.EventFilterResult;
 import org.eclipse.milo.opcua.stack.core.types.structured.FilterOperand;
@@ -42,6 +43,8 @@ import org.eclipse.milo.opcua.stack.core.types.structured.ReadValueId;
 import org.eclipse.milo.opcua.stack.core.types.structured.SimpleAttributeOperand;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 public class EventContentFilterTest {
 
@@ -154,6 +157,52 @@ public class EventContentFilterTest {
     }
   }
 
+  @Nested
+  class ElementOperandValidation {
+
+    /**
+     * Part 4 §7.7.4.2: an ElementOperand index is valid only if it is greater than the index of the
+     * element it is part of and it references an existing element.
+     */
+    @ParameterizedTest(name = "element {0} referencing element {1}")
+    @CsvSource({"0, 0", "1, 0", "1, 1", "0, 2", "1, 2"})
+    void backwardSelfOrOutOfRangeElementOperandIsRejected(int elementIndex, int referencedIndex)
+        throws Exception {
+
+      ContentFilterElement[] elements = new ContentFilterElement[2];
+      elements[elementIndex] = element(FilterOperator.Not, elementOperand(referencedIndex));
+      elements[1 - elementIndex] = element(FilterOperator.IsNull, literal(null));
+
+      EventFilterResult result =
+          EventContentFilter.validate(filterContext(), eventFilter(elements));
+
+      ContentFilterElementResult elementResult =
+          result.getWhereClauseResult().getElementResults()[elementIndex];
+
+      assertEquals(
+          StatusCodes.Bad_FilterOperandInvalid,
+          elementResult.getOperandStatusCodes()[0].value(),
+          "operand status code");
+    }
+
+    @Test
+    void forwardElementOperandIsAccepted() throws Exception {
+      ContentFilterElement[] elements = {
+        element(FilterOperator.Not, elementOperand(1)),
+        element(FilterOperator.IsNull, literal(null))
+      };
+
+      EventFilterResult result =
+          EventContentFilter.validate(filterContext(), eventFilter(elements));
+
+      ContentFilterElementResult elementResult =
+          result.getWhereClauseResult().getElementResults()[0];
+
+      assertTrue(elementResult.getStatusCode().isGood());
+      assertTrue(elementResult.getOperandStatusCodes()[0].isGood());
+    }
+  }
+
   private static FilterContext filterContext() {
     OpcUaServer server = mock(OpcUaServer.class);
     when(server.getStaticEncodingContext()).thenReturn(DefaultEncodingContext.INSTANCE);
@@ -188,5 +237,9 @@ public class EventContentFilterTest {
 
   private static LiteralOperand literal(Object value) {
     return new LiteralOperand(new Variant(value));
+  }
+
+  private static ElementOperand elementOperand(int index) {
+    return new ElementOperand(uint(index));
   }
 }

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/EventContentFilterTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/EventContentFilterTest.java
@@ -13,16 +13,21 @@ package org.eclipse.milo.opcua.sdk.server.events;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
 import org.eclipse.milo.opcua.stack.core.AttributeId;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.FilterOperator;
@@ -33,7 +38,9 @@ import org.eclipse.milo.opcua.stack.core.types.structured.EventFilter;
 import org.eclipse.milo.opcua.stack.core.types.structured.EventFilterResult;
 import org.eclipse.milo.opcua.stack.core.types.structured.FilterOperand;
 import org.eclipse.milo.opcua.stack.core.types.structured.LiteralOperand;
+import org.eclipse.milo.opcua.stack.core.types.structured.ReadValueId;
 import org.eclipse.milo.opcua.stack.core.types.structured.SimpleAttributeOperand;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 public class EventContentFilterTest {
@@ -90,6 +97,61 @@ public class EventContentFilterTest {
         StatusCodes.Bad_FilterOperatorUnsupported, elementResults[0].getStatusCode().value());
     assertEquals(
         StatusCodes.Bad_FilterOperatorUnsupported, elementResults[1].getStatusCode().value());
+  }
+
+  @Nested
+  class OperandDecoding {
+
+    // Operands are decoded again on every event. An operand that decodes to a structure other
+    // than a FilterOperand must be reported as a filter error, not as an unchecked
+    // ClassCastException
+    // escaping the event delivery path.
+    @Test
+    void operandThatIsNotAFilterOperandFailsEvaluationWithBadFilterOperandInvalid() {
+      ExtensionObject notAFilterOperand =
+          ExtensionObject.encode(
+              DefaultEncodingContext.INSTANCE,
+              new ReadValueId(NodeIds.Server, AttributeId.Value.uid(), null, null));
+
+      ContentFilter whereClause =
+          new ContentFilter(
+              new ContentFilterElement[] {
+                new ContentFilterElement(
+                    FilterOperator.IsNull, new ExtensionObject[] {notAFilterOperand})
+              });
+
+      UaException e =
+          assertThrows(
+              UaException.class,
+              () ->
+                  EventContentFilter.evaluate(
+                      filterContext(), whereClause, mock(BaseEventTypeNode.class)));
+
+      assertEquals(StatusCodes.Bad_FilterOperandInvalid, e.getStatusCode().value());
+    }
+
+    // An operand with an encoding id the server cannot decode must likewise be reported as a
+    // filter error rather than an unchecked UaSerializationException.
+    @Test
+    void operandThatCannotBeDecodedFailsEvaluationWithBadFilterOperandInvalid() {
+      ExtensionObject undecodable =
+          ExtensionObject.of(ByteString.of(new byte[] {0}), new NodeId(2, 999));
+
+      ContentFilter whereClause =
+          new ContentFilter(
+              new ContentFilterElement[] {
+                new ContentFilterElement(FilterOperator.IsNull, new ExtensionObject[] {undecodable})
+              });
+
+      UaException e =
+          assertThrows(
+              UaException.class,
+              () ->
+                  EventContentFilter.evaluate(
+                      filterContext(), whereClause, mock(BaseEventTypeNode.class)));
+
+      assertEquals(StatusCodes.Bad_FilterOperandInvalid, e.getStatusCode().value());
+    }
   }
 
   private static FilterContext filterContext() {

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/items/MonitoredEventItemTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/items/MonitoredEventItemTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.items;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.eclipse.milo.opcua.sdk.core.typetree.ReferenceTypeTree;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.sdk.server.Session;
+import org.eclipse.milo.opcua.sdk.server.model.objects.BaseEventTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNodeContext;
+import org.eclipse.milo.opcua.stack.core.AttributeId;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
+import org.eclipse.milo.opcua.stack.core.types.UaStructuredType;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.FilterOperator;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.MonitoringMode;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.TimestampsToReturn;
+import org.eclipse.milo.opcua.stack.core.types.structured.ContentFilter;
+import org.eclipse.milo.opcua.stack.core.types.structured.ContentFilterElement;
+import org.eclipse.milo.opcua.stack.core.types.structured.ContentFilterElementResult;
+import org.eclipse.milo.opcua.stack.core.types.structured.ElementOperand;
+import org.eclipse.milo.opcua.stack.core.types.structured.EventFilter;
+import org.eclipse.milo.opcua.stack.core.types.structured.EventFilterResult;
+import org.eclipse.milo.opcua.stack.core.types.structured.FilterOperand;
+import org.eclipse.milo.opcua.stack.core.types.structured.LiteralOperand;
+import org.eclipse.milo.opcua.stack.core.types.structured.ReadValueId;
+import org.eclipse.milo.opcua.stack.core.types.structured.SimpleAttributeOperand;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class MonitoredEventItemTest {
+
+  private final OpcUaServer server = mock(OpcUaServer.class);
+  private final BaseEventTypeNode eventNode = mock(BaseEventTypeNode.class);
+
+  private MonitoredEventItem item;
+
+  @BeforeEach
+  void setUp() {
+    when(server.getStaticEncodingContext()).thenReturn(DefaultEncodingContext.INSTANCE);
+    when(server.getReferenceTypeTree()).thenReturn(mock(ReferenceTypeTree.class));
+
+    UaNodeContext nodeContext = mock(UaNodeContext.class);
+    when(nodeContext.getServer()).thenReturn(server);
+    when(eventNode.getNodeContext()).thenReturn(nodeContext);
+
+    item =
+        new MonitoredEventItem(
+            server,
+            mock(Session.class),
+            uint(1),
+            uint(1),
+            new ReadValueId(NodeIds.Server, AttributeId.EventNotifier.uid(), null, null),
+            MonitoringMode.Reporting,
+            TimestampsToReturn.Neither,
+            uint(1),
+            0.0,
+            uint(10),
+            true);
+  }
+
+  @Nested
+  class FilterArming {
+
+    /**
+     * Element 1's operand is a structure that is not a FilterOperand, so validation reports the
+     * element as Good but its operand as Bad_FilterOperandInvalid. Element 0 is Or(true, Element
+     * 1), which never resolves element 1, so the where clause evaluates to true if it is armed.
+     */
+    private final ContentFilter badOperandWhereClause =
+        where(
+            element(FilterOperator.Or, literal(true), elementOperand(1)),
+            element(FilterOperator.IsNull, notAFilterOperand()));
+
+    @Test
+    void filterWithBadOperandStatusIsNotArmed() throws Exception {
+      item.installFilter(eventFilter(badOperandWhereClause));
+
+      EventFilterResult filterResult = decodeFilterResult();
+      ContentFilterElementResult elementResult =
+          filterResult.getWhereClauseResult().getElementResults()[1];
+      assertTrue(elementResult.getStatusCode().isGood(), "element status");
+      assertEquals(
+          StatusCodes.Bad_FilterOperandInvalid,
+          elementResult.getOperandStatusCodes()[0].value(),
+          "operand status");
+
+      item.onEvent(eventNode);
+
+      assertEquals(
+          0, drainNotifications().size(), "event delivered by a filter with a bad operand");
+    }
+
+    // Control for the test above: the same where clause shape with a valid operand is armed.
+    @Test
+    void filterWithGoodOperandStatusIsArmed() throws Exception {
+      item.installFilter(
+          eventFilter(
+              where(
+                  element(FilterOperator.Or, literal(true), elementOperand(1)),
+                  element(FilterOperator.IsNull, literal(null)))));
+
+      item.onEvent(eventNode);
+
+      assertEquals(1, drainNotifications().size());
+    }
+  }
+
+  private EventFilterResult decodeFilterResult() {
+    return (EventFilterResult) item.getFilterResult().decode(DefaultEncodingContext.INSTANCE);
+  }
+
+  private List<UaStructuredType> drainNotifications() {
+    var notifications = new ArrayList<UaStructuredType>();
+    item.getNotifications(notifications, Integer.MAX_VALUE);
+    return notifications;
+  }
+
+  private static EventFilter eventFilter(ContentFilter whereClause) {
+    SimpleAttributeOperand selectClause =
+        new SimpleAttributeOperand(
+            NodeIds.BaseEventType,
+            new QualifiedName[] {new QualifiedName(0, "Message")},
+            AttributeId.Value.uid(),
+            null);
+
+    return new EventFilter(new SimpleAttributeOperand[] {selectClause}, whereClause);
+  }
+
+  private static ContentFilter where(ContentFilterElement... elements) {
+    return new ContentFilter(elements);
+  }
+
+  private static ContentFilterElement element(FilterOperator operator, Object... operands) {
+    var encodedOperands = new ExtensionObject[operands.length];
+
+    for (int i = 0; i < operands.length; i++) {
+      encodedOperands[i] =
+          operands[i] instanceof ExtensionObject xo
+              ? xo
+              : ExtensionObject.encode(
+                  DefaultEncodingContext.INSTANCE, (FilterOperand) operands[i]);
+    }
+
+    return new ContentFilterElement(operator, encodedOperands);
+  }
+
+  private static ExtensionObject notAFilterOperand() {
+    return ExtensionObject.encode(
+        DefaultEncodingContext.INSTANCE,
+        new ReadValueId(NodeIds.Server, AttributeId.Value.uid(), null, null));
+  }
+
+  private static LiteralOperand literal(Object value) {
+    return new LiteralOperand(new Variant(value));
+  }
+
+  private static ElementOperand elementOperand(int index) {
+    return new ElementOperand(uint(index));
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/items/MonitoredEventItemTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/items/MonitoredEventItemTest.java
@@ -11,8 +11,10 @@
 package org.eclipse.milo.opcua.sdk.server.items;
 
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -123,6 +125,33 @@ class MonitoredEventItemTest {
       item.onEvent(eventNode);
 
       assertEquals(1, drainNotifications().size());
+    }
+  }
+
+  @Nested
+  class FilterEvaluation {
+
+    // Event delivery loops call onEvent for every registered item; an unexpected exception from
+    // evaluating one item's filter must be contained in that item.
+    @Test
+    void unexpectedExceptionDuringEvaluationDoesNotPropagate() throws Exception {
+      item.installFilter(
+          eventFilter(
+              where(
+                  element(
+                      FilterOperator.Equals,
+                      new SimpleAttributeOperand(
+                          NodeIds.BaseEventType,
+                          new QualifiedName[] {new QualifiedName(0, "Severity")},
+                          AttributeId.Value.uid(),
+                          null),
+                      literal(1)))));
+
+      when(eventNode.findNode(any(QualifiedName.class), any(), any()))
+          .thenThrow(new IllegalStateException("event node lookup failure"));
+
+      assertDoesNotThrow(() -> item.onEvent(eventNode));
+      assertEquals(0, drainNotifications().size());
     }
   }
 


### PR DESCRIPTION
Several independent defects in the server-side EventFilter delivery path let a single monitored item's filter interfere with event delivery to other items, or let filters that Part 4 says are invalid through validation only to fail on every event afterwards.

`EventContentFilter.decodeOperands` cast each decoded operand to `FilterOperand` unchecked, so an operand that decodes to some other structure raised `ClassCastException` and one with an unknown encoding id raised `UaSerializationException`. Neither is a `UaException`, so both escaped `MonitoredEventItem.onEvent`. Related to that, `installFilter` only looked at select clause and element status codes when deciding whether to arm the filter, so an element whose operand had been reported as `Bad_FilterOperandInvalid` still armed. And `ServerEventNotifier.fire` notified listeners in a plain loop, so an exception from one listener stopped delivery to every listener registered after it and propagated to the caller, including the ConditionRefresh method that fires the RefreshStart and RefreshEnd markers directly.

Operands are now decoded explicitly and reported as `Bad_FilterOperandInvalid`, operand status codes participate in the arming decision, `onEvent` contains any exception from evaluation, and `fire` isolates each listener. The item result for a filter that validates with errors is unchanged: the item is created with Good and the `EventFilterResult` carries the per-clause codes, as before.

Two further issues in `ElementOperand` handling are addressed. `validate` recorded Good for every `ElementOperand`; it now enforces Part 4 §7.7.4.2 (the index must be greater than the containing element's index and reference an existing element) so these filters are rejected at CreateMonitoredItems. And the cycle guard added in #1780 tracks only the current evaluation path, so an element referenced from several places in an acyclic filter was evaluated once per path, which is exponential for a chain of `And` elements that each reference the next element twice. `DefaultOperatorContext` now caches each element's result, or the `UaException` it raised, for the lifetime of one event evaluation. This is sound because element evaluation has no side effects within a single event.

Verification: `spotless:apply`, `clean compile`, and the full `sdk-server` test suite pass, along with the integration tests for event filter operators, ConditionRefresh, and the new event delivery isolation test. Each new unit test was also run against the unmodified production code to confirm it fails there.

The same fixes are opened separately against `integration/1.2`, where the surrounding delivery code has diverged.
