### PR TITLE
Encode and decode structured node values by ValueRank

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/UaNodeValueConversionTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/client/UaNodeValueConversionTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.client;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.stream.Stream;
+import org.eclipse.milo.opcua.sdk.client.nodes.UaVariableNode;
+import org.eclipse.milo.opcua.sdk.core.ValueRanks;
+import org.eclipse.milo.opcua.sdk.test.AbstractClientServerTest;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
+import org.eclipse.milo.opcua.stack.core.types.UaStructuredType;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
+import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
+import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Matrix;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UByte;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.enumerated.NodeClass;
+import org.eclipse.milo.opcua.stack.core.types.structured.Argument;
+import org.eclipse.milo.opcua.stack.core.types.structured.Range;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class UaNodeValueConversionTest extends AbstractClientServerTest {
+
+  private static final Argument ARGUMENT =
+      new Argument("value", NodeIds.String, ValueRanks.Scalar, null, LocalizedText.english("d"));
+
+  private static final Argument[] ARGUMENTS = {ARGUMENT, null};
+
+  private static Matrix argumentMatrix() {
+    return new Matrix(
+        new Argument[] {null, ARGUMENT},
+        new int[] {1, 2},
+        OpcUaDataType.ExtensionObject,
+        NodeIds.Argument.expanded());
+  }
+
+  // A typed wrapper for a ScalarOrOneDimension Variable accepts either shape through one method,
+  // so the encoded form must follow the actual value, not the declaration.
+  @Test
+  public void scalarOrOneDimensionEncodesByActualShape() {
+    ValueNode node = new ValueNode(client, "Flexible", ValueRanks.ScalarOrOneDimension);
+
+    assertInstanceOf(ExtensionObject.class, node.encode(ARGUMENT));
+    ExtensionObject[] encoded = (ExtensionObject[]) node.encode(ARGUMENTS);
+    assertEquals(2, encoded.length);
+    assertNull(encoded[1]);
+    assertNull(node.encode(null));
+    assertNull(node.encode(Matrix.ofNull()));
+  }
+
+  // Reading back what was written must produce the declared Java type in the declared shape,
+  // including a typed array with its null position and a Matrix with its datatype id.
+  @Test
+  public void decodeRestoresTheDeclaredTypeInEveryShape() {
+    ValueNode node = new ValueNode(client, "Any", ValueRanks.Any);
+
+    assertEquals(ARGUMENT, node.decode(node.encode(ARGUMENT)));
+    assertArrayEquals(ARGUMENTS, (Argument[]) node.decode(node.encode(ARGUMENTS)));
+
+    Matrix decoded = (Matrix) node.decode(node.encode(argumentMatrix()));
+    assertArrayEquals(argumentMatrix().getDimensions(), decoded.getDimensions());
+    assertEquals(argumentMatrix().getDataTypeId(), decoded.getDataTypeId());
+    assertArrayEquals(new Argument[] {null, ARGUMENT}, (Argument[]) decoded.getElements());
+
+    assertNull(node.decode(null));
+    assertNull(node.decode(Matrix.ofNull()));
+    assertSame(ARGUMENT, node.decode(ARGUMENT), "already decoded values pass through");
+  }
+
+  // An empty or all-null array carries no element to derive a class from, but a wrapper still
+  // casts the result to the declared array type, so the node must supply that type itself.
+  @Test
+  public void emptyAndAllNullArraysDecodeToTheDeclaredArrayType() {
+    ValueNode node = new ValueNode(client, "Empty", ValueRanks.Any);
+    Matrix allNull =
+        new Matrix(
+            new Argument[] {null, null},
+            new int[] {1, 2},
+            OpcUaDataType.ExtensionObject,
+            NodeIds.Argument.expanded());
+
+    assertEquals(Argument[].class, node.decode(new ExtensionObject[0]).getClass());
+    assertEquals(Argument[].class, node.decode(new ExtensionObject[] {null}).getClass());
+    assertEquals(Argument[].class, node.decode(new UaStructuredType[0]).getClass());
+
+    Matrix decoded = (Matrix) node.decode(node.encode(allNull));
+    assertEquals(Argument[].class, decoded.getElements().getClass());
+    assertEquals(allNull, decoded);
+  }
+
+  static Stream<Arguments> shapes() {
+    Argument[] empty = new Argument[0];
+    return Stream.of(
+        Arguments.of(ValueRanks.Scalar, ARGUMENT, true),
+        Arguments.of(ValueRanks.Scalar, ARGUMENTS, false),
+        Arguments.of(ValueRanks.Scalar, empty, false),
+        Arguments.of(ValueRanks.OneDimension, ARGUMENTS, true),
+        Arguments.of(ValueRanks.OneDimension, ARGUMENT, false),
+        Arguments.of(ValueRanks.OneDimension, argumentMatrix(), false),
+        Arguments.of(ValueRanks.ScalarOrOneDimension, argumentMatrix(), false),
+        Arguments.of(ValueRanks.OneOrMoreDimensions, ARGUMENT, false),
+        Arguments.of(ValueRanks.OneOrMoreDimensions, argumentMatrix(), true),
+        Arguments.of(ValueRanks.Any, argumentMatrix(), true),
+        Arguments.of(2, argumentMatrix(), true),
+        Arguments.of(2, ARGUMENTS, false),
+        Arguments.of(2, empty, true),
+        Arguments.of(3, argumentMatrix(), false));
+  }
+
+  // Part 3 §5.6.2 defines which shapes a ValueRank permits. The wrapper rejects the rest before
+  // a write so the caller gets an exception naming the node instead of Bad_TypeMismatch from the
+  // server. The empty one-dimensional array is the wire form of an empty value of any rank.
+  @ParameterizedTest
+  @MethodSource("shapes")
+  public void valueRankPermitsOnlyMatchingShapes(int valueRank, Object value, boolean permitted) {
+    ValueNode node = new ValueNode(client, "Shape", valueRank);
+
+    if (permitted) {
+      node.decode(node.encode(value));
+    } else {
+      IllegalArgumentException e =
+          assertThrows(IllegalArgumentException.class, () -> node.encode(value));
+      assertTrue(e.getMessage().contains("Shape"), e.getMessage());
+      assertTrue(e.getMessage().contains("ValueRank=" + valueRank), e.getMessage());
+      assertThrows(IllegalArgumentException.class, () -> node.decode(value));
+    }
+  }
+
+  // A value of the wrong structure type would otherwise be encoded and rejected by the server,
+  // or decoded and fail a cast far from the node that read it.
+  @Test
+  public void elementsMustBeInstancesOfTheDeclaredType() {
+    ValueNode node = new ValueNode(client, "Typed", ValueRanks.ScalarOrOneDimension);
+    Range range = new Range(0.0, 1.0);
+
+    IllegalArgumentException scalar =
+        assertThrows(IllegalArgumentException.class, () -> node.encode(range));
+    assertTrue(scalar.getMessage().contains(Argument.class.getName()), scalar.getMessage());
+    assertTrue(scalar.getMessage().contains(Range.class.getName()), scalar.getMessage());
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> node.encode(new UaStructuredType[] {ARGUMENT, range}));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> node.decode(ExtensionObject.encode(client.getStaticEncodingContext(), range)));
+  }
+
+  private static class ValueNode extends UaVariableNode {
+
+    ValueNode(OpcUaClient client, String name, int valueRank) {
+      super(
+          client,
+          new NodeId(1, name),
+          NodeClass.Variable,
+          new QualifiedName(1, name),
+          LocalizedText.english(name),
+          LocalizedText.NULL_VALUE,
+          UInteger.MIN,
+          UInteger.MIN,
+          DataValue.valueOnly(Variant.NULL_VALUE),
+          NodeIds.Argument,
+          valueRank,
+          null,
+          UByte.MIN,
+          UByte.MIN,
+          0.0,
+          false);
+    }
+
+    Object encode(Object value) {
+      return encodeValue(value, Argument.class, getValueRank());
+    }
+
+    Object decode(Object value) {
+      return decodeValue(value, Argument.class, getValueRank());
+    }
+  }
+}

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/nodes/UaNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/nodes/UaNode.java
@@ -35,9 +35,11 @@ import org.eclipse.milo.opcua.sdk.client.AddressSpace.BrowseOptions;
 import org.eclipse.milo.opcua.sdk.client.OpcUaClient;
 import org.eclipse.milo.opcua.sdk.client.model.variables.PropertyTypeNode;
 import org.eclipse.milo.opcua.sdk.core.QualifiedProperty;
