### PR TITLE
Hash DynamicUnionType by its DataType's NodeId

### DIFF
--- a/opc-ua-sdk/sdk-core/src/main/java/org/eclipse/milo/opcua/sdk/core/types/DynamicUnionType.java
+++ b/opc-ua-sdk/sdk-core/src/main/java/org/eclipse/milo/opcua/sdk/core/types/DynamicUnionType.java
@@ -107,7 +107,7 @@ public final class DynamicUnionType extends DynamicType implements UaStructuredT
 
   @Override
   public int hashCode() {
-    return Objects.hash(dataType, value);
+    return Objects.hash(dataType.getNodeId(), value);
   }
 
   @Override

--- a/opc-ua-sdk/sdk-core/src/test/java/org/eclipse/milo/opcua/sdk/core/types/DynamicUnionTypeTest.java
+++ b/opc-ua-sdk/sdk-core/src/test/java/org/eclipse/milo/opcua/sdk/core/types/DynamicUnionTypeTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2025 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.core.types;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.eclipse.milo.opcua.sdk.core.types.DynamicUnionType.UnionValue;
+import org.eclipse.milo.opcua.sdk.core.types.util.AbstractDataType;
+import org.eclipse.milo.opcua.sdk.core.typetree.DataType;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.junit.jupiter.api.Test;
+
+class DynamicUnionTypeTest {
+
+  private static final NodeId DATA_TYPE_ID = new NodeId(2, "MyUnion");
+
+  // equals() compares the DataType by NodeId because DataType implementations are not required to
+  // define equals()/hashCode(), so two DataType instances describing the same DataType - obtained
+  // from a rebuilt DataTypeTree, say - must not change how a DynamicUnionType hashes.
+  @Test
+  void equalUnionsHashTheSame() {
+    DynamicUnionType u1 = new DynamicUnionType(dataType(), new UnionValue("foo", 42));
+    DynamicUnionType u2 = new DynamicUnionType(dataType(), new UnionValue("foo", 42));
+
+    assertEquals(u1, u2);
+    assertEquals(u1.hashCode(), u2.hashCode());
+
+    Map<DynamicUnionType, String> map = new HashMap<>();
+    map.put(u1, "value");
+
+    assertEquals("value", map.get(u2));
+  }
+
+  @Test
+  void unionsWithDifferentValuesAreNotEqual() {
+    DataType dataType = dataType();
+
+    assertNotEquals(
+        new DynamicUnionType(dataType, new UnionValue("foo", 42)),
+        new DynamicUnionType(dataType, new UnionValue("foo", 43)));
+
+    assertNotEquals(
+        new DynamicUnionType(dataType, new UnionValue("foo", 42)),
+        new DynamicUnionType(dataType, new UnionValue("bar", 42)));
+  }
+
+  /** A new DataType instance, equivalent to but not identical with any other one returned here. */
+  private static DataType dataType() {
+    return new AbstractDataType(DATA_TYPE_ID, new QualifiedName(2, "MyUnion"), null, false) {};
+  }
+}


### PR DESCRIPTION
`DynamicUnionType.equals` compares the DataType by NodeId:

```java
public boolean equals(Object o) {
  ...
  return Objects.equals(dataType.getNodeId(), that.dataType.getNodeId())
      && Objects.equals(value, that.value);
}

public int hashCode() {
  return Objects.hash(dataType, value);   // the DataType object, not its NodeId
}
```

`DataType` implementations are not required to define `equals`/`hashCode`, and several do not —
`BsdDataType` and `DictionaryDataType` both `implements DataType` without either, so they hash by
identity. Two `DynamicUnionType` values built from distinct `DataType` instances describing the
same DataType are then equal with different hashes:

```java
NodeId id = new NodeId(2, "MyUnion");
DataType dt1 = /* MyUnion */;
DataType dt2 = /* MyUnion, a second instance */;

var u1 = new DynamicUnionType(dt1, new UnionValue("foo", 42));
var u2 = new DynamicUnionType(dt2, new UnionValue("foo", 42));

u1.equals(u2);                    // true
u1.hashCode() == u2.hashCode();   // false
map.put(u1, "value"); map.get(u2) // null
```

The two sibling classes written alongside it already hash the NodeId:

```java
DynamicStructType.hashCode() -> Objects.hash(dataType.getNodeId(), members)
DynamicEnumType.hashCode()   -> Objects.hash(dataType.getNodeId(), name, value)
```

### Scope

Within a single `DataTypeTree` this does not bite: `TypeTree` holds a `Map<NodeId, Tree<T>>`, so
`getDataType(id)` returns the same instance every time and the hash is stable. It bites when the
instances differ — a rebuilt DataTypeTree, or a DataType constructed separately. Nothing in the
repository puts a `DynamicUnionType` into a hash-based collection today, so this is a public API
contract fix rather than a fix for a broken internal path.

### Change

Hash `dataType.getNodeId()` instead of `dataType`, matching `equals` and the two siblings. When
both values share a DataType instance the hash is unchanged.

### Tests

`DynamicUnionTypeTest.equalUnionsHashTheSame` fails before the change and passes after:

```
DynamicUnionTypeTest.equalUnionsHashTheSame  expected: <912482254> but was: <-751886955>
```

It uses the existing `AbstractDataType` test helper, which defines no `equals`/`hashCode`, to build
two distinct DataType instances with the same NodeId.
`DynamicUnionTypeTest.unionsWithDifferentValuesAreNotEqual` is added as a guard that the change
does not make unrelated unions compare equal.

Verified on JDK 17 with `mvn -pl opc-ua-sdk/integration-tests -am verify`: all 14 modules pass —
2329 tests, 0 failures, 0 errors — including `spotless:check` and Checkstyle.

---

- [ ] You have signed an Eclipse Contributor Agreement and are committing using the same email address
- [x] Your code contains any tests relevant to the problem you are solving
- [x] All new and existing tests passed
- [x] Code follows the style guidelines and Checkstyle passes
