### PR TITLE
Retain the CreateSession server certificate for the Session's lifetime

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/SecurityConfiguration.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/SecurityConfiguration.java
@@ -165,8 +165,7 @@ public final class SecurityConfiguration {
     return channelThumbprint;
   }
 
-  private static ByteString getCertificateBytes(@Nullable X509Certificate certificate)
-      throws UaException {
+  static ByteString getCertificateBytes(@Nullable X509Certificate certificate) throws UaException {
 
     if (certificate == null) {
       return ByteString.NULL_VALUE;
@@ -179,8 +178,8 @@ public final class SecurityConfiguration {
     }
   }
 
-  private static ByteString getCertificateChainBytes(
-      @Nullable List<X509Certificate> certificateChain) throws UaException {
+  static ByteString getCertificateChainBytes(@Nullable List<X509Certificate> certificateChain)
+      throws UaException {
 
     if (certificateChain == null) {
       return ByteString.NULL_VALUE;

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/Session.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/Session.java
@@ -94,6 +94,7 @@ public class Session {
   private volatile ScheduledFuture<?> checkTimeoutFuture;
 
   private volatile EndpointDescription endpoint;
+  private final SessionServerCertificate originalServerCertificate;
   private volatile long secureChannelId;
   private volatile SecurityConfiguration securityConfiguration;
   private volatile InetAddress clientAddress;
@@ -134,6 +135,7 @@ public class Session {
     this.secureChannelId = secureChannelId;
     this.securityConfiguration = securityConfiguration;
     this.endpoint = endpoint;
+    originalServerCertificate = SessionServerCertificate.of(endpoint, securityConfiguration);
 
     sessionDiagnostics = new SessionDiagnostics(this);
     sessionSecurityDiagnostics = new SessionSecurityDiagnostics(this);
@@ -153,6 +155,19 @@ public class Session {
 
   public SecurityConfiguration getSecurityConfiguration() {
     return securityConfiguration;
+  }
+
+  /**
+   * Get the server application certificate this Session was created with.
+   *
+   * <p>Unlike {@link #getSecurityConfiguration()}, which follows the Session onto a replacement
+   * SecureChannel, this never changes: ActivateSession signatures and encrypted token secrets are
+   * bound to it for the life of the Session.
+   *
+   * @return the CreateSession server certificate and its key material.
+   */
+  public SessionServerCertificate getOriginalServerCertificate() {
+    return originalServerCertificate;
   }
 
   public EndpointDescription getEndpoint() {

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/SessionManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/SessionManager.java
@@ -555,7 +555,7 @@ public class SessionManager {
           "requested enhanced user-token policy is not available on the selected endpoint");
     }
 
-    KeyPair signingKeyPair = selectUserTokenSigningKeyPair(securityConfiguration, session);
+    KeyPair signingKeyPair = selectUserTokenSigningKeyPair(session);
 
     KeyPair ephemeralKeyPair =
         EccEncryptedSecret.generateEphemeralKeyPair(securityPolicy.getProfile());
@@ -575,23 +575,24 @@ public class SessionManager {
     return response;
   }
 
-  private KeyPair selectUserTokenSigningKeyPair(
-      SecurityConfiguration securityConfiguration, Session session) throws UaException {
+  private KeyPair selectUserTokenSigningKeyPair(Session session) throws UaException {
+    SessionServerCertificate original = session.getOriginalServerCertificate();
 
     /*
      * The client verifies the EphemeralKeyType signature with the certificate advertised by the
      * selected endpoint. SecureChannel key material is used only when it is the same endpoint
      * identity; otherwise the key is resolved from the certificate manager by endpoint thumbprint.
      */
-    if (securityConfiguration.getKeyPair() != null
-        && securityConfiguration.getServerCertificate() != null
-        && serverCertificateMatchesEndpoint(securityConfiguration, session)) {
-      return securityConfiguration.getKeyPair();
+    KeyPair keyPair = original.keyPair();
+    if (keyPair != null
+        && original.certificate() != null
+        && original.createSessionCertificate().equals(original.certificateBytes())) {
+      return keyPair;
     }
 
-    ByteString endpointCertificateBytes = session.getEndpoint().getServerCertificate();
+    ByteString endpointCertificateBytes = original.createSessionCertificate();
 
-    if (endpointCertificateBytes == null || endpointCertificateBytes.isNullOrEmpty()) {
+    if (endpointCertificateBytes.isNullOrEmpty()) {
       throw new UaException(
           StatusCodes.Bad_ConfigurationError,
           "enhanced user-token negotiation requires an advertised server certificate");
@@ -609,15 +610,6 @@ public class SessionManager {
                 new UaException(
                     StatusCodes.Bad_ConfigurationError,
                     "no server application key pair found for advertised certificate"));
-  }
-
-  private static boolean serverCertificateMatchesEndpoint(
-      SecurityConfiguration securityConfiguration, Session session) throws UaException {
-
-    ByteString endpointCertificateBytes = session.getEndpoint().getServerCertificate();
-
-    return endpointCertificateBytes != null
-        && endpointCertificateBytes.equals(securityConfiguration.getServerCertificateBytes());
   }
 
   /**
@@ -891,7 +883,7 @@ public class SessionManager {
         SecurityConfiguration securityConfiguration = session.getSecurityConfiguration();
 
         if (session.getSecureChannelId() == secureChannelId) {
-          verifyClientSignature(session, request, securityConfiguration, session.getEndpoint());
+          verifyClientSignature(session, request, securityConfiguration);
 
           /*
            * Identity change
@@ -932,7 +924,7 @@ public class SessionManager {
 
           EndpointDescription endpoint = findSessionEndpoint(context);
 
-          verifyClientSignature(session, request, newSecurityConfiguration, endpoint);
+          verifyClientSignature(session, request, newSecurityConfiguration);
 
           ByteString clientCertificateBytes =
               context.getSecureChannel().getRemoteCertificateBytes();
@@ -1013,8 +1005,7 @@ public class SessionManager {
         throw new UaException(StatusCodes.Bad_SecurityChecksFailed);
       }
 
-      verifyClientSignature(
-          session, request, session.getSecurityConfiguration(), session.getEndpoint());
+      verifyClientSignature(session, request, session.getSecurityConfiguration());
 
       UserIdentityToken identityToken =
           decodeIdentityToken(
@@ -1114,18 +1105,22 @@ public class SessionManager {
   }
 
   private static void verifyClientSignature(
-      Session session,
-      ActivateSessionRequest request,
-      SecurityConfiguration securityConfiguration,
-      EndpointDescription endpoint)
+      Session session, ActivateSessionRequest request, SecurityConfiguration securityConfiguration)
       throws UaException {
     if (securityConfiguration.getSecurityPolicy() != SecurityPolicy.None) {
       SignatureData clientSignature = request.getClientSignature();
       SecurityPolicy securityPolicy = securityConfiguration.getSecurityPolicy();
+      // The client signs over the server certificate from CreateSession, so verification uses the
+      // certificate the Session was created with even after the server certificate rotates. A
+      // Session created on an unsecured channel has none; use the carrying channel's.
+      SessionServerCertificate original = session.getOriginalServerCertificate();
+      boolean createdUnsecured = original.certificate() == null;
       ByteString serverCertificateBs =
           securityPolicy.getProfile().secureChannelEnhancements()
-              ? endpoint.getServerCertificate()
-              : securityConfiguration.getServerCertificateBytes();
+              ? original.createSessionCertificate()
+              : createdUnsecured
+                  ? securityConfiguration.getServerCertificateBytes()
+                  : original.certificateBytes();
       ByteString lastNonceBs = session.getLastNonce();
 
       try {
@@ -1152,7 +1147,9 @@ public class SessionManager {
         // Maybe try again using the full certificate chain bytes instead
 
         ByteString serverCertificateChainBs =
-            securityConfiguration.getServerCertificateChainBytes();
+            createdUnsecured
+                ? securityConfiguration.getServerCertificateChainBytes()
+                : original.certificateChainBytes();
 
         if (serverCertificateBs.equals(serverCertificateChainBs)) {
           throw e;

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/SessionServerCertificate.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/SessionServerCertificate.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server;
+
+import java.security.KeyPair;
+import java.security.cert.X509Certificate;
+import java.util.List;
+import java.util.Objects;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * The server application certificate a {@link Session} was created with.
+ *
+ * <p>Part 4 5.7.3.1 computes ActivateSession client signatures over the serverCertificate returned
+ * by CreateSession and encrypts token secrets to its public key for the lifetime of the Session, so
+ * these inputs must outlive a server certificate rotation and reactivation on a replacement
+ * SecureChannel. A Session created on an unsecured channel has no certificate or key pair.
+ *
+ * @param createSessionCertificate the serverCertificate returned by CreateSession, i.e. the
+ *     endpoint's advertised certificate, or {@link ByteString#NULL_VALUE}.
+ * @param certificate the server application certificate of the creating channel, or null.
+ * @param certificateChain the server certificate chain of the creating channel, or null.
+ * @param keyPair the key pair for {@code certificate}, or null.
+ */
+public record SessionServerCertificate(
+    ByteString createSessionCertificate,
+    @Nullable X509Certificate certificate,
+    @Nullable List<X509Certificate> certificateChain,
+    @Nullable KeyPair keyPair) {
+
+  /**
+   * Capture the server certificate a Session is being created with.
+   *
+   * @param endpoint the endpoint CreateSession was received on.
+   * @param securityConfiguration the security configuration of the creating SecureChannel.
+   * @return the CreateSession server certificate and its key material.
+   */
+  public static SessionServerCertificate of(
+      EndpointDescription endpoint, SecurityConfiguration securityConfiguration) {
+
+    return new SessionServerCertificate(
+        Objects.requireNonNullElse(endpoint.getServerCertificate(), ByteString.NULL_VALUE),
+        securityConfiguration.getServerCertificate(),
+        securityConfiguration.getServerCertificateChain(),
+        securityConfiguration.getKeyPair());
+  }
+
+  /**
+   * @return the DER encoding of {@link #certificate()}, or {@link ByteString#NULL_VALUE}.
+   * @throws UaException if the certificate cannot be encoded.
+   */
+  public ByteString certificateBytes() throws UaException {
+    return SecurityConfiguration.getCertificateBytes(certificate);
+  }
+
+  /**
+   * @return the concatenated DER encoding of {@link #certificateChain()}, or {@link
+   *     ByteString#NULL_VALUE}.
+   * @throws UaException if a certificate cannot be encoded.
+   */
+  public ByteString certificateChainBytes() throws UaException {
+    return SecurityConfiguration.getCertificateChainBytes(certificateChain);
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractIdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractIdentityValidator.java
@@ -17,6 +17,7 @@ import java.security.KeyPair;
 import java.security.cert.X509Certificate;
 import javax.crypto.Cipher;
 import org.eclipse.milo.opcua.sdk.server.Session;
+import org.eclipse.milo.opcua.sdk.server.SessionServerCertificate;
 import org.eclipse.milo.opcua.sdk.server.identity.Identity.AnonymousIdentity;
 import org.eclipse.milo.opcua.sdk.server.identity.Identity.IssuedIdentity;
 import org.eclipse.milo.opcua.sdk.server.identity.Identity.UsernameIdentity;
@@ -177,9 +178,10 @@ public abstract class AbstractIdentityValidator implements IdentityValidator {
   protected byte[] decryptTokenData(Session session, SecurityAlgorithm algorithm, byte[] dataBytes)
       throws UaException {
 
+    SessionServerCertificate original = session.getOriginalServerCertificate();
+
     X509Certificate certificate =
-        CertificateUtil.decodeCertificate(
-            session.getEndpoint().getServerCertificate().bytesOrEmpty());
+        CertificateUtil.decodeCertificate(original.createSessionCertificate().bytesOrEmpty());
 
     int cipherTextBlockSize =
         SecureChannel.getAsymmetricCipherTextBlockSize(certificate, algorithm);
@@ -192,13 +194,17 @@ public abstract class AbstractIdentityValidator implements IdentityValidator {
     ByteBuffer passwordNioBuffer = ByteBuffer.wrap(dataBytes);
 
     try {
-      KeyPair keyPair =
-          session
-              .getServer()
-              .getConfig()
-              .getCertificateManager()
-              .getKeyPair(ByteString.of(DigestUtil.sha1(certificate.getEncoded())))
-              .orElseThrow(() -> new UaException(StatusCodes.Bad_SecurityChecksFailed));
+      // A retained Session still encrypts credentials to its original application certificate.
+      KeyPair keyPair = original.keyPair();
+      if (keyPair == null || !certificate.equals(original.certificate())) {
+        keyPair =
+            session
+                .getServer()
+                .getConfig()
+                .getCertificateManager()
+                .getKeyPair(ByteString.of(DigestUtil.sha1(certificate.getEncoded())))
+                .orElseThrow(() -> new UaException(StatusCodes.Bad_SecurityChecksFailed));
+      }
 
       Cipher cipher = getCipher(algorithm, keyPair);
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractX509IdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractX509IdentityValidator.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Set;
 import org.eclipse.milo.opcua.sdk.server.SecurityConfiguration;
 import org.eclipse.milo.opcua.sdk.server.Session;
+import org.eclipse.milo.opcua.sdk.server.SessionServerCertificate;
 import org.eclipse.milo.opcua.sdk.server.identity.Identity.X509UserIdentity;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
@@ -172,10 +173,11 @@ public abstract class AbstractX509IdentityValidator extends AbstractIdentityVali
     // the peer and SecurityMode this is the endpoint (leaf) bytes, the server application
     // certificate bytes, or the full chain bytes; try each candidate to match a chain-returning
     // peer. A forged signature verifies against none of them, so trying several is safe.
+    SessionServerCertificate original = session.getOriginalServerCertificate();
     List<ByteString> serverCertificateCandidates = new ArrayList<>();
-    addCandidate(serverCertificateCandidates, session.getEndpoint().getServerCertificate());
-    addCandidate(serverCertificateCandidates, sc.getServerCertificateBytes());
-    addCandidate(serverCertificateCandidates, sc.getServerCertificateChainBytes());
+    addCandidate(serverCertificateCandidates, original.createSessionCertificate());
+    addCandidate(serverCertificateCandidates, original.certificateBytes());
+    addCandidate(serverCertificateCandidates, original.certificateChainBytes());
 
     UaException failure = null;
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/package-info.java
@@ -86,5 +86,11 @@
  * owned by the transport package, and request handling is delegated to service-set implementations.
  * Code added to this package should preserve those boundaries and keep endpoint validation aligned
  * with the certificates and security policies that the transport layer can actually serve.
+ *
+ * <p>Sessions retain the server certificate and key pair they were created with, separately from
+ * the current channel configuration. When a retained Session moves to a replacement SecureChannel,
+ * application signatures still include that original certificate. Enhanced signatures also include
+ * the replacement channel's certificate and thumbprint. A certificate rotation can remove
+ * old-thumbprint lookup without rewriting the security information of retained Sessions.
  */
 package org.eclipse.milo.opcua.sdk.server;

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractUsernameIdentityValidatorTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractUsernameIdentityValidatorTest.java
@@ -36,6 +36,7 @@ import org.eclipse.milo.opcua.sdk.server.OpcUaServerConfig;
 import org.eclipse.milo.opcua.sdk.server.OpcUaServerConfigLimits;
 import org.eclipse.milo.opcua.sdk.server.SecurityConfiguration;
 import org.eclipse.milo.opcua.sdk.server.Session;
+import org.eclipse.milo.opcua.sdk.server.SessionServerCertificate;
 import org.eclipse.milo.opcua.sdk.server.identity.Identity.UsernameIdentity;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
@@ -817,13 +818,17 @@ class AbstractUsernameIdentityValidatorTest {
     when(endpoint.getServerCertificate()).thenReturn(ByteString.of(rsaCertificate.getEncoded()));
 
     Session session = mock(Session.class);
+    SecurityConfiguration securityConfiguration =
+        new SecurityConfiguration(
+            securityPolicy, MessageSecurityMode.SignAndEncrypt, null, null, null, null, null);
     when(session.getEndpoint()).thenReturn(endpoint);
     when(session.getLastNonce()).thenReturn(SERVER_NONCE);
     when(session.getServer()).thenReturn(server);
-    when(session.getSecurityConfiguration())
-        .thenReturn(
-            new SecurityConfiguration(
-                securityPolicy, MessageSecurityMode.SignAndEncrypt, null, null, null, null, null));
+    when(session.getSecurityConfiguration()).thenReturn(securityConfiguration);
+    // Built before the stubbing call: of() reads the endpoint mock.
+    SessionServerCertificate originalServerCertificate =
+        SessionServerCertificate.of(endpoint, securityConfiguration);
+    when(session.getOriginalServerCertificate()).thenReturn(originalServerCertificate);
     return session;
   }
 

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractX509IdentityValidatorTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractX509IdentityValidatorTest.java
@@ -21,6 +21,7 @@ import java.security.cert.X509Certificate;
 import java.util.List;
 import org.eclipse.milo.opcua.sdk.server.SecurityConfiguration;
 import org.eclipse.milo.opcua.sdk.server.Session;
+import org.eclipse.milo.opcua.sdk.server.SessionServerCertificate;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.security.ChannelBoundSignatureData;
@@ -111,23 +112,33 @@ class AbstractX509IdentityValidatorTest {
       throws Exception {
 
     Session session = mock(Session.class);
-    when(session.getSecurityConfiguration())
-        .thenReturn(
-            new SecurityConfiguration(
-                channelPolicy,
-                securityMode,
-                null,
-                serverCertificate,
-                serverCertificate != null ? List.of(serverCertificate) : null,
-                null,
-                null));
+    SecurityConfiguration securityConfiguration =
+        new SecurityConfiguration(
+            channelPolicy,
+            securityMode,
+            null,
+            serverCertificate,
+            serverCertificate != null ? List.of(serverCertificate) : null,
+            null,
+            null);
+    when(session.getSecurityConfiguration()).thenReturn(securityConfiguration);
     when(session.getLastNonce()).thenReturn(SERVER_NONCE);
     when(session.getClientNonce()).thenReturn(ByteString.NULL_VALUE);
 
+    ByteString createSessionCertificate = ByteString.NULL_VALUE;
     if (serverCertificate != null && tokenPolicy != null) {
-      when(session.getEndpoint())
-          .thenReturn(endpoint(channelPolicy, securityMode, tokenPolicy, serverCertificate));
+      EndpointDescription endpoint =
+          endpoint(channelPolicy, securityMode, tokenPolicy, serverCertificate);
+      when(session.getEndpoint()).thenReturn(endpoint);
+      createSessionCertificate = endpoint.getServerCertificate();
     }
+    when(session.getOriginalServerCertificate())
+        .thenReturn(
+            new SessionServerCertificate(
+                createSessionCertificate,
+                securityConfiguration.getServerCertificate(),
+                securityConfiguration.getServerCertificateChain(),
+                null));
 
     return session;
   }


### PR DESCRIPTION
Part 4 5.7.3.1 binds ActivateSession client signatures and encrypted token secrets to the serverCertificate returned by CreateSession. The server verified and decrypted against the endpoint's current certificate or the carrying channel's, so a Session retained across a server certificate rotation could not be reactivated with credentials on a replacement SecureChannel.

Sessions now capture the CreateSession certificate, chain, and key pair at creation and use them for client signature verification, user token decryption, X509 token signature checks, and enhanced user-token key selection. A Session created on an unsecured channel still uses the carrying channel's certificate.

This is the server half of #1949, split out because it is an independent server correctness fix that benefits any client reactivating a retained Session after rotation. #1949 will be rebased onto this branch; its rotation integration test exercises credential reactivation against a live server and depends on this change.