+import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.sdk.core.nodes.Node;
 import org.eclipse.milo.opcua.stack.core.AttributeId;
 import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.UaEnumeratedType;
@@ -46,6 +48,7 @@ import org.eclipse.milo.opcua.stack.core.types.builtin.DataValue;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExpandedNodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.ExtensionObject;
 import org.eclipse.milo.opcua.stack.core.types.builtin.LocalizedText;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Matrix;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.QualifiedName;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
@@ -70,6 +73,7 @@ import org.eclipse.milo.opcua.stack.core.types.structured.RelativePathElement;
 import org.eclipse.milo.opcua.stack.core.types.structured.RolePermissionType;
 import org.eclipse.milo.opcua.stack.core.types.structured.WriteResponse;
 import org.eclipse.milo.opcua.stack.core.types.structured.WriteValue;
+import org.eclipse.milo.opcua.stack.core.util.ArrayUtil;
 import org.jspecify.annotations.Nullable;
 
 public abstract class UaNode implements Node {
@@ -1386,5 +1390,142 @@ public abstract class UaNode implements Node {
     } else {
       return clazz.cast(o);
     }
+  }
+
+  /**
+   * Decode a structured value read from this node and check it against the declared structure type
+   * and ValueRank.
+   *
+   * <p>The result is null, an instance of {@code type}, an array of {@code type}, or a {@link
+   * Matrix} of {@code type}, whichever shape {@code valueRank} permits. A value that is already
+   * decoded is checked and returned as is.
+   *
+   * <pre>{@code
+   * Argument[] arguments =
+   *     (Argument[]) decodeValue(value.value().value(), Argument.class, ValueRanks.OneDimension);
+   * }</pre>
+   *
+   * @param value the value of a Variant, typically an ExtensionObject, an ExtensionObject array or
+   *     a Matrix of ExtensionObjects.
+   * @param type the declared structure type.
+   * @param valueRank the declared ValueRank, see {@link ValueRanks}.
+   * @return the decoded value, or null if {@code value} is null or a null Matrix.
+   * @throws IllegalArgumentException if the shape of {@code value} is not permitted by {@code
+   *     valueRank} or an element is not an instance of {@code type}.
+   */
+  protected @Nullable Object decodeValue(
+      @Nullable Object value, Class<? extends UaStructuredType> type, int valueRank) {
+
+    Object decoded = ExtensionObject.decodeValue(client.getStaticEncodingContext(), value);
+
+    return retype(checkValue(decoded, type, valueRank), type);
+  }
+
+  /**
+   * Check a structured value against the declared structure type and ValueRank and encode it for a
+   * write to this node.
+   *
+   * <p>{@code value} is null, an instance of {@code type}, an array of {@code type}, or a {@link
+   * Matrix} of {@code type}, whichever shape {@code valueRank} permits. An empty one-dimensional
+   * array is accepted for any ValueRank that permits arrays.
+   *
+   * <pre>{@code
+   * Object encoded = encodeValue(arguments, Argument.class, ValueRanks.OneDimension);
+   * writeAttributeAsync(AttributeId.Value, DataValue.valueOnly(Variant.of(encoded)));
+   * }</pre>
+   *
+   * @param value the value to write.
+   * @param type the declared structure type.
+   * @param valueRank the declared ValueRank, see {@link ValueRanks}.
+   * @return the encoded value, or null if {@code value} is null or a null Matrix.
+   * @throws IllegalArgumentException if the shape of {@code value} is not permitted by {@code
+   *     valueRank} or an element is not an instance of {@code type}.
+   */
+  protected @Nullable Object encodeValue(
+      @Nullable Object value, Class<? extends UaStructuredType> type, int valueRank) {
+
+    Object checked = checkValue(value, type, valueRank);
+
+    return ExtensionObject.encodeValue(client.getStaticEncodingContext(), checked);
+  }
+
+  private @Nullable Object checkValue(
+      @Nullable Object value, Class<? extends UaStructuredType> type, int valueRank) {
+
+    if (value == null || value instanceof Matrix matrix && matrix.isNull()) {
+      return null;
+    }
+
+    Object elements = value instanceof Matrix matrix ? matrix.getElements() : value;
+    int rank =
+        value instanceof Matrix matrix ? matrix.getValueRank() : ArrayUtil.getValueRank(value);
+    boolean empty = rank == 1 && Array.getLength(elements) == 0;
+
+    boolean permitted =
+        switch (valueRank) {
+          case ValueRanks.Any -> true;
+          case ValueRanks.Scalar -> rank == ValueRanks.Scalar;
+          case ValueRanks.ScalarOrOneDimension -> rank == ValueRanks.Scalar || rank == 1;
+          case ValueRanks.OneOrMoreDimensions -> rank >= 1;
+          default -> rank == valueRank || empty;
+        };
+
+    if (!permitted) {
+      throw new IllegalArgumentException(
+          "%s ValueRank=%d does not permit %s"
+              .formatted(describeValue(), valueRank, value.getClass().getTypeName()));
+    }
+
+    if (rank == ValueRanks.Scalar) {
+      checkElement(elements, type);
+    } else {
+      for (int i = 0; i < Array.getLength(elements); i++) {
+        checkElement(Array.get(elements, i), type);
+      }
+    }
+
+    return value;
+  }
+
+  /**
+   * Copy a checked array whose component type is a supertype of {@code type}, such as the {@code
+   * UaStructuredType[]} decoded from an empty or all-null array, into a {@code type[]}.
+   */
+  private static @Nullable Object retype(
+      @Nullable Object value, Class<? extends UaStructuredType> type) {
+
+    Object elements = value instanceof Matrix matrix ? matrix.getElements() : value;
+
+    if (!(elements instanceof Object[] array) || array.getClass().getComponentType() == type) {
+      return value;
+    }
+
+    @SuppressWarnings("unchecked")
+    Class<? extends UaStructuredType[]> arrayType =
+        (Class<? extends UaStructuredType[]>) type.arrayType();
+    UaStructuredType[] typed = Arrays.copyOf(array, array.length, arrayType);
+
+    if (value instanceof Matrix matrix) {
+      return new Matrix(
+          typed,
+          matrix.getDimensions(),
+          OpcUaDataType.ExtensionObject,
+          matrix.getDataTypeId().orElse(null));
+    } else {
+      return typed;
+    }
+  }
+
+  private void checkElement(@Nullable Object element, Class<? extends UaStructuredType> type) {
+    if (element != null && !type.isInstance(element)) {
+      throw new IllegalArgumentException(
+          "%s expected %s, received %s"
+              .formatted(describeValue(), type.getName(), element.getClass().getTypeName()));
+    }
+  }
+
+  private String describeValue() {
+    return "Value of %s (%s):"
+        .formatted(getBrowseName().getName(), getNodeId().toParseableString());
   }
 }

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/ExtensionObject.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/ExtensionObject.java
@@ -10,8 +10,10 @@
 
 package org.eclipse.milo.opcua.stack.core.types.builtin;
 
