### PR TITLE
Support complete synchronous Method outcomes

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/methods/SynchronousMethodServiceTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/methods/SynchronousMethodServiceTest.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.milo.opcua.sdk.server.methods;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClientConfigBuilder;
+import org.eclipse.milo.opcua.sdk.client.OpcUaSession;
+import org.eclipse.milo.opcua.sdk.client.identity.UsernameProvider;
+import org.eclipse.milo.opcua.sdk.server.DiagnosticsContext;
+import org.eclipse.milo.opcua.sdk.server.ManagedNamespaceWithLifecycle;
+import org.eclipse.milo.opcua.sdk.server.items.DataItem;
+import org.eclipse.milo.opcua.sdk.server.items.MonitoredItem;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaMethodNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectNode;
+import org.eclipse.milo.opcua.sdk.test.AbstractClientServerTest;
+import org.eclipse.milo.opcua.sdk.test.TestNamespace;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.types.builtin.*;
+import org.eclipse.milo.opcua.stack.core.types.structured.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class SynchronousMethodServiceTest extends AbstractClientServerTest {
+  private DiagnosticNamespace first;
+  private DiagnosticNamespace second;
+
+  @Override
+  protected void customizeClientConfig(OpcUaClientConfigBuilder builder) {
+    builder.setIdentityProvider(new UsernameProvider("user1", "password"));
+  }
+
+  @Override
+  protected void configureTestNamespace(TestNamespace ignored) {
+    first = new DiagnosticNamespace("urn:milo:test:method-diagnostics:first");
+    second = new DiagnosticNamespace("urn:milo:test:method-diagnostics:second");
+    first.startup();
+    second.startup();
+  }
+
+  @AfterAll
+  void stopNamespaces() {
+    if (first != null) first.shutdown();
+    if (second != null) second.shutdown();
+  }
+
+  // The request crosses two namespace dispatch groups and one denied access group.
+  @Test
+  void authenticatedCallSharesDiagnosticTableAcrossGroupsAndRetainsDeniedPosition()
+      throws Exception {
+    int deniedBefore = first.deniedCalls.get();
+    CallResponse response =
+        call(
+            0x3e0,
+            first.request("diagnostic", Variant.NULL_VALUE),
+            first.request("denied", Variant.NULL_VALUE),
+            second.request("diagnostic", Variant.NULL_VALUE));
+    assertEquals(StatusCode.GOOD, response.getResponseHeader().getServiceResult());
+    assertEquals(
+        new StatusCode(StatusCodes.Bad_UserAccessDenied), response.getResults()[1].getStatusCode());
+    assertEquals(deniedBefore, first.deniedCalls.get());
+    for (int index : new int[] {0, 2}) {
+      CallMethodResult result = response.getResults()[index];
+      assertEquals(new StatusCode(StatusCodes.Bad_InvalidArgument), result.getStatusCode());
+      assertEquals(1, result.getInputArgumentDiagnosticInfos().length);
+      DiagnosticInfo info = result.getInputArgumentDiagnosticInfos()[0];
+      String[] table = response.getResponseHeader().getStringTable();
+      assertEquals("urn:vendor", table[info.namespaceUri()]);
+      assertEquals("range", table[info.symbolicId()]);
+      assertEquals("en", table[info.locale()]);
+      assertEquals("outside range", table[info.localizedText()]);
+      assertEquals("argument", info.additionalInfo());
+    }
+    assertEquals(4, response.getResponseHeader().getStringTable().length);
+    assertTrue(response.getDiagnosticInfos() == null || response.getDiagnosticInfos().length == 0);
+    assertTrue(
+        response.getResponseHeader().getServiceDiagnostics() == null
+            || response
+                .getResponseHeader()
+                .getServiceDiagnostics()
+                .equals(DiagnosticInfo.NULL_VALUE));
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {0, 31})
+  void zeroAndServiceOnlyMasksSuppressArgumentDiagnosticsOnWire(int mask) throws Exception {
+    CallResponse response = call(mask, first.request("diagnostic", Variant.NULL_VALUE));
+    assertEquals(
+        new StatusCode(StatusCodes.Bad_InvalidArgument), response.getResults()[0].getStatusCode());
+    DiagnosticInfo[] diagnostics = response.getResults()[0].getInputArgumentDiagnosticInfos();
+    assertTrue(diagnostics == null || diagnostics.length == 0);
+    String[] table = response.getResponseHeader().getStringTable();
+    assertTrue(table == null || table.length == 0);
+  }
+
+  @Test
+  void optionalSuffixAndUncertainOutputsCrossActualCallService() throws Exception {
+    CallResponse response =
+        call(
+            0,
+            first.request("optional"),
+            first.request("optional", Variant.NULL_VALUE),
+            first.request("optional", new Variant("label")),
+            first.request("optional", new Variant(7)));
+    assertEquals(StatusCode.UNCERTAIN, response.getResults()[0].getStatusCode());
+    assertArrayEquals(
+        new Variant[] {new Variant("omitted")}, response.getResults()[0].getOutputArguments());
+    assertEquals(StatusCode.UNCERTAIN, response.getResults()[1].getStatusCode());
+    assertArrayEquals(
+        new Variant[] {Variant.NULL_VALUE}, response.getResults()[1].getOutputArguments());
+    assertArrayEquals(
+        new Variant[] {new Variant("label")}, response.getResults()[2].getOutputArguments());
+    assertEquals(
+        new StatusCode(StatusCodes.Bad_InvalidArgument), response.getResults()[3].getStatusCode());
+  }
+
+  @Test
+  void malformedRequestedIndexDropsOnlyThatOperationsDiagnostics() throws Exception {
+    CallResponse response =
+        call(
+            0x20,
+            first.request("malformed", Variant.NULL_VALUE),
+            second.request("optional", new Variant("survives")));
+    CallMethodResult malformed = response.getResults()[0];
+    assertEquals(new StatusCode(StatusCodes.Bad_InvalidArgument), malformed.getStatusCode());
+    assertEquals(1, malformed.getInputArgumentResults().length);
+    DiagnosticInfo[] diagnostics = malformed.getInputArgumentDiagnosticInfos();
+    assertTrue(diagnostics == null || diagnostics.length == 0);
+    assertEquals(StatusCode.UNCERTAIN, response.getResults()[1].getStatusCode());
+    assertArrayEquals(
+        new Variant[] {new Variant("survives")}, response.getResults()[1].getOutputArguments());
+  }
+
+  private CallResponse call(int mask, CallMethodRequest... operations) throws Exception {
+    OpcUaSession session = client.getSessionAsync().get(10, TimeUnit.SECONDS);
+    RequestHeader base = client.newRequestHeader(session.getAuthenticationToken());
+    RequestHeader header =
+        new RequestHeader(
+            base.getAuthenticationToken(),
+            base.getTimestamp(),
+            base.getRequestHandle(),
+            uint(mask),
+            base.getAuditEntryId(),
+            base.getTimeoutHint(),
+            base.getAdditionalHeader());
+    return (CallResponse)
+        client.sendRequestAsync(new CallRequest(header, operations)).get(10, TimeUnit.SECONDS);
+  }
+
+  private final class DiagnosticNamespace extends ManagedNamespaceWithLifecycle {
+    private final UaObjectNode owner;
+    private final AtomicInteger deniedCalls = new AtomicInteger();
+
+    DiagnosticNamespace(String uri) {
+      super(SynchronousMethodServiceTest.this.server, uri);
+      owner =
+          UaObjectNode.builder(getNodeContext())
+              .setNodeId(newNodeId("owner"))
+              .setBrowseName(newQualifiedName("owner"))
+              .setDisplayName(LocalizedText.english("owner"))
+              .buildAndAdd();
+      for (String name : List.of("diagnostic", "denied", "malformed", "optional")) {
+        UaMethodNode method =
+            UaMethodNode.builder(getNodeContext())
+                .setNodeId(newNodeId(name))
+                .setBrowseName(newQualifiedName(name))
+                .setDisplayName(LocalizedText.english(name))
+                .buildAndAdd();
+        owner.addComponent(method);
+        method.setUserExecutable(!name.equals("denied"));
+        Argument[] inputs = {
+          new Argument("Label", NodeIds.String, -1, null, LocalizedText.NULL_VALUE)
+        };
+        Argument[] outputs =
+            name.equals("optional")
+                ? new Argument[] {
+                  new Argument("Label", NodeIds.String, -1, null, LocalizedText.NULL_VALUE)
+                }
+                : new Argument[0];
+        method.setInputArguments(inputs);
+        method.setOutputArguments(outputs);
+        method.setInvocationHandler(
+            new AbstractMethodInvocationHandler(method) {
+              public Argument[] getInputArguments() {
+                return inputs;
+              }
+
+              public Argument[] getOutputArguments() {
+                return outputs;
+              }
+
+              protected int getRequiredInputArgumentCount(Argument[] metadata) {
+                return name.equals("optional") ? 0 : 1;
+              }
+
+              protected CallMethodResult invokeResult(InvocationContext context, Variant[] values) {
+                assertTrue(context.getSession().isPresent());
+                if (name.equals("optional")) {
+                  return new CallMethodResult(
+                      StatusCode.UNCERTAIN,
+                      null,
+                      null,
+                      values.length == 0 ? new Variant[] {new Variant("omitted")} : values);
+                }
+                if (name.equals("denied")) deniedCalls.incrementAndGet();
+                DiagnosticsContext<CallMethodRequest> diagnostics =
+                    context.getCallDiagnostics().orElseThrow();
+                DiagnosticInfo info =
+                    name.equals("malformed")
+                        ? new DiagnosticInfo(-1, 999, -1, -1, null, null, null)
+                        : new DiagnosticInfo(
+                            diagnostics.addString("urn:vendor"),
+                            diagnostics.addString("range"),
+                            diagnostics.addString("en"),
+                            diagnostics.addString("outside range"),
+                            "argument",
+                            new StatusCode(StatusCodes.Bad_OutOfRange),
+                            null);
+                return new CallMethodResult(
+                    new StatusCode(StatusCodes.Bad_InvalidArgument),
+                    new StatusCode[] {new StatusCode(StatusCodes.Bad_OutOfRange)},
+                    new DiagnosticInfo[] {info},
+                    new Variant[0]);
+              }
+            });
+      }
+    }
+
+    CallMethodRequest request(String name, Variant... inputs) {
+      return new CallMethodRequest(owner.getNodeId(), newNodeId(name), inputs);
+    }
+
+    public void onDataItemsCreated(List<DataItem> items) {}
+
+    public void onDataItemsModified(List<DataItem> items) {}
+
+    public void onDataItemsDeleted(List<DataItem> items) {}
+
+    public void onMonitoringModeChanged(List<MonitoredItem> items) {}
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/DiagnosticsContext.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/DiagnosticsContext.java
@@ -10,16 +10,72 @@
 
 package org.eclipse.milo.opcua.sdk.server;
 
+import static java.util.Objects.requireNonNull;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+
 import java.util.Arrays;
 import java.util.EnumSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DiagnosticInfo;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
 
+/**
+ * Request-local diagnostic state: the requested ReturnDiagnostics mask, a string table for
+ * DiagnosticInfo indexes, and operation diagnostic storage.
+ *
+ * <p>Operation handlers intern strings with {@link #addString(String)} and reference them by index
+ * from the DiagnosticInfo entries they return. The service that builds the response decides which
+ * of those entries and strings the client asked for; see the Call service for an example. Interning
+ * and snapshots are thread-safe.
+ */
 public class DiagnosticsContext<T> {
 
   private final Map<T, DiagnosticInfo> diagnosticsMap = new ConcurrentHashMap<>();
+  private final Map<String, Integer> strings = new LinkedHashMap<>();
+  private final UInteger returnDiagnostics;
+
+  /** Create a context for a request with no requested diagnostics. */
+  public DiagnosticsContext() {
+    this(uint(0));
+  }
+
+  /**
+   * Create a context for a request.
+   *
+   * @param returnDiagnostics the request's ReturnDiagnostics mask.
+   */
+  public DiagnosticsContext(UInteger returnDiagnostics) {
+    this.returnDiagnostics = requireNonNull(returnDiagnostics);
+  }
+
+  /**
+   * @return the request's ReturnDiagnostics mask.
+   */
+  public UInteger getReturnDiagnostics() {
+    return returnDiagnostics;
+  }
+
+  /**
+   * Intern a string for use as a DiagnosticInfo index in this request.
+   *
+   * @param value the diagnostic string.
+   * @return the index of {@code value} in this request's string table; the same string always
+   *     receives the same index.
+   */
+  public synchronized int addString(String value) {
+    return strings.computeIfAbsent(requireNonNull(value), v -> strings.size());
+  }
+
+  /**
+   * @return a snapshot of this request's string table, indexed as returned by {@link
+   *     #addString(String)}.
+   */
+  public synchronized String[] getStringTable() {
+    return strings.keySet().toArray(String[]::new);
+  }
 
   public EnumSet<OperationDiagnostic> getRequestedOperationDiagnostics(T t) {
     return null;

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/methods/AbstractMethodInvocationHandler.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/methods/AbstractMethodInvocationHandler.java
@@ -20,6 +20,8 @@ import org.eclipse.milo.opcua.sdk.core.ValueRanks;
 import org.eclipse.milo.opcua.sdk.core.typetree.DataType;
 import org.eclipse.milo.opcua.sdk.core.typetree.DataTypeTree;
 import org.eclipse.milo.opcua.sdk.server.AccessContext;
+import org.eclipse.milo.opcua.sdk.server.AddressSpace.CallContext;
+import org.eclipse.milo.opcua.sdk.server.DiagnosticsContext;
 import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
 import org.eclipse.milo.opcua.sdk.server.Session;
 import org.eclipse.milo.opcua.sdk.server.nodes.UaMethodNode;
@@ -41,6 +43,8 @@ import org.eclipse.milo.opcua.stack.core.types.structured.CallMethodRequest;
 import org.eclipse.milo.opcua.stack.core.types.structured.CallMethodResult;
 import org.eclipse.milo.opcua.stack.core.util.ArrayUtil;
 import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A partial implementation of {@link MethodInvocationHandler} that validates input argument counts,
@@ -50,6 +54,9 @@ import org.jspecify.annotations.Nullable;
  * configured access controller before invoking this handler.
  */
 public abstract class AbstractMethodInvocationHandler implements MethodInvocationHandler {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(AbstractMethodInvocationHandler.class);
 
   private final UaMethodNode node;
 
@@ -66,23 +73,30 @@ public abstract class AbstractMethodInvocationHandler implements MethodInvocatio
 
   @Override
   public final CallMethodResult invoke(AccessContext accessContext, CallMethodRequest request) {
-    try {
-      // Defensive copy: values for structure-typed arguments may be substituted with their
-      // decoded values below, and the request's array should not be modified.
-      Variant[] inputArgumentValues =
-          requireNonNullElse(request.getInputArguments(), new Variant[0]).clone();
+    // Defensive copy: values for structure-typed arguments may be substituted with their
+    // decoded values below, and the request's array should not be modified.
+    Variant[] inputArgumentValues =
+        requireNonNullElse(request.getInputArguments(), new Variant[0]).clone();
 
-      if (inputArgumentValues.length < getInputArguments().length) {
+    CallMethodResult result;
+    try {
+      // Read the metadata once so the count check and the loop below see the same Arguments.
+      Argument[] inputArguments = getInputArguments();
+      int requiredCount = getRequiredInputArgumentCount(inputArguments);
+      if (requiredCount < 0 || requiredCount > inputArguments.length) {
+        throw new UaException(StatusCodes.Bad_InternalError, "Invalid required input count");
+      }
+      if (inputArgumentValues.length < requiredCount) {
         throw new UaException(StatusCodes.Bad_ArgumentsMissing);
       }
-      if (inputArgumentValues.length > getInputArguments().length) {
+      if (inputArgumentValues.length > inputArguments.length) {
         throw new UaException(StatusCodes.Bad_TooManyArguments);
       }
 
       StatusCode[] inputDataTypeCheckResults = new StatusCode[inputArgumentValues.length];
 
       for (int i = 0; i < inputArgumentValues.length; i++) {
-        Argument argument = getInputArguments()[i];
+        Argument argument = inputArguments[i];
 
         Variant variant = inputArgumentValues[i];
         Object value = variant.value();
@@ -195,22 +209,74 @@ public abstract class AbstractMethodInvocationHandler implements MethodInvocatio
             public Optional<Session> getSession() {
               return accessContext.getSession();
             }
+
+            @Override
+            public Optional<DiagnosticsContext<CallMethodRequest>> getCallDiagnostics() {
+              return accessContext instanceof CallContext callContext
+                  ? Optional.of(callContext.getDiagnosticsContext())
+                  : Optional.empty();
+            }
           };
 
-      Variant[] outputValues = invoke(invocationContext, inputArgumentValues);
-
-      return new CallMethodResult(
-          StatusCode.GOOD, new StatusCode[0], new DiagnosticInfo[0], outputValues);
+      result = invokeResult(invocationContext, inputArgumentValues);
     } catch (InvalidArgumentException e) {
-      return new CallMethodResult(
-          e.getStatusCode(),
-          e.getInputArgumentResults(),
-          e.getInputArgumentDiagnosticInfos(),
-          new Variant[0]);
+      result =
+          new CallMethodResult(
+              e.getStatusCode(),
+              e.getInputArgumentResults(),
+              e.getInputArgumentDiagnosticInfos(),
+              new Variant[0]);
     } catch (UaException e) {
-      return new CallMethodResult(
-          e.getStatusCode(), new StatusCode[0], new DiagnosticInfo[0], new Variant[0]);
+      return failure(e.getStatusCode());
     }
+
+    String problem = problemWith(result, inputArgumentValues.length);
+    if (problem == null) {
+      return result;
+    } else {
+      LOGGER.warn("Invalid result for methodId={}: {}", node.getNodeId(), problem);
+      return failure(new StatusCode(StatusCodes.Bad_InternalError));
+    }
+  }
+
+  /**
+   * Check {@code result} against the CallMethodResult rules in OPC 10000-4, 5.12.2.2: a Bad status
+   * carries no outputs, and input argument results are populated only for Bad_InvalidArgument, one
+   * per supplied input. Argument diagnostics, when present, are also one per supplied input.
+   *
+   * @return a description of the first rule {@code result} breaks, or {@code null} if it is valid.
+   */
+  private static @Nullable String problemWith(@Nullable CallMethodResult result, int inputCount) {
+    if (result == null || result.getStatusCode() == null) {
+      return "null result or status";
+    }
+    StatusCode status = result.getStatusCode();
+    int results = lengthOf(result.getInputArgumentResults());
+    int diagnostics = lengthOf(result.getInputArgumentDiagnosticInfos());
+    int outputs = lengthOf(result.getOutputArguments());
+
+    if (status.isBad() && outputs != 0) {
+      return "Bad status with output arguments";
+    }
+    if (results != 0 && status.getValue() != StatusCodes.Bad_InvalidArgument) {
+      return "input argument results with a status other than Bad_InvalidArgument";
+    }
+    if (results != 0 && results != inputCount) {
+      return results + " input argument results for " + inputCount + " inputs";
+    }
+    if (diagnostics != 0 && diagnostics != inputCount) {
+      return diagnostics + " input argument diagnostics for " + inputCount + " inputs";
+    }
+    return null;
+  }
+
+  private static int lengthOf(Object @Nullable [] array) {
+    return array == null ? 0 : array.length;
+  }
+
+  private static CallMethodResult failure(StatusCode statusCode) {
+    return new CallMethodResult(
+        statusCode, new StatusCode[0], new DiagnosticInfo[0], new Variant[0]);
   }
 
   /** The flat elements of a Matrix, or {@code value} itself for any other value. */
@@ -419,6 +485,43 @@ public abstract class AbstractMethodInvocationHandler implements MethodInvocatio
   public abstract Argument[] getOutputArguments();
 
   /**
+   * Get the number of leading inputs a caller must supply; any inputs after them are optional.
+   *
+   * <p>The default requires every declared input. Override this to accept calls that omit trailing
+   * inputs. Omitted inputs are absent from the array passed to {@link #invokeResult}, whereas a
+   * supplied null value keeps its position. A count outside the valid range fails the call with
+   * Bad_InternalError before any application code runs.
+   *
+   * @param inputArguments the input {@link Argument}s this call is validated against; do not
+   *     modify.
+   * @return a count between zero and {@code inputArguments.length}, inclusive.
+   */
+  protected int getRequiredInputArgumentCount(Argument[] inputArguments) {
+    return inputArguments.length;
+  }
+
+  /**
+   * Invoke this Method with its validated inputs and return the complete result.
+   *
+   * <p>The default delegates to {@link #invoke(InvocationContext, Variant[])} and reports Good.
+   * Override this to return a different status, for example Uncertain with outputs. A Bad status
+   * carries no outputs. Input argument results may be populated only with Bad_InvalidArgument, one
+   * per supplied input; argument diagnostics, when present, are also one per supplied input. A
+   * result that breaks these rules, or a null result, is logged and reported as Bad_InternalError.
+   *
+   * @param context the {@link InvocationContext}.
+   * @param suppliedValues the supplied inputs, validated and decoded as described by {@link
+   *     #invoke(InvocationContext, Variant[])}. Omitted optional inputs are absent, not padded.
+   * @return the complete result.
+   * @throws UaException if invocation fails; its status is reported without outputs.
+   */
+  protected CallMethodResult invokeResult(InvocationContext context, Variant[] suppliedValues)
+      throws UaException {
+    return new CallMethodResult(
+        StatusCode.GOOD, new StatusCode[0], new DiagnosticInfo[0], invoke(context, suppliedValues));
+  }
+
+  /**
    * Invoke this method and return the values for its output arguments, if any.
    *
    * <p>Input arguments have already passed shape, data type and application value validation.
@@ -437,8 +540,10 @@ public abstract class AbstractMethodInvocationHandler implements MethodInvocatio
    * @return this output values matching this Method's output arguments, if any.
    * @throws UaException if invocation has failed for some reason.
    */
-  protected abstract Variant[] invoke(InvocationContext invocationContext, Variant[] inputValues)
-      throws UaException;
+  protected Variant[] invoke(InvocationContext invocationContext, Variant[] inputValues)
+      throws UaException {
+    throw new UaException(StatusCodes.Bad_NotImplemented);
+  }
 
   /**
    * Validate the input values against the expected input arguments.
@@ -460,6 +565,15 @@ public abstract class AbstractMethodInvocationHandler implements MethodInvocatio
    * AbstractMethodInvocationHandler}.
    */
   public interface InvocationContext extends AccessContext {
+
+    /**
+     * Get the request-wide Call diagnostics context, when invoked through the Call service.
+     *
+     * @return the context used to intern diagnostic strings, or empty for independent invocations.
+     */
+    default Optional<DiagnosticsContext<CallMethodRequest>> getCallDiagnostics() {
+      return Optional.empty();
+    }
 
     /**
      * Get the {@link OpcUaServer} instance.

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/methods/MethodInvocationHandler.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/methods/MethodInvocationHandler.java
@@ -27,9 +27,10 @@ public interface MethodInvocationHandler {
   NotImplementedHandler NOT_IMPLEMENTED = new NotImplementedHandler();
 
   /**
-   * Invoke the given {@link CallMethodRequest} and complete {@code future} when finished.
+   * Invoke the given {@link CallMethodRequest} synchronously and return its outcome.
    *
-   * <p>Under no circumstances should the future be completed exceptionally.
+   * <p>Report operation failures in the returned result. Direct callers are responsible for access
+   * checks; normal server dispatch applies ownership and service access checks before invocation.
    *
    * @param accessContext the {@link AccessContext}.
    * @param request the {@link CallMethodRequest}.

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/methods/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/methods/package-info.java
@@ -33,5 +33,19 @@
  * report individual failures with {@link
  * org.eclipse.milo.opcua.sdk.server.methods.InvalidArgumentException}. The invocation context
  * preserves the calling session, object and Method node.
+ *
+ * <p>A handler chooses one of two callbacks. The output callback, {@code invoke}, receives every
+ * declared input and reports Good with its output array. The result callback, {@code invokeResult},
+ * returns a complete result, so it can report Uncertain with outputs or Bad without them. A handler
+ * overriding the result callback can also override {@code getRequiredInputArgumentCount} to let
+ * callers omit trailing inputs; omitted inputs are absent from the supplied array, while a supplied
+ * null keeps its position. A result that breaks the CallMethodResult rules is logged and reported
+ * as Bad_InternalError.
+ *
+ * <p>When dispatched through the Call service, the invocation context exposes the request's {@link
+ * org.eclipse.milo.opcua.sdk.server.DiagnosticsContext}. A handler interns diagnostic strings there
+ * and returns argument diagnostics that index them, one per supplied input. After every
+ * address-space group has finished, the service keeps only the fields the ReturnDiagnostics mask
+ * requests and builds the response StringTable from the strings those fields reference.
  */
 package org.eclipse.milo.opcua.sdk.server.methods;

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/servicesets/AbstractServiceSet.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/servicesets/AbstractServiceSet.java
@@ -37,12 +37,20 @@ public abstract class AbstractServiceSet {
       UaRequestMessageType request,
       StatusCode serviceResult,
       @Nullable ExtensionObject additionalHeader) {
+    return createResponseHeader(request, serviceResult, null, additionalHeader);
+  }
+
+  public static ResponseHeader createResponseHeader(
+      UaRequestMessageType request,
+      StatusCode serviceResult,
+      String @Nullable [] stringTable,
+      @Nullable ExtensionObject additionalHeader) {
     return new ResponseHeader(
         DateTime.now(),
         request.getRequestHeader().getRequestHandle(),
         serviceResult,
         null,
-        null,
+        stringTable,
         additionalHeader);
   }
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/servicesets/impl/DefaultMethodServiceSet.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/servicesets/impl/DefaultMethodServiceSet.java
@@ -10,8 +10,10 @@
 
 package org.eclipse.milo.opcua.sdk.server.servicesets.impl;
 
+import static java.util.Objects.requireNonNullElse;
 import static org.eclipse.milo.opcua.sdk.core.util.GroupMapCollate.groupMapCollate;
 import static org.eclipse.milo.opcua.sdk.server.servicesets.AbstractServiceSet.createResponseHeader;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
 
 import java.util.Collections;
 import java.util.List;
@@ -25,6 +27,7 @@ import org.eclipse.milo.opcua.sdk.server.servicesets.impl.AccessController.Acces
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
 import org.eclipse.milo.opcua.stack.core.UaException;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DiagnosticInfo;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
 import org.eclipse.milo.opcua.stack.core.types.structured.CallMethodRequest;
 import org.eclipse.milo.opcua.stack.core.types.structured.CallMethodResult;
 import org.eclipse.milo.opcua.stack.core.types.structured.CallRequest;
@@ -74,6 +77,11 @@ public class DefaultMethodServiceSet implements MethodServiceSet {
     Map<CallMethodRequest, AccessResult> accessResults =
         server.getAccessController().checkCallAccess(session, methodsToCall);
 
+    // One context for the whole request, so handlers in every group share a string table.
+    var diagnosticsContext =
+        new DiagnosticsContext<CallMethodRequest>(
+            requireNonNullElse(request.getRequestHeader().getReturnDiagnostics(), uint(0)));
+
     List<CallMethodResult> results =
         groupMapCollate(
             methodsToCall,
@@ -84,8 +92,6 @@ public class DefaultMethodServiceSet implements MethodServiceSet {
                     var result = new CallMethodResult(denied.statusCode(), null, null, null);
                     return Collections.nCopies(group.size(), result);
                   } else {
-                    var diagnosticsContext = new DiagnosticsContext<CallMethodRequest>();
-
                     var callContext =
                         new CallContext(
                             server,
@@ -99,9 +105,17 @@ public class DefaultMethodServiceSet implements MethodServiceSet {
                   }
                 });
 
-    ResponseHeader header = createResponseHeader(request);
+    MethodDiagnostics.Normalized normalized =
+        MethodDiagnostics.normalize(
+            diagnosticsContext.getReturnDiagnostics(),
+            methodsToCall,
+            results,
+            diagnosticsContext.getStringTable(),
+            server.getConfig().getEncodingLimits().getMaxRecursionDepth());
 
-    return new CallResponse(
-        header, results.toArray(CallMethodResult[]::new), new DiagnosticInfo[0]);
+    ResponseHeader header =
+        createResponseHeader(request, StatusCode.GOOD, normalized.stringTable(), null);
+
+    return new CallResponse(header, normalized.results(), new DiagnosticInfo[0]);
   }
 }

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/servicesets/impl/MethodDiagnostics.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/servicesets/impl/MethodDiagnostics.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.servicesets.impl;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.types.builtin.DiagnosticInfo;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
+import org.eclipse.milo.opcua.stack.core.types.builtin.Variant;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.structured.CallMethodRequest;
+import org.eclipse.milo.opcua.stack.core.types.structured.CallMethodResult;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Reduces the argument diagnostics returned by Method handlers to the fields the client requested
+ * and builds the response StringTable those fields reference.
+ *
+ * <p>Handlers intern strings in the request's working string table and index it from the
+ * DiagnosticInfo entries they return. Only strings referenced by a requested field are carried into
+ * the response table, so every retained index is reassigned here. Malformed diagnostics are dropped
+ * from their operation without changing its status or outputs, because the Method has already run.
+ */
+final class MethodDiagnostics {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(MethodDiagnostics.class);
+
+  private static final DiagnosticInfo[] NONE = new DiagnosticInfo[0];
+
+  // OPC 10000-4, Table 1: the operation-level ReturnDiagnostics bits.
+  private static final int SYMBOLIC_ID = 0x20;
+  private static final int LOCALIZED_TEXT = 0x40;
+  private static final int ADDITIONAL_INFO = 0x80;
+  private static final int INNER_STATUS_CODE = 0x100;
+  private static final int INNER_DIAGNOSTICS = 0x200;
+  private static final int OPERATION_LEVEL =
+      SYMBOLIC_ID | LOCALIZED_TEXT | ADDITIONAL_INFO | INNER_STATUS_CODE | INNER_DIAGNOSTICS;
+
+  private final Map<String, Integer> table = new LinkedHashMap<>();
+
+  private final int mask;
+  private final String[] source;
+  private final int maxDepth;
+
+  private MethodDiagnostics(int mask, String[] source, int maxDepth) {
+    this.mask = mask;
+    this.source = source;
+    this.maxDepth = maxDepth;
+  }
+
+  /**
+   * Filter the argument diagnostics of each result and build the response StringTable.
+   *
+   * @param returnDiagnostics the request's ReturnDiagnostics mask.
+   * @param requests the operations, in request order.
+   * @param results one result per operation, in the same order.
+   * @param source the request's working string table, as indexed by the results.
+   * @param maxDepth the deepest inner DiagnosticInfo nesting accepted.
+   * @return the results to send, and the StringTable their diagnostics index, or {@code null} when
+   *     no string is referenced.
+   */
+  static Normalized normalize(
+      UInteger returnDiagnostics,
+      List<CallMethodRequest> requests,
+      List<CallMethodResult> results,
+      String[] source,
+      int maxDepth) {
+
+    var diagnostics =
+        new MethodDiagnostics(returnDiagnostics.intValue() & OPERATION_LEVEL, source, maxDepth);
+
+    var normalized = new CallMethodResult[results.size()];
+    for (int i = 0; i < normalized.length; i++) {
+      normalized[i] = diagnostics.normalize(requests.get(i), results.get(i));
+    }
+
+    String[] stringTable =
+        diagnostics.table.isEmpty() ? null : diagnostics.table.keySet().toArray(String[]::new);
+
+    return new Normalized(normalized, stringTable);
+  }
+
+  private CallMethodResult normalize(CallMethodRequest request, @Nullable CallMethodResult result) {
+    if (result == null || result.getStatusCode() == null) {
+      LOGGER.warn("Null result for methodId={}", request.getMethodId());
+      return new CallMethodResult(
+          new StatusCode(StatusCodes.Bad_InternalError), new StatusCode[0], NONE, new Variant[0]);
+    }
+
+    DiagnosticInfo[] original = result.getInputArgumentDiagnosticInfos();
+    if (original == null || original.length == 0) {
+      return result;
+    }
+
+    Variant[] inputs = request.getInputArguments();
+    int supplied = inputs == null ? 0 : inputs.length;
+
+    DiagnosticInfo[] filtered;
+    if (mask == 0) {
+      filtered = NONE;
+    } else if (original.length != supplied) {
+      LOGGER.warn(
+          "Discarding argument diagnostics for methodId={}: {} entries for {} inputs",
+          request.getMethodId(),
+          original.length,
+          supplied);
+      filtered = NONE;
+    } else {
+      filtered = filter(request.getMethodId(), original);
+    }
+
+    return new CallMethodResult(
+        result.getStatusCode(),
+        result.getInputArgumentResults(),
+        filtered,
+        result.getOutputArguments());
+  }
+
+  /** The requested fields of each entry, or none if any entry is malformed or nothing remains. */
+  private DiagnosticInfo[] filter(NodeId methodId, DiagnosticInfo[] original) {
+    var filtered = new DiagnosticInfo[original.length];
+    boolean any = false;
+    try {
+      for (int i = 0; i < original.length; i++) {
+        filtered[i] = filter(original[i], 0);
+        any |= !DiagnosticInfo.NULL_VALUE.equals(filtered[i]);
+      }
+    } catch (IllegalArgumentException e) {
+      LOGGER.warn("Discarding argument diagnostics for methodId={}: {}", methodId, e.getMessage());
+      return NONE;
+    }
+    return any ? filtered : NONE;
+  }
+
+  private DiagnosticInfo filter(@Nullable DiagnosticInfo info, int depth) {
+    if (info == null) {
+      return DiagnosticInfo.NULL_VALUE;
+    }
+    if (depth >= maxDepth) {
+      throw new IllegalArgumentException("inner DiagnosticInfo nesting exceeds " + maxDepth);
+    }
+
+    boolean symbolicId = (mask & SYMBOLIC_ID) != 0;
+    boolean localizedText = (mask & LOCALIZED_TEXT) != 0;
+
+    DiagnosticInfo inner =
+        (mask & INNER_DIAGNOSTICS) != 0
+            ? filter(info.innerDiagnosticInfo(), depth + 1)
+            : DiagnosticInfo.NULL_VALUE;
+
+    return new DiagnosticInfo(
+        symbolicId ? index(info.namespaceUri()) : -1,
+        symbolicId ? index(info.symbolicId()) : -1,
+        localizedText ? index(info.locale()) : -1,
+        localizedText ? index(info.localizedText()) : -1,
+        (mask & ADDITIONAL_INFO) != 0 ? info.additionalInfo() : null,
+        (mask & INNER_STATUS_CODE) != 0 ? info.innerStatusCode() : null,
+        DiagnosticInfo.NULL_VALUE.equals(inner) ? null : inner);
+  }
+
+  /** Map an index into the working table to its index in the response table. */
+  private int index(int original) {
+    if (original == -1) {
+      return -1;
+    }
+    if (original < 0 || original >= source.length) {
+      throw new IllegalArgumentException(
+          "string index " + original + " is not in the request's string table");
+    }
+    return table.computeIfAbsent(source[original], s -> table.size());
+  }
+
+  record Normalized(CallMethodResult[] results, String @Nullable [] stringTable) {}
+}

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/methods/SynchronousMethodOutcomeTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/methods/SynchronousMethodOutcomeTest.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.milo.opcua.sdk.server.methods;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Stream;
+import org.eclipse.milo.opcua.sdk.core.typetree.DataTypeTree;
+import org.eclipse.milo.opcua.sdk.server.AccessContext;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaMethodNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNodeContext;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.types.builtin.*;
+import org.eclipse.milo.opcua.stack.core.types.structured.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class SynchronousMethodOutcomeTest {
+  private final AtomicInteger calls = new AtomicInteger();
+  private final UaMethodNode node = mock(UaMethodNode.class);
+  private final AccessContext access = Optional::empty;
+  private final Argument[] arguments = {
+    new Argument("Value", NodeIds.Int32, -1, null, LocalizedText.NULL_VALUE),
+    new Argument("Label", NodeIds.String, -1, null, LocalizedText.NULL_VALUE)
+  };
+
+  SynchronousMethodOutcomeTest() {
+    UaNodeContext context = mock(UaNodeContext.class);
+    OpcUaServer server = mock(OpcUaServer.class);
+    when(node.getNodeContext()).thenReturn(context);
+    when(context.getServer()).thenReturn(server);
+    when(server.getDataTypeTree()).thenReturn(mock(DataTypeTree.class));
+  }
+
+  private AbstractMethodInvocationHandler handler(int required, CallMethodResult outcome) {
+    return new AbstractMethodInvocationHandler(node) {
+      public Argument[] getInputArguments() {
+        return arguments;
+      }
+
+      public Argument[] getOutputArguments() {
+        return new Argument[0];
+      }
+
+      protected int getRequiredInputArgumentCount(Argument[] inputArguments) {
+        return required;
+      }
+
+      protected CallMethodResult invokeResult(InvocationContext context, Variant[] supplied) {
+        calls.incrementAndGet();
+        return outcome == null
+            ? new CallMethodResult(StatusCode.UNCERTAIN, null, null, supplied)
+            : outcome;
+      }
+    };
+  }
+
+  private CallMethodResult call(MethodInvocationHandler handler, Variant... inputs) {
+    return handler.invoke(
+        access, new CallMethodRequest(new NodeId(1, 1), new NodeId(1, 2), inputs));
+  }
+
+  @Test
+  void omissionAndSuppliedNullRetainDifferentCountsAndUncertainOutputs() {
+    AbstractMethodInvocationHandler handler = handler(1, null);
+    Variant[] inputs = {new Variant(7), Variant.NULL_VALUE};
+    CallMethodResult omitted = call(handler, new Variant(7));
+    CallMethodResult supplied = call(handler, inputs);
+    assertEquals(StatusCode.UNCERTAIN, omitted.getStatusCode());
+    assertEquals(1, omitted.getOutputArguments().length);
+    assertEquals(2, supplied.getOutputArguments().length);
+    assertSame(Variant.NULL_VALUE, supplied.getOutputArguments()[1]);
+    assertNotSame(inputs, supplied.getOutputArguments());
+    assertEquals(2, calls.get());
+  }
+
+  @Test
+  void badCountsAndTypesSuppressApplicationCallback() {
+    AbstractMethodInvocationHandler handler = handler(1, null);
+    assertEquals(new StatusCode(StatusCodes.Bad_ArgumentsMissing), call(handler).getStatusCode());
+    assertEquals(
+        new StatusCode(StatusCodes.Bad_TooManyArguments),
+        call(handler, new Variant(7), Variant.NULL_VALUE, Variant.NULL_VALUE).getStatusCode());
+    CallMethodResult wrong = call(handler, new Variant("wrong"));
+    assertEquals(new StatusCode(StatusCodes.Bad_InvalidArgument), wrong.getStatusCode());
+    assertArrayEquals(
+        new StatusCode[] {new StatusCode(StatusCodes.Bad_TypeMismatch)},
+        wrong.getInputArgumentResults());
+    assertEquals(0, calls.get());
+  }
+
+  @Test
+  void invalidConfiguredCountsSuppressCallback() {
+    assertEquals(
+        new StatusCode(StatusCodes.Bad_InternalError),
+        call(handler(-1, null), new Variant(7)).getStatusCode());
+    assertEquals(
+        new StatusCode(StatusCodes.Bad_InternalError),
+        call(handler(3, null), new Variant(7)).getStatusCode());
+    assertEquals(0, calls.get());
+  }
+
+  @Test
+  void valueValidationRunsAfterShapeValidationAndMayRejectConcreteEnums() {
+    AbstractMethodInvocationHandler handler =
+        new AbstractMethodInvocationHandler(node) {
+          public Argument[] getInputArguments() {
+            return new Argument[] {arguments[0]};
+          }
+
+          public Argument[] getOutputArguments() {
+            return new Argument[0];
+          }
+
+          protected void validateInputArgumentValues(Variant[] supplied)
+              throws InvalidArgumentException {
+            calls.incrementAndGet();
+            throw new InvalidArgumentException(
+                new StatusCode[] {new StatusCode(StatusCodes.Bad_OutOfRange)});
+          }
+        };
+    assertEquals(
+        new StatusCode(StatusCodes.Bad_InvalidArgument),
+        call(handler, new Variant("wrong")).getStatusCode());
+    assertEquals(0, calls.get());
+    CallMethodResult result = call(handler, new Variant(99));
+    assertArrayEquals(
+        new StatusCode[] {new StatusCode(StatusCodes.Bad_OutOfRange)},
+        result.getInputArgumentResults());
+    assertEquals(1, calls.get());
+  }
+
+  @Test
+  void legacySubclassRetainsExactCountAndGoodOutcome() {
+    AbstractMethodInvocationHandler legacy =
+        new AbstractMethodInvocationHandler(node) {
+          public Argument[] getInputArguments() {
+            return arguments;
+          }
+
+          public Argument[] getOutputArguments() {
+            return new Argument[0];
+          }
+
+          protected Variant[] invoke(InvocationContext context, Variant[] values) {
+            calls.incrementAndGet();
+            return values;
+          }
+        };
+    assertEquals(
+        new StatusCode(StatusCodes.Bad_ArgumentsMissing),
+        call(legacy, new Variant(7)).getStatusCode());
+    assertEquals(StatusCode.GOOD, call(legacy, new Variant(7), Variant.NULL_VALUE).getStatusCode());
+    assertEquals(1, calls.get());
+  }
+
+  static Stream<CallMethodResult> invalidOutcomes() {
+    return Stream.of(
+        new CallMethodResult(
+            new StatusCode(StatusCodes.Bad_NotSupported),
+            null,
+            null,
+            new Variant[] {new Variant(1)}),
+        new CallMethodResult(StatusCode.GOOD, new StatusCode[] {StatusCode.GOOD}, null, null),
+        new CallMethodResult(
+            new StatusCode(StatusCodes.Bad_InvalidArgument),
+            new StatusCode[] {StatusCode.GOOD, StatusCode.GOOD},
+            null,
+            null),
+        new CallMethodResult(
+            StatusCode.GOOD,
+            null,
+            new DiagnosticInfo[] {DiagnosticInfo.NULL_VALUE, DiagnosticInfo.NULL_VALUE},
+            null),
+        new CallMethodResult(null, null, null, null));
+  }
+
+  // Part 4 Call outcomes cannot attach outputs to Bad or populate input results for other statuses.
+  @ParameterizedTest
+  @MethodSource("invalidOutcomes")
+  void invalidCompleteOutcomesBecomeInternalError(CallMethodResult outcome) {
+    CallMethodResult result = call(handler(1, outcome), new Variant(7));
+    assertEquals(new StatusCode(StatusCodes.Bad_InternalError), result.getStatusCode());
+    assertEquals(0, result.getOutputArguments().length);
+  }
+
+  @Test
+  void goodSubcodesAreDelivered() {
+    CallMethodResult outcome =
+        new CallMethodResult(new StatusCode(StatusCodes.Good_Clamped), null, null, null);
+    assertEquals(
+        outcome.getStatusCode(), call(handler(1, outcome), new Variant(7)).getStatusCode());
+  }
+
+  // The exception path is checked by the same rules as a returned result.
+  @Test
+  void invalidArgumentExceptionWithMismatchedResultsBecomesInternalError() {
+    AbstractMethodInvocationHandler handler =
+        new AbstractMethodInvocationHandler(node) {
+          public Argument[] getInputArguments() {
+            return arguments;
+          }
+
+          public Argument[] getOutputArguments() {
+            return new Argument[0];
+          }
+
+          protected int getRequiredInputArgumentCount(Argument[] inputArguments) {
+            return 1;
+          }
+
+          protected void validateInputArgumentValues(Variant[] supplied)
+              throws InvalidArgumentException {
+            throw new InvalidArgumentException(
+                new StatusCode[] {StatusCode.GOOD, new StatusCode(StatusCodes.Bad_OutOfRange)});
+          }
+        };
+    assertEquals(
+        new StatusCode(StatusCodes.Bad_InternalError),
+        call(handler, new Variant(7)).getStatusCode());
+    assertEquals(
+        new StatusCode(StatusCodes.Bad_InvalidArgument),
+        call(handler, new Variant(7), new Variant("label")).getStatusCode());
+  }
+
+  @Test
+  void nullCompleteOutcomeBecomesInternalError() {
+    AbstractMethodInvocationHandler handler =
+        new AbstractMethodInvocationHandler(node) {
+          public Argument[] getInputArguments() {
+            return new Argument[0];
+          }
+
+          public Argument[] getOutputArguments() {
+            return new Argument[0];
+          }
+
+          protected CallMethodResult invokeResult(InvocationContext context, Variant[] values) {
+            return null;
+          }
+        };
+    assertEquals(new StatusCode(StatusCodes.Bad_InternalError), call(handler).getStatusCode());
+  }
+
+  @Test
+  void metadataIsReadOnceBeforeValidationAndLegacyNullOutputsArePreserved() {
+    AtomicInteger metadataReads = new AtomicInteger();
+    AbstractMethodInvocationHandler legacy =
+        new AbstractMethodInvocationHandler(node) {
+          public Argument[] getInputArguments() {
+            return metadataReads.getAndIncrement() == 0 ? new Argument[] {arguments[0]} : arguments;
+          }
+
+          public Argument[] getOutputArguments() {
+            return new Argument[0];
+          }
+
+          protected Variant[] invoke(InvocationContext context, Variant[] values) {
+            return null;
+          }
+        };
+    CallMethodResult result = call(legacy, new Variant(7));
+    assertEquals(StatusCode.GOOD, result.getStatusCode());
+    assertNull(result.getOutputArguments());
+    assertEquals(1, metadataReads.get());
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/servicesets/impl/DefaultMethodServiceSetTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/servicesets/impl/DefaultMethodServiceSetTest.java
@@ -33,6 +33,7 @@ import org.eclipse.milo.opcua.sdk.server.SessionManager;
 import org.eclipse.milo.opcua.sdk.server.diagnostics.SessionDiagnostics;
 import org.eclipse.milo.opcua.sdk.server.servicesets.impl.AccessController.AccessResult;
 import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.channel.EncodingLimits;
 import org.eclipse.milo.opcua.stack.core.types.builtin.DateTime;
 import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
 import org.eclipse.milo.opcua.stack.core.types.builtin.StatusCode;
@@ -69,6 +70,7 @@ class DefaultMethodServiceSetTest {
 
     when(server.getConfig()).thenReturn(config);
     when(config.getLimits()).thenReturn(new OpcUaServerConfigLimits() {});
+    when(config.getEncodingLimits()).thenReturn(EncodingLimits.DEFAULT);
     when(server.getSessionManager()).thenReturn(sessionManager);
     when(sessionManager.getSession(context, requestHeader)).thenReturn(session);
     when(session.getSessionDiagnostics()).thenReturn(new SessionDiagnostics(session));

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/servicesets/impl/MethodDiagnosticsTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/servicesets/impl/MethodDiagnosticsTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.servicesets.impl;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Arrays;
+import java.util.List;
+import org.eclipse.milo.opcua.sdk.server.DiagnosticsContext;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.types.builtin.*;
+import org.eclipse.milo.opcua.stack.core.types.structured.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class MethodDiagnosticsTest {
+  private static final CallMethodRequest REQUEST =
+      new CallMethodRequest(new NodeId(1, 1), new NodeId(1, 2), new Variant[] {Variant.NULL_VALUE});
+  private static final StatusCode INVALID = new StatusCode(StatusCodes.Bad_InvalidArgument);
+  private static final int MAX_DEPTH = 128;
+
+  private static CallMethodResult result(DiagnosticInfo... diagnostics) {
+    return new CallMethodResult(
+        INVALID,
+        new StatusCode[] {new StatusCode(StatusCodes.Bad_OutOfRange)},
+        diagnostics,
+        new Variant[0]);
+  }
+
+  private static MethodDiagnostics.Normalized normalize(
+      int mask, List<CallMethodResult> results, String... source) {
+    return MethodDiagnostics.normalize(
+        uint(mask),
+        List.of(REQUEST, REQUEST, REQUEST).subList(0, results.size()),
+        results,
+        source,
+        MAX_DEPTH);
+  }
+
+  @Test
+  void compactsIndexesAcrossResultsAndDoesNotMutateRawDiagnostics() {
+    DiagnosticInfo info = new DiagnosticInfo(3, 1, 2, 0, "details", StatusCode.BAD, null);
+    MethodDiagnostics.Normalized normalized =
+        normalize(0x20, List.of(result(info), result(info)), "text", "symbol", "en", "urn:vendor");
+    assertArrayEquals(new String[] {"urn:vendor", "symbol"}, normalized.stringTable());
+    DiagnosticInfo filtered = normalized.results()[1].getInputArgumentDiagnosticInfos()[0];
+    assertEquals(new DiagnosticInfo(0, 1, -1, -1, null, null, null), filtered);
+    assertEquals(3, info.namespaceUri());
+    assertEquals("details", info.additionalInfo());
+  }
+
+  // Service-level flags do not authorize argument-level diagnostic fields.
+  @ParameterizedTest
+  @ValueSource(ints = {0, 1, 31})
+  void noOperationMaskReturnsNoDiagnosticsOrStrings(int mask) {
+    MethodDiagnostics.Normalized normalized =
+        normalize(
+            mask,
+            List.of(
+                result(new DiagnosticInfo(999, 999, 999, 999, "private", StatusCode.BAD, null))));
+    assertEquals(INVALID, normalized.results()[0].getStatusCode());
+    assertEquals(0, normalized.results()[0].getInputArgumentDiagnosticInfos().length);
+    assertNull(normalized.stringTable());
+  }
+
+  @Test
+  void resultsWithoutDiagnosticsPassThroughUnchanged() {
+    CallMethodResult denied =
+        new CallMethodResult(new StatusCode(StatusCodes.Bad_UserAccessDenied), null, null, null);
+    CallMethodResult good =
+        new CallMethodResult(
+            StatusCode.GOOD,
+            new StatusCode[0],
+            new DiagnosticInfo[0],
+            new Variant[] {new Variant(1)});
+    MethodDiagnostics.Normalized normalized = normalize(0x3e0, Arrays.asList(denied, good, null));
+    assertSame(denied, normalized.results()[0]);
+    assertSame(good, normalized.results()[1]);
+    assertEquals(
+        new StatusCode(StatusCodes.Bad_InternalError), normalized.results()[2].getStatusCode());
+    assertNull(normalized.stringTable());
+  }
+
+  @Test
+  void innerDiagnosticsUseTheSameMask() {
+    DiagnosticInfo inner = new DiagnosticInfo(-1, 0, -1, -1, "inner", null, null);
+    DiagnosticInfo outer = new DiagnosticInfo(-1, 1, -1, -1, "outer", null, inner);
+    MethodDiagnostics.Normalized normalized =
+        normalize(0x2a0, List.of(result(outer)), "inner", "outer");
+    DiagnosticInfo actual = normalized.results()[0].getInputArgumentDiagnosticInfos()[0];
+    String[] table = normalized.stringTable();
+    assertEquals("outer", table[actual.symbolicId()]);
+    assertEquals("outer", actual.additionalInfo());
+    assertEquals("inner", table[actual.innerDiagnosticInfo().symbolicId()]);
+    assertEquals("inner", actual.innerDiagnosticInfo().additionalInfo());
+  }
+
+  // The Method already ran, so a malformed diagnostic loses only the diagnostic.
+  @Test
+  void malformedIndexCardinalityAndDepthDropOnlyTheirOwnDiagnostics() {
+    DiagnosticInfo malformed = new DiagnosticInfo(-1, 99, -1, -1, null, null, null);
+    DiagnosticInfo inner = new DiagnosticInfo(-1, 0, -1, -1, "inner", null, null);
+    DiagnosticInfo outer = new DiagnosticInfo(-1, 0, -1, -1, "outer", null, inner);
+    MethodDiagnostics.Normalized normalized =
+        MethodDiagnostics.normalize(
+            uint(0x2a0),
+            List.of(REQUEST, REQUEST, REQUEST),
+            List.of(result(malformed), result(inner, inner), result(outer)),
+            new String[] {"symbol"},
+            1);
+    for (CallMethodResult result : normalized.results()) {
+      assertEquals(INVALID, result.getStatusCode());
+      assertEquals(1, result.getInputArgumentResults().length);
+      assertEquals(0, result.getInputArgumentDiagnosticInfos().length);
+    }
+  }
+
+  @Test
+  void requestedFieldMasksAreIndependent() {
+    DiagnosticInfo all =
+        new DiagnosticInfo(0, 1, 2, 3, "info", StatusCode.BAD, DiagnosticInfo.NULL_VALUE);
+    DiagnosticInfo localized =
+        normalize(0x40, List.of(result(all)), "ns", "symbol", "en", "text")
+            .results()[0]
+            .getInputArgumentDiagnosticInfos()[0];
+    assertEquals(new DiagnosticInfo(-1, -1, 0, 1, null, null, null), localized);
+    DiagnosticInfo status =
+        normalize(0x100, List.of(result(all))).results()[0].getInputArgumentDiagnosticInfos()[0];
+    assertEquals(new DiagnosticInfo(-1, -1, -1, -1, null, StatusCode.BAD, null), status);
+  }
+
+  @Test
+  void stringInterningIsStableAndSnapshotsAreIndependent() {
+    DiagnosticsContext<CallMethodRequest> context = new DiagnosticsContext<>(uint(0x3e0));
+    assertEquals(0, context.addString("one"));
+    assertEquals(1, context.addString("two"));
+    assertEquals(0, context.addString("one"));
+    String[] snapshot = context.getStringTable();
+    snapshot[0] = "changed";
+    assertArrayEquals(new String[] {"one", "two"}, context.getStringTable());
+  }
+}


### PR DESCRIPTION
Methods with optional trailing inputs currently fail with Bad_ArgumentsMissing before their callback, and AbstractMethodInvocationHandler always converts a successful callback to Good. This adds synchronous hooks that reuse the existing validator, preserve omitted inputs and allow complete outcomes such as Uncertain with outputs. It also carries requested argument diagnostics through the Call service with a response-wide StringTable.

Targets `integration/1.2`. Existing subclasses keep their current callback and validation behavior; applications opt into the new hooks.

## Optional inputs and complete outcomes

Before, the handler requires the full declared count and unconditionally wraps its legacy callback with Good:

```java
if (inputArgumentValues.length < getInputArguments().length) {
  throw new UaException(StatusCodes.Bad_ArgumentsMissing);
}
// Existing type, rank and value validation runs here.
Variant[] outputValues = invoke(invocationContext, inputArgumentValues);
return new CallMethodResult(
    StatusCode.GOOD, new StatusCode[0], new DiagnosticInfo[0], outputValues);
```

After, a handler can override two additive hooks. This is the optional-input branch used by the integration test fixture:

```java
protected int getRequiredInputArgumentCount(Argument[] inputArguments) {
  return 0;
}

protected CallMethodResult invokeResult(InvocationContext context, Variant[] values) {
  return new CallMethodResult(
      StatusCode.UNCERTAIN,
      null,
      null,
      values.length == 0 ? new Variant[] {new Variant("omitted")} : values);
}
```

| Request input | Before | After |
| --- | --- | --- |
| No argument | Bad_ArgumentsMissing, callback suppressed | Uncertain, output `"omitted"` |
| Supplied null | One validated input position; legacy callback reports Good | Uncertain, one null output |
| String | Legacy callback reports Good | Uncertain, String output |
| Integer | Bad_InvalidArgument with per-input Bad_TypeMismatch | Same failure, complete callback suppressed |

The required-count hook permits omission only from the trailing input positions. Omitted inputs are absent from the supplied array; a supplied null keeps its position. Existing shape, type and value validation, decoded structured inputs and Matrix handling remain shared with legacy callbacks.

Results, whether returned from `invokeResult` or built from a thrown `InvalidArgumentException`, are checked against the Part 4 CallMethodResult rules: a Bad status carries no outputs, input results are populated only with Bad_InvalidArgument and match the supplied count, and argument diagnostics match the supplied count when present. A result that breaks a rule, or a null result, is logged with the reason and reported as Bad_InternalError.

## Request-wide argument diagnostics

Before, `DefaultMethodServiceSet` allocates a DiagnosticsContext inside each access group and never sets a StringTable.

After, the service creates one context per request. `InvocationContext.getCallDiagnostics()` exposes it to handlers; independent invocations get `Optional.empty()`. A handler interns strings there and returns argument-indexed DiagnosticInfo entries. After all groups complete, `MethodDiagnostics` keeps the fields the ReturnDiagnostics mask requests and builds a compact response table from the strings those fields reference.

Only operation mask bits 0x20 through 0x200 select argument diagnostic fields, including inner diagnostics. Zero and service-only masks produce no argument diagnostics and no table. A malformed diagnostic (bad index, wrong cardinality, excess nesting) is dropped from its operation with a warning; the operation's status and outputs are kept because the Method has already run. String storage is bounded by the encoder's limits, not by a separate budget.

Clients need a CallRequest with a nonzero ReturnDiagnostics mask to receive argument diagnostics. `OpcUaClient.callAsync()` still requests none.

## Compatibility and verification

The legacy `invoke` callback is now a concrete method that returns Bad_NotImplemented, so subclasses overriding only `invokeResult` compile. Existing subclasses keep their exact-count validation, Good status and null output-array behavior; a source-level legacy subclass test covers this.

Verified with Java 17: sdk-server and integration-tests compile, and the Method suites pass (SynchronousMethodOutcomeTest, MethodDiagnosticsTest, DefaultMethodServiceSetTest, AbstractMethodInvocationHandlerTest, the 190-case MethodArgumentValidationTest, SynchronousMethodServiceTest, and the Condition and Alias integration suites).
