### PR TITLE
Enforce connection limits on every inbound connection

### DIFF
--- a/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/server/tcp/RateLimitingHandler.java
+++ b/opc-ua-stack/transport/src/main/java/org/eclipse/milo/opcua/stack/transport/server/tcp/RateLimitingHandler.java
@@ -23,6 +23,7 @@ import java.util.LinkedList;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import org.eclipse.milo.opcua.stack.core.Stack;
 import org.slf4j.Logger;
@@ -82,6 +83,13 @@ public class RateLimitingHandler extends AbstractRemoteAddressFilter<InetSocketA
 
   private final Multiset<InetAddress> connections = ConcurrentHashMultiset.create();
 
+  /**
+   * The total number of live connections, tracked alongside {@link #connections} because {@link
+   * Multiset#size()} sums every entry, which is O(distinct addresses) on a path that now runs for
+   * every inbound connection.
+   */
+  private final AtomicInteger totalConnections = new AtomicInteger(0);
+
   private RateLimitingHandler(
       boolean enabled,
       int maxAttempts,
@@ -113,6 +121,24 @@ public class RateLimitingHandler extends AbstractRemoteAddressFilter<InetSocketA
       return true;
     }
 
+    int connectionsTotal = totalConnections.get();
+    int connectionsFromAddress = connections.count(address);
+
+    // Checked for every connection, and before anything is recorded for the address: a rejected
+    // connection never reaches channelAccepted(), so nothing would remove its timestamps entry.
+    if (connectionsTotal >= maxConnections || connectionsFromAddress >= maxConnectionsPerAddress) {
+      logger.debug(
+          "Rejecting connection from {}. connectionsTotal={}, connectionsFromAddress={}",
+          isa,
+          connectionsTotal,
+          connectionsFromAddress);
+
+      long cumulativeConnectionsRejected = CUMULATIVE_CONNECTIONS_REJECTED.incrementAndGet();
+      logger.debug("cumulativeConnectionsRejected={}", cumulativeConnectionsRejected);
+
+      return false;
+    }
+
     LinkedList<Long> attempts = timestamps.computeIfAbsent(address, ia -> new LinkedList<>());
 
     long now = System.currentTimeMillis();
@@ -132,15 +158,11 @@ public class RateLimitingHandler extends AbstractRemoteAddressFilter<InetSocketA
         attempts.removeFirst();
       }
 
-      int connectionsTotal = connections.size();
-      int connectionsFromAddress = connections.count(address);
-
-      boolean accept =
-          attemptsInWindow < maxAttempts
-              && connectionsTotal < maxConnections
-              && connectionsFromAddress < maxConnectionsPerAddress;
+      boolean accept = attemptsInWindow < maxAttempts;
 
       if (accept) {
+        admit(address);
+
         logger.debug(
             "Accepting connection from {}. window={}ms, attemptsInWindow={},"
                 + " connectionsTotal={}, connectionsFromAddress={}",
@@ -166,9 +188,21 @@ public class RateLimitingHandler extends AbstractRemoteAddressFilter<InetSocketA
       return accept;
     } else {
       attempts.addLast(now);
+      admit(address);
 
       return true;
     }
+  }
+
+  /**
+   * Records the connection while {@link #accept} still holds the lock, so that the checks above and
+   * this reservation cannot interleave with another admission. Netty calls {@link #channelAccepted}
+   * immediately after {@link #accept} returns true, and that is where the connection is released
+   * again.
+   */
+  private void admit(InetAddress address) {
+    connections.add(address);
+    totalConnections.incrementAndGet();
   }
 
   @Override
@@ -178,8 +212,6 @@ public class RateLimitingHandler extends AbstractRemoteAddressFilter<InetSocketA
     if (!enabled || address.isLoopbackAddress()) {
       return;
     }
-
-    connections.add(address);
 
     ctx.channel().closeFuture().addListener(new ChannelCloseListener(address, ctx));
   }
