### PR TITLE
Support Aes256_Sha256_RsaPss without BC provider registration

### DIFF
--- a/docs/releases/1.2.0.md
+++ b/docs/releases/1.2.0.md
@@ -64,6 +64,10 @@ support and certificate compatibility determine whether an endpoint can be adver
 Only the AEAD-suffixed ECC policy URIs are supported; older suffix-less ECC URIs are
 rejected. Existing RSA policies remain available.
 
+`Aes256_Sha256_RsaPss` now works with the built-in JDK 17+ providers without registering
+`BouncyCastleProvider`. Bouncy Castle libraries remain dependencies for certificate
+utilities and other security policies.
+
 `CertificateIdentity` joins a key pair, certificate chain, type, and owning group.
 `CertificateIdentitySelector` selects compatible material for connection setup.
 See the [stack security package][security-package] for supported profiles and providers,
@@ -380,6 +384,12 @@ an explicit non-None certificate-token policy. An explicitly specified non-None 
 secured channel's RSA/ECC public-key family, including signed X.509 tokens. Enhanced username secrets require a secured channel; this restriction
 does not prohibit enhanced signed X.509 tokens on None channels. `UsernameProvider` selects
 usable policies before invoking a custom chooser, so review chooser assumptions.
+
+Direct users of `SecurityAlgorithm.getTransformation()` for RSA signatures or ciphers
+should create those JCA operations through `SignatureFactory` and `CipherFactory` in
+`org.eclipse.milo.opcua.stack.core.util`. The RSA-PSS and RSA-OAEP transformation strings
+changed to the JDK names, and those algorithms now require the explicit parameters from
+`SecurityAlgorithm.getAlgorithmParameterSpec()`. The factories apply them.
 
 For direct policy users, do not dereference legacy algorithm getters across every
 `SecurityPolicy.values()` entry. Enhanced policies return null for symmetric signature,
@@ -714,6 +724,8 @@ Supporting evidence: [instantiation package][instantiation-package],
   update concurrency, restart persistence, and application-owned resource closure.
 - Inspect advertised endpoints and token policies. Test equivalent hostname aliases,
   discovery-only None channels, all identity types, failed authentication, and renewal.
+- Replace direct RSA `Signature`/`Cipher` construction from `SecurityAlgorithm`
+  transformations with `SignatureFactory` and `CipherFactory`.
 - If adopting Reverse Connect, configure endpoint selection and validation explicitly; test
   reconnect mode, discovery/production connection separation, and client/listener cleanup.
 - If migrating factories, compare persisted NodeIds, optional methods, modeled permissions,

--- a/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/ClientExampleRunner.java
+++ b/milo-examples/client-examples/src/main/java/org/eclipse/milo/examples/client/ClientExampleRunner.java
@@ -14,12 +14,10 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.security.Security;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.eclipse.milo.examples.server.ExampleServer;
 import org.eclipse.milo.opcua.sdk.client.EndpointConfiguration;
 import org.eclipse.milo.opcua.sdk.client.EndpointResolver;
