### PR TITLE
Encode null elements in structured Variant arrays

### DIFF
--- a/opc-ua-stack/encoding-json/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoder.java
+++ b/opc-ua-stack/encoding-json/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/json/OpcUaJsonEncoder.java
@@ -953,7 +953,8 @@ public class OpcUaJsonEncoder implements UaEncoder, AutoCloseable {
     }
   }
 
-  private void encodeVariantBodyValue(Object value, TypeHint typeHint, int typeId) {
+  private void encodeVariantBodyValue(Object value, TypeHint typeHint, int typeId)
+      throws IOException {
     switch (typeHint) {
       case BUILTIN:
         {
@@ -969,8 +970,13 @@ public class OpcUaJsonEncoder implements UaEncoder, AutoCloseable {
       case STRUCT:
         {
           UaStructuredType struct = (UaStructuredType) value;
-          ExtensionObject xo = ExtensionObject.encode(encodingContext, struct);
-          encodeBuiltinTypeValue(null, typeId, xo);
+          if (struct == null) {
+            // Part 6, 5.4.5: null array elements are JSON null in both encoding modes.
+            jsonWriter.nullValue();
+          } else {
+            ExtensionObject xo = ExtensionObject.encode(encodingContext, struct);
+            encodeBuiltinTypeValue(null, typeId, xo);
+          }
           break;
         }
       case OPTION_SET:

--- a/opc-ua-stack/encoding-json/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/json/package-info.java
+++ b/opc-ua-stack/encoding-json/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/json/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/**
+ * Converts OPC UA values between JSON and the stack's Java value types.
+ *
+ * <p>Encoders and decoders use an encoding context to resolve namespaces and structured-type
+ * codecs. The encoder supports compact and verbose output; the decoder reads each value from its
+ * current input position. Callers supply the context and manage the encoder's output lifecycle.
+ *
+ * <p>Variants carry structures as ExtensionObjects. Non-null structure bodies use their registered
+ * encoding. Null elements of typed structure arrays and Matrices are JSON {@code null} in both
+ * modes, as required for array elements by OPC UA Part 6, 5.4.5. Decoding returns ExtensionObject
+ * arrays with those null positions preserved; callers decode non-null bodies using the context.
+ */
+package org.eclipse.milo.opcua.stack.core.encoding.json;

--- a/opc-ua-stack/encoding-json/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/json/JsonStructuredVariantSerializationTest.java
+++ b/opc-ua-stack/encoding-json/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/json/JsonStructuredVariantSerializationTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.core.encoding.json;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.stream.JsonToken;
+import java.util.stream.Stream;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
+import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
+import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
+import org.eclipse.milo.opcua.stack.core.encoding.json.OpcUaJsonEncoder.Encoding;
+import org.eclipse.milo.opcua.stack.core.types.UaStructuredType;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Matrix;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.structured.XVType;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class JsonStructuredVariantSerializationTest {
+  private final EncodingContext context = new DefaultEncodingContext();
+
+  // Structure arrays preserve nullable positions rather than passing null into a structure codec.
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("structureArrays")
+  void structureArrayVariantRoundTrips(String name, Encoding encoding, UaStructuredType[] values)
+      throws Exception {
+    String json = encode(new Variant(values), encoding);
+    assertJsonElements(values, json);
+
+    var decoder = new OpcUaJsonDecoder(context, json);
+    ExtensionObject[] decoded =
+        assertInstanceOf(ExtensionObject[].class, decoder.decodeVariant(null).value());
+    assertStructureElements(values, decoded);
+    assertEquals(JsonToken.END_DOCUMENT, decoder.jsonReader.peek());
+  }
+
+  // Positive Matrix dimensions and structure element order must survive Variant conversion.
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("structureMatrices")
+  void structureMatrixVariantRoundTrips(String name, Encoding encoding, Matrix matrix)
+      throws Exception {
+    UaStructuredType[] values = (UaStructuredType[]) matrix.getElements();
+    String json = encode(new Variant(matrix), encoding);
+    assertJsonElements(values, json);
+
+    var decoder = new OpcUaJsonDecoder(context, json);
+    Matrix decoded = assertInstanceOf(Matrix.class, decoder.decodeVariant(null).value());
+    assertEquals(OpcUaDataType.ExtensionObject, decoded.getDataType().orElseThrow());
+    assertArrayEquals(matrix.getDimensions(), decoded.getDimensions());
+    assertStructureElements(
+        values, assertInstanceOf(ExtensionObject[].class, decoded.getElements()));
+    assertEquals(JsonToken.END_DOCUMENT, decoder.jsonReader.peek());
+  }
+
+  private String encode(Variant value, Encoding encoding) throws Exception {
+    try (var encoder = new OpcUaJsonEncoder(context)) {
+      encoder.setEncoding(encoding);
+      encoder.encodeVariant(null, value);
+      return encoder.getOutputString();
+    }
+  }
+
+  private static void assertJsonElements(UaStructuredType[] expected, String json) {
+    JsonObject object = JsonParser.parseString(json).getAsJsonObject();
+    assertEquals(22, object.get("UaType").getAsInt());
+    JsonArray elements = object.getAsJsonArray("Value");
+    assertEquals(expected.length, elements.size());
+    for (int i = 0; i < expected.length; i++) {
+      assertEquals(expected[i] == null, elements.get(i).isJsonNull(), "JSON null at index " + i);
+    }
+  }
+
+  private void assertStructureElements(UaStructuredType[] expected, ExtensionObject[] actual) {
+    assertEquals(expected.length, actual.length);
+    for (int i = 0; i < expected.length; i++) {
+      if (expected[i] == null) {
+        assertNull(actual[i], "null structure at index " + i);
+      } else {
+        assertEquals(expected[i], actual[i].decode(context), "structure at index " + i);
+      }
+    }
+  }
+
+  static Stream<Arguments> structureValues() {
+    XVType first = new XVType(1.0, 2.0f);
+    XVType second = new XVType(3.0, 4.0f);
+    return Stream.of(
+        Arguments.of("concrete empty", new XVType[0]),
+        Arguments.of("concrete all null", new XVType[4]),
+        Arguments.of("concrete trailing null", new XVType[] {first, null}),
+        Arguments.of("concrete mixed null", new XVType[] {null, first, second, null}),
+        Arguments.of("concrete nonnull", new XVType[] {first, second, first, second}),
+        Arguments.of("interface empty", new UaStructuredType[0]),
+        Arguments.of("interface all null", new UaStructuredType[4]),
+        Arguments.of("interface mixed null", new UaStructuredType[] {null, first, second, null}),
+        Arguments.of("interface nonnull", new UaStructuredType[] {first, second, first, second}));
+  }
+
+  static Stream<Arguments> structureMatrices() {
+    return structureValues()
+        .filter(arguments -> ((UaStructuredType[]) arguments.get()[1]).length > 0)
+        .flatMap(
+            arguments -> {
+              Object[] values = arguments.get();
+              String name = (String) values[0];
+              UaStructuredType[] elements = (UaStructuredType[]) values[1];
+              int rows = elements.length / 2;
+              return Stream.of(
+                      Arguments.of(name + " 2D", structureMatrix(elements, new int[] {rows, 2})),
+                      Arguments.of(name + " 3D", structureMatrix(elements, new int[] {1, rows, 2})))
+                  .flatMap(JsonStructuredVariantSerializationTest::withEncodings);
+            });
+  }
+
+  static Stream<Arguments> structureArrays() {
+    return structureValues().flatMap(JsonStructuredVariantSerializationTest::withEncodings);
+  }
+
+  private static Stream<Arguments> withEncodings(Arguments arguments) {
+    Object[] values = arguments.get();
+    return Stream.of(Encoding.values())
+        .map(encoding -> Arguments.of(values[0] + " " + encoding, encoding, values[1]));
+  }
+
+  private static Matrix structureMatrix(UaStructuredType[] elements, int[] dimensions) {
+    return new Matrix(elements, dimensions, OpcUaDataType.ExtensionObject, XVType.TYPE_ID);
+  }
+}

--- a/opc-ua-stack/encoding-xml/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlEncoder.java
+++ b/opc-ua-stack/encoding-xml/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/xml/OpcUaXmlEncoder.java
@@ -530,8 +530,13 @@ public class OpcUaXmlEncoder implements UaEncoder, AutoCloseable {
   @Override
   public void encodeExtensionObject(String field, ExtensionObject value)
       throws UaSerializationException {
+    encodeExtensionObjectValue(field, value, false);
+  }
 
-    if (beginField(field, value == null, true)) {
+  private void encodeExtensionObjectValue(
+      String field, ExtensionObject value, boolean isArrayElement) throws UaSerializationException {
+
+    if (beginField(field, value == null, true, isArrayElement)) {
       namespaceStack.push(Namespaces.OPC_UA_XSD);
       try {
         if (value == null || value.isNull()) {
@@ -710,8 +715,10 @@ public class OpcUaXmlEncoder implements UaEncoder, AutoCloseable {
               for (int i = 0; i < array.length; i++) {
                 UaStructuredType structValue = array[i];
                 xos[i] =
-                    ExtensionObject.encode(
-                        context, structValue, OpcUaDefaultXmlEncoding.getInstance());
+                    structValue != null
+                        ? ExtensionObject.encode(
+                            context, structValue, OpcUaDefaultXmlEncoding.getInstance())
+                        : null;
               }
               encodeBuiltinTypeArrayValue(xos, OpcUaDataType.ExtensionObject);
             }
@@ -1493,7 +1500,7 @@ public class OpcUaXmlEncoder implements UaEncoder, AutoCloseable {
 
         assert value != null;
         for (ExtensionObject v : value) {
-          encodeExtensionObject("ExtensionObject", v);
+          encodeExtensionObjectValue("ExtensionObject", v, true);
         }
       } finally {
         namespaceStack.pop();
@@ -1832,7 +1839,7 @@ public class OpcUaXmlEncoder implements UaEncoder, AutoCloseable {
             case ExtensionObject -> {
               if (elements instanceof ExtensionObject[] array) {
                 for (ExtensionObject element : array) {
-                  encodeExtensionObject("ExtensionObject", element);
+                  encodeExtensionObjectValue("ExtensionObject", element, true);
                 }
               }
             }
@@ -1939,7 +1946,9 @@ public class OpcUaXmlEncoder implements UaEncoder, AutoCloseable {
         value.transform(
             e -> {
               UaStructuredType struct = (UaStructuredType) e;
-              return ExtensionObject.encode(context, struct, OpcUaDefaultXmlEncoding.getInstance());
+              return struct != null
+                  ? ExtensionObject.encode(context, struct, OpcUaDefaultXmlEncoding.getInstance())
+                  : null;
             },
             ExtensionObject.class,
             OpcUaDataType.ExtensionObject);

--- a/opc-ua-stack/encoding-xml/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/xml/package-info.java
+++ b/opc-ua-stack/encoding-xml/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/xml/package-info.java
@@ -19,5 +19,11 @@
  * <p>Variants identify their contained builtin type from the XML element name. Matrix decoding
  * validates dimensions, element types, and element counts for both Variants and directly decoded
  * matrices. Structured values are delegated to the codecs registered in the context.
+ *
+ * <p>Structures inside Variants are carried as ExtensionObjects. Null elements of typed structure
+ * arrays and Matrices use an {@code xsi:nil} ExtensionObject element; they are not passed to a
+ * structure codec. Decoding retains these positions as null-valued ExtensionObjects. Matrices
+ * passed to the Variant encoder need explicit data type metadata when their first element cannot
+ * identify the structure type.
  */
 package org.eclipse.milo.opcua.stack.core.encoding.xml;

--- a/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/XmlStructuredVariantSerializationTest.java
+++ b/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/XmlStructuredVariantSerializationTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.core.encoding.xml;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.StringReader;
+import java.util.stream.Stream;
+import javax.xml.XMLConstants;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
+import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
+import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
+import org.eclipse.milo.opcua.stack.core.types.UaStructuredType;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Matrix;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.structured.XVType;
+import org.eclipse.milo.opcua.stack.core.util.Namespaces;
+import org.eclipse.milo.opcua.stack.core.util.SecureXmlUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+class XmlStructuredVariantSerializationTest {
+  private final EncodingContext context = new DefaultEncodingContext();
+
+  // Each null structure must remain an xsi:nil ExtensionObject element in the array.
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("structureArrays")
+  void structureArrayVariantRoundTrips(String name, UaStructuredType[] values) throws Exception {
+    String xml = encode(new Variant(values));
+    assertXmlElements(values, xml);
+
+    try (var decoder = new OpcUaXmlDecoder(context, xml)) {
+      ExtensionObject[] decoded =
+          assertInstanceOf(ExtensionObject[].class, decoder.decodeVariant("Test").value());
+      assertStructureElements(values, decoded);
+    }
+  }
+
+  // Typed Matrix conversion must preserve nulls without invoking their XML structure codec.
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("structureMatrices")
+  void structureMatrixVariantRoundTrips(String name, Matrix matrix) throws Exception {
+    UaStructuredType[] values = (UaStructuredType[]) matrix.getElements();
+    String xml = encode(new Variant(matrix));
+    assertXmlElements(values, xml);
+
+    try (var decoder = new OpcUaXmlDecoder(context, xml)) {
+      Matrix decoded = assertInstanceOf(Matrix.class, decoder.decodeVariant("Test").value());
+      assertEquals(OpcUaDataType.ExtensionObject, decoded.getDataType().orElseThrow());
+      assertArrayEquals(matrix.getDimensions(), decoded.getDimensions());
+      assertStructureElements(
+          values, assertInstanceOf(ExtensionObject[].class, decoded.getElements()));
+    }
+  }
+
+  // Required array positions must not change omission of optional null scalar fields.
+  @Test
+  void nullExtensionObjectScalarFieldIsOmitted() throws Exception {
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeExtensionObject("OptionalField", null);
+      assertEquals("", encoder.getOutputString());
+    }
+  }
+
+  private String encode(Variant value) throws Exception {
+    try (var encoder = new OpcUaXmlEncoder(context)) {
+      encoder.encodeVariant("Test", value);
+      return encoder.getOutputString();
+    }
+  }
+
+  private static void assertXmlElements(UaStructuredType[] expected, String xml) throws Exception {
+    var document =
+        SecureXmlUtil.SHARED_DOCUMENT_BUILDER_FACTORY
+            .newDocumentBuilder()
+            .parse(new InputSource(new StringReader(xml)));
+    NodeList elements = document.getElementsByTagNameNS(Namespaces.OPC_UA_XSD, "ExtensionObject");
+    assertEquals(expected.length, elements.getLength());
+    for (int i = 0; i < expected.length; i++) {
+      Element element = (Element) elements.item(i);
+      assertEquals(
+          expected[i] == null ? "true" : "",
+          element.getAttributeNS(XMLConstants.W3C_XML_SCHEMA_INSTANCE_NS_URI, "nil"),
+          "XML nil at index " + i);
+    }
+  }
+
+  private void assertStructureElements(UaStructuredType[] expected, ExtensionObject[] actual) {
+    assertEquals(expected.length, actual.length);
+    for (int i = 0; i < expected.length; i++) {
+      if (expected[i] == null) {
+        assertTrue(actual[i].isNull(), "null structure at index " + i);
+        assertEquals(NodeId.NULL_VALUE, actual[i].getEncodingOrTypeId());
+      } else {
+        assertEquals(expected[i], actual[i].decode(context), "structure at index " + i);
+      }
+    }
+  }
+
+  static Stream<Arguments> structureArrays() {
+    XVType first = new XVType(1.0, 2.0f);
+    XVType second = new XVType(3.0, 4.0f);
+    return Stream.of(
+        Arguments.of("concrete empty", new XVType[0]),
+        Arguments.of("concrete all null", new XVType[4]),
+        Arguments.of("concrete trailing null", new XVType[] {first, null}),
+        Arguments.of("concrete mixed null", new XVType[] {null, first, second, null}),
+        Arguments.of("concrete nonnull", new XVType[] {first, second, first, second}),
+        Arguments.of("interface empty", new UaStructuredType[0]),
+        Arguments.of("interface all null", new UaStructuredType[4]),
+        Arguments.of("interface mixed null", new UaStructuredType[] {null, first, second, null}),
+        Arguments.of("interface nonnull", new UaStructuredType[] {first, second, first, second}));
+  }
+
+  static Stream<Arguments> structureMatrices() {
+    return structureArrays()
+        .filter(arguments -> ((UaStructuredType[]) arguments.get()[1]).length > 0)
+        .flatMap(
+            arguments -> {
+              Object[] values = arguments.get();
+              String name = (String) values[0];
+              UaStructuredType[] elements = (UaStructuredType[]) values[1];
+              int rows = elements.length / 2;
+              return Stream.of(
+                  Arguments.of(name + " 2D", structureMatrix(elements, new int[] {rows, 2})),
+                  Arguments.of(name + " 3D", structureMatrix(elements, new int[] {1, rows, 2})));
+            });
+  }
+
+  private static Matrix structureMatrix(UaStructuredType[] elements, int[] dimensions) {
+    // Explicit metadata supports XML encoding even when no non-null first element identifies a
+    // type.
+    return new Matrix(elements, dimensions, OpcUaDataType.ExtensionObject, XVType.TYPE_ID);
+  }
+}

--- a/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/args/VariantArguments.java
+++ b/opc-ua-stack/encoding-xml/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/xml/args/VariantArguments.java
@@ -1577,7 +1577,7 @@ public class VariantArguments {
             </Test>
             """),
 
-        // ExtensionObject matrix (2D)
+        // A 2x2 null ExtensionObject Matrix still has four encoded elements.
         Arguments.of(
             Variant.ofMatrix(
                 Matrix.ofExtensionObject(new ExtensionObject[][] {{null, null}, {null, null}})),
@@ -1590,6 +1590,10 @@ public class VariantArguments {
                     <uax:Int32>2</uax:Int32>
                   </uax:Dimensions>
                   <uax:Elements>
+                    <uax:ExtensionObject xsi:nil="true" />
+                    <uax:ExtensionObject xsi:nil="true" />
+                    <uax:ExtensionObject xsi:nil="true" />
+                    <uax:ExtensionObject xsi:nil="true" />
                   </uax:Elements>
                 </uax:Matrix>
               </uax:Value>

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryEncoder.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryEncoder.java
@@ -686,7 +686,8 @@ public class OpcUaBinaryEncoder implements UaEncoder {
     if (structure) {
       UaStructuredType struct = (UaStructuredType) value;
 
-      ExtensionObject extensionObject = ExtensionObject.encode(context, struct);
+      ExtensionObject extensionObject =
+          struct != null ? ExtensionObject.encode(context, struct) : null;
 
       encodeBuiltinType(typeId, extensionObject);
     } else if (enumeration) {

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/package-info.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/**
+ * Encodes and decodes OPC UA Binary values in caller-supplied Netty buffers.
+ *
+ * <p>{@link org.eclipse.milo.opcua.stack.core.encoding.binary.OpcUaBinaryEncoder} and {@link
+ * org.eclipse.milo.opcua.stack.core.encoding.binary.OpcUaBinaryDecoder} read and write built-in
+ * values and delegate structure fields to codecs registered in the {@link
+ * org.eclipse.milo.opcua.stack.core.encoding.EncodingContext}. Callers set the buffer before use
+ * and remain responsible for releasing it.
+ *
+ * <p>Variants carry structures as ExtensionObjects, including elements of typed structure arrays
+ * and Matrices. Non-null structures use their registered binary encoding; null structure elements
+ * use a null ExtensionObject with no encoded body, as defined by OPC 10000-6, 5.2.2.15. Decoding a
+ * Variant returns those ExtensionObjects; callers use the encoding context to decode non-null
+ * bodies into structures. {@link
+ * org.eclipse.milo.opcua.stack.core.encoding.binary.OpcUaDefaultBinaryEncoding} supplies this
+ * structure-to-body conversion and resolves codecs by their encoding NodeIds.
+ */
+package org.eclipse.milo.opcua.stack.core.encoding.binary;

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/binary/StructuredVariantSerializationTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/binary/StructuredVariantSerializationTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.core.encoding.binary;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import java.util.stream.Stream;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
+import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
+import org.eclipse.milo.opcua.stack.core.types.UaStructuredType;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Matrix;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.structured.XVType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class StructuredVariantSerializationTest {
+
+  private final ByteBuf buffer = Unpooled.buffer();
+  private final OpcUaBinaryEncoder encoder =
+      new OpcUaBinaryEncoder(DefaultEncodingContext.INSTANCE).setBuffer(buffer);
+  private final OpcUaBinaryDecoder decoder =
+      new OpcUaBinaryDecoder(DefaultEncodingContext.INSTANCE).setBuffer(buffer);
+
+  @AfterEach
+  void releaseBuffer() {
+    buffer.release();
+  }
+
+  // Typed structure arrays must preserve null positions as null ExtensionObjects on the wire.
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("structureArrays")
+  void structureArrayVariantRoundTrips(String name, UaStructuredType[] values) {
+    encoder.encodeVariant(new Variant(values));
+
+    assertEquals(0x96, buffer.getUnsignedByte(0));
+    ExtensionObject[] decoded =
+        assertInstanceOf(ExtensionObject[].class, decoder.decodeVariant().value());
+    assertStructureElements(values, decoded);
+    assertEquals(0, buffer.readableBytes());
+  }
+
+  // Matrix dimensions and element order must survive the same nullable structure conversion.
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("structureMatrices")
+  void structureMatrixVariantRoundTrips(String name, Matrix matrix) {
+    encoder.encodeVariant(new Variant(matrix));
+
+    assertEquals(0xD6, buffer.getUnsignedByte(0));
+    Matrix decoded = assertInstanceOf(Matrix.class, decoder.decodeVariant().value());
+    assertEquals(OpcUaDataType.ExtensionObject, decoded.getDataType().orElseThrow());
+    assertArrayEquals(matrix.getDimensions(), decoded.getDimensions());
+    assertStructureElements(
+        (UaStructuredType[]) matrix.getElements(),
+        assertInstanceOf(ExtensionObject[].class, decoded.getElements()));
+    assertEquals(0, buffer.readableBytes());
+  }
+
+  static Stream<Arguments> structureArrays() {
+    XVType first = new XVType(1.0, 2.0f);
+    XVType second = new XVType(3.0, 4.0f);
+    return Stream.of(
+        Arguments.of("concrete empty", new XVType[0]),
+        Arguments.of("concrete all null", new XVType[4]),
+        Arguments.of("concrete trailing null", new XVType[] {first, null}),
+        Arguments.of("concrete mixed null", new XVType[] {null, first, second, null}),
+        Arguments.of("concrete nonnull", new XVType[] {first, second, first, second}),
+        Arguments.of("interface empty", new UaStructuredType[0]),
+        Arguments.of("interface all null", new UaStructuredType[4]),
+        Arguments.of("interface mixed null", new UaStructuredType[] {null, first, second, null}),
+        Arguments.of("interface nonnull", new UaStructuredType[] {first, second, first, second}));
+  }
+
+  static Stream<Arguments> structureMatrices() {
+    return structureArrays()
+        // Part 6, 5.2.2.16: wire Matrix dimensions must be positive; empty values use arrays.
+        .filter(arguments -> ((UaStructuredType[]) arguments.get()[1]).length > 0)
+        .flatMap(
+            arguments -> {
+              Object[] values = arguments.get();
+              String name = (String) values[0];
+              UaStructuredType[] elements = (UaStructuredType[]) values[1];
+              int rows = elements.length / 2;
+              return Stream.of(
+                  Arguments.of(name + " 2D", new Matrix(elements, new int[] {rows, 2})),
+                  Arguments.of(name + " 3D", new Matrix(elements, new int[] {1, rows, 2})));
+            });
+  }
+
+  private static void assertStructureElements(
+      UaStructuredType[] expected, ExtensionObject[] actual) {
+    assertEquals(expected.length, actual.length);
+    for (int i = 0; i < expected.length; i++) {
+      if (expected[i] == null) {
+        assertTrue(actual[i].isNull(), "null structure at index " + i);
+        assertEquals(NodeId.NULL_VALUE, actual[i].getEncodingOrTypeId());
+      } else {
+        assertEquals(
+            expected[i],
+            actual[i].decode(DefaultEncodingContext.INSTANCE),
+            "structure at index " + i);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Variant encoding throws a NullPointerException when a typed structure array contains a null element, such as `new XVType[] {new XVType(1.0, 2.0f), null}`. Preserve these positions through binary, JSON, and XML encoding without passing null to a structure codec. Binary writes the null ExtensionObject form, JSON writes literal `null` in both compact and verbose modes, and XML writes `xsi:nil` elements. XML distinguishes array elements from optional scalar fields so null positions are retained.

The regressions round-trip concrete and UaStructuredType arrays and supported 2D/3D Matrices, including empty arrays and all-null and mixed-null elements. They check wire null representations, decoded values, element order, and dimensions. Positive tests reproduced the failures before each repair.

Empty Matrices are excluded from the new wire tests because binary Variant dimensions must all be positive. The existing encoder behavior is tracked separately in #1968. Adjacent enum and OptionSet handling remains unchanged.

Independent review found no remaining issues. Verification passed on the final source with Java 17: `mise exec -- mvn -q spotless:apply`, `mise exec -- mvn -q -pl opc-ua-stack/encoding-json,opc-ua-stack/encoding-xml -am clean verify`, `mise exec -- mvn -q clean compile`, and `mise exec -- mvn -q clean verify`. The affected-module reactor passed 2,107 tests. Full reactor verification passed 4,841 tests with zero failures or errors and four existing skips. All 23 binary, 46 JSON and 24 XML regression cases passed.