+import java.util.Arrays;
 import java.util.Objects;
 import java.util.StringJoiner;
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaSerializationException;
 import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
@@ -20,6 +22,7 @@ import org.eclipse.milo.opcua.stack.core.types.DataTypeEncoding;
 import org.eclipse.milo.opcua.stack.core.types.UaStructuredType;
 import org.eclipse.milo.opcua.stack.core.util.Lazy;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.LoggerFactory;
 
 @NullMarked
@@ -218,6 +221,126 @@ public abstract sealed class ExtensionObject
     }
 
     return xos;
+  }
+
+  /**
+   * Encode the structured values contained in a Variant value, whatever its shape.
+   *
+   * <p>A {@link UaStructuredType} is encoded to an ExtensionObject. A {@link UaStructuredType}
+   * array is encoded element by element to an ExtensionObject array of the same length, and null
+   * elements stay null. A {@link Matrix} of structured values is encoded to a Matrix of
+   * ExtensionObjects with the same dimensions and datatype id. Any other value, including null, a
+   * null Matrix, and a value that is already encoded, is returned unchanged.
+   *
+   * <pre>{@code
+   * Object encoded = ExtensionObject.encodeValue(context, new Argument[] {argument, null});
+   * client.writeValue(nodeId, DataValue.valueOnly(Variant.of(encoded)));
+   * }</pre>
+   *
+   * @param context an {@link EncodingContext}.
+   * @param value the value to encode.
+   * @return {@code value} with its structured elements encoded in the default binary encoding.
+   * @throws UaSerializationException if encoding fails.
+   */
+  public static @Nullable Object encodeValue(EncodingContext context, @Nullable Object value)
+      throws UaSerializationException {
+
+    if (value instanceof UaStructuredType struct) {
+      return encode(context, struct);
+    } else if (value instanceof UaStructuredType[] structs) {
+      return encodeElements(context, structs);
+    } else if (value instanceof Matrix matrix
+        && matrix.getElements() instanceof UaStructuredType[] structs) {
+      return new Matrix(
+          encodeElements(context, structs),
+          matrix.getDimensions(),
+          OpcUaDataType.ExtensionObject,
+          matrix.getDataTypeId().orElse(null));
+    } else {
+      return value;
+    }
+  }
+
+  /**
+   * Decode the ExtensionObjects contained in a Variant value, whatever its shape.
+   *
+   * <p>An ExtensionObject is decoded to its {@link UaStructuredType}. An ExtensionObject array is
+   * decoded element by element to an array of the same length, and null elements stay null. The
+   * array is typed by the decoded elements' class when they all share one, otherwise it is a {@code
+   * UaStructuredType[]}. A {@link Matrix} of ExtensionObjects is decoded to a Matrix of structured
+   * values with the same dimensions and datatype id. Any other value, including null, a null
+   * Matrix, and a value that is already decoded, is returned unchanged.
+   *
+   * <pre>{@code
+   * DataValue value = client.readValue(0.0, TimestampsToReturn.Neither, nodeId);
+   * Argument[] arguments = (Argument[]) ExtensionObject.decodeValue(context, value.value().value());
+   * }</pre>
+   *
+   * @param context an {@link EncodingContext}.
+   * @param value the value to decode.
+   * @return {@code value} with its ExtensionObjects decoded.
+   * @throws UaSerializationException if decoding fails.
+   */
+  public static @Nullable Object decodeValue(EncodingContext context, @Nullable Object value)
+      throws UaSerializationException {
+
+    if (value instanceof ExtensionObject xo) {
+      return xo.decode(context);
+    } else if (value instanceof ExtensionObject[] xos) {
+      return decodeElements(context, xos);
+    } else if (value instanceof Matrix matrix
+        && matrix.getElements() instanceof ExtensionObject[] xos) {
+      return new Matrix(
+          decodeElements(context, xos),
+          matrix.getDimensions(),
+          OpcUaDataType.ExtensionObject,
+          matrix.getDataTypeId().orElse(null));
+    } else {
+      return value;
+    }
+  }
+
+  private static @Nullable ExtensionObject[] encodeElements(
+      EncodingContext context, @Nullable UaStructuredType[] structs) {
+
+    var xos = new @Nullable ExtensionObject[structs.length];
+
+    for (int i = 0; i < structs.length; i++) {
+      UaStructuredType struct = structs[i];
+      if (struct != null) {
+        xos[i] = encode(context, struct);
+      }
+    }
+
+    return xos;
+  }
+
+  private static @Nullable UaStructuredType[] decodeElements(
+      EncodingContext context, @Nullable ExtensionObject[] xos) {
+
+    var structs = new @Nullable UaStructuredType[xos.length];
+    Class<?> elementType = null;
+
+    for (int i = 0; i < xos.length; i++) {
+      ExtensionObject xo = xos[i];
+      if (xo != null) {
+        UaStructuredType struct = xo.decode(context);
+        structs[i] = struct;
+        elementType =
+            elementType == null || elementType == struct.getClass()
+                ? struct.getClass()
+                : UaStructuredType.class;
+      }
+    }
+
+    if (elementType == null || elementType == UaStructuredType.class) {
+      return structs;
+    } else {
+      @SuppressWarnings("unchecked")
+      Class<? extends UaStructuredType[]> arrayType =
+          (Class<? extends UaStructuredType[]>) elementType.arrayType();
+      return Arrays.copyOf(structs, structs.length, arrayType);
+    }
   }
 
   /**

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/types/builtin/ExtensionObjectTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/types/builtin/ExtensionObjectTest.java
@@ -2,6 +2,13 @@ package org.eclipse.milo.opcua.stack.core.types.builtin;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import org.eclipse.milo.opcua.stack.core.OpcUaDataType;
+import org.eclipse.milo.opcua.stack.core.encoding.DefaultEncodingContext;
+import org.eclipse.milo.opcua.stack.core.encoding.EncodingContext;
+import org.eclipse.milo.opcua.stack.core.types.UaStructuredType;
+import org.eclipse.milo.opcua.stack.core.types.structured.Range;
+import org.eclipse.milo.opcua.stack.core.types.structured.ThreeDVector;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,5 +45,95 @@ class ExtensionObjectTest {
     LOGGER.debug("{}", extensionObject);
     assertEquals(jsonString, extensionObject.getBody());
     assertInstanceOf(ExtensionObject.Json.class, extensionObject);
+  }
+
+  @Nested
+  class ValueConversion {
+
+    private final EncodingContext context = DefaultEncodingContext.INSTANCE;
+    private final ThreeDVector vector = new ThreeDVector(1.0, 2.0, 3.0);
+    private final Range range = new Range(0.0, 10.0);
+
+    // A Variant carries a structure as an ExtensionObject; the array and Matrix forms must keep
+    // their length, positions and dimensions so index range and element order survive the trip.
+    @Test
+    void structuredValuesRoundTripInEveryShape() {
+      ThreeDVector[] array = {vector, new ThreeDVector(4.0, 5.0, 6.0)};
+      Matrix matrix = Matrix.ofStruct(new ThreeDVector[][] {{vector}, {vector}});
+
+      assertEquals(vector, ExtensionObject.decodeValue(context, encoded(vector)));
+      assertArrayEquals(
+          array, (ThreeDVector[]) ExtensionObject.decodeValue(context, encoded(array)));
+      assertEquals(matrix, ExtensionObject.decodeValue(context, encoded(matrix)));
+    }
+
+    // Part 6 allows a null element in an array of ExtensionObjects. Encoding must not fail on it
+    // and decoding must leave the position null rather than drop or shift elements.
+    @Test
+    void nullElementsKeepTheirPositions() {
+      ThreeDVector[] array = {null, vector};
+
+      ExtensionObject[] encoded = (ExtensionObject[]) ExtensionObject.encodeValue(context, array);
+      assertNull(encoded[0]);
+      assertNotNull(encoded[1]);
+
+      assertArrayEquals(array, (ThreeDVector[]) ExtensionObject.decodeValue(context, encoded));
+    }
+
+    // A caller reading a Variable declared as Argument[] expects an Argument[] back, not an
+    // UaStructuredType[] it has to copy; mixed element types cannot be narrowed that way.
+    @Test
+    void decodedArraysAreTypedByTheirElements() {
+      Object same = ExtensionObject.decodeValue(context, encoded(new UaStructuredType[] {vector}));
+      Object mixed =
+          ExtensionObject.decodeValue(context, encoded(new UaStructuredType[] {vector, range}));
+      Object empty = ExtensionObject.decodeValue(context, new ExtensionObject[0]);
+
+      assertEquals(ThreeDVector[].class, same.getClass());
+      assertEquals(UaStructuredType[].class, mixed.getClass());
+      assertEquals(UaStructuredType[].class, empty.getClass());
+    }
+
+    // The datatype id is the only type information an empty or null-first Matrix carries, so the
+    // conversion must copy it instead of re-deriving it from elements that are not there.
+    @Test
+    void matrixConversionPreservesDimensionsAndDataTypeId() {
+      Matrix matrix =
+          new Matrix(
+              new ThreeDVector[] {null, vector},
+              new int[] {1, 2},
+              OpcUaDataType.ExtensionObject,
+              ThreeDVector.TYPE_ID);
+
+      Matrix encoded = (Matrix) ExtensionObject.encodeValue(context, matrix);
+      assertInstanceOf(ExtensionObject[].class, encoded.getElements());
+      assertArrayEquals(matrix.getDimensions(), encoded.getDimensions());
+      assertEquals(matrix.getDataTypeId(), encoded.getDataTypeId());
+
+      Matrix decoded = (Matrix) ExtensionObject.decodeValue(context, encoded);
+      assertEquals(matrix, decoded);
+      assertEquals(matrix.getDataTypeId(), decoded.getDataTypeId());
+    }
+
+    // Callers hand these methods whatever a Variant holds. Values with nothing to convert,
+    // including values already in the target form, must come back untouched rather than fail.
+    @Test
+    void valuesWithoutStructuresPassThroughUnchanged() {
+      Matrix nullMatrix = Matrix.ofNull();
+      ExtensionObject encoded = ExtensionObject.encode(context, vector);
+
+      assertNull(ExtensionObject.encodeValue(context, null));
+      assertNull(ExtensionObject.decodeValue(context, null));
+      assertSame(nullMatrix, ExtensionObject.encodeValue(context, nullMatrix));
+      assertSame(nullMatrix, ExtensionObject.decodeValue(context, nullMatrix));
+      assertEquals(42, ExtensionObject.encodeValue(context, 42));
+      assertEquals(42, ExtensionObject.decodeValue(context, 42));
+      assertSame(encoded, ExtensionObject.encodeValue(context, encoded));
+      assertSame(vector, ExtensionObject.decodeValue(context, vector));
+    }
+
+    private Object encoded(Object value) {
+      return ExtensionObject.encodeValue(context, value);
+    }
   }
 }


### PR DESCRIPTION
Generated client model classes, and any hand-written typed wrapper around a Variable, need to move structured values between their Java types and the ExtensionObject form a Variant carries. Milo had `ExtensionObject.encode`, `encodeArray` and the client `UaNode.cast`, which together cover a scalar and a one-dimensional array in one direction each. A Variable declared with ValueRank -3, -2, 0 or 2 and above had no helper for either direction, and the server diagnostics variables walk struct arrays by hand for the same reason.

This adds the missing pieces in two layers, one commit each.

**stack-core: `ExtensionObject.encodeValue` and `decodeValue`.** Both accept whatever a Variant holds and convert only the structured parts: a structure, a structure array, or a Matrix of structures. Arrays keep their length and null positions (Part 6 permits a null element). A Matrix keeps its dimensions and datatype id instead of re-deriving them from elements that may be absent. A decoded array is typed by its elements when they share a class, so reading an `Argument[]` Variable yields an `Argument[]`. Anything else, including values already in the target form, is returned unchanged.

**sdk-client: `UaNode.decodeValue` and `encodeValue`.** Protected methods for subclasses and typed wrappers that pair the conversion with a check against the declared structure type and ValueRank. The permitted shapes follow Part 3 §5.6.2, and an empty one-dimensional array is accepted for any rank that permits arrays, matching what `AttributeWriter` accepts on the server since #1971. A mismatch throws `IllegalArgumentException` naming the node, so a wrapper fails before a write instead of surfacing `Bad_TypeMismatch`, and a read fails at the node that produced the value instead of at a cast far away. `cast` is unchanged.

The immediate consumer is generated client model classes, where the accessor for a flexible-rank structured Variable becomes one call to `encodeValue` or `decodeValue`. That regeneration follows separately; nothing in the checked-in model changes here.

Tests: `ExtensionObjectTest.ValueConversion` covers round trips in each shape, null positions, array typing and Matrix metadata. `UaNodeValueConversionTest` covers the shape table per ValueRank, element type rejection and pass-through of already decoded values.
