### PR TITLE
Convert every UInt64 to Double and Float

### DIFF
--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/UInt64Conversions.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/events/conversions/UInt64Conversions.java
@@ -43,26 +43,14 @@ final class UInt64Conversions {
     }
   }
 
-  @Nullable
+  @NonNull
   static Double uInt64ToDouble(@NonNull ULong ul) {
-    long l = ul.longValue();
-
-    if (Long.compareUnsigned(l, (long) Double.MAX_VALUE) <= 0) {
-      return ul.doubleValue();
-    } else {
-      return null;
-    }
+    return ul.doubleValue();
   }
 
-  @Nullable
+  @NonNull
   static Float uInt64ToFloat(@NonNull ULong ul) {
-    long l = ul.longValue();
-
-    if (Long.compareUnsigned(l, (long) Float.MAX_VALUE) <= 0) {
-      return ul.floatValue();
-    } else {
-      return null;
-    }
+    return ul.floatValue();
   }
 
   @Nullable

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/conversions/UInt64ConversionsTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/events/conversions/UInt64ConversionsTest.java
@@ -48,14 +48,25 @@ public class UInt64ConversionsTest extends AbstractConversionTest<ULong> {
 
       case Double:
         {
-          ULong dMax = ulong((long) Double.MAX_VALUE);
-          return new Conversion[] {c(ulong(0), (0d)), c(dMax, dMax.doubleValue())};
+          // ulong(Long.MIN_VALUE) is 2^63, the first value with the sign bit set, and ULong.MAX is
+          // 2^64-1; neither is representable exactly, so the expected values are the nearest
+          // double.
+          return new Conversion[] {
+            c(ulong(0), 0d),
+            c(ulong(Long.MAX_VALUE), 9.223372036854776E18),
+            c(ulong(Long.MIN_VALUE), 9.223372036854776E18),
+            c(ULong.MAX, 1.8446744073709552E19)
+          };
         }
 
       case Float:
         {
-          ULong fMax = ulong((long) Float.MAX_VALUE);
-          return new Conversion[] {c(ulong(0), 0f), c(fMax, fMax.floatValue())};
+          return new Conversion[] {
+            c(ulong(0), 0f),
+            c(ulong(Long.MAX_VALUE), 9.223372E18f),
+            c(ulong(Long.MIN_VALUE), 9.223372E18f),
+            c(ULong.MAX, 1.8446744E19f)
+          };
         }
 
       case Int16:


### PR DESCRIPTION
`uInt64ToDouble` and `uInt64ToFloat` guard their result with

```java
Long.compareUnsigned(l, (long) Double.MAX_VALUE) <= 0
```

`(long) Double.MAX_VALUE` and `(long) Float.MAX_VALUE` both saturate to `Long.MAX_VALUE`, so the guard rejects everything with the sign bit set and every value >= 2^63 converts to `null`.

Both are implicit conversions, and the sibling classes convert to Double and Float unconditionally — `uInt32ToDouble`, `uInt16ToDouble`, `byteToDouble`, `int64ToDouble` are all `@NonNull` one-liners. Double and Float cover the whole UInt64 range, so there is nothing to reject; it looks like the `compareUnsigned(l, BOUND)` pattern used for the integer targets in the same file applied where it does not fit.

The `null` is not inert. `ImplicitConversionBinaryOperator` treats a failed common-type conversion as `false`, so `Equals`, `GreaterThan`, `LessThan`, `Between` and `InList` answer `false` for a UInt64 operand >= 2^63 compared against a Double or Float, and `Cast` returns `null`.

The existing Double and Float cases in `UInt64ConversionsTest` used `ulong((long) Double.MAX_VALUE)`, which is `Long.MAX_VALUE`, so they never crossed the boundary. Added cases for 2^63 and `ULong.MAX`; they fail before the change and pass after.

---

- [ ] You have signed an Eclipse Contributor Agreement and are committing using the same email address
- [x] Your code contains any tests relevant to the problem you are solving
- [x] All new and existing tests passed
- [x] Code follows the style guidelines and Checkstyle passes