@@ -38,11 +36,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ClientExampleRunner {
-
-  static {
-    // Required for SecurityPolicy.Aes256_Sha256_RsaPss
-    Security.addProvider(new BouncyCastleProvider());
-  }
 
   private final Logger logger = LoggerFactory.getLogger(getClass());
 

--- a/milo-examples/server-examples/src/main/java/org/eclipse/milo/examples/server/ExampleServer.java
+++ b/milo-examples/server-examples/src/main/java/org/eclipse/milo/examples/server/ExampleServer.java
@@ -20,7 +20,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.KeyPair;
-import java.security.Security;
 import java.security.cert.X509Certificate;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -31,7 +30,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.eclipse.milo.opcua.sdk.server.EndpointConfig;
 import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
 import org.eclipse.milo.opcua.sdk.server.OpcUaServerConfig;
@@ -77,9 +75,6 @@ public class ExampleServer {
   private final int tcpBindPort;
 
   static {
-    // Required for SecurityPolicy.Aes256_Sha256_RsaPss
-    Security.addProvider(new BouncyCastleProvider());
-
     try {
       NonceUtil.blockUntilSecureRandomSeeded(10, TimeUnit.SECONDS);
     } catch (ExecutionException | InterruptedException | TimeoutException e) {

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/session/RsaSessionIntegrationTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/session/RsaSessionIntegrationTest.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client.session;
+
+import static org.eclipse.milo.opcua.sdk.server.OpcUaServerConfig.USER_TOKEN_POLICY_ANONYMOUS;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.security.Provider;
+import java.security.Security;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
+import org.eclipse.milo.opcua.sdk.client.identity.AnonymousProvider;
+import org.eclipse.milo.opcua.sdk.client.identity.IdentityProvider;
+import org.eclipse.milo.opcua.sdk.client.identity.UsernameProvider;
+import org.eclipse.milo.opcua.sdk.client.identity.X509IdentityProvider;
+import org.eclipse.milo.opcua.sdk.server.EndpointConfig;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServerConfigBuilder;
+import org.eclipse.milo.opcua.sdk.test.TestServer;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.security.DefaultClientCertificateValidator;
+import org.eclipse.milo.opcua.stack.core.security.MemoryCertificateQuarantine;
+import org.eclipse.milo.opcua.stack.core.security.MemoryTrustListManager;
+import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.MessageSecurityMode;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.TimestampsToReturn;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.UserTokenType;
+import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.parallel.Isolated;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@Isolated("Changes the JVM security provider order")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class RsaSessionIntegrationTest {
+
+  private static final Provider BC = new BouncyCastleProvider();
+  private static final List<SecurityPolicy> RSA_POLICIES =
+      List.of(
+          SecurityPolicy.Basic128Rsa15,
+          SecurityPolicy.Basic256,
+          SecurityPolicy.Basic256Sha256,
+          SecurityPolicy.Aes128_Sha256_RsaOaep,
+          SecurityPolicy.Aes256_Sha256_RsaPss);
+  private static final List<MessageSecurityMode> MODES =
+      List.of(MessageSecurityMode.Sign, MessageSecurityMode.SignAndEncrypt);
+  private static final List<UserTokenType> IDENTITIES =
+      List.of(UserTokenType.Anonymous, UserTokenType.UserName, UserTokenType.Certificate);
+  private TestServer testServer;
+  private OpcUaServer server;
+  private String endpointUrl;
+  private DefaultClientCertificateValidator certificateValidator;
+  private Provider previousBc;
+
+  @BeforeAll
+  void startServer() throws Exception {
+    previousBc = Security.getProvider("BC");
+    Security.removeProvider("BC");
+    testServer = TestServer.create(builder -> builder.setEndpoints(rsaEndpoints(builder)));
+    server = testServer.getServer();
+    EndpointConfig endpoint = server.getConfig().getEndpoints().iterator().next();
+    endpointUrl = endpoint.getEndpointUrl();
+    var trustList = new MemoryTrustListManager();
+    trustList.addTrustedCertificate(endpoint.getCertificate());
+    certificateValidator =
+        new DefaultClientCertificateValidator(trustList, new MemoryCertificateQuarantine());
+    server.startup().get(10, TimeUnit.SECONDS);
+    assertNull(Security.getProvider("BC"), "server setup must not register BC");
+  }
+
+  @AfterAll
+  void stopServer() throws Exception {
+    try {
+      if (server != null) {
+        server.shutdown().get(10, TimeUnit.SECONDS);
+      }
+    } finally {
+      Security.removeProvider("BC");
+      if (previousBc != null) {
+        Security.addProvider(previousBc);
+      }
+    }
+  }
+
+  // Username and certificate token policies leave the security policy URI null so the token
+  // inherits the endpoint's RSA policy, unlike the Basic256Sha256-pinned OpcUaServerConfig
+  // constants.
+  private static Set<EndpointConfig> rsaEndpoints(OpcUaServerConfigBuilder builder) {
+    EndpointConfig base = builder.build().getEndpoints().iterator().next();
+    Set<EndpointConfig> endpoints = new LinkedHashSet<>();
+    for (SecurityPolicy policy : RSA_POLICIES) {
+      for (MessageSecurityMode mode : MODES) {
+        endpoints.add(
+            EndpointConfig.newBuilder()
+                .setBindAddress("localhost")
+                .setHostname("localhost")
+                .setBindPort(base.getBindPort())
+                .setPath("/test")
+                .setTransportProfile(base.getTransportProfile())
+                .setCertificate(base.getCertificate())
+                .setSecurityPolicy(policy)
+                .setSecurityMode(mode)
+                .addTokenPolicies(
+                    USER_TOKEN_POLICY_ANONYMOUS,
+                    new UserTokenPolicy("username", UserTokenType.UserName, null, null, null),
+                    new UserTokenPolicy("certificate", UserTokenType.Certificate, null, null, null))
+                .build());
+      }
+    }
+    return endpoints;
+  }
+
+  @BeforeEach
+  @AfterEach
+  void removeBouncyCastle() {
+    Security.removeProvider("BC");
+  }
+
+  // A successful authenticated Read requires OpenSecureChannel, CreateSession, and ActivateSession
+  // to agree on the RSA policy. Token policies inherit the endpoint policy, including RSA-PSS.
+  @ParameterizedTest
+  @MethodSource("rsaConfigurations")
+  void establishesChannelActivatesSessionAndReads(
+      SecurityPolicy policy, MessageSecurityMode mode, UserTokenType identity, boolean bcFirst)
+      throws Exception {
+    if (bcFirst) {
+      Security.insertProviderAt(BC, 1);
+    }
+    IdentityProvider provider =
+        switch (identity) {
+          case Anonymous -> AnonymousProvider.INSTANCE;
+          case UserName -> new UsernameProvider("user1", "password");
+          case Certificate ->
+              new X509IdentityProvider(
+                  testServer.getIdentityCertificate1().certificate(),
+                  testServer.getIdentityCertificate1().keyPair().getPrivate());
+          default -> throw new IllegalArgumentException(identity.name());
+        };
+    OpcUaClient client = createClient(policy, mode, provider);
+    try {
+      client.connectAsync().get(10, TimeUnit.SECONDS);
+      assertNotNull(client.getSession());
+      assertEquals(policy.getUri(), client.getConfig().getEndpoint().getSecurityPolicyUri());
+      assertEquals(mode, client.getConfig().getEndpoint().getSecurityMode());
+      DataValue value =
+          client.readValue(0, TimestampsToReturn.Neither, NodeIds.Server_ServerStatus_State);
+      assertTrue(value.statusCode().isGood());
+      assertNotNull(value.value().value());
+      assertEquals(
+          bcFirst,
+          Security.getProvider("BC") != null,
+          "connection must not change BC registration");
+    } finally {
+      client.disconnectAsync().get(10, TimeUnit.SECONDS);
+    }
+  }
+
+  // A wrong password must fail activation even when an anonymous token policy is also advertised.
+  // The legacy encrypted-token validator reports Bad_IdentityTokenInvalid for bad credentials.
+  @ParameterizedTest
+  @EnumSource(
+      value = MessageSecurityMode.class,
+      names = {"Sign", "SignAndEncrypt"})
+  void rejectsIncorrectPasswordWithRsaPss(MessageSecurityMode mode) throws Exception {
+    OpcUaClient client =
+        createClient(
+            SecurityPolicy.Aes256_Sha256_RsaPss, mode, new UsernameProvider("user1", "incorrect"));
+    try {
+      ExecutionException failure =
+          assertThrows(
+              ExecutionException.class, () -> client.connectAsync().get(10, TimeUnit.SECONDS));
+      assertEquals(
+          StatusCodes.Bad_IdentityTokenInvalid,
+          UaException.extract(failure).orElseThrow().getStatusCode().value());
+    } finally {
+      client.disconnectAsync().get(10, TimeUnit.SECONDS);
+    }
+  }
+
+  private OpcUaClient createClient(
+      SecurityPolicy policy, MessageSecurityMode mode, IdentityProvider identity)
+      throws UaException {
+    return OpcUaClient.create(
+        endpointUrl,
+        endpoints ->
+            endpoints.stream()
+                .filter(
+                    e ->
+                        policy.getUri().equals(e.getSecurityPolicyUri())
+                            && e.getSecurityMode() == mode)
+                .findFirst(),
+        transportBuilder -> {},
+        builder ->
+            builder
+                .setCertificateIdentity(
+                    testServer.getClientKeyPair(), testServer.getClientCertificateChain())
+                .setCertificateValidator(certificateValidator)
+                .setIdentityProvider(identity)
+                .setRequestTimeout(uint(5_000)));
+  }
+
+  private static Stream<Arguments> rsaConfigurations() {
+    List<Arguments> configurations = new ArrayList<>();
+    for (SecurityPolicy policy : RSA_POLICIES) {
+      for (MessageSecurityMode mode : MODES) {
+        for (UserTokenType identity : IDENTITIES) {
+          for (boolean bcFirst : List.of(false, true)) {
+            configurations.add(Arguments.of(policy, mode, identity, bcFirst));
+          }
+        }
+      }
+    }
+    return configurations.stream();
+  }
+}

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/test/TestServer.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/test/TestServer.java
@@ -17,14 +17,12 @@ import static org.eclipse.milo.opcua.sdk.server.OpcUaServerConfig.USER_TOKEN_POL
 import java.io.File;
 import java.nio.file.Files;
 import java.security.KeyPair;
-import java.security.Security;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.eclipse.milo.opcua.sdk.server.EndpointConfig;
 import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
 import org.eclipse.milo.opcua.sdk.server.OpcUaServerConfig;
@@ -60,11 +58,6 @@ import org.eclipse.milo.opcua.stack.transport.server.tcp.OpcTcpServerTransportCo
 public final class TestServer {
 
   private static TestCertificateMaterial certificateMaterial;
-
-  static {
-    // Required for SecurityPolicy.Aes256_Sha256_RsaPss
-    Security.addProvider(new BouncyCastleProvider());
-  }
 
   private final OpcUaServer opcUaServer;
   private final X509Certificate clientCertificate;

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/identity/UsernameProvider.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/identity/UsernameProvider.java
@@ -46,6 +46,7 @@ import org.eclipse.milo.opcua.stack.core.types.structured.SignatureData;
 import org.eclipse.milo.opcua.stack.core.types.structured.UserNameIdentityToken;
 import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
 import org.eclipse.milo.opcua.stack.core.util.CertificateUtil;
+import org.eclipse.milo.opcua.stack.core.util.CipherFactory;
 import org.eclipse.milo.opcua.stack.core.util.EndpointUtil;
 import org.eclipse.milo.opcua.stack.core.util.NonceUtil;
 import org.slf4j.Logger;
@@ -553,10 +554,8 @@ public class UsernameProvider implements IdentityProvider {
     assert (serverCertificate != null);
 
     try {
-      String transformation = securityPolicy.getAsymmetricEncryptionAlgorithm().getTransformation();
-      Cipher cipher = Cipher.getInstance(transformation);
-      cipher.init(Cipher.ENCRYPT_MODE, serverCertificate.getPublicKey());
-      return cipher;
+      return CipherFactory.createForEncryption(
+          securityPolicy.getAsymmetricEncryptionAlgorithm(), serverCertificate.getPublicKey());
     } catch (GeneralSecurityException e) {
       throw new UaException(StatusCodes.Bad_SecurityChecksFailed, e);
     }

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/identity/package-info.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/identity/package-info.java
@@ -40,6 +40,11 @@
  * material. Certificate-token providers may use ECC or RSA-DH security policies, but they must not
  * request username-secret key negotiation.
  *
+ * <p>Legacy RSA username-token encryption uses the shared stack {@link
+ * org.eclipse.milo.opcua.stack.core.util.CipherFactory}. The selected token policy supplies
+ * explicit OAEP parameters, independently of the channel's policy and the configured JCA provider's
+ * defaults.
+ *
  * <h2>Extension guidance</h2>
  *
  * <p>Custom providers should keep policy selection and token construction aligned. If a provider

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractIdentityValidator.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractIdentityValidator.java
@@ -36,6 +36,7 @@ import org.eclipse.milo.opcua.stack.core.types.structured.UserNameIdentityToken;
 import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
 import org.eclipse.milo.opcua.stack.core.types.structured.X509IdentityToken;
 import org.eclipse.milo.opcua.stack.core.util.CertificateUtil;
+import org.eclipse.milo.opcua.stack.core.util.CipherFactory;
 import org.eclipse.milo.opcua.stack.core.util.DigestUtil;
 
 public abstract class AbstractIdentityValidator implements IdentityValidator {
@@ -222,10 +223,7 @@ public abstract class AbstractIdentityValidator implements IdentityValidator {
 
   private Cipher getCipher(SecurityAlgorithm algorithm, KeyPair keyPair) throws UaException {
     try {
-      String transformation = algorithm.getTransformation();
-      Cipher cipher = Cipher.getInstance(transformation);
-      cipher.init(Cipher.DECRYPT_MODE, keyPair.getPrivate());
-      return cipher;
+      return CipherFactory.createForDecryption(algorithm, keyPair.getPrivate());
     } catch (GeneralSecurityException e) {
       throw new UaException(StatusCodes.Bad_SecurityChecksFailed, e);
     }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/identity/package-info.java
@@ -33,6 +33,11 @@
  * signature before calling application authentication; the channel restrictions for encrypted
  * username or issued-token secrets do not apply to certificate tokens.
  *
+ * <p>Legacy RSA username-token decryption uses the shared stack {@link
+ * org.eclipse.milo.opcua.stack.core.util.CipherFactory}. The selected token policy supplies
+ * explicit OAEP parameters, independently of the channel's policy and the configured JCA provider's
+ * defaults.
+ *
  * <h2>Extension guidance</h2>
  *
  * <p>Applications usually extend the abstract validators and implement only the final credential

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractUsernameIdentityValidatorTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/identity/AbstractUsernameIdentityValidatorTest.java
@@ -53,6 +53,7 @@ import org.eclipse.milo.opcua.stack.core.types.structured.EndpointDescription;
 import org.eclipse.milo.opcua.stack.core.types.structured.SignatureData;
 import org.eclipse.milo.opcua.stack.core.types.structured.UserNameIdentityToken;
 import org.eclipse.milo.opcua.stack.core.types.structured.UserTokenPolicy;
+import org.eclipse.milo.opcua.stack.core.util.CipherFactory;
 import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateBuilder;
 import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateGenerator;
 import org.jspecify.annotations.Nullable;
@@ -862,8 +863,7 @@ class AbstractUsernameIdentityValidatorTest {
 
   private static byte[] encrypt(SecurityPolicy securityPolicy, byte[] plainText) throws Exception {
     SecurityAlgorithm algorithm = securityPolicy.getAsymmetricEncryptionAlgorithm();
-    Cipher cipher = Cipher.getInstance(algorithm.getTransformation());
-    cipher.init(Cipher.ENCRYPT_MODE, rsaCertificate.getPublicKey());
+    Cipher cipher = CipherFactory.createForEncryption(algorithm, rsaCertificate.getPublicKey());
     return cipher.doFinal(plainText);
   }
 

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/channel/SecureChannelStrategies.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/channel/SecureChannelStrategies.java
@@ -43,7 +43,9 @@ import org.eclipse.milo.opcua.stack.core.security.SecurityPolicyProfile.KeyAgree
 import org.eclipse.milo.opcua.stack.core.security.SecurityProviderResolver;
 import org.eclipse.milo.opcua.stack.core.security.SecurityProviderResolver.ProviderProfile;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.util.CipherFactory;
 import org.eclipse.milo.opcua.stack.core.util.PShaUtil;
+import org.eclipse.milo.opcua.stack.core.util.SignatureFactory;
 import org.eclipse.milo.opcua.stack.core.util.SignatureUtil;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -427,9 +429,8 @@ final class SecureChannelStrategies {
 
       try {
         Signature signature =
-            Signature.getInstance(profile.asymmetricSignatureAlgorithm().getTransformation());
-
-        signature.initVerify(certificate);
+            SignatureFactory.createForVerification(
+                profile.asymmetricSignatureAlgorithm(), certificate);
 
         for (ByteBuffer signedByteBuffer : signedBytes) {
           signature.update(signedByteBuffer);
@@ -438,12 +439,12 @@ final class SecureChannelStrategies {
         if (!signature.verify(signatureBytes)) {
           throw new UaException(StatusCodes.Bad_SecurityChecksFailed, "could not verify signature");
         }
-      } catch (java.security.NoSuchAlgorithmException e) {
-        throw new UaException(StatusCodes.Bad_InternalError, e);
       } catch (SignatureException e) {
         throw new UaException(StatusCodes.Bad_ApplicationSignatureInvalid, e);
       } catch (InvalidKeyException e) {
         throw new UaException(StatusCodes.Bad_CertificateInvalid, e);
+      } catch (GeneralSecurityException e) {
+        throw new UaException(StatusCodes.Bad_InternalError, e);
       }
     }
 
@@ -1616,10 +1617,8 @@ final class SecureChannelStrategies {
         throws UaException {
 
       try {
-        Cipher cipher =
-            Cipher.getInstance(profile.asymmetricEncryptionAlgorithm().getTransformation());
-        cipher.init(Cipher.ENCRYPT_MODE, remoteCertificate.getPublicKey());
-        return cipher;
+        return CipherFactory.createForEncryption(
+            profile.asymmetricEncryptionAlgorithm(), remoteCertificate.getPublicKey());
       } catch (GeneralSecurityException e) {
         throw new UaException(StatusCodes.Bad_SecurityChecksFailed, e);
       }
@@ -1630,10 +1629,8 @@ final class SecureChannelStrategies {
         throws UaException {
 
       try {
-        Cipher cipher =
-            Cipher.getInstance(profile.asymmetricEncryptionAlgorithm().getTransformation());
-        cipher.init(Cipher.DECRYPT_MODE, privateKey);
-        return cipher;
+        return CipherFactory.createForDecryption(
+            profile.asymmetricEncryptionAlgorithm(), privateKey);
       } catch (GeneralSecurityException e) {
         throw new UaException(StatusCodes.Bad_InternalError, e);
       }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/channel/package-info.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/channel/package-info.java
@@ -41,6 +41,12 @@
  * the negotiated client/server nonces into directional symmetric keys. Chunk protection then uses
  * those keys to sign, verify, pad, encrypt, or decrypt ordinary service chunks.
  *
+ * <p>RSA authentication and asymmetric encryption apply the explicit parameters from {@link
+ * org.eclipse.milo.opcua.stack.core.security.SecurityAlgorithm}. Cipher creation is shared with
+ * username-token protection through {@link org.eclipse.milo.opcua.stack.core.util.CipherFactory},
+ * and signature creation is shared with session authentication through {@link
+ * org.eclipse.milo.opcua.stack.core.util.SignatureFactory}.
+ *
  * <p>Existing RSA policies use RSA signatures, RSA-nonce P_SHA key derivation, RSA asymmetric
  * OpenSecureChannel encryption, and CBC/HMAC symmetric chunks. ECC and RSA-DH OpenSecureChannel
  * policies carry ephemeral public keys in the nonce fields and keep the first OpenSecureChannel

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/EccEncryptedSecret.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/EccEncryptedSecret.java
@@ -45,6 +45,7 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned;
 import org.eclipse.milo.opcua.stack.core.types.structured.EphemeralKeyType;
 import org.eclipse.milo.opcua.stack.core.util.CertificateUtil;
 import org.eclipse.milo.opcua.stack.core.util.HkdfUtil;
+import org.eclipse.milo.opcua.stack.core.util.SignatureFactory;
 import org.eclipse.milo.opcua.stack.core.util.SignatureUtil;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -885,8 +886,8 @@ public final class EccEncryptedSecret {
       throws UaException {
     try {
       if (profile.authAxis() == SecurityPolicyProfile.AuthAxis.RSA_PKCS1_SHA256) {
-        Signature verifier = Signature.getInstance(SecurityAlgorithm.RsaSha256.getTransformation());
-        verifier.initVerify(publicKey);
+        Signature verifier =
+            SignatureFactory.createForVerification(SecurityAlgorithm.RsaSha256, publicKey);
         verifier.update(data);
 
         if (!verifier.verify(signature)) {

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/SecurityAlgorithm.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/SecurityAlgorithm.java
@@ -12,10 +12,16 @@ package org.eclipse.milo.opcua.stack.core.security;
 
 import java.security.MessageDigest;
 import java.security.Signature;
+import java.security.spec.AlgorithmParameterSpec;
+import java.security.spec.MGF1ParameterSpec;
+import java.security.spec.PSSParameterSpec;
 import javax.crypto.Cipher;
 import javax.crypto.Mac;
+import javax.crypto.spec.OAEPParameterSpec;
+import javax.crypto.spec.PSource;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
+import org.jspecify.annotations.Nullable;
 
 public enum SecurityAlgorithm {
   None("", ""),
@@ -44,31 +50,30 @@ public enum SecurityAlgorithm {
   /**
    * Asymmetric Signature; transformation to be used with {@link Signature#getInstance(String)}.
    *
-   * <p>Requires Bouncy Castle installed as a Security Provider.
+   * <p>Requires the explicit PSS parameters from {@link #getAlgorithmParameterSpec()}.
    */
-  RsaSha256Pss("http://opcfoundation.org/UA/security/rsa-pss-sha2-256", "SHA256withRSA/PSS"),
+  RsaSha256Pss("http://opcfoundation.org/UA/security/rsa-pss-sha2-256", "RSASSA-PSS"),
 
   /** Asymmetric Encryption; transformation to be used with {@link Cipher#getInstance(String)}. */
   Rsa15("http://www.w3.org/2001/04/xmlenc#rsa-1_5", "RSA/ECB/PKCS1Padding"),
 
-  /** Asymmetric Encryption; transformation to be used with {@link Cipher#getInstance(String)}. */
+  /**
+   * Asymmetric Encryption; transformation to be used with {@link Cipher#getInstance(String)}.
+   *
+   * <p>{@link #getAlgorithmParameterSpec()} returns the JDK default OAEP parameters (SHA-1 for both
+   * the digest and MGF1), pinned explicitly so provider defaults cannot change the wire format.
+   */
   RsaOaepSha1("http://www.w3.org/2001/04/xmlenc#rsa-oaep", "RSA/ECB/OAEPWithSHA-1AndMGF1Padding"),
 
   /**
    * Asymmetric Encryption; transformation to be used with {@link Cipher#getInstance(String)}.
    *
-   * <p>Important note: the transformation used is "RSA/ECB/OAEPWithSHA256AndMGF1Padding" as opposed
-   * to "RSA/ECB/OAEPWithSHA-256AndMGF1Padding".
-   *
-   * <p>While similar, the former is provided by Bouncy Castle whereas the latter is provided by
-   * SunJCE.
-   *
-   * <p>This is important because the BC version uses SHA256 in the padding while the SunJCE version
-   * uses Sha1.
+   * <p>Requires the explicit OAEP parameters from {@link #getAlgorithmParameterSpec()} so both the
+   * digest and MGF1 use SHA-256 regardless of provider defaults.
    */
   RsaOaepSha256(
       "http://opcfoundation.org/UA/security/rsa-oaep-sha2-256",
-      "RSA/ECB/OAEPWithSHA256AndMGF1Padding"),
+      "RSA/ECB/OAEPWithSHA-256AndMGF1Padding"),
 
   /** Asymmetric Key Wrap */
   KwRsa15("http://www.w3.org/2001/04/xmlenc#rsa-1_5", ""),
@@ -97,6 +102,13 @@ public enum SecurityAlgorithm {
    */
   Sha384("http://www.w3.org/2001/04/xmldsig-more#sha384", "SHA-384");
 
+  private static final PSSParameterSpec PSS_SHA256 =
+      new PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 32, 1);
+
+  private static final OAEPParameterSpec OAEP_SHA256 =
+      new OAEPParameterSpec(
+          "SHA-256", "MGF1", MGF1ParameterSpec.SHA256, PSource.PSpecified.DEFAULT);
+
   private final String uri;
   private final String transformation;
 
@@ -117,6 +129,26 @@ public enum SecurityAlgorithm {
    */
   public String getTransformation() {
     return transformation;
+  }
+
+  /**
+   * Returns the parameters required by this algorithm, or {@code null} if none are needed.
+   *
+   * <p>RSA-PSS uses SHA-256, MGF1/SHA-256, a 32-byte salt, and trailer field 1. RSA-OAEP uses the
+   * named digest for both OAEP and MGF1, with an empty label. Callers creating JCA operations
+   * directly must apply these parameters when initializing a cipher or configuring a signature;
+   * {@link org.eclipse.milo.opcua.stack.core.util.SignatureFactory} and {@link
+   * org.eclipse.milo.opcua.stack.core.util.CipherFactory} do this.
+   *
+   * @return the algorithm parameters, or {@code null} if none are needed.
+   */
+  public @Nullable AlgorithmParameterSpec getAlgorithmParameterSpec() {
+    return switch (this) {
+      case RsaSha256Pss -> PSS_SHA256;
+      case RsaOaepSha256 -> OAEP_SHA256;
+      case RsaOaepSha1 -> OAEPParameterSpec.DEFAULT;
+      default -> null;
+    };
   }
 
   public static SecurityAlgorithm fromUri(String securityAlgorithmUri) throws UaException {

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/package-info.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/package-info.java
@@ -22,6 +22,12 @@
  * org.eclipse.milo.opcua.stack.core.security.SecurityPolicyProfiles} instead of hard-coding policy
  * switches.
  *
+ * <p>Legacy RSA policies, including {@code Aes256_Sha256_RsaPss}, work with the built-in JDK 17
+ * providers without registering Bouncy Castle. {@link
+ * org.eclipse.milo.opcua.stack.core.security.SecurityAlgorithm} supplies explicit PSS and OAEP
+ * parameters so configured JCA providers produce the same wire format. Bouncy Castle libraries
+ * remain in use for certificate utilities and enhanced policies that need them.
+ *
  * <h2>Current enhanced profile families</h2>
  *
  * <p>Current ECC policies split authentication, key agreement, and chunk protection into separate

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/CipherFactory.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/CipherFactory.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.core.util;
+
+import java.security.GeneralSecurityException;
+import java.security.Key;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.spec.AlgorithmParameterSpec;
+import javax.crypto.Cipher;
+import org.eclipse.milo.opcua.stack.core.security.SecurityAlgorithm;
+import org.jspecify.annotations.NullMarked;
+
+/** Creates RSA ciphers with the parameters required by OPC UA security algorithms. */
+@NullMarked
+public final class CipherFactory {
+
+  private CipherFactory() {}
+
+  /**
+   * Creates an initialized asymmetric encryption cipher using the configured JCA providers.
+   *
+   * @param algorithm the asymmetric encryption algorithm.
+   * @param publicKey the receiver's public key.
+   * @return the initialized cipher.
+   * @throws GeneralSecurityException if the cipher cannot be created or initialized.
+   */
+  public static Cipher createForEncryption(SecurityAlgorithm algorithm, PublicKey publicKey)
+      throws GeneralSecurityException {
+    return create(algorithm, Cipher.ENCRYPT_MODE, publicKey);
+  }
+
+  /**
+   * Creates an initialized asymmetric decryption cipher using the configured JCA providers.
+   *
+   * @param algorithm the asymmetric encryption algorithm.
+   * @param privateKey the receiver's private key.
+   * @return the initialized cipher.
+   * @throws GeneralSecurityException if the cipher cannot be created or initialized.
+   */
+  public static Cipher createForDecryption(SecurityAlgorithm algorithm, PrivateKey privateKey)
+      throws GeneralSecurityException {
+    return create(algorithm, Cipher.DECRYPT_MODE, privateKey);
+  }
+
+  private static Cipher create(SecurityAlgorithm algorithm, int mode, Key key)
+      throws GeneralSecurityException {
+    Cipher cipher = Cipher.getInstance(algorithm.getTransformation());
+    AlgorithmParameterSpec parameters = algorithm.getAlgorithmParameterSpec();
+    if (parameters != null) {
+      cipher.init(mode, key, parameters);
+    } else {
+      cipher.init(mode, key);
+    }
+    return cipher;
+  }
+}

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/SignatureFactory.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/SignatureFactory.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.core.util;
+
+import java.security.GeneralSecurityException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.Signature;
+import java.security.cert.Certificate;
+import java.security.spec.AlgorithmParameterSpec;
+import org.eclipse.milo.opcua.stack.core.security.SecurityAlgorithm;
+import org.jspecify.annotations.NullMarked;
+
+/** Creates RSA signatures with the parameters required by OPC UA security algorithms. */
+@NullMarked
+public final class SignatureFactory {
+
+  private SignatureFactory() {}
+
+  /**
+   * Creates a signature initialized for signing using the configured JCA providers.
+   *
+   * @param algorithm the asymmetric signature algorithm.
+   * @param privateKey the signer's private key.
+   * @return the initialized signature.
+   * @throws GeneralSecurityException if the signature cannot be created or initialized.
+   */
+  public static Signature createForSigning(SecurityAlgorithm algorithm, PrivateKey privateKey)
+      throws GeneralSecurityException {
+    Signature signature = Signature.getInstance(algorithm.getTransformation());
+    signature.initSign(privateKey);
+    applyParameters(signature, algorithm);
+    return signature;
+  }
+
+  /**
+   * Creates a signature initialized for verification using the configured JCA providers.
+   *
+   * @param algorithm the asymmetric signature algorithm.
+   * @param publicKey the signer's public key.
+   * @return the initialized signature.
+   * @throws GeneralSecurityException if the signature cannot be created or initialized.
+   */
+  public static Signature createForVerification(SecurityAlgorithm algorithm, PublicKey publicKey)
+      throws GeneralSecurityException {
+    Signature signature = Signature.getInstance(algorithm.getTransformation());
+    signature.initVerify(publicKey);
+    applyParameters(signature, algorithm);
+    return signature;
+  }
+
+  /**
+   * Creates a signature initialized for verification using the configured JCA providers.
+   *
+   * <p>Unlike the {@link PublicKey} overload, this rejects X.509 certificates whose critical key
+   * usage extension excludes digital signatures.
+   *
+   * @param algorithm the asymmetric signature algorithm.
+   * @param certificate the signer's certificate.
+   * @return the initialized signature.
+   * @throws GeneralSecurityException if the signature cannot be created or initialized.
+   */
+  public static Signature createForVerification(
+      SecurityAlgorithm algorithm, Certificate certificate) throws GeneralSecurityException {
+    Signature signature = Signature.getInstance(algorithm.getTransformation());
+    signature.initVerify(certificate);
+    applyParameters(signature, algorithm);
+    return signature;
+  }
+
+  // Parameters are applied after init so delayed provider selection can consider the key type.
+  private static void applyParameters(Signature signature, SecurityAlgorithm algorithm)
+      throws GeneralSecurityException {
+    AlgorithmParameterSpec parameters = algorithm.getAlgorithmParameterSpec();
+    if (parameters != null) {
+      signature.setParameter(parameters);
+    }
+  }
+}

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/SignatureUtil.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/SignatureUtil.java
@@ -16,7 +16,6 @@ import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.Signature;
-import java.security.SignatureException;
 import java.security.cert.X509Certificate;
 import java.util.HashMap;
 import java.util.Map;
@@ -42,11 +41,8 @@ public class SignatureUtil {
       SecurityAlgorithm securityAlgorithm, PrivateKey privateKey, ByteBuffer... buffers)
       throws UaException {
 
-    String transformation = securityAlgorithm.getTransformation();
-
     try {
-      Signature signature = Signature.getInstance(transformation);
-      signature.initSign(privateKey);
+      Signature signature = SignatureFactory.createForSigning(securityAlgorithm, privateKey);
 
       for (ByteBuffer buffer : buffers) {
         signature.update(buffer);
@@ -76,18 +72,16 @@ public class SignatureUtil {
       throws UaException {
 
     try {
-      Signature signature = Signature.getInstance(algorithm.getTransformation());
-      signature.initVerify(certificate);
-
+      Signature signature = SignatureFactory.createForVerification(algorithm, certificate);
       signature.update(dataBytes);
 
       if (!signature.verify(signatureBytes)) {
         throw new UaException(StatusCodes.Bad_SecurityChecksFailed, "could not verify signature");
       }
-    } catch (NoSuchAlgorithmException | SignatureException e) {
-      throw new UaException(StatusCodes.Bad_InternalError, e);
     } catch (InvalidKeyException e) {
       throw new UaException(StatusCodes.Bad_SecurityChecksFailed, e);
+    } catch (GeneralSecurityException e) {
+      throw new UaException(StatusCodes.Bad_InternalError, e);
     }
   }
 

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/package-info.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/util/package-info.java
@@ -15,6 +15,14 @@
  * coordination. The calling transport or SDK retains authority over protocol validation and
  * resource lifecycles; utility objects do not own its channels, sessions, or executor shutdown.
  *
+ * <p>{@link org.eclipse.milo.opcua.stack.core.util.CipherFactory} and {@link
+ * org.eclipse.milo.opcua.stack.core.util.SignatureFactory} create initialized RSA JCA operations
+ * with the algorithm parameters shared by SecureChannel, session signatures, and user-token
+ * protection; {@link org.eclipse.milo.opcua.stack.core.util.SignatureUtil} builds on the signature
+ * factory. RSA operations use configured JCA provider order; explicit PSS and OAEP parameters keep
+ * the wire format consistent across providers. Callers retain authority over mapping cryptographic
+ * failures to protocol status codes.
+ *
  * <p>{@link org.eclipse.milo.opcua.stack.core.util.ExecutionQueue} serializes callbacks by default
  * and can permit an explicit number of concurrent workers. It retains queued tasks when executor
  * dispatch throws a runtime exception by running the worker on the submitting thread. Pausing stops

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/channel/RsaCryptoInteropTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/channel/RsaCryptoInteropTest.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.core.channel;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.Provider;
+import java.security.Security;
+import java.security.Signature;
+import java.security.cert.X509Certificate;
+import java.security.spec.MGF1ParameterSpec;
+import java.security.spec.PSSParameterSpec;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import javax.crypto.Cipher;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.security.SecurityPolicy;
+import org.eclipse.milo.opcua.stack.core.security.SecurityPolicyProfile;
+import org.eclipse.milo.opcua.stack.core.util.CipherFactory;
+import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateBuilder;
+import org.eclipse.milo.opcua.stack.core.util.SelfSignedCertificateGenerator;
+import org.eclipse.milo.opcua.stack.core.util.SignatureUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.parallel.Isolated;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@Isolated("Changes the JVM security provider order")
+class RsaCryptoInteropTest {
+
+  private static final Provider BC = new BouncyCastleProvider();
+  private static final byte[] MESSAGE =
+      "OPC UA RSA interoperability".getBytes(StandardCharsets.UTF_8);
+  private static final List<SecurityPolicy> RSA_POLICIES =
+      List.of(
+          SecurityPolicy.Basic128Rsa15,
+          SecurityPolicy.Basic256,
+          SecurityPolicy.Basic256Sha256,
+          SecurityPolicy.Aes128_Sha256_RsaOaep,
+          SecurityPolicy.Aes256_Sha256_RsaPss);
+  private static KeyPair keyPair;
+  private static X509Certificate certificate;
+  private Provider previousBc;
+
+  @BeforeAll
+  static void createCertificate() throws Exception {
+    keyPair = SelfSignedCertificateGenerator.generateRsaKeyPair(2048);
+    certificate = new SelfSignedCertificateBuilder(keyPair).build();
+  }
+
+  @BeforeEach
+  void saveProviders() {
+    previousBc = Security.getProvider("BC");
+    Security.removeProvider("BC");
+  }
+
+  @AfterEach
+  void restoreProviders() {
+    Security.removeProvider("BC");
+    if (previousBc != null) {
+      Security.addProvider(previousBc);
+    }
+  }
+
+  // A peer using Milo's former BC names/defaults must accept new signatures and vice versa.
+  // Testing both entry points protects session signatures and OpenSecureChannel verification.
+  @ParameterizedTest
+  @MethodSource("rsaConfigurations")
+  void signaturesInteroperateWithLegacyBouncyCastle(
+      SecurityPolicy policy, boolean bcFirst, boolean secureChannel) throws Exception {
+    configureProvider(bcFirst);
+    SecurityPolicyProfile profile = policy.getProfile();
+    Signature peer = Signature.getInstance(legacySignatureName(policy), BC);
+    peer.initVerify(certificate);
+    peer.update(MESSAGE);
+    byte[] signed =
+        secureChannel
+            ? SecureChannelStrategies.authentication(profile)
+                .sign(profile, keyPair.getPrivate(), ByteBuffer.wrap(MESSAGE))
+            : SignatureUtil.sign(
+                profile.asymmetricSignatureAlgorithm(),
+                keyPair.getPrivate(),
+                ByteBuffer.wrap(MESSAGE));
+    assertTrue(peer.verify(signed));
+
+    peer.initSign(keyPair.getPrivate());
+    peer.update(MESSAGE);
+    byte[] peerSignature = peer.sign();
+    verify(profile, secureChannel, MESSAGE, peerSignature);
+    byte[] tampered = MESSAGE.clone();
+    tampered[0] ^= 1;
+    assertThrows(UaException.class, () -> verify(profile, secureChannel, tampered, peerSignature));
+  }
+
+  // BC's old OAEP alias uses SHA-256 for MGF1. A same-provider round trip would miss an
+  // accidental SunJCE MGF1/SHA-1 default, so decrypt each implementation's ciphertext in the other.
+  @ParameterizedTest
+  @MethodSource("rsaConfigurations")
+  void encryptionInteroperatesWithLegacyBouncyCastle(
+      SecurityPolicy policy, boolean bcFirst, boolean secureChannel) throws Exception {
+    configureProvider(bcFirst);
+    SecurityPolicyProfile profile = policy.getProfile();
+    Cipher encrypt =
+        secureChannel
+            ? SecureChannelStrategies.asymmetricEncryption(profile)
+                .getEncryptionCipher(profile, certificate)
+            : CipherFactory.createForEncryption(
+                profile.asymmetricEncryptionAlgorithm(), keyPair.getPublic());
+    Cipher decrypt =
+        secureChannel
+            ? SecureChannelStrategies.asymmetricEncryption(profile)
+                .getDecryptionCipher(profile, keyPair.getPrivate())
+            : CipherFactory.createForDecryption(
+                profile.asymmetricEncryptionAlgorithm(), keyPair.getPrivate());
+    assertProviderSelection(bcFirst, encrypt.getProvider());
+    assertProviderSelection(bcFirst, decrypt.getProvider());
+
+    Cipher peer = Cipher.getInstance(legacyCipherName(policy), BC);
+    peer.init(Cipher.DECRYPT_MODE, keyPair.getPrivate());
+    assertArrayEquals(MESSAGE, peer.doFinal(encrypt.doFinal(MESSAGE)));
+    peer.init(Cipher.ENCRYPT_MODE, keyPair.getPublic());
+    assertArrayEquals(MESSAGE, decrypt.doFinal(peer.doFinal(MESSAGE)));
+  }
+
+  // PSS signatures with the wrong MGF1 digest or salt length are not OPC UA RSA-PSS signatures.
+  @ParameterizedTest
+  @MethodSource("invalidPssParameters")
+  void rejectsPssSignaturesWithWrongParameters(boolean secureChannel, PSSParameterSpec parameters)
+      throws Exception {
+    Signature peer = Signature.getInstance("RSASSA-PSS", "SunRsaSign");
+    peer.initSign(keyPair.getPrivate());
+    peer.setParameter(parameters);
+    peer.update(MESSAGE);
+    byte[] signature = peer.sign();
+    assertThrows(
+        UaException.class,
+        () ->
+            verify(
+                SecurityPolicy.Aes256_Sha256_RsaPss.getProfile(),
+                secureChannel,
+                MESSAGE,
+                signature));
+  }
+
+  private static void verify(
+      SecurityPolicyProfile profile, boolean secureChannel, byte[] message, byte[] signature)
+      throws UaException {
+    if (secureChannel) {
+      SecureChannelStrategies.authentication(profile)
+          .verify(profile, certificate, signature, ByteBuffer.wrap(message));
+    } else {
+      SignatureUtil.verify(profile.asymmetricSignatureAlgorithm(), certificate, message, signature);
+    }
+  }
+
+  private static void configureProvider(boolean bcFirst) throws Exception {
+    if (bcFirst) {
+      Security.insertProviderAt(BC, 1);
+    } else {
+      assertNull(Security.getProvider("BC"));
+    }
+    assertProviderSelection(bcFirst, Signature.getInstance("RSASSA-PSS").getProvider());
+  }
+
+  // The JDK provider name varies with java.security configuration; only BC's position matters.
+  private static void assertProviderSelection(boolean bcFirst, Provider provider) {
+    if (bcFirst) {
+      assertEquals("BC", provider.getName());
+    } else {
+      assertNotEquals("BC", provider.getName());
+    }
+  }
+
+  private static String legacySignatureName(SecurityPolicy policy) {
+    return switch (policy) {
+      case Basic128Rsa15, Basic256 -> "SHA1withRSA";
+      case Basic256Sha256, Aes128_Sha256_RsaOaep -> "SHA256withRSA";
+      case Aes256_Sha256_RsaPss -> "SHA256withRSA/PSS";
+      default -> throw new IllegalArgumentException(policy.name());
+    };
+  }
+
+  private static String legacyCipherName(SecurityPolicy policy) {
+    return switch (policy) {
+      case Basic128Rsa15 -> "RSA/ECB/PKCS1Padding";
+      case Basic256, Basic256Sha256, Aes128_Sha256_RsaOaep -> "RSA/ECB/OAEPWithSHA-1AndMGF1Padding";
+      case Aes256_Sha256_RsaPss -> "RSA/ECB/OAEPWithSHA256AndMGF1Padding";
+      default -> throw new IllegalArgumentException(policy.name());
+    };
+  }
+
+  private static Stream<Arguments> rsaConfigurations() {
+    List<Arguments> configurations = new ArrayList<>();
+    for (SecurityPolicy policy : RSA_POLICIES) {
+      for (boolean bcFirst : List.of(false, true)) {
+        for (boolean secureChannel : List.of(false, true)) {
+          configurations.add(Arguments.of(policy, bcFirst, secureChannel));
+        }
+      }
+    }
+    return configurations.stream();
+  }
+
+  private static Stream<Arguments> invalidPssParameters() {
+    return Stream.of(false, true)
+        .flatMap(
+            secureChannel ->
+                Stream.of(
+                    Arguments.of(
+                        secureChannel,
+                        new PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA1, 32, 1)),
+                    Arguments.of(
+                        secureChannel,
+                        new PSSParameterSpec("SHA-256", "MGF1", MGF1ParameterSpec.SHA256, 20, 1))));
+  }
+}

--- a/opc-ua-stack/stack-tests/src/test/java/org/eclipse/milo/opcua/stack/ChunkSerializationTest.java
+++ b/opc-ua-stack/stack-tests/src/test/java/org/eclipse/milo/opcua/stack/ChunkSerializationTest.java
@@ -20,12 +20,10 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.util.ReferenceCountUtil;
-import java.security.Security;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.eclipse.milo.opcua.stack.core.channel.ChannelParameters;
 import org.eclipse.milo.opcua.stack.core.channel.ChunkDecoder;
 import org.eclipse.milo.opcua.stack.core.channel.ChunkEncoder;
@@ -50,11 +48,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ChunkSerializationTest extends SecureChannelFixture {
-
-  static {
-    // Required for SecurityPolicy.Aes256_Sha256_RsaPss
-    Security.addProvider(new BouncyCastleProvider());
-  }
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ChunkSerializationTest.class);
 

--- a/opc-ua-stack/transport/src/test/java/org/eclipse/milo/opcua/stack/transport/client/tcp/OpcTcpTransportTest.java
+++ b/opc-ua-stack/transport/src/test/java/org/eclipse/milo/opcua/stack/transport/client/tcp/OpcTcpTransportTest.java
@@ -29,7 +29,6 @@ import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
 import java.security.KeyPair;
-import java.security.Security;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.List;
@@ -42,7 +41,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.channel.ChannelParameters;
 import org.eclipse.milo.opcua.stack.core.channel.ChannelSecurity;
@@ -113,11 +111,6 @@ class OpcTcpTransportTest extends SecurityFixture {
 
   private InetSocketAddress serverAddress;
   private OpcServerTransport serverTransport;
-
-  static {
-    // Required for SecurityPolicy.Aes256_Sha256_RsaPss
-    Security.addProvider(new BouncyCastleProvider());
-  }
 
   @AfterEach
   void unbindServerTransport() throws Exception {


### PR DESCRIPTION
Allow applications to use `Aes256_Sha256_RsaPss` with the built-in JDK 17+ providers in both `Sign` and `SignAndEncrypt` modes without registering `BouncyCastleProvider`. BC libraries remain dependencies for certificate utilities and other security policies.

Use standard RSA-PSS and RSA-OAEP transformations with explicit parameters through shared `SignatureFactory` and `CipherFactory` helpers. Apply those parameters consistently to SecureChannel operations, session signatures, and username-token protection. Update examples and document migration for callers that construct JCA operations directly.

Tests cover all five legacy RSA policies, anonymous/username/X.509 activation, invalid credentials, and interoperability with BC's legacy algorithms. Spotless and the targeted RSA interoperability, encrypted-secret, username-validator, and session tests pass.

Closes #1959.
