### PR TITLE
Accept the empty-array wire form for rank-n values

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/api/util/AttributeWriterTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/api/util/AttributeWriterTest.java
@@ -16,6 +16,7 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -40,6 +41,7 @@ import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ByteString;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Matrix;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
@@ -298,6 +300,47 @@ public class AttributeWriterTest extends AbstractClientServerTest {
     assertEquals(StatusCode.GOOD, statusCode);
   }
 
+  // Part 6 5.2.2.16: an empty Matrix is written as an empty array with no ArrayDimensions, so a
+  // conforming client's empty value for a rank-2 Variable arrives with no rank of its own. Storing
+  // it as a Matrix keeps the node's value consistent with its declared ValueRank.
+  @Test
+  void writeEmptyArrayToMatrixVariableStoresMatrixOfDeclaredRank() {
+    UaServerNode node = getManagedNode("Int32Matrix");
+
+    StatusCode statusCode =
+        AttributeWriter.writeAttribute(
+            AccessContext.INTERNAL,
+            node,
+            AttributeId.Value,
+            DataValue.valueOnly(new Variant(new Integer[0])),
+            null);
+
+    assertEquals(StatusCode.GOOD, statusCode);
+
+    DataValue stored = (DataValue) node.getAttribute(AccessContext.INTERNAL, AttributeId.Value);
+    Matrix matrix = assertInstanceOf(Matrix.class, stored.value().value());
+
+    assertArrayEquals(new int[] {0, 0}, matrix.getDimensions());
+    assertEquals(0, ((Integer[]) matrix.getElements()).length);
+  }
+
+  // Control for the case above: only an empty value carries no rank, so a populated
+  // one-dimensional array must still be rejected for ValueRank 2.
+  @Test
+  void rejectNonEmptyOneDimensionalArrayForMatrixVariable() {
+    UaServerNode node = getManagedNode("Int32Matrix");
+
+    StatusCode statusCode =
+        AttributeWriter.writeAttribute(
+            AccessContext.INTERNAL,
+            node,
+            AttributeId.Value,
+            DataValue.valueOnly(new Variant(new Integer[] {1, 2})),
+            null);
+
+    assertEquals(new StatusCode(StatusCodes.Bad_TypeMismatch), statusCode);
+  }
+
   @Test
   void writeValue_VariableNode_SuccessAndFailure() throws Exception {
     StatusCode ok =
@@ -481,6 +524,19 @@ public class AttributeWriterTest extends AbstractClientServerTest {
                 b.setDataType(NodeIds.Byte);
                 b.setValueRank(ValueRanks.OneDimension);
                 b.setArrayDimensions(new UInteger[] {UInteger.valueOf(0)});
+                b.setAccessLevel(AccessLevel.READ_WRITE);
+                b.setUserAccessLevel(AccessLevel.READ_WRITE);
+                return b.buildAndAdd();
+              });
+
+          UaVariableNode.build(
+              context,
+              b -> {
+                b.setNodeId(new NodeId(2, "Int32Matrix"));
+                b.setBrowseName(new QualifiedName(2, "Int32Matrix"));
+                b.setDisplayName(LocalizedText.english("Int32Matrix"));
+                b.setDataType(NodeIds.Int32);
+                b.setValueRank(2);
                 b.setAccessLevel(AccessLevel.READ_WRITE);
                 b.setUserAccessLevel(AccessLevel.READ_WRITE);
                 return b.buildAndAdd();

--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/methods/MethodArgumentValidationTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/methods/MethodArgumentValidationTest.java
@@ -13,11 +13,13 @@ import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.Mockito.mock;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -174,7 +176,8 @@ class MethodArgumentValidationTest extends AbstractClientServerTest {
                 baseValue(2, new Matrix(new XVType[] {null, xv}, new int[] {1, 2})),
                 baseValue(2, new Matrix(new UaStructuredType[] {null, xv}, new int[] {1, 2})),
                 // Local only: Part 6 5.2.2.16 encodes an empty Matrix as an empty array with no
-                // dimensions, so the wire form arrives as a one-dimensional empty array.
+                // dimensions, so the wire form arrives as a one-dimensional empty array and is
+                // delivered as a Matrix of the declared rank rather than the payload sent.
                 baseValue(2, new Matrix(new String[0], new int[] {0, 2})),
                 baseValue(2, new Matrix(new XVType[0], new int[] {0, 2})),
                 baseValue(-1, Matrix.ofNull())))
@@ -351,6 +354,7 @@ class MethodArgumentValidationTest extends AbstractClientServerTest {
     return Stream.of(
         shape(-1, 1, true),
         shape(-1, new Integer[] {1}, false),
+        shape(-1, new Integer[0], false),
         shape(1, 1, false),
         shape(1, new Integer[0], true),
         shape(1, new Matrix(new Integer[] {1, 2}, new int[] {1, 2}), false),
@@ -369,6 +373,8 @@ class MethodArgumentValidationTest extends AbstractClientServerTest {
         shape(2, new Matrix(new Integer[] {1, 2}, new int[] {1, 2}), true),
         shape(3, new Matrix(new Integer[] {1, 2}, new int[] {1, 2}), false),
         shape(3, new Matrix(new Integer[] {1, 2}, new int[] {1, 1, 2}), true),
+        shape(2, new Matrix(new Integer[0], new int[] {0, 2}), true),
+        shape(3, new Matrix(new Integer[0], new int[] {0, 1, 2}), true),
         shape(-1, null, true),
         shape(1, null, true),
         shape(2, null, true),
@@ -381,6 +387,11 @@ class MethodArgumentValidationTest extends AbstractClientServerTest {
         shape(1, new UInteger[] {uint(2)}, new Integer[] {1, 2}, true),
         shape(1, new UInteger[] {uint(1)}, new Integer[] {1, 2}, false),
         shape(1, new UInteger[] {UInteger.MAX}, new Integer[] {1, 2}, true),
+        shape(
+            2,
+            new UInteger[] {uint(1), uint(1)},
+            new Matrix(new Integer[0], new int[] {0, 2}),
+            true),
         shape(
             2,
             new UInteger[] {uint(0), uint(2)},
@@ -430,6 +441,7 @@ class MethodArgumentValidationTest extends AbstractClientServerTest {
         new Case(NodeIds.Structure, 1, null, new UaStructuredType[] {xv, vector}, true),
         new Case(NodeIds.Vector, -1, null, vector, true),
         new Case(NodeIds.XVType, 2, null, new Matrix(new XVType[] {xv}, new int[] {1, 1}), true),
+        new Case(NodeIds.XVType, 2, null, new Matrix(new XVType[0], new int[] {0, 2}), true),
         new Case(
             NodeIds.Structure,
             2,
@@ -490,8 +502,41 @@ class MethodArgumentValidationTest extends AbstractClientServerTest {
             true));
   }
 
-  private void assertValidation(Case c) {
-    assertValidation(c, wireValue(c.value));
+  // Part 6 5.2.2.16: an empty Matrix is encoded as an empty array with no ArrayDimensions, so the
+  // declared rank is the only thing left to restore the Matrix a rank-n argument takes. A handler
+  // must not have to tell an empty value apart by its Java type.
+  @TestFactory
+  Stream<DynamicTest> deliversEmptyWireValueAsMatrixOfDeclaredRank() {
+    return Stream.of(
+            new Case(NodeIds.Int32, 2, null, new Matrix(new Integer[0], new int[] {0, 2}), true),
+            new Case(NodeIds.Int32, 3, null, new Matrix(new Integer[0], new int[] {0, 1, 2}), true),
+            new Case(NodeIds.XVType, 2, null, new Matrix(new XVType[0], new int[] {0, 2}), true),
+            new Case(
+                NodeIds.BaseDataType, 2, null, new Matrix(new String[0], new int[] {0, 2}), true))
+        .map(
+            c ->
+                DynamicTest.dynamicTest(
+                    c.toString(),
+                    () -> {
+                      RecordingHandler handler = assertValidation(c);
+
+                      Matrix delivered =
+                          assertInstanceOf(Matrix.class, handler.received[0].value());
+
+                      assertArrayEquals(
+                          new int[c.rank],
+                          delivered.getDimensions(),
+                          "a zero length in every declared dimension");
+                      assertEquals(
+                          ((Matrix) c.value).getElementType().orElseThrow(),
+                          delivered.getElementType().orElseThrow(),
+                          "element type");
+                      assertEquals(0, Array.getLength(delivered.getElements()));
+                    }));
+  }
+
+  private RecordingHandler assertValidation(Case c) {
+    return assertValidation(c, wireValue(c.value));
   }
 
   private RecordingHandler assertValidation(Case c, Variant input) {

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/AttributeWriter.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/AttributeWriter.java
@@ -189,7 +189,7 @@ public class AttributeWriter {
         }
 
         if (valueRank > 0) {
-          validateArrayType(valueRank, arrayDimensions, value);
+          value = validateArrayType(valueRank, arrayDimensions, value);
         }
       } catch (UaException e) {
         return e.getStatusCode();
@@ -424,13 +424,23 @@ public class AttributeWriter {
     return value;
   }
 
-  private static void validateArrayType(
+  /**
+   * Check a written value against the declared ValueRank and ArrayDimensions of a Variable or
+   * VariableType.
+   *
+   * @param valueRank the declared ValueRank.
+   * @param arrayDimensions the declared ArrayDimensions, which are maxima.
+   * @param value the value to check.
+   * @return {@code value}, or the equivalent value to store in its place.
+   * @throws UaException if the value does not match the declared shape.
+   */
+  private static DataValue validateArrayType(
       Integer valueRank, UInteger[] arrayDimensions, DataValue value) throws UaException {
 
     Variant variant = value.value();
 
     Object o = variant.value();
-    if (o == null) return;
+    if (o == null) return value;
 
     if (o instanceof Matrix matrix) {
       o = matrix.nestedArrayValue();
@@ -473,6 +483,18 @@ public class AttributeWriter {
         int[] valueDimensions = ArrayUtil.getDimensions(o);
 
         if (valueDimensions.length != valueRank) {
+          // OPC 10000-6, 5.2.2.16 and 5.3.1.17 carry an empty Matrix as an empty array with no
+          // ArrayDimensions, so an empty value arrives with no rank of its own. Accept it and
+          // store the Matrix the declared rank calls for, with a zero length in every dimension.
+          // The declared maxima are not checked: an empty value has no element to exceed them.
+          if (valueDimensions.length == 1 && valueDimensions[0] == 0) {
+            return new DataValue(
+                new Variant(new Matrix(o, new int[valueRank])),
+                value.statusCode(),
+                value.sourceTime(),
+                value.serverTime());
+          }
+
           throw new UaException(StatusCodes.Bad_TypeMismatch);
         }
 
@@ -501,5 +523,7 @@ public class AttributeWriter {
         }
         break;
     }
+
+    return value;
   }
 }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/methods/AbstractMethodInvocationHandler.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/methods/AbstractMethodInvocationHandler.java
@@ -161,6 +161,7 @@ public abstract class AbstractMethodInvocationHandler implements MethodInvocatio
         }
 
         if (dataTypeMatch) {
+          inputArgumentValues[i] = restoreMatrixRank(argument, inputArgumentValues[i]);
           inputDataTypeCheckResults[i] = StatusCode.GOOD;
         } else {
           inputDataTypeCheckResults[i] = new StatusCode(StatusCodes.Bad_TypeMismatch);
@@ -227,20 +228,23 @@ public abstract class AbstractMethodInvocationHandler implements MethodInvocatio
     int rank =
         value instanceof Matrix matrix ? matrix.getValueRank() : ArrayUtil.getValueRank(value);
     int valueRank = argument.getValueRank();
+    boolean emptyArray = isEmptyArray(value);
     boolean rankMatches =
         switch (valueRank) {
           case ValueRanks.ScalarOrOneDimension -> rank == ValueRanks.Scalar || rank == 1;
           case ValueRanks.Any -> true;
           case ValueRanks.Scalar -> rank == ValueRanks.Scalar;
           case ValueRanks.OneOrMoreDimensions -> rank >= 1;
-          default -> valueRank > 0 && rank == valueRank;
+          default -> valueRank > 0 && (rank == valueRank || emptyArray);
         };
     if (!rankMatches) {
       return false;
     }
 
     UInteger[] maxima = argument.getArrayDimensions();
-    if (valueRank > 0 && maxima != null && maxima.length > 0) {
+    // An empty array has no element to exceed a maximum, and its single dimension does not line up
+    // with the dimensions declared for a higher rank.
+    if (valueRank > 0 && !emptyArray && maxima != null && maxima.length > 0) {
       int[] dimensions =
           value instanceof Matrix matrix ? matrix.getDimensions() : ArrayUtil.getDimensions(value);
       if (maxima.length != dimensions.length) {
@@ -254,6 +258,36 @@ public abstract class AbstractMethodInvocationHandler implements MethodInvocatio
       }
     }
     return true;
+  }
+
+  /**
+   * Whether {@code value} is a zero-length one-dimensional array, the form an empty value of any
+   * rank arrives in.
+   *
+   * <p>OPC 10000-6, 5.2.2.16 and 5.3.1.17 carry an empty Matrix as an empty array with no
+   * ArrayDimensions, so an empty value has no rank of its own on the wire.
+   */
+  private static boolean isEmptyArray(@Nullable Object value) {
+    return value != null && ArrayUtil.getValueRank(value) == 1 && Array.getLength(value) == 0;
+  }
+
+  /**
+   * Give an empty value supplied for an Argument of ValueRank 2 or greater the Matrix
+   * representation its declared rank calls for, with a zero length in every dimension.
+   *
+   * @param argument the {@link Argument} the value was supplied for.
+   * @param variant the value supplied for {@code argument}.
+   * @return {@code variant}, or an empty {@link Matrix} of the Argument's declared rank.
+   */
+  private static Variant restoreMatrixRank(Argument argument, Variant variant) {
+    int valueRank = argument.getValueRank();
+    Object value = variant.value();
+
+    if (valueRank >= 2 && isEmptyArray(value)) {
+      return new Variant(new Matrix(value, new int[valueRank]));
+    } else {
+      return variant;
+    }
   }
 
   private @Nullable UaStructuredType decodeStructure(@Nullable ExtensionObject xo) {
@@ -397,7 +431,9 @@ public abstract class AbstractMethodInvocationHandler implements MethodInvocatio
    *     arguments, an array of the DataType's registered class, e.g. {@code XVType[]}) rather than
    *     the raw {@link ExtensionObject}(s) received in the request. A null ExtensionObject, whether
    *     scalar or an array element, is delivered as {@code null}. Matrix arguments retain their
-   *     original representation; their elements are decoded only for validation.
+   *     original representation; their elements are decoded only for validation. An empty value for
+   *     an argument of ValueRank 2 or greater is delivered as an empty {@link Matrix} of the
+   *     declared rank, because its wire form carries no dimensions.
    * @return this output values matching this Method's output arguments, if any.
    * @throws UaException if invocation has failed for some reason.
    */

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/methods/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/methods/package-info.java
@@ -24,7 +24,9 @@
  * checks. Structure declarations validate decoded type identities using the server's data type tree
  * and encoding context. Their scalar and array inputs are delivered as decoded structures; Matrix
  * inputs retain their original representation. Variant-backed inputs also retain their payload
- * representation. A null Matrix is delivered as a null value for any declaration.
+ * representation. A null Matrix is delivered as a null value for any declaration. An empty value
+ * for a declaration of ValueRank 2 or greater is delivered as an empty Matrix of the declared rank,
+ * since the wire form of an empty value carries no dimensions.
  *
  * <p>Validation uses a copy of the request's argument array, so substitutions do not modify the
  * request. Implementations add value constraints through {@code validateInputArgumentValues} and


### PR DESCRIPTION
Fixes #1970.

Since #1969 the binary encoder writes a `Matrix` with any zero or negative dimension as a plain empty array, because Part 6 §5.2.2.16 only allows `ArrayDimensions` when there are at least two dimensions and every one is greater than 0. The XML encoding has the same restriction (§5.3.1.17). An empty `Matrix` and an empty one-dimensional array therefore produce identical bytes:

```text
Matrix(XVType[0], [0, 2])    96 00000000    mask=ExtensionObject|Array, length 0
XVType[0]                    96 00000000    mask=ExtensionObject|Array, length 0
```

The receiver cannot tell them apart, so an empty value arrives with no rank of its own, and the server's shape check compared that rank to the declared `ValueRank`. An empty value sent to a `ValueRank` 2 Method argument decoded as rank 1 and came back `Bad_TypeMismatch`. Between Milo peers this used to work because both sides used the nonconforming encoding; clients from other stacks already hit the rejection. A conforming client was left with no way to pass an empty value to a rank-n slot other than null.

Part 6 defines the `ArrayLength` 0 form so that empty matrices can be sent, and nowhere says to send null instead, so the receiver should accept it. Part 4 §5.12.2 sets the precedent for accepting a structurally identical form: "A Server shall accept a ByteString if an array of Byte is expected."

So the shape check now treats a zero-length one-dimensional array as compatible with any `ValueRank` that permits arrays, and stops comparing its single dimension against the declared `ArrayDimensions`:

```diff
 shapeMatches(argument, value)
-  the value's rank must equal the declared ValueRank
+  the value's rank must equal the declared ValueRank,
+  or the value is an empty array and the declaration permits arrays
   if ArrayDimensions are declared
+    an empty array skips this check
     the dimension counts must match
     no dimension may exceed its maximum
```

Skipping the maxima check matters because one dimension cannot be lined up against two maxima, and an empty value has no element to exceed one in any case. `Scalar` still rejects an empty array, and a populated one-dimensional array still does not match a higher rank.

| declared ValueRank | empty array | populated 1-d array |
| --- | --- | --- |
| 2 or greater | accepted (new) | rejected |
| OneDimension, OneOrMoreDimensions, Any, ScalarOrOneDimension | accepted | accepted |
| Scalar | rejected | rejected |

The issue asks for the same rule wherever shape is checked. That is two places: `AbstractMethodInvocationHandler.shapeMatches` for Method arguments and `AttributeWriter.validateArrayType` for Variable and VariableType writes. `EventContentFilter` and `AttributeSnapshot` read `ValueRank` but never validate against it, so they are untouched.

Accepting the form raises the question of what a rank-n slot then holds, since an empty flat array is not the representation either side is declared to use. Both paths restore the `Matrix` the declared rank calls for, with a zero length in every dimension:

```text
client sends   Matrix(XVType[0], [0, 2])
wire           96 00000000
decoded        ExtensionObject[0]
substituted    XVType[0]                    (existing struct-array substitution)
delivered      Matrix(XVType[0], [0, 0])
```

A handler for a rank-n argument then sees a `Matrix` whether or not the value is empty, so one that casts to `Matrix` keeps working instead of throwing `ClassCastException` out of the Call service. A rank-n Variable keeps a value whose shape matches its `ValueRank`, which index range reads in `AttributeReader` and the `Matrix` comparison in `DataChangeMonitoringFilter` both depend on. The dimensions the sender used are not on the wire and are not restored, so the delivered dimensions are all zero rather than the `[0, 2]` in the example above. The `invoke` javadoc and the `methods` package documentation now say so.

The two wire cases #1969 removed are restored as the regression tests: an empty `Integer` Matrix with dimensions `[0, 2]` against a `ValueRank` 2 Int32 argument, and an empty `XVType` Matrix against a `ValueRank` 2 XVType argument. Alongside them are a rank 3 case, a case with `ArrayDimensions [1, 1]` that covers the skipped maxima check, a `Scalar` rejection control, and a test for the delivered representation across Int32, XVType and BaseDataType declarations. `AttributeWriterTest` gains a `ValueRank` 2 node with an empty write and a populated control.

Verification: `spotless:apply` and a full `clean verify` both pass locally, with no test failures or errors.
