### PR TITLE
Accept payloads for Variant-backed Method arguments

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/methods/MethodArgumentValidationTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/methods/MethodArgumentValidationTest.java
@@ -10,6 +10,7 @@
 package org.eclipse.milo.opcua.sdk.server.methods;
 
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -28,6 +29,7 @@ import org.eclipse.milo.opcua.sdk.server.nodes.UaMethodNode;
 import org.eclipse.milo.opcua.sdk.test.AbstractClientServerTest;
 import org.eclipse.milo.opcua.sdk.test.TestNamespace;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaSerializationException;
 import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
@@ -39,6 +41,7 @@ import org.eclipse.milo.opcua.stack.core.encoding.binary.OpcUaBinaryDecoder;
 import org.eclipse.milo.opcua.stack.core.encoding.binary.OpcUaBinaryEncoder;
 import org.eclipse.milo.opcua.stack.core.types.UaStructuredType;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DiagnosticInfo;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
@@ -47,6 +50,7 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
 import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.ServerState;
 import org.eclipse.milo.opcua.stack.core.types.structured.Argument;
 import org.eclipse.milo.opcua.stack.core.types.structured.CallMethodRequest;
 import org.eclipse.milo.opcua.stack.core.types.structured.CallMethodResult;
@@ -58,6 +62,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestFactory;
 
 class MethodArgumentValidationTest extends AbstractClientServerTest {
+
+  private static final NodeId VARIANT_BACKED_TYPE_ID = new NodeId(2, "VariantBackedValue");
 
   record Case(NodeId type, int rank, UInteger[] dimensions, Object value, boolean valid) {
     @Override
@@ -76,6 +82,24 @@ class MethodArgumentValidationTest extends AbstractClientServerTest {
   protected void configureTestNamespace(TestNamespace namespace) {
     namespace.configure(
         (context, nodeManager) -> {
+          var variantTypeNode =
+              new UaDataTypeNode(
+                  context,
+                  VARIANT_BACKED_TYPE_ID,
+                  newQualifiedName("VariantBackedValue"),
+                  LocalizedText.english("VariantBackedValue"),
+                  LocalizedText.NULL_VALUE,
+                  uint(0),
+                  uint(0),
+                  true);
+          variantTypeNode.addReference(
+              new Reference(
+                  VARIANT_BACKED_TYPE_ID,
+                  NodeIds.HasSubtype,
+                  NodeIds.BaseDataType.expanded(),
+                  Reference.Direction.INVERSE));
+          nodeManager.addNode(variantTypeNode);
+
           NodeId typeId = UnionOfScalar.TYPE_ID;
           var typeNode =
               new UaDataTypeNode(
@@ -122,6 +146,198 @@ class MethodArgumentValidationTest extends AbstractClientServerTest {
             new Case(NodeIds.XVType, -1, null, union, false),
             new Case(NodeIds.Union, -1, null, new XVType(1.0, 2.0f), false))
         .map(c -> DynamicTest.dynamicTest(c.toString(), () -> assertValidation(c)));
+  }
+
+  // BaseDataType describes the Variant's payload, not a nested Java Variant wrapper.
+  @Test
+  void acceptsBaseDataTypeStringThroughPublicInvocation() {
+    assertBaseDataTypeValidation(baseValue(-1, "hello"), true);
+  }
+
+  @TestFactory
+  Stream<DynamicTest> acceptsWireDecodedBaseDataTypeValues() {
+    return baseDataTypeValues()
+        .map(
+            c ->
+                DynamicTest.dynamicTest(c.toString(), () -> assertBaseDataTypeValidation(c, true)));
+  }
+
+  // Local calls retain concrete Java structures and enums, which wire decoding reduces to builtins.
+  @TestFactory
+  Stream<DynamicTest> acceptsLocalBaseDataTypeValues() {
+    var xv = new XVType(1.0, 2.0f);
+    return Stream.concat(
+            baseDataTypeValues(),
+            Stream.of(
+                baseValue(1, new XVType[] {null, xv}),
+                baseValue(1, new UaStructuredType[] {null, xv}),
+                baseValue(2, new Matrix(new XVType[] {null, xv}, new int[] {1, 2})),
+                baseValue(2, new Matrix(new UaStructuredType[] {null, xv}, new int[] {1, 2})),
+                // Local shape validation does not establish a wire encoding for empty Matrices.
+                baseValue(2, new Matrix(new String[0], new int[] {0, 2})),
+                baseValue(2, new Matrix(new XVType[0], new int[] {0, 2})),
+                baseValue(-1, Matrix.ofNull())))
+        .map(
+            c ->
+                DynamicTest.dynamicTest(
+                    c.toString(), () -> assertBaseDataTypeValidation(c, false)));
+  }
+
+  static Stream<Case> baseDataTypeValues() {
+    var xv = new XVType(1.0, 2.0f);
+    var vector = new ThreeDVector(1.0, 2.0, 3.0);
+    ExtensionObject nullStructure = ExtensionObject.of(ByteString.NULL_VALUE, NodeId.NULL_VALUE);
+    ExtensionObject encoded = ExtensionObject.encode(DefaultEncodingContext.INSTANCE, xv);
+    return Stream.of(
+        baseValue(-1, "hello"),
+        baseValue(-1, 42),
+        baseValue(-1, 42.5),
+        baseValue(-1, uint(42)),
+        baseValue(-1, ByteString.of(new byte[] {1, 2})),
+        baseValue(-1, xv),
+        baseValue(-1, ServerState.Running),
+        baseValue(-1, null),
+        baseValue(-3, "hello"),
+        baseValue(-3, new String[] {"hello"}),
+        baseValue(-2, "hello"),
+        baseValue(-2, new String[] {"hello"}),
+        baseValue(-2, new Matrix(new String[] {"hello"}, new int[] {1, 1})),
+        baseValue(0, new String[0]),
+        baseValue(0, new Matrix(new String[] {"hello"}, new int[] {1, 1})),
+        baseValue(1, new String[] {null, "hello"}),
+        baseValue(1, new String[0]),
+        baseValue(1, new String[] {null}),
+        baseValue(1, new int[] {1, 2}),
+        baseValue(1, new Double[] {1.0, 2.0}),
+        baseValue(1, new XVType[] {xv}),
+        baseValue(1, new XVType[0]),
+        baseValue(1, new UaStructuredType[] {xv, vector}),
+        baseValue(1, new ExtensionObject[] {nullStructure, encoded}),
+        baseValue(1, new ExtensionObject[] {nullStructure}),
+        baseValue(1, new ServerState[] {ServerState.Running, ServerState.Suspended}),
+        baseValue(1, new ServerState[0]),
+        baseValue(
+            1, new Variant[] {Variant.ofString("hello"), Variant.ofInt32(42), Variant.NULL_VALUE}),
+        baseValue(1, null),
+        baseValue(2, new Matrix(new String[] {null, "hello"}, new int[] {1, 2})),
+        baseValue(2, new Matrix(new int[] {1, 2}, new int[] {1, 2})),
+        baseValue(2, new Matrix(new XVType[] {xv}, new int[] {1, 1})),
+        baseValue(2, new Matrix(new UaStructuredType[] {xv, vector}, new int[] {1, 2})),
+        baseValue(2, new Matrix(new ExtensionObject[] {nullStructure, encoded}, new int[] {1, 2})),
+        baseValue(2, new Matrix(new ServerState[] {ServerState.Running}, new int[] {1, 1})),
+        baseValue(
+            2,
+            new Matrix(
+                new Variant[] {Variant.ofString("hello"), Variant.ofInt32(42)}, new int[] {1, 2})),
+        baseValue(2, null));
+  }
+
+  private static Case baseValue(int rank, Object value) {
+    return new Case(NodeIds.BaseDataType, rank, null, value, true);
+  }
+
+  private void assertBaseDataTypeValidation(Case c, boolean wire) {
+    Variant input = wire ? wireValue(c.value) : new Variant(c.value);
+    RecordingHandler handler = assertValidation(c, input);
+    Variant expected =
+        c.value instanceof Matrix matrix && matrix.isNull() ? Variant.NULL_VALUE : input;
+    assertSame(
+        expected, handler.received[0], "BaseDataType must preserve the payload representation");
+  }
+
+  // Accepting BaseDataType must still enforce declared shapes and narrower data types.
+  @TestFactory
+  Stream<DynamicTest> rejectsIncompatibleBaseDataTypeShapesAndNarrowerTypes() {
+    return Stream.of(
+            new Case(NodeIds.BaseDataType, -1, null, new String[] {"hello"}, false),
+            new Case(NodeIds.BaseDataType, 1, null, "hello", false),
+            new Case(
+                NodeIds.BaseDataType,
+                -3,
+                null,
+                new Matrix(new String[] {"hello"}, new int[] {1, 1}),
+                false),
+            new Case(NodeIds.BaseDataType, 0, null, "hello", false),
+            new Case(
+                NodeIds.BaseDataType,
+                3,
+                null,
+                new Matrix(new String[] {"hello"}, new int[] {1, 1}),
+                false),
+            new Case(
+                NodeIds.BaseDataType, 1, new UInteger[] {uint(1)}, new String[] {"a", "b"}, false),
+            new Case(
+                NodeIds.BaseDataType,
+                2,
+                new UInteger[] {uint(1), uint(1)},
+                new Matrix(new String[] {"a", "b"}, new int[] {1, 2}),
+                false),
+            new Case(NodeIds.Int32, -1, null, "hello", false),
+            new Case(NodeIds.Number, 1, null, new String[] {"hello"}, false),
+            new Case(NodeIds.Integer, -1, null, 1.0, false),
+            new Case(NodeIds.Integer, -1, null, uint(1), false),
+            new Case(NodeIds.UInteger, -1, null, 1, false),
+            new Case(NodeIds.XVType, -1, null, "hello", false))
+        .map(c -> DynamicTest.dynamicTest(c.toString(), () -> assertValidation(c)));
+  }
+
+  // The unchecked Variant constructor can carry objects which have no valid UA Variant encoding.
+  @TestFactory
+  Stream<DynamicTest> rejectsUnsupportedLocalBaseDataTypePayloads() {
+    return Stream.of(
+            new Object(),
+            new Object[] {"hello"},
+            Variant.ofString("hello"),
+            DiagnosticInfo.NULL_VALUE,
+            new Matrix(new DiagnosticInfo[] {DiagnosticInfo.NULL_VALUE}, new int[] {1, 1}),
+            new Matrix(new Object[] {"hello"}, new int[] {1, 1}, OpcUaDataType.ExtensionObject))
+        .map(value -> new Case(NodeIds.BaseDataType, -2, null, value, false))
+        .map(
+            c ->
+                DynamicTest.dynamicTest(
+                    c.toString(), () -> assertValidation(c, new Variant(c.value))));
+  }
+
+  // Vendor abstract types with Variant backing must accept payloads while retaining shape checks.
+  @TestFactory
+  Stream<DynamicTest> validatesVariantBackedAbstractDataTypeValues() {
+    return Stream.of(
+            new Case(VARIANT_BACKED_TYPE_ID, -1, null, "hello", true),
+            new Case(VARIANT_BACKED_TYPE_ID, -1, null, 42, true),
+            new Case(VARIANT_BACKED_TYPE_ID, 1, null, new String[] {"hello"}, true),
+            new Case(
+                VARIANT_BACKED_TYPE_ID,
+                2,
+                null,
+                new Matrix(new int[] {1, 2}, new int[] {1, 2}),
+                true),
+            new Case(VARIANT_BACKED_TYPE_ID, -1, null, new XVType(1.0, 2.0f), true),
+            new Case(VARIANT_BACKED_TYPE_ID, -1, null, ServerState.Running, true),
+            new Case(VARIANT_BACKED_TYPE_ID, -1, null, null, true),
+            new Case(VARIANT_BACKED_TYPE_ID, -1, null, new String[] {"hello"}, false),
+            new Case(
+                VARIANT_BACKED_TYPE_ID,
+                1,
+                new UInteger[] {uint(1)},
+                new String[] {"a", "b"},
+                false))
+        .map(c -> DynamicTest.dynamicTest(c.toString(), () -> assertValidation(c)));
+  }
+
+  // Variant-backed declarations still reject Java values without a UA Variant representation.
+  @Test
+  void rejectsUnsupportedLocalVariantBackedAbstractDataTypeValue() {
+    Object value = new Object();
+    assertValidation(new Case(VARIANT_BACKED_TYPE_ID, -1, null, value, false), new Variant(value));
+  }
+
+  // An unchecked local Matrix can carry invalid element classes; return UA statuses, not Java
+  // errors.
+  @Test
+  void rejectsLocalMatrixElementsInBaseDataTypeMatrix() {
+    var nested = new Matrix(new int[] {42}, new int[] {1, 1});
+    var matrix = new Matrix(new Matrix[] {nested}, new int[] {1, 1}, OpcUaDataType.Variant);
+    assertValidation(new Case(NodeIds.BaseDataType, 2, null, matrix, false), new Variant(matrix));
   }
 
   // Part 3 8.6: ranks constrain shape, and dimensions are maxima, not exact lengths.
@@ -276,28 +492,39 @@ class MethodArgumentValidationTest extends AbstractClientServerTest {
   }
 
   private void assertValidation(Case c) {
+    assertValidation(c, wireValue(c.value));
+  }
+
+  private RecordingHandler assertValidation(Case c, Variant input) {
     var argument = new Argument("Input", c.type, c.rank, c.dimensions, LocalizedText.NULL_VALUE);
     var handler = new RecordingHandler(argument);
-    Variant input = wireValue(c.value);
     CallMethodRequest request = handler.request(input);
 
     CallMethodResult result = handler.invoke(AccessContext.INTERNAL, request);
 
-    assertEquals(
-        c.valid ? StatusCode.GOOD : StatusCode.of(StatusCodes.Bad_InvalidArgument),
-        result.getStatusCode());
+    assertAll(
+        () ->
+            assertEquals(
+                c.valid ? StatusCode.GOOD : StatusCode.of(StatusCodes.Bad_InvalidArgument),
+                result.getStatusCode()),
+        () ->
+            assertArrayEquals(
+                c.valid
+                    ? new StatusCode[0]
+                    : new StatusCode[] {
+                      StatusCode.of(StatusCodes.Bad_TypeMismatch), StatusCode.GOOD
+                    },
+                result.getInputArgumentResults(),
+                "input results: " + Arrays.toString(result.getInputArgumentResults())),
+        () -> assertEquals(c.valid ? 1 : 0, handler.callbackCount, "callback count"),
+        () -> assertEquals(c.valid ? 1 : 0, handler.validationCount, "value validation count"));
     assertSame(input, request.getInputArguments()[0], "validation must not mutate the request");
-    if (c.valid) {
-      assertEquals(0, result.getInputArgumentResults().length);
-      if (input.value() instanceof Matrix) {
-        assertSame(input, handler.received[0], "matrix validation must not replace wire values");
-      }
-    } else {
-      assertArrayEquals(
-          new StatusCode[] {StatusCode.of(StatusCodes.Bad_TypeMismatch), StatusCode.GOOD},
-          result.getInputArgumentResults());
-      assertEquals(0, result.getOutputArguments().length);
+    assertEquals(0, result.getOutputArguments().length);
+    assertEquals(0, result.getInputArgumentDiagnosticInfos().length);
+    if (c.valid && input.value() instanceof Matrix matrix && !matrix.isNull()) {
+      assertSame(input, handler.received[0], "matrix validation must not replace wire values");
     }
+    return handler;
   }
 
   // Validation must preserve session identity and the object on which the method was called.
@@ -405,6 +632,8 @@ class MethodArgumentValidationTest extends AbstractClientServerTest {
     private final Argument argument;
     private Optional<Session> expectedSession = Optional.empty();
     private Variant[] received;
+    private int callbackCount;
+    private int validationCount;
 
     RecordingHandler(Argument argument) {
       super(
@@ -434,7 +663,13 @@ class MethodArgumentValidationTest extends AbstractClientServerTest {
     }
 
     @Override
+    protected void validateInputArgumentValues(Variant[] values) {
+      validationCount++;
+    }
+
+    @Override
     protected Variant[] invoke(InvocationContext context, Variant[] values) {
+      callbackCount++;
       assertSame(server, context.getServer());
       assertSame(getNode(), context.getMethodNode());
       assertEquals(NodeIds.ObjectsFolder, context.getObjectId());

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/methods/AbstractMethodInvocationHandler.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/methods/AbstractMethodInvocationHandler.java
@@ -43,9 +43,11 @@ import org.eclipse.milo.opcua.stack.core.util.ArrayUtil;
 import org.jspecify.annotations.Nullable;
 
 /**
- * A partial implementation of {@link MethodInvocationHandler} that handles checking the Executable
- * and UserExecutable attributes as well as validating the supplied input values against the input
- * {@link Argument}s.
+ * A partial implementation of {@link MethodInvocationHandler} that validates input argument counts,
+ * shapes and data types before invoking application code.
+ *
+ * <p>Callers are responsible for access checks. Normal server Method dispatch applies the
+ * configured access controller before invoking this handler.
  */
 public abstract class AbstractMethodInvocationHandler implements MethodInvocationHandler {
 
@@ -102,7 +104,15 @@ public abstract class AbstractMethodInvocationHandler implements MethodInvocatio
           boolean argIsStructType =
               NodeIds.Structure.equals(argDataTypeId) || dataTypeTree.isStructType(argDataTypeId);
 
-          if (argIsStructType) {
+          if (dataTypeTree.getBackingClass(argDataTypeId) == Variant.class) {
+            // Variant-backed declarations accept payload types, not just the wrapper class.
+            // Check Matrix elements without replacing the original representation.
+            try {
+              Variant.of(elementsOf(value));
+            } catch (IllegalArgumentException | ClassCastException e) {
+              dataTypeMatch = false;
+            }
+          } else if (argIsStructType) {
             try {
               if (value instanceof ExtensionObject xo) {
                 UaStructuredType decoded = decodeStructure(xo);
@@ -377,8 +387,8 @@ public abstract class AbstractMethodInvocationHandler implements MethodInvocatio
   /**
    * Invoke this method and return the values for its output arguments, if any.
    *
-   * <p>The Executable and UserExecutable attributes have already been checked to ensure this method
-   * is allowed to execute.
+   * <p>Input arguments have already passed shape, data type and application value validation.
+   * Callers remain responsible for access checks.
    *
    * @param invocationContext the {@link InvocationContext}.
    * @param inputValues the user-supplied values for the input arguments. Each value has been

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/methods/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/methods/package-info.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+/**
+ * Handles Method calls dispatched by the server's address spaces.
+ *
+ * <p>{@link org.eclipse.milo.opcua.sdk.server.methods.MethodInvocationHandler} is the call
+ * boundary. {@link org.eclipse.milo.opcua.sdk.server.methods.AbstractMethodInvocationHandler}
+ * checks argument counts, ranks, dimensions and data types before calling application value
+ * validation and the implementation callback. Type or shape mismatches produce operation and
+ * per-argument statuses without entering the callback. The Method service applies the configured
+ * access controller before address-space dispatch resolves the Method. Direct callers are
+ * responsible for access checks.
+ *
+ * <p>BaseDataType and other Variant-backed declarations accept supported Variant payload types
+ * while retaining their declared shape constraints. Narrower declarations keep their own type
+ * checks. Structure declarations validate decoded type identities using the server's data type tree
+ * and encoding context. Their scalar and array inputs are delivered as decoded structures; Matrix
+ * inputs retain their original representation. Variant-backed inputs also retain their payload
+ * representation. A null Matrix is delivered as a null value for any declaration.
+ *
+ * <p>Validation uses a copy of the request's argument array, so substitutions do not modify the
+ * request. Implementations add value constraints through {@code validateInputArgumentValues} and
+ * report individual failures with {@link
+ * org.eclipse.milo.opcua.sdk.server.methods.InvalidArgumentException}. The invocation context
+ * preserves the calling session, object and Method node.
+ */
+package org.eclipse.milo.opcua.sdk.server.methods;


### PR DESCRIPTION
Method arguments with a Variant backing class, including BaseDataType, reject valid values such as String before calling application code. The payload's Java class is compared with the Variant wrapper class, producing Bad_InvalidArgument with per-input Bad_TypeMismatch.

Use Milo's checked Variant rules for these arguments after rank and dimension validation. This also covers registered abstract data types that inherit Variant backing from BaseDataType. Unsupported local payloads, including malformed Matrix values, return UA argument statuses without calling application code. Narrower declarations retain their existing type and subtype checks, and the shared type mappings are unchanged.

Public invocation regressions cover wire-decoded and direct scalar, array, Matrix, structure, enum and null values with exact statuses and callback counts. Positive String and vendor abstract-type cases failed before their repairs, and a malformed local Matrix reproduced the escaping ClassCastException. New empty-Matrix cases use direct invocation; the existing binary zero-dimension encoding issue is tracked separately in [#1968](https://github.com/eclipse-milo/milo/issues/1968).

The class, callback and package documentation now describe input validation and the actual access-control boundary. The Method service checks access before address-space dispatch; direct callers remain responsible for access checks.

Independent review found no remaining issues. Verification passed on the final source with Java 17: `mise exec -- mvn -q spotless:apply`, `mise exec -- mvn -q clean compile`, and `mise exec -- mvn -q clean verify`. The clean targeted reactor gate also passed with `mise exec -- mvn -q -pl opc-ua-sdk/integration-tests -am clean verify -Dtest=MethodArgumentValidationTest,AbstractMethodInvocationHandlerTest -Dsurefire.failIfNoSpecifiedTests=false`. All 183 Method validation and 10 handler tests passed. Full reactor verification ran 4,860 tests with zero failures or errors and four existing skips.