@@ -196,7 +228,9 @@ public class RateLimitingHandler extends AbstractRemoteAddressFilter<InetSocketA
 
     @Override
     public void operationComplete(ChannelFuture channelFuture) {
-      connections.remove(address);
+      if (connections.remove(address)) {
+        totalConnections.decrementAndGet();
+      }
 
       if (connections.count(address) == 0) {
         logger.debug("Scheduling timestamp removal for {}", address);

--- a/opc-ua-stack/transport/src/test/java/org/eclipse/milo/opcua/stack/transport/server/tcp/RateLimitingHandlerTest.java
+++ b/opc-ua-stack/transport/src/test/java/org/eclipse/milo/opcua/stack/transport/server/tcp/RateLimitingHandlerTest.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.transport.server.tcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.embedded.EmbeddedChannel;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Instances are built directly rather than through {@link RateLimitingHandler#getInstance()}: the
+ * shared instance latches {@code Stack.ConnectionLimits} the first time it is asked for, and any
+ * test that binds a server has already asked for it, which would make these tests order-dependent.
+ */
+class RateLimitingHandlerTest {
+
+  private static RateLimitingHandler handler(
+      int maxAttempts, int windowMs, int maxConnections, int maxConnectionsPerAddress)
+      throws Exception {
+
+    Constructor<RateLimitingHandler> ctor =
+        RateLimitingHandler.class.getDeclaredConstructor(
+            boolean.class, int.class, int.class, int.class, int.class);
+    ctor.setAccessible(true);
+
+    return ctor.newInstance(true, maxAttempts, windowMs, maxConnections, maxConnectionsPerAddress);
+  }
+
+  /** Stands in for the pipeline: Netty calls channelAccepted() only when accept() returned true. */
+  private static boolean connect(
+      RateLimitingHandler handler, ChannelHandlerContext ctx, String address, int port) {
+
+    var isa = new InetSocketAddress(address, port);
+    boolean accepted = handler.accept(ctx, isa);
+
+    if (accepted) {
+      handler.channelAccepted(ctx, isa);
+    }
+
+    return accepted;
+  }
+
+  private static EmbeddedChannel channel() {
+    return new EmbeddedChannel(new ChannelInboundHandlerAdapter());
+  }
+
+  private static int totalConnections(RateLimitingHandler handler) throws Exception {
+    Field field = RateLimitingHandler.class.getDeclaredField("totalConnections");
+    field.setAccessible(true);
+
+    return ((java.util.concurrent.atomic.AtomicInteger) field.get(handler)).get();
+  }
+
+  private static int multisetSize(RateLimitingHandler handler) throws Exception {
+    Field field = RateLimitingHandler.class.getDeclaredField("connections");
+    field.setAccessible(true);
+
+    return ((com.google.common.collect.Multiset<?>) field.get(handler)).size();
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<InetAddress, ?> timestamps(RateLimitingHandler handler) throws Exception {
+    Field field = RateLimitingHandler.class.getDeclaredField("timestamps");
+    field.setAccessible(true);
+
+    return (Map<InetAddress, ?>) field.get(handler);
+  }
+
+  @Test
+  void maxConnectionsAppliesToEveryAddress() throws Exception {
+    RateLimitingHandler handler = handler(4, 60_000, 10, 100);
+    ChannelHandlerContext ctx = channel().pipeline().firstContext();
+
+    // Each address stays within its allowed attempts, so nothing here is rate limited; only the
+    // total connection count can reject.
+    int accepted = 0;
+    for (int address = 1; address <= 20; address++) {
+      for (int i = 0; i < 4; i++) {
+        if (connect(handler, ctx, "198.51.100." + address, 40000 + i)) {
+          accepted++;
+        }
+      }
+    }
+
+    assertEquals(10, accepted, "connections accepted beyond maxConnections");
+  }
+
+  @Test
+  void maxConnectionsPerAddressAppliesFromTheFirstConnection() throws Exception {
+    RateLimitingHandler handler = handler(4, 60_000, 100, 2);
+    ChannelHandlerContext ctx = channel().pipeline().firstContext();
+
+    int accepted = 0;
+    for (int i = 0; i < 4; i++) {
+      if (connect(handler, ctx, "198.51.100.1", 40000 + i)) {
+        accepted++;
+      }
+    }
+
+    assertEquals(2, accepted, "connections accepted beyond maxConnectionsPerAddress");
+  }
+
+  @Test
+  void aBurstFromOneAddressIsRateLimited() throws Exception {
+    // Connection limits set out of reach, so only the rate limit can reject.
+    RateLimitingHandler handler = handler(4, 60_000, 1_000_000, 1_000_000);
+    ChannelHandlerContext ctx = channel().pipeline().firstContext();
+
+    var results = new StringBuilder();
+    for (int i = 0; i < 8; i++) {
+      results.append(connect(handler, ctx, "198.51.100.1", 40000 + i) ? 'A' : 'r');
+    }
+
+    assertEquals("AAAArrrr", results.toString());
+  }
+
+  @Test
+  void loopbackIsExempt() throws Exception {
+    RateLimitingHandler handler = handler(1, 60_000, 0, 0);
+    ChannelHandlerContext ctx = channel().pipeline().firstContext();
+
+    for (int i = 0; i < 8; i++) {
+      assertTrue(connect(handler, ctx, "127.0.0.1", 40000 + i), "loopback was rejected");
+    }
+  }
+
+  @Test
+  void aRejectedConnectionRecordsNothing() throws Exception {
+    // maxConnections of 0 rejects every address on its first attempt, before timestamps is
+    // touched, so there is nothing for the cleanup task to remove later.
+    RateLimitingHandler handler = handler(4, 1000, 0, 100);
+    ChannelHandlerContext ctx = channel().pipeline().firstContext();
+
+    for (int address = 1; address <= 5; address++) {
+      assertFalse(connect(handler, ctx, "198.51.100." + address, 40000), "connection was accepted");
+    }
+
+    assertEquals(0, timestamps(handler).size(), "timestamps recorded for a rejected connection");
+  }
+
+  @Test
+  void closingAConnectionFreesItsSlot() throws Exception {
+    RateLimitingHandler handler = handler(4, 60_000, 2, 100);
+
+    EmbeddedChannel first = channel();
+    EmbeddedChannel second = channel();
+
+    assertTrue(connect(handler, first.pipeline().firstContext(), "198.51.100.1", 40000));
+    assertTrue(connect(handler, second.pipeline().firstContext(), "198.51.100.2", 40000));
+    assertEquals(2, totalConnections(handler));
+    assertEquals(multisetSize(handler), totalConnections(handler));
+
+    // the cap is now full
+    assertFalse(connect(handler, channel().pipeline().firstContext(), "198.51.100.3", 40000));
+
+    first.close();
+    first.runPendingTasks();
+
+    assertEquals(1, totalConnections(handler), "closing a connection did not free its slot");
+    assertEquals(multisetSize(handler), totalConnections(handler), "counters drifted apart");
+
+    // and the freed slot is usable again
+    assertTrue(connect(handler, channel().pipeline().firstContext(), "198.51.100.3", 40000));
+    assertEquals(2, totalConnections(handler));
+    assertEquals(multisetSize(handler), totalConnections(handler));
+  }
+
+  @Test
+  void totalMatchesTheMultisetAcrossOpensAndCloses() throws Exception {
+    // Several connections per address, closed out of order, so that both the add/increment and the
+    // remove/decrement paths run many times and interleave.
+    RateLimitingHandler handler = handler(1000, 600_000, 1_000_000, 1_000_000);
+
+    var open = new java.util.ArrayList<EmbeddedChannel>();
+    var random = new java.util.Random(1);
+
+    for (int step = 0; step < 2_000; step++) {
+      if (open.isEmpty() || random.nextInt(100) < 60) {
+        EmbeddedChannel channel = channel();
+        String address = "198.51.100." + (1 + random.nextInt(8));
+        assertTrue(connect(handler, channel.pipeline().firstContext(), address, 40000 + step));
+        open.add(channel);
+      } else {
+        EmbeddedChannel channel = open.remove(random.nextInt(open.size()));
+        channel.close();
+        channel.runPendingTasks();
+      }
+
+      assertEquals(
+          open.size(), totalConnections(handler), "total diverged from the connections held open");
+      assertEquals(
+          multisetSize(handler), totalConnections(handler), "total diverged from the multiset");
+    }
+
+    while (!open.isEmpty()) {
+      EmbeddedChannel channel = open.remove(open.size() - 1);
+      channel.close();
+      channel.runPendingTasks();
+    }
+
+    assertEquals(0, totalConnections(handler), "total did not return to zero");
+    assertEquals(0, multisetSize(handler));
+  }
+
+  @Test
+  void acceptReservesTheSlotItChecked() throws Exception {
+    // The reservation happens while accept() still holds the lock, so a second caller sees the
+    // first one's connection even though channelAccepted() has not run for it yet.
+    RateLimitingHandler handler = handler(4, 60_000, 1, 100);
+    ChannelHandlerContext ctx = channel().pipeline().firstContext();
+
+    assertTrue(handler.accept(ctx, new InetSocketAddress("198.51.100.1", 40000)));
+    assertEquals(1, totalConnections(handler), "accept() returned true without reserving a slot");
+
+    assertFalse(
+        handler.accept(ctx, new InetSocketAddress("198.51.100.2", 40000)),
+        "the reserved slot was not visible to the next caller");
+  }
+}


### PR DESCRIPTION
The maxConnections and maxConnectionsPerAddress checks in accept() sit inside the branch taken once an address has already made maxAttempts attempts, so the first few connections from each address go through before either limit is looked at. Across many distinct addresses that adds up: 3001 addresses making 4 connections each gave 12004 accepted against a cap of 10000.

I read the field javadoc, "the maximum number of connections allowed in total", and the goal listed in d597ba201 as meaning both limits should apply to every connection, so they now run ahead of the branch. Happy to be told otherwise if the current behaviour was intentional.

It shows up most where the cap has been lowered for a small device: 20 is used up by 5 addresses. At the default of 10000 it takes 2500.

Three variants were timed, one accept() for a connection that is accepted, with n live connections from n distinct addresses:

```
live     main     checks moved, no counter    this PR
10       307 ns   338 ns                      345 ns
100      300 ns   1299 ns                     382 ns
1000     248 ns   8054 ns                     345 ns
10000    267 ns   78362 ns                    284 ns
```

main is flat because it does not call ConcurrentHashMultiset.size() on that path. Moving the checks alone makes it linear in the number of live addresses, hence the AtomicInteger.

Rate limiting and the loopback exemption are unchanged. One behaviour change worth calling out: a connection refused by a connection limit no longer records an attempt, so it does not consume that address's rate limit window. That is also what keeps rejected addresses from leaving timestamps entries behind.

Three of the tests fail against main: 80 accepted where the cap is 10, 4 where the per-address cap is 2, and a connection accepted where maxConnections is 0. They build the handler through its private constructor by reflection, since the shared instance latches Stack.ConnectionLimits on first use and any test that binds a server has already triggered that.

---

- [x] You have signed an Eclipse Contributor Agreement and are committing using the same email address
- [x] Your code contains any tests relevant to the problem you are solving
- [x] All new and existing tests passed
- [x] Code follows the style guidelines and Checkstyle passes
