### PR TITLE
Remove trust list certificates and CRLs by content, not filename

### DIFF
--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/FileBasedTrustListManager.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/FileBasedTrustListManager.java
@@ -20,9 +20,11 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardWatchEventKinds;
 import java.nio.file.WatchKey;
 import java.nio.file.WatchService;
@@ -36,6 +38,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -48,6 +51,7 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
 import org.eclipse.milo.opcua.stack.core.util.CertificateUtil;
 import org.eclipse.milo.opcua.stack.core.util.WatchKeyRunner;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -227,7 +231,7 @@ public class FileBasedTrustListManager implements TrustListManager, Closeable {
       Set<X509CRL> toDelete = Sets.difference(oldSet, this.issuerCrls);
 
       toWrite.forEach(crl -> writeCrlToDir(crl, issuerCrlDir));
-      toDelete.forEach(crl -> deleteCrlFromDir(crl, issuerCrlDir));
+      deleteCrlsFromDir(toDelete, issuerCrlDir);
     } finally {
       readWriteLock.writeLock().unlock();
     }
@@ -246,7 +250,7 @@ public class FileBasedTrustListManager implements TrustListManager, Closeable {
       Set<X509CRL> toDelete = Sets.difference(oldSet, this.trustedCrls);
 
       toWrite.forEach(crl -> writeCrlToDir(crl, trustedCrlDir));
-      toDelete.forEach(crl -> deleteCrlFromDir(crl, trustedCrlDir));
+      deleteCrlsFromDir(toDelete, trustedCrlDir);
     } finally {
       readWriteLock.writeLock().unlock();
     }
@@ -265,7 +269,7 @@ public class FileBasedTrustListManager implements TrustListManager, Closeable {
       Set<X509Certificate> toDelete = Sets.difference(oldSet, this.issuerCertificates);
 
       toWrite.forEach(cert -> writeCertificateToDir(cert, issuerCertsDir));
-      toDelete.forEach(cert -> deleteCertificateFromDir(cert, issuerCertsDir));
+      deleteCertificatesFromDir(thumbprints(toDelete), issuerCertsDir);
     } finally {
       readWriteLock.writeLock().unlock();
     }
@@ -284,7 +288,7 @@ public class FileBasedTrustListManager implements TrustListManager, Closeable {
       Set<X509Certificate> toDelete = Sets.difference(oldSet, this.trustedCertificates);
 
       toWrite.forEach(cert -> writeCertificateToDir(cert, trustedCertsDir));
-      toDelete.forEach(cert -> deleteCertificateFromDir(cert, trustedCertsDir));
+      deleteCertificatesFromDir(thumbprints(toDelete), trustedCertsDir);
     } finally {
       readWriteLock.writeLock().unlock();
     }
