### PR TITLE
Omit binary Variant dimensions for empty Matrices

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/methods/MethodArgumentValidationTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/methods/MethodArgumentValidationTest.java
@@ -173,7 +173,8 @@ class MethodArgumentValidationTest extends AbstractClientServerTest {
                 baseValue(1, new UaStructuredType[] {null, xv}),
                 baseValue(2, new Matrix(new XVType[] {null, xv}, new int[] {1, 2})),
                 baseValue(2, new Matrix(new UaStructuredType[] {null, xv}, new int[] {1, 2})),
-                // Local shape validation does not establish a wire encoding for empty Matrices.
+                // Local only: Part 6 5.2.2.16 encodes an empty Matrix as an empty array with no
+                // dimensions, so the wire form arrives as a one-dimensional empty array.
                 baseValue(2, new Matrix(new String[0], new int[] {0, 2})),
                 baseValue(2, new Matrix(new XVType[0], new int[] {0, 2})),
                 baseValue(-1, Matrix.ofNull())))
@@ -368,7 +369,6 @@ class MethodArgumentValidationTest extends AbstractClientServerTest {
         shape(2, new Matrix(new Integer[] {1, 2}, new int[] {1, 2}), true),
         shape(3, new Matrix(new Integer[] {1, 2}, new int[] {1, 2}), false),
         shape(3, new Matrix(new Integer[] {1, 2}, new int[] {1, 1, 2}), true),
-        shape(2, new Matrix(new Integer[0], new int[] {0, 2}), true),
         shape(-1, null, true),
         shape(1, null, true),
         shape(2, null, true),
@@ -430,7 +430,6 @@ class MethodArgumentValidationTest extends AbstractClientServerTest {
         new Case(NodeIds.Structure, 1, null, new UaStructuredType[] {xv, vector}, true),
         new Case(NodeIds.Vector, -1, null, vector, true),
         new Case(NodeIds.XVType, 2, null, new Matrix(new XVType[] {xv}, new int[] {1, 1}), true),
-        new Case(NodeIds.XVType, 2, null, new Matrix(new XVType[0], new int[] {0, 2}), true),
         new Case(
             NodeIds.Structure,
             2,

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryEncoder.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryEncoder.java
@@ -650,6 +650,15 @@ public class OpcUaBinaryEncoder implements UaEncoder {
         } else {
           int[] dimensions = ((Matrix) value).getDimensions();
 
+          if (!allDimensionsPositive(dimensions)) {
+            // OPC 10000-6, 5.2.2.16: ArrayDimensions is only present when every dimension is
+            // greater than 0, and ArrayLength is 0 when any dimension is not. Write an empty
+            // one-dimensional array of the element type instead of a Matrix.
+            buffer.writeByte(typeId | 0x80);
+            buffer.writeIntLE(0);
+            return;
+          }
+
           buffer.writeByte(typeId | 0xC0);
 
           Object elements = ((Matrix) value).getElements();
@@ -800,6 +809,13 @@ public class OpcUaBinaryEncoder implements UaEncoder {
     return componentType != null
         && (componentType == OpcUaDataType.getBackingClass(typeId)
             || componentType == OpcUaDataType.getPrimitiveBackingClass(typeId));
+  }
+
+  private static boolean allDimensionsPositive(int[] dimensions) {
+    for (int dimension : dimensions) {
+      if (dimension <= 0) return false;
+    }
+    return true;
   }
 
   /**

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryEncoder.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryEncoder.java
@@ -649,20 +649,24 @@ public class OpcUaBinaryEncoder implements UaEncoder {
           }
         } else {
           int[] dimensions = ((Matrix) value).getDimensions();
-
-          if (!allDimensionsPositive(dimensions)) {
-            // OPC 10000-6, 5.2.2.16: ArrayDimensions is only present when every dimension is
-            // greater than 0, and ArrayLength is 0 when any dimension is not. Write an empty
-            // one-dimensional array of the element type instead of a Matrix.
-            buffer.writeByte(typeId | 0x80);
-            buffer.writeIntLE(0);
-            return;
-          }
-
-          buffer.writeByte(typeId | 0xC0);
-
           Object elements = ((Matrix) value).getElements();
           int length = Array.getLength(elements);
+
+          // OPC 10000-6, 5.2.2.16: ArrayDimensions is only present when there are at least two
+          // dimensions and every dimension is greater than 0, and ArrayLength is 0 when any
+          // dimension is not. Anything else is written as a one-dimensional array.
+          boolean allPositive = allDimensionsPositive(dimensions);
+          boolean encodeDimensions = dimensions.length > 1 && allPositive;
+
+          if (!allPositive && length != 0) {
+            throw new UaSerializationException(
+                StatusCodes.Bad_EncodingError,
+                String.format(
+                    "matrix has %s elements but a dimension <= 0 (dimensions=%s)",
+                    length, Arrays.toString(dimensions)));
+          }
+
+          buffer.writeByte(typeId | (encodeDimensions ? 0xC0 : 0x80));
           buffer.writeIntLE(length);
 
           if (isPlainBuiltinArray(typeId, elements)) {
@@ -675,9 +679,11 @@ public class OpcUaBinaryEncoder implements UaEncoder {
             }
           }
 
-          encodeInt32(dimensions.length);
-          for (int dimension : dimensions) {
-            encodeInt32(dimension);
+          if (encodeDimensions) {
+            encodeInt32(dimensions.length);
+            for (int dimension : dimensions) {
+              encodeInt32(dimension);
+            }
           }
         }
       } else {

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryEncoder.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryEncoder.java
@@ -654,15 +654,15 @@ public class OpcUaBinaryEncoder implements UaEncoder {
 
           // OPC 10000-6, 5.2.2.16: ArrayDimensions is only present when there are at least two
           // dimensions and every dimension is greater than 0, and ArrayLength is 0 when any
-          // dimension is not. Anything else is written as a one-dimensional array.
-          boolean allPositive = allDimensionsPositive(dimensions);
-          boolean encodeDimensions = dimensions.length > 1 && allPositive;
+          // dimension is not. An empty Matrix is therefore written as an empty one-dimensional
+          // array; a Matrix with elements must have at least two positive dimensions.
+          boolean encodeDimensions = dimensions.length > 1 && allDimensionsPositive(dimensions);
 
-          if (!allPositive && length != 0) {
+          if (!encodeDimensions && length != 0) {
             throw new UaSerializationException(
                 StatusCodes.Bad_EncodingError,
                 String.format(
-                    "matrix has %s elements but a dimension <= 0 (dimensions=%s)",
+                    "matrix has %s elements but invalid dimensions %s",
                     length, Arrays.toString(dimensions)));
           }
 

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryEncoderTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryEncoderTest.java
@@ -17,7 +17,9 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
+import java.util.stream.Stream;
 import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaSerializationException;
@@ -29,6 +31,9 @@ import org.eclipse.milo.opcua.stack.core.types.structured.AccessLevelType;
 import org.eclipse.milo.opcua.stack.core.types.structured.XVType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class OpcUaBinaryEncoderTest {
 
@@ -300,6 +305,74 @@ public class OpcUaBinaryEncoderTest {
         matrix,
         decodedMatrix.transform(
             v -> ((ExtensionObject) v).decode(DefaultEncodingContext.INSTANCE)));
+  }
+
+  static Stream<Arguments> matrixVariantEncodings() {
+    return Stream.of(
+        // Empty Matrices: mask has only the array bit, ArrayLength is 0, no ArrayDimensions.
+        Arguments.of(
+            "empty structure Matrix, zero first dimension",
+            new Matrix(new XVType[0], new int[] {0, 2}),
+            "9600000000"),
+        Arguments.of(
+            "empty Int32 Matrix, zero last dimension",
+            new Matrix(new Integer[0], new int[] {2, 0}),
+            "8600000000"),
+        Arguments.of(
+            "empty primitive Int32 Matrix, zero middle dimension",
+            new Matrix(new int[0], new int[] {2, 0, 3}),
+            "8600000000"),
+        Arguments.of(
+            "empty String Matrix, negative dimension",
+            new Matrix(new String[0], new int[] {-1, 2}),
+            "8c00000000"),
+        Arguments.of(
+            "empty enumeration Matrix encodes as Int32",
+            new Matrix(new ApplicationType[0], new int[] {0, 1}),
+            "8600000000"),
+        Arguments.of(
+            "empty option set Matrix encodes as Byte",
+            new Matrix(new AccessLevelType[0], new int[] {2, -3}),
+            "8300000000"),
+        // Nonempty Matrices keep the dimensions bit and the ArrayDimensions field.
+        Arguments.of(
+            "2x2 Int32 Matrix keeps dimensions",
+            Matrix.ofInt32(new Integer[][] {{1, 2}, {3, 4}}),
+            "c6"
+                + "04000000"
+                + "01000000020000000300000004000000"
+                + "02000000"
+                + "0200000002000000"),
+        Arguments.of(
+            "1x2 Int32 Matrix keeps a dimension of length 1",
+            Matrix.ofInt32(new Integer[][] {{1, 2}}),
+            "c6" + "02000000" + "0100000002000000" + "02000000" + "0100000002000000"));
+  }
+
+  // OPC 10000-6, 5.2.2.16, Table 26: ArrayDimensions is present only when there are at least two
+  // dimensions and every dimension is greater than 0, and ArrayLength is 0 when any dimension is
+  // not. A Matrix with a zero or negative dimension must therefore encode as a plain empty array of
+  // its element type, without the dimensions bit or the ArrayDimensions field.
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("matrixVariantEncodings")
+  void encodeVariantOfMatrixWritesDimensionsOnlyWhenAllArePositive(
+      String description, Matrix matrix, String expectedHex) {
+    encoder.encodeVariant(new Variant(matrix));
+
+    assertEquals(expectedHex, ByteBufUtil.hexDump(buffer), description);
+  }
+
+  // The empty-array form carries no dimensions, so a peer (and this decoder) sees a
+  // one-dimensional empty array of the element type rather than a Matrix.
+  @Test
+  void encodeVariantOfEmptyMatrixDecodesAsEmptyArray() {
+    encoder.encodeVariant(new Variant(new Matrix(new XVType[0], new int[] {0, 2})));
+
+    var decoder = new OpcUaBinaryDecoder(DefaultEncodingContext.INSTANCE).setBuffer(buffer);
+    Variant decoded = decoder.decodeVariant();
+
+    assertArrayEquals(new ExtensionObject[0], (ExtensionObject[]) decoded.value());
+    assertEquals(0, buffer.readableBytes(), "decoder consumed the whole encoding");
   }
 
   @Test

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryEncoderTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryEncoderTest.java
@@ -353,6 +353,9 @@ public class OpcUaBinaryEncoderTest {
   // dimensions and every dimension is greater than 0, and ArrayLength is 0 when any dimension is
   // not. A Matrix with a zero or negative dimension must therefore encode as a plain empty array of
   // its element type, without the dimensions bit or the ArrayDimensions field.
+  //
+  // A Matrix with fewer than two dimensions cannot be constructed while assertions are enabled, so
+  // the rank half of the condition is not covered here.
   @ParameterizedTest(name = "{0}")
   @MethodSource("matrixVariantEncodings")
   void encodeVariantOfMatrixWritesDimensionsOnlyWhenAllArePositive(
@@ -364,6 +367,21 @@ public class OpcUaBinaryEncoderTest {
 
   // The empty-array form carries no dimensions, so a peer (and this decoder) sees a
   // one-dimensional empty array of the element type rather than a Matrix.
+  // The Matrix constructors only assert consistency, so a Matrix can carry elements alongside a
+  // dimension of 0. The empty-array form would silently drop those elements; reject the value
+  // instead.
+  @Test
+  void encodeVariantOfMatrixWithElementsAndNonpositiveDimensionReportsEncodingError() {
+    Matrix matrix = new Matrix(new Integer[] {1, 2}, new int[] {0, 2});
+
+    UaSerializationException ex =
+        assertThrows(
+            UaSerializationException.class, () -> encoder.encodeVariant(new Variant(matrix)));
+
+    assertEquals(new StatusCode(StatusCodes.Bad_EncodingError), ex.getStatusCode());
+    assertEquals(0, buffer.readableBytes(), "nothing is written for a rejected Matrix");
+  }
+
   @Test
   void encodeVariantOfEmptyMatrixDecodesAsEmptyArray() {
     encoder.encodeVariant(new Variant(new Matrix(new XVType[0], new int[] {0, 2})));

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryEncoderTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/encoding/binary/OpcUaBinaryEncoderTest.java
@@ -355,7 +355,7 @@ public class OpcUaBinaryEncoderTest {
   // its element type, without the dimensions bit or the ArrayDimensions field.
   //
   // A Matrix with fewer than two dimensions cannot be constructed while assertions are enabled, so
-  // the rank half of the condition is not covered here.
+  // the rank half of the condition is not covered here or in the rejection test below.
   @ParameterizedTest(name = "{0}")
   @MethodSource("matrixVariantEncodings")
   void encodeVariantOfMatrixWritesDimensionsOnlyWhenAllArePositive(
@@ -368,8 +368,8 @@ public class OpcUaBinaryEncoderTest {
   // The empty-array form carries no dimensions, so a peer (and this decoder) sees a
   // one-dimensional empty array of the element type rather than a Matrix.
   // The Matrix constructors only assert consistency, so a Matrix can carry elements alongside a
-  // dimension of 0. The empty-array form would silently drop those elements; reject the value
-  // instead.
+  // dimension of 0. The empty-array form would silently drop those elements, and no other wire
+  // form can represent the value; reject it instead.
   @Test
   void encodeVariantOfMatrixWithElementsAndNonpositiveDimensionReportsEncodingError() {
     Matrix matrix = new Matrix(new Integer[] {1, 2}, new int[] {0, 2});


### PR DESCRIPTION
Fixes #1968.

When a Variant holds a Matrix with a zero or negative dimension, the binary encoder wrote the ArrayDimensions bit and the dimension values anyway. Part 6 §5.2.2.16 (Table 26) says ArrayDimensions may only appear when there are at least two dimensions and every dimension is greater than 0, and that ArrayLength is 0 when any dimension is not. A stricter peer can reject the old form. Milo's own decoder accepts it, so a local round trip did not catch this.

The encoder now writes such a Matrix as a plain empty array of its built-in element type: the array bit only, ArrayLength 0, and no dimensions. For an empty `XVType` Matrix with dimensions `[0, 2]`, the bytes change like this:

```diff
-d6 00000000 02000000 00000000 02000000   mask=ExtensionObject|Array|Dims, length 0, dims [0, 2]
+96 00000000                              mask=ExtensionObject|Array,      length 0
```

Nonempty Matrices are unchanged and still carry their dimensions. The Matrix constructors only assert consistency, so a Matrix can carry elements alongside a dimension of 0; the encoder now rejects that with Bad_EncodingError rather than writing an empty array and silently dropping the elements. The element type is preserved, so an empty enumeration Matrix still encodes as Int32 and an empty option set Matrix as its backing unsigned type. The Matrix class itself and the type metadata it keeps for empty values (from #1791) are not touched.

One consequence: the receiving side can no longer tell an empty Matrix from an empty one-dimensional array, because the wire form is the same. The server's Method argument shape check compares the decoded rank to the declared ValueRank, so an empty Matrix sent to a ValueRank 2 argument now decodes as rank 1 and is rejected with Bad_TypeMismatch. Two integration test cases relied on the old encoding to pass that check, and this PR removes them; local (non-wire) cases for the same values remain. Whether a ValueRank ≥ 2 argument should accept an empty array from the wire is a server validation question, left for a follow-up.

Verification: `spotless:apply`, `clean compile`, the stack-core binary encoder and decoder test classes, and `MethodArgumentValidationTest` in integration-tests (with `-am`) all pass locally. New golden-byte tests cover zero and negative lengths in first, middle, and last dimension positions, structure, enumeration, option set, boxed, and primitive element types, and nonempty controls that keep their dimensions.

