### PR TITLE
Honor the declared output type in Matrix.transform

### DIFF
--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/Matrix.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/Matrix.java
@@ -191,8 +191,18 @@ public class Matrix {
    * Create a new Matrix by applying the transform function {@code f} to each of the elements in
    * this Matrix.
    *
+   * <p>For a nonempty Matrix, the first transformed element must be non-null. Its runtime class
+   * determines the output array component type; subsequent results may be null or assignable to
+   * that class. Use {@link #transform(Function, Class, OpcUaDataType)} when the first result may be
+   * null or the results require a common superclass or interface.
+   *
+   * <p>An empty Matrix retains its element type and UA type metadata without invoking {@code f}. A
+   * null Matrix produces a null Matrix without invoking {@code f}.
+   *
    * @param f the transform function applied to each element.
    * @return a new Matrix containing transformed elements.
+   * @throws NullPointerException if the first transformed element is null.
+   * @throws IllegalArgumentException if a later result cannot be stored in the inferred array type.
    */
   public Matrix transform(Function<Object, Object> f) {
     if (flatArray == null) {
@@ -223,13 +233,16 @@ public class Matrix {
    * Create a new Matrix by applying the transform function {@code f} to each element, using
    * explicit metadata for the transformed element type.
    *
-   * <p>Use this overload when the Matrix may be empty and the transformed element type cannot be
-   * inferred from the first transformed element.
+   * <p>The output array uses {@code transformedType} as its component type, including when the
+   * Matrix is empty. Reference types permit null results and any results assignable to that type.
+   * Primitive types use the unboxing and widening conversions supported by {@link Array#set}. A
+   * null Matrix produces a null Matrix without invoking {@code f}.
    *
    * @param f the transform function applied to each element.
-   * @param transformedType the Java class of the transformed elements.
+   * @param transformedType the Java component type of the output array.
    * @param transformedDataType the {@link OpcUaDataType} of the transformed elements.
    * @return a new Matrix containing transformed elements.
+   * @throws IllegalArgumentException if a result cannot be stored in the declared array type.
    */
   public Matrix transform(
       Function<Object, Object> f, Class<?> transformedType, OpcUaDataType transformedDataType) {
@@ -240,14 +253,18 @@ public class Matrix {
    * Create a new Matrix by applying the transform function {@code f} to each element, using
    * explicit metadata for the transformed element type.
    *
-   * <p>Use this overload when the Matrix may be empty and the transformed element type cannot be
-   * inferred from the first transformed element.
+   * <p>The output array uses {@code transformedType} as its component type, including when the
+   * Matrix is empty. Reference types permit null results and any results assignable to that type.
+   * Primitive types use the unboxing and widening conversions supported by {@link Array#set}. A
+   * null Matrix produces a null Matrix without invoking {@code f}.
    *
    * @param f the transform function applied to each element.
-   * @param transformedType the Java class of the transformed elements.
+   * @param transformedType the Java component type of the output array.
    * @param transformedDataType the {@link OpcUaDataType} of the transformed elements.
-   * @param transformedDataTypeId the {@link ExpandedNodeId} of the transformed element DataType.
+   * @param transformedDataTypeId the {@link ExpandedNodeId} of the transformed element DataType, or
+   *     null to derive it from the output array.
    * @return a new Matrix containing transformed elements.
+   * @throws IllegalArgumentException if a result cannot be stored in the declared array type.
    */
   public Matrix transform(
       Function<Object, Object> f,
@@ -258,19 +275,12 @@ public class Matrix {
       return new Matrix(null);
     } else {
       int length = Array.getLength(flatArray);
-      Object transformedArray = null;
+      Object transformedArray = Array.newInstance(transformedType, length);
 
       for (int i = 0; i < length; i++) {
         Object e = Array.get(flatArray, i);
         Object t = f.apply(e);
-        if (transformedArray == null) {
-          transformedArray = Array.newInstance(t.getClass(), length);
-        }
         Array.set(transformedArray, i, t);
-      }
-
-      if (transformedArray == null) {
-        transformedArray = Array.newInstance(transformedType, 0);
       }
 
       return new Matrix(transformedArray, dimensions, transformedDataType, transformedDataTypeId);

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/types/builtin/MatrixTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/types/builtin/MatrixTest.java
@@ -13,6 +13,7 @@ package org.eclipse.milo.opcua.stack.core.types.builtin;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Array;
@@ -23,12 +24,16 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
+import org.eclipse.milo.opcua.stack.core.types.UaStructuredType;
 import org.eclipse.milo.opcua.stack.core.types.enumerated.ApplicationType;
+import org.eclipse.milo.opcua.stack.core.types.structured.Argument;
+import org.eclipse.milo.opcua.stack.core.types.structured.Range;
 import org.eclipse.milo.opcua.stack.core.types.structured.ThreeDVector;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class MatrixTest {
   private final int[][] primitiveInt2d = {{1, 2}, {3, 4}};
@@ -76,6 +81,94 @@ class MatrixTest {
     assertEquals(OpcUaDataType.String, transformed.getDataType().orElseThrow());
     assertEquals(
         OpcUaDataType.String.getNodeId().expanded(), transformed.getDataTypeId().orElseThrow());
+  }
+
+  // The declared interface must accommodate nulls and different structured implementations (#1957).
+  @ParameterizedTest
+  @MethodSource("structuredTransformResults")
+  void transformUsesDeclaredComponentType(UaStructuredType[] results, boolean explicitDataTypeId) {
+    Integer[] indices = Stream.iterate(0, i -> i + 1).limit(results.length).toArray(Integer[]::new);
+    int[] dimensions = {1, results.length};
+    Matrix input = new Matrix(indices, dimensions);
+    ExpandedNodeId dataTypeId = OpcUaDataType.ExtensionObject.getNodeId().expanded();
+
+    Matrix transformed =
+        explicitDataTypeId
+            ? input.transform(
+                i -> results[(Integer) i],
+                UaStructuredType.class,
+                OpcUaDataType.ExtensionObject,
+                dataTypeId)
+            : input.transform(
+                i -> results[(Integer) i], UaStructuredType.class, OpcUaDataType.ExtensionObject);
+
+    assertEquals(UaStructuredType[].class, transformed.getElements().getClass());
+    assertArrayEquals(results, (UaStructuredType[]) transformed.getElements());
+    assertArrayEquals(dimensions, transformed.getDimensions());
+    assertEquals(OpcUaDataType.ExtensionObject, transformed.getDataType().orElseThrow());
+    if (explicitDataTypeId) {
+      assertEquals(dataTypeId, transformed.getDataTypeId().orElseThrow());
+    }
+  }
+
+  private static Stream<Arguments> structuredTransformResults() {
+    Argument argument = new Argument(null, null, -1, null, null);
+    Range range = new Range(0.0, 1.0);
+    return Stream.of(
+            new UaStructuredType[0],
+            new UaStructuredType[] {null, range},
+            new UaStructuredType[] {null, null},
+            new UaStructuredType[] {argument, range},
+            new UaStructuredType[] {range, null},
+            new UaStructuredType[] {range, range})
+        .flatMap(results -> Stream.of(Arguments.of(results, false), Arguments.of(results, true)));
+  }
+
+  // Even the first result must be checked against the declared type, rather than defining it.
+  @ParameterizedTest
+  @ValueSource(ints = {1, 2})
+  void transformRejectsResultsIncompatibleWithDeclaredType(int incompatibleIndex) {
+    Matrix input = new Matrix(new Integer[] {1, 2}, new int[] {1, 2});
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            input.transform(
+                i -> (Integer) i >= incompatibleIndex ? "invalid" : i,
+                Integer.class,
+                OpcUaDataType.Int32));
+  }
+
+  // Explicit primitive component types must also be honored for nonempty transformations.
+  @Test
+  void transformUsesDeclaredPrimitiveComponentType() {
+    Matrix input = new Matrix(new Integer[] {1, 2}, new int[] {1, 2});
+
+    Matrix transformed = input.transform(i -> (Integer) i + 1, int.class, OpcUaDataType.Int32);
+
+    assertArrayEquals(new int[] {2, 3}, (int[]) transformed.getElements());
+    assertArrayEquals(new int[] {1, 2}, transformed.getDimensions());
+  }
+
+  @Test
+  void inferredTransformRejectsNullFirstResult() {
+    Matrix input = new Matrix(new Integer[] {1, 2}, new int[] {1, 2});
+
+    assertThrows(NullPointerException.class, () -> input.transform(i -> null));
+  }
+
+  @Test
+  void inferredTransformRejectsResultsIncompatibleWithFirstResult() {
+    Matrix input = new Matrix(new Integer[] {1, 2}, new int[] {1, 2});
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            input.transform(
+                i ->
+                    (Integer) i == 1
+                        ? new Range(0.0, 1.0)
+                        : new Argument(null, null, -1, null, null)));
   }
 
   @Test


### PR DESCRIPTION
Typed `Matrix.transform()` calls currently allocate nonempty output arrays from the first result's runtime class, ignoring the declared component type. This fails for a null first result or mixed structured implementations even when all results fit the requested interface.

Allocate the output array from `transformedType` for both empty and nonempty matrices, preserving dimensions and supplied UA metadata. Compatible null and heterogeneous results are accepted, and incompatible results fail with `IllegalArgumentException`. Document the inference-only overload's existing limits and direct callers to the typed overload when needed.

Regression coverage includes null-first and all-null output, mixed structured implementations, empty output, explicit metadata, primitive component types, and incompatible results. Formatting and the full reactor compile passed, along with all 583 stack-core tests.

Fixes #1957.