@@ -318,7 +322,7 @@ public class FileBasedTrustListManager implements TrustListManager, Closeable {
   public boolean removeIssuerCertificate(ByteString thumbprint) {
     readWriteLock.writeLock().lock();
     try {
-      deleteCertificateFromDir(thumbprint, issuerCertsDir);
+      deleteCertificatesFromDir(Set.of(thumbprint), issuerCertsDir);
 
       return remove(thumbprint, issuerCertificates);
     } finally {
@@ -330,7 +334,7 @@ public class FileBasedTrustListManager implements TrustListManager, Closeable {
   public boolean removeTrustedCertificate(ByteString thumbprint) {
     readWriteLock.writeLock().lock();
     try {
-      deleteCertificateFromDir(thumbprint, trustedCertsDir);
+      deleteCertificatesFromDir(Set.of(thumbprint), trustedCertsDir);
 
       return remove(thumbprint, trustedCertificates);
     } finally {
@@ -339,14 +343,23 @@ public class FileBasedTrustListManager implements TrustListManager, Closeable {
   }
 
   private static boolean remove(ByteString thumbprint, Set<X509Certificate> certificates) {
-    return certificates.removeIf(
-        certificate -> {
-          try {
-            return CertificateUtil.thumbprint(certificate).equals(thumbprint);
-          } catch (UaException ignored) {
-            return false;
-          }
-        });
+    return certificates.removeIf(certificate -> thumbprint.equals(thumbprintOf(certificate)));
+  }
+
+  private static Set<ByteString> thumbprints(Set<X509Certificate> certificates) {
+    return certificates.stream()
+        .map(FileBasedTrustListManager::thumbprintOf)
+        .filter(Objects::nonNull)
+        .collect(Collectors.toSet());
+  }
+
+  private static @Nullable ByteString thumbprintOf(X509Certificate certificate) {
+    try {
+      return CertificateUtil.thumbprint(certificate);
+    } catch (UaException e) {
+      LOGGER.warn("Error computing certificate thumbprint", e);
+      return null;
+    }
   }
 
   @Override
@@ -470,26 +483,37 @@ public class FileBasedTrustListManager implements TrustListManager, Closeable {
     }
   }
 
-  private static void deleteCertificateFromDir(X509Certificate certificate, Path path) {
-    try {
-      deleteCertificateFromDir(ByteString.of(sha1(certificate.getEncoded())), path);
-    } catch (Exception e) {
-      LOGGER.error("Error deleting certificate", e);
+  /**
+   * Delete every file in {@code directory} that decodes to a certificate whose thumbprint is in
+   * {@code thumbprints}.
+   *
+   * <p>Files are matched by their decoded contents rather than by name, so certificates that were
+   * imported under an arbitrary filename, or written by an older version of Milo, are found too.
+   */
+  private static void deleteCertificatesFromDir(Set<ByteString> thumbprints, Path directory) {
+    if (thumbprints.isEmpty()) {
+      return;
     }
-  }
 
-  private static void deleteCertificateFromDir(ByteString thumbprint, Path path) {
-    try {
-      String filename = String.format("%s.der", ByteBufUtil.hexDump(thumbprint.bytesOrEmpty()));
-      File file = path.resolve(filename).toFile();
+    try (var files = Files.list(directory)) {
+      for (Path file : files.toList()) {
+        boolean matches =
+            decodeCertificateFile(file)
+                .map(certificate -> thumbprints.contains(thumbprintOf(certificate)))
+                .orElse(false);
 
-      if (file.exists()) {
-        Files.delete(file.toPath());
+        if (matches) {
+          try {
+            Files.delete(file);
 
-        LOGGER.debug("Deleted certificate: {}", file.getAbsolutePath());
+            LOGGER.debug("Deleted certificate: {}", file.toAbsolutePath());
+          } catch (IOException e) {
+            LOGGER.error("Error deleting certificate: {}", file, e);
+          }
+        }
       }
-    } catch (Exception e) {
-      LOGGER.error("Error deleting certificate", e);
+    } catch (IOException e) {
+      LOGGER.error("Error listing certificate directory: {}", directory, e);
     }
   }
 
@@ -510,26 +534,69 @@ public class FileBasedTrustListManager implements TrustListManager, Closeable {
     }
   }
 
-  private static void deleteCrlFromDir(X509CRL crl, Path path) {
-    try {
-      deleteCrlFromDir(ByteString.of(sha1(crl.getEncoded())), path);
-    } catch (Exception e) {
-      LOGGER.error("Error deleting CRL", e);
+  /**
+   * Remove every CRL in {@code removed} from the files in {@code directory}.
+   *
+   * <p>Files are matched by their decoded contents rather than by name. A file that contains only
+   * removed CRLs is deleted; a file that also contains other CRLs is rewritten without the removed
+   * ones.
+   */
+  private static void deleteCrlsFromDir(Set<X509CRL> removed, Path directory) {
+    if (removed.isEmpty()) {
+      return;
+    }
+
+    try (var files = Files.list(directory)) {
+      for (Path file : files.toList()) {
+        List<X509CRL> contents = decodeCrlFile(file).orElse(List.of());
+        List<X509CRL> retained = contents.stream().filter(crl -> !removed.contains(crl)).toList();
+
+        if (retained.size() == contents.size()) {
+          continue;
+        }
+
+        try {
+          if (retained.isEmpty()) {
+            Files.delete(file);
+
+            LOGGER.debug("Deleted CRL: {}", file.toAbsolutePath());
+          } else {
+            replaceCrlFile(file, retained);
+
+            LOGGER.debug("Removed CRLs from bundle: {}", file.toAbsolutePath());
+          }
+        } catch (Exception e) {
+          LOGGER.error("Error removing CRLs from file: {}", file, e);
+        }
+      }
+    } catch (IOException e) {
+      LOGGER.error("Error listing CRL directory: {}", directory, e);
     }
   }
 
-  private static void deleteCrlFromDir(ByteString thumbprint, Path path) {
+  private static void replaceCrlFile(Path file, List<X509CRL> crls) throws Exception {
+    // Write the surviving CRLs to a temporary file first so a failure part way through cannot
+    // destroy the unrelated CRLs the bundle also contains.
+    Path temporary = Files.createTempFile(file.getParent(), ".crl-", ".tmp");
     try {
-      String filename = String.format("%s.crl", ByteBufUtil.hexDump(thumbprint.bytesOrEmpty()));
-      File file = path.resolve(filename).toFile();
-
-      if (file.exists()) {
-        Files.delete(file.toPath());
-
-        LOGGER.debug("Deleted CRL: {}", file.getAbsolutePath());
+      if (file.getFileSystem().supportedFileAttributeViews().contains("posix")) {
+        Files.setPosixFilePermissions(temporary, Files.getPosixFilePermissions(file));
       }
-    } catch (Exception e) {
-      LOGGER.error("Error deleting CRL", e);
+
+      try (var output = Files.newOutputStream(temporary)) {
+        for (X509CRL crl : crls) {
+          output.write(crl.getEncoded());
+        }
+      }
+
+      try {
+        Files.move(
+            temporary, file, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+      } catch (AtomicMoveNotSupportedException e) {
+        Files.move(temporary, file, StandardCopyOption.REPLACE_EXISTING);
+      }
+    } finally {
+      Files.deleteIfExists(temporary);
     }
   }
 

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/FileBasedTrustListManager.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/FileBasedTrustListManager.java
@@ -583,10 +583,13 @@ public class FileBasedTrustListManager implements TrustListManager, Closeable {
         Files.setPosixFilePermissions(temporary, Files.getPosixFilePermissions(file));
       }
 
-      try (var output = Files.newOutputStream(temporary)) {
+      try (var output = new FileOutputStream(temporary.toFile())) {
         for (X509CRL crl : crls) {
           output.write(crl.getEncoded());
         }
+        // Force the surviving CRLs to stable storage before the rename publishes the file, so a
+        // crash cannot leave a truncated bundle in place of the original.
+        output.getFD().sync();
       }
 
       try {

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/security/FileBasedTrustListManagerTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/security/FileBasedTrustListManagerTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.core.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.security.KeyPair;
+import java.security.PrivateKey;
+import java.security.Security;
+import java.security.cert.X509CRL;
+import java.security.cert.X509Certificate;
+import java.util.Base64;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.cert.X509CRLHolder;
+import org.bouncycastle.cert.X509v2CRLBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509CRLConverter;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.util.CertificateUtil;
+import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateBuilder;
+import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateGenerator;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class FileBasedTrustListManagerTest {
+
+  static {
+    Security.addProvider(new BouncyCastleProvider());
+  }
+
+  @TempDir Path directory;
+
+  // Files may have been hand-copied into the directory or written by an older Milo version under
+  // a different naming scheme. Removal must find them by content, or the certificate comes back
+  // the next time the directory is synchronized. Reopening the manager checks the on-disk result
+  // rather than the in-memory set.
+  @ParameterizedTest
+  @CsvSource({"trusted,remove", "trusted,replace", "issuer,remove", "issuer,replace"})
+  void removingCertificateWithArbitraryFilenameDeletesItsFiles(String list, String operation)
+      throws Exception {
+    Material removed = material("Removed");
+    Material retained = material("Retained");
+    Path certs = Files.createDirectories(directory.resolve(list).resolve("certs"));
+    Path imported = certs.resolve("operator-certificate.pem");
+    Path duplicate = certs.resolve("another-name.cer");
+    Files.writeString(imported, pem("CERTIFICATE", removed.certificate().getEncoded()));
+    Files.write(duplicate, removed.certificate().getEncoded());
+    Files.write(certs.resolve("retained.cer"), retained.certificate().getEncoded());
+
+    try (var manager = FileBasedTrustListManager.createAndInitialize(directory)) {
+      assertEquals(
+          Set.of(removed.certificate(), retained.certificate()),
+          Set.copyOf(certificates(manager, list)));
+
+      if (operation.equals("remove")) {
+        ByteString thumbprint = CertificateUtil.thumbprint(removed.certificate());
+        boolean changed =
+            list.equals("trusted")
+                ? manager.removeTrustedCertificate(thumbprint)
+                : manager.removeIssuerCertificate(thumbprint);
+        assertTrue(changed);
+      } else if (list.equals("trusted")) {
+        manager.setTrustedCertificates(List.of(retained.certificate()));
+      } else {
+        manager.setIssuerCertificates(List.of(retained.certificate()));
+      }
+
+      assertEquals(List.of(retained.certificate()), certificates(manager, list));
+    }
+
+    assertFalse(Files.exists(imported));
+    assertFalse(Files.exists(duplicate));
+
+    try (var reopened = FileBasedTrustListManager.createAndInitialize(directory)) {
+      assertEquals(List.of(retained.certificate()), certificates(reopened, list));
+    }
+  }
+
+  // A single CRL file can bundle several CRLs. Removing one member must not delete the file and
+  // take the other members with it, and must not leave a second copy of the removed CRL behind.
+  @ParameterizedTest
+  @ValueSource(strings = {"trusted", "issuer"})
+  void removingCrlFromBundlePreservesOtherMembers(String list) throws Exception {
+    Material removed = material("Removed");
+    Material retained = material("Retained");
+    Material alsoRetained = material("AlsoRetained");
+    Path crls = Files.createDirectories(directory.resolve(list).resolve("crl"));
+    Path bundle = crls.resolve("operator-bundle.pem");
+    Files.writeString(
+        bundle,
+        pem("X509 CRL", removed.crl().getEncoded())
+            + pem("X509 CRL", retained.crl().getEncoded())
+            + pem("X509 CRL", alsoRetained.crl().getEncoded()));
+    Path duplicate = crls.resolve("duplicate.revocations");
+    Files.write(duplicate, removed.crl().getEncoded());
+
+    boolean posix = bundle.getFileSystem().supportedFileAttributeViews().contains("posix");
+    if (posix) {
+      Files.setPosixFilePermissions(bundle, PosixFilePermissions.fromString("rw-r-----"));
+    }
+
+    try (var manager = FileBasedTrustListManager.createAndInitialize(directory)) {
+      assertEquals(
+          Set.of(removed.crl(), retained.crl(), alsoRetained.crl()),
+          Set.copyOf(crls(manager, list)));
+
+      if (list.equals("trusted")) {
+        manager.setTrustedCrls(List.of(retained.crl(), alsoRetained.crl()));
+      } else {
+        manager.setIssuerCrls(List.of(retained.crl(), alsoRetained.crl()));
+      }
+
+      assertEquals(Set.of(retained.crl(), alsoRetained.crl()), Set.copyOf(crls(manager, list)));
+    }
+
+    assertFalse(Files.exists(duplicate));
+    assertTrue(Files.exists(bundle));
+    if (posix) {
+      assertEquals(
+          PosixFilePermissions.fromString("rw-r-----"), Files.getPosixFilePermissions(bundle));
+    }
+
+    try (var reopened = FileBasedTrustListManager.createAndInitialize(directory)) {
+      assertEquals(Set.of(retained.crl(), alsoRetained.crl()), Set.copyOf(crls(reopened, list)));
+    }
+  }
+
+  private static List<X509Certificate> certificates(
+      FileBasedTrustListManager manager, String list) {
+    return list.equals("trusted")
+        ? manager.getTrustedCertificates()
+        : manager.getIssuerCertificates();
+  }
+
+  private static List<X509CRL> crls(FileBasedTrustListManager manager, String list) {
+    return list.equals("trusted") ? manager.getTrustedCrls() : manager.getIssuerCrls();
+  }
+
+  private static Material material(String name) throws Exception {
+    KeyPair keyPair = SelfSignedCertificateGenerator.generateRsaKeyPair(2048);
+    X509Certificate certificate =
+        new SelfSignedCertificateBuilder(keyPair)
+            .setCommonName(name)
+            .setApplicationUri("urn:eclipse:milo:test:" + name)
+            .build();
+
+    return new Material(certificate, generateCrl(certificate, keyPair.getPrivate()));
+  }
+
+  private static X509CRL generateCrl(X509Certificate issuer, PrivateKey privateKey)
+      throws Exception {
+    X509v2CRLBuilder builder =
+        new X509v2CRLBuilder(
+            X500Name.getInstance(issuer.getSubjectX500Principal().getEncoded()), new Date());
+    builder.setNextUpdate(new Date(System.currentTimeMillis() + 60_000));
+
+    JcaContentSignerBuilder signerBuilder = new JcaContentSignerBuilder("SHA256WithRSAEncryption");
+    signerBuilder.setProvider("BC");
+
+    X509CRLHolder holder = builder.build(signerBuilder.build(privateKey));
+
+    JcaX509CRLConverter converter = new JcaX509CRLConverter();
+    converter.setProvider("BC");
+
+    return converter.getCRL(holder);
+  }
+
+  private static String pem(String type, byte[] bytes) {
+    return "-----BEGIN "
+        + type
+        + "-----\n"
+        + Base64.getMimeEncoder(64, new byte[] {'\n'}).encodeToString(bytes)
+        + "\n-----END "
+        + type
+        + "-----\n";
+  }
+
+  private record Material(X509Certificate certificate, X509CRL crl) {}
+}


### PR DESCRIPTION
`FileBasedTrustListManager` removed certificates and CRLs by reconstructing the `<sha1>.der` or `<sha1>.crl` filename it would have written itself. A file placed in the directory under any other name, whether hand-copied or carried over from a Milo 0.6/0.7 trust list, was never deleted. The in-memory removal still succeeded and `removeTrustedCertificate` returned `true`, but the next directory synchronization (triggered by any other change in the directory, or a restart) re-read the surviving file and the certificate came back. Since the file was still on disk, it was also still trusted for validation the whole time.

This change locates files by decoding them and comparing their contents, the same approach `FileBasedCertificateQuarantine` already uses. Every file matching a removed certificate is deleted, so duplicates under different names go too. For CRLs, a file that bundles several CRLs is rewritten without the removed members instead of being deleted outright, so unrelated CRLs in the same file survive. The rewrite goes through a temporary file and preserves the bundle's POSIX permissions. Both `remove*Certificate` and the `set*` replacement paths route through the new helpers.

This is a hand-written port of #1911 (merged to `integration/1.2`) onto the mutable-set API that `main` still uses, so the fix can ship in 1.1.7.

Verification: added `FileBasedTrustListManagerTest`, which reproduces the issue with certificates and CRL bundles under arbitrary filenames and checks the on-disk result by reopening the manager. All six cases fail against the previous code and pass with this change. `mvn -pl opc-ua-stack/stack-core clean verify` passes, including the spotless check.

Fixes #1961
