### PR TITLE
Bind shared Methods by invocation ObjectId

### DIFF
--- a/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/methods/MethodBindingsServiceTest.java
+++ b/opc-ua-sdk/integration-tests/src/test/java/org/eclipse/milo/opcua/sdk/server/methods/MethodBindingsServiceTest.java
@@ -1,0 +1,302 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.milo.opcua.sdk.server.methods;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.ushort;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.eclipse.milo.opcua.sdk.client.OpcUaClientConfigBuilder;
+import org.eclipse.milo.opcua.sdk.client.identity.UsernameProvider;
+import org.eclipse.milo.opcua.sdk.core.Reference;
+import org.eclipse.milo.opcua.sdk.server.ManagedNamespaceWithLifecycle;
+import org.eclipse.milo.opcua.sdk.server.conditions.AcknowledgeableCondition;
+import org.eclipse.milo.opcua.sdk.server.conditions.Condition;
+import org.eclipse.milo.opcua.sdk.server.items.DataItem;
+import org.eclipse.milo.opcua.sdk.server.items.MonitoredItem;
+import org.eclipse.milo.opcua.sdk.server.model.objects.AcknowledgeableConditionTypeNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.*;
+import org.eclipse.milo.opcua.sdk.server.nodes.instantiation.InstantiationRequest;
+import org.eclipse.milo.opcua.sdk.server.nodes.instantiation.MethodInstantiation;
+import org.eclipse.milo.opcua.sdk.test.AbstractClientServerTest;
+import org.eclipse.milo.opcua.sdk.test.TestNamespace;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.*;
+import org.eclipse.milo.opcua.stack.core.types.structured.*;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+
+class MethodBindingsServiceTest extends AbstractClientServerTest {
+  private BindingNamespace namespace;
+
+  @Override
+  protected void customizeClientConfig(OpcUaClientConfigBuilder builder) {
+    builder.setIdentityProvider(new UsernameProvider("user1", "password"));
+  }
+
+  @Override
+  protected void configureTestNamespace(TestNamespace ignored) {
+    namespace = new BindingNamespace();
+    namespace.startup();
+    server.updateReferenceTypeTree();
+  }
+
+  @AfterAll
+  void stopBindingNamespace() {
+    if (namespace != null) namespace.shutdown();
+  }
+
+  // Both owners reach the shared Method through a custom HasComponent subtype.
+  @Test
+  void authenticatedCallsPreserveObjectDispatchAndDenyNonExecutableMethods() throws Exception {
+    try (MethodBindings bindings = new MethodBindings()) {
+      AtomicInteger calls = new AtomicInteger();
+      namespace.method.setInvocationHandler(reply("fallback", calls));
+      MethodBinding first = bindings.bind(namespace.first, namespace.method, reply("first", calls));
+      MethodBinding second =
+          bindings.bind(namespace.second, namespace.method, reply("second", calls));
+      assertEquals("first", value(call(namespace.first, namespace.method)));
+      assertEquals("second", value(call(namespace.second, namespace.method)));
+      MethodBinding replacement =
+          bindings.bind(namespace.first, namespace.method, reply("replacement", calls));
+      first.close();
+      assertEquals("replacement", value(call(namespace.first, namespace.method)));
+      namespace.method.setUserExecutable(false);
+      try {
+        int before = calls.get();
+        assertEquals(
+            new StatusCode(StatusCodes.Bad_UserAccessDenied),
+            call(namespace.first, namespace.method).getStatusCode());
+        assertEquals(before, calls.get());
+      } finally {
+        namespace.method.setUserExecutable(true);
+      }
+      replacement.close();
+      assertEquals("fallback", value(call(namespace.first, namespace.method)));
+      second.close();
+    }
+  }
+
+  @Test
+  void typeLevelMethodsAreCallableButModelledInstanceDeclarationsAreRejected() throws Exception {
+    try (MethodBindings bindings = new MethodBindings()) {
+      bindings.bind(namespace.type, namespace.typeMethod, reply("type", new AtomicInteger()));
+      assertEquals("type", value(call(namespace.type, namespace.typeMethod)));
+      assertEquals(
+          new StatusCode(StatusCodes.Bad_MethodInvalid),
+          assertThrows(
+                  UaException.class,
+                  () ->
+                      bindings.bind(
+                          namespace.type,
+                          namespace.instanceDeclaration,
+                          reply("invalid", new AtomicInteger())))
+              .getStatusCode());
+      assertEquals(
+          new StatusCode(StatusCodes.Bad_MethodInvalid),
+          call(namespace.type, namespace.instanceDeclaration).getStatusCode());
+    }
+  }
+
+  @Test
+  void modelledConditionMethodsThroughReferenceSubtypesKeepConditionTypeFailure() throws Exception {
+    UaObjectTypeNode conditionType =
+        (UaObjectTypeNode)
+            server.getAddressSpaceManager().getManagedNode(NodeIds.ConditionType).orElseThrow();
+    Reference reference =
+        new Reference(
+            conditionType.getNodeId(),
+            namespace.componentId,
+            namespace.instanceDeclaration.getNodeId().expanded(),
+            Reference.Direction.FORWARD);
+    conditionType.addReference(reference);
+    try {
+      assertEquals(
+          new StatusCode(StatusCodes.Bad_NodeIdInvalid),
+          call(conditionType, namespace.instanceDeclaration).getStatusCode());
+    } finally {
+      conditionType.removeReference(reference);
+    }
+  }
+
+  @Test
+  void registeredConditionManagerRetainsMethodDispatchPrecedence() throws Exception {
+    Condition condition = namespace.createCondition();
+    server.getConditionManager().register(condition);
+    try (MethodBindings bindings = new MethodBindings()) {
+      UaMethodNode method = condition.getNode().getEnableMethodNode();
+      assertTrue(
+          server
+              .getConditionManager()
+              .findMethodInvocationHandler(condition.getConditionId(), method.getNodeId())
+              .isPresent());
+      assertEquals(
+          new StatusCode(StatusCodes.Bad_NotSupported),
+          assertThrows(
+                  UaException.class,
+                  () ->
+                      bindings.bind(
+                          condition.getNode(), method, reply("invalid", new AtomicInteger())))
+              .getStatusCode());
+      // Adopted Conditions default to Enabled, so the Condition's own handler answers, not a
+      // fallback.
+      assertEquals(
+          new StatusCode(StatusCodes.Bad_ConditionAlreadyEnabled),
+          call(condition.getNode(), method).getStatusCode());
+    } finally {
+      server.getConditionManager().unregister(condition);
+    }
+  }
+
+  private CallMethodResult call(UaNode owner, UaMethodNode method) throws UaException {
+    return client.call(
+            List.of(new CallMethodRequest(owner.getNodeId(), method.getNodeId(), new Variant[0])))
+        .getResults()[0];
+  }
+
+  private static MethodInvocationHandler reply(String value, AtomicInteger calls) {
+    return (context, request) -> {
+      calls.incrementAndGet();
+      return new CallMethodResult(StatusCode.GOOD, null, null, new Variant[] {new Variant(value)});
+    };
+  }
+
+  private static String value(CallMethodResult result) {
+    assertEquals(StatusCode.GOOD, result.getStatusCode());
+    return (String) result.getOutputArguments()[0].value();
+  }
+
+  private final class BindingNamespace extends ManagedNamespaceWithLifecycle {
+    final UaObjectNode first;
+    final UaObjectNode second;
+    final UaMethodNode method;
+    final UaObjectTypeNode type;
+    final UaMethodNode typeMethod;
+    final UaMethodNode instanceDeclaration;
+    final NodeId componentId;
+
+    BindingNamespace() {
+      super(MethodBindingsServiceTest.this.server, "urn:milo:test:binding-service");
+      componentId = newNodeId("CustomComponent");
+      UaReferenceTypeNode reference =
+          new UaReferenceTypeNode(
+              getNodeContext(),
+              componentId,
+              newQualifiedName("CustomComponent"),
+              LocalizedText.english("CustomComponent"),
+              LocalizedText.NULL_VALUE,
+              uint(0),
+              uint(0),
+              false,
+              false,
+              LocalizedText.english("CustomComponentOf"));
+      getNodeManager().addNode(reference);
+      reference.addReference(
+          new Reference(
+              componentId,
+              NodeIds.HasSubtype,
+              NodeIds.HasComponent.expanded(),
+              Reference.Direction.INVERSE));
+      first = object("first");
+      second = object("second");
+      method = method("shared");
+      first.addReference(
+          new Reference(
+              first.getNodeId(),
+              componentId,
+              method.getNodeId().expanded(),
+              Reference.Direction.FORWARD));
+      second.addReference(
+          new Reference(
+              second.getNodeId(),
+              componentId,
+              method.getNodeId().expanded(),
+              Reference.Direction.FORWARD));
+      type =
+          UaObjectTypeNode.builder(getNodeContext())
+              .setNodeId(newNodeId("Type"))
+              .setBrowseName(newQualifiedName("Type"))
+              .setDisplayName(LocalizedText.english("Type"))
+              .buildAndAdd();
+      typeMethod = method("type");
+      instanceDeclaration = method("instanceDeclaration");
+      type.addReference(
+          new Reference(
+              type.getNodeId(),
+              componentId,
+              typeMethod.getNodeId().expanded(),
+              Reference.Direction.FORWARD));
+      type.addReference(
+          new Reference(
+              type.getNodeId(),
+              componentId,
+              instanceDeclaration.getNodeId().expanded(),
+              Reference.Direction.FORWARD));
+      instanceDeclaration.addReference(
+          new Reference(
+              instanceDeclaration.getNodeId(),
+              NodeIds.HasModellingRule,
+              NodeIds.ModellingRule_Mandatory.expanded(),
+              Reference.Direction.FORWARD));
+    }
+
+    private UaObjectNode object(String name) {
+      return UaObjectNode.builder(getNodeContext())
+          .setNodeId(newNodeId(name))
+          .setBrowseName(newQualifiedName(name))
+          .setDisplayName(LocalizedText.english(name))
+          .setTypeDefinition(NodeIds.BaseObjectType)
+          .buildAndAdd();
+    }
+
+    private UaMethodNode method(String name) {
+      UaMethodNode result =
+          UaMethodNode.builder(getNodeContext())
+              .setNodeId(newNodeId(name))
+              .setBrowseName(newQualifiedName(name))
+              .setDisplayName(LocalizedText.english(name))
+              .buildAndAdd();
+      result.setOutputArguments(
+          new Argument[] {
+            new Argument("Message", NodeIds.String, -1, null, LocalizedText.NULL_VALUE)
+          });
+      return result;
+    }
+
+    Condition createCondition() throws UaException {
+      InstantiationRequest<AcknowledgeableConditionTypeNode> request =
+          InstantiationRequest.of(
+                  AcknowledgeableConditionTypeNode.class, NodeIds.AcknowledgeableConditionType)
+              .nodeId(newNodeId("condition"))
+              .browseName(newQualifiedName("Condition"))
+              .target(getNodeManager())
+              .methodInstantiation(MethodInstantiation.SHARE)
+              .build();
+      AcknowledgeableConditionTypeNode node =
+          getServer().getNodeInstantiator().instantiate(request).root();
+      node.setEventType(NodeIds.AcknowledgeableConditionType);
+      node.setSeverity(ushort(500));
+      return AcknowledgeableCondition.adopt(
+          getNodeContext(), node.getNodeId(), builder -> builder.conditionSource(first));
+    }
+
+    public void onDataItemsCreated(List<DataItem> items) {}
+
+    public void onDataItemsModified(List<DataItem> items) {}
+
+    public void onDataItemsDeleted(List<DataItem> items) {}
+
+    public void onMonitoringModeChanged(List<MonitoredItem> items) {}
+  }
+}

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/nodes/UaNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/nodes/UaNode.java
@@ -234,7 +234,7 @@ public abstract class UaNode implements Node {
    * @see #readRolePermissions()
    */
   @Override
-  public synchronized @Nullable RolePermissionType[] getRolePermissions() {
+  public synchronized RolePermissionType @Nullable [] getRolePermissions() {
     return rolePermissions;
   }
 
@@ -246,7 +246,7 @@ public abstract class UaNode implements Node {
    * @see #readUserRolePermissions()
    */
   @Override
-  public synchronized @Nullable RolePermissionType[] getUserRolePermissions() {
+  public synchronized RolePermissionType @Nullable [] getUserRolePermissions() {
     return userRolePermissions;
   }
 
@@ -534,8 +534,7 @@ public abstract class UaNode implements Node {
    * @return the {@link RolePermissionType} read from the server.
    * @throws UaException if a service- or operation-level error occurs.
    */
-  @Nullable
-  public RolePermissionType[] readRolePermissions() throws UaException {
+  public RolePermissionType @Nullable [] readRolePermissions() throws UaException {
     DataValue value = readAttribute(AttributeId.RolePermissions);
 
     StatusCode statusCode = value.statusCode();
@@ -557,8 +556,7 @@ public abstract class UaNode implements Node {
    * @return the {@link RolePermissionType} read from the server.
    * @throws UaException if a service- or operation-level error occurs.
    */
-  @Nullable
-  public RolePermissionType[] readUserRolePermissions() throws UaException {
+  public RolePermissionType @Nullable [] readUserRolePermissions() throws UaException {
     DataValue value = readAttribute(AttributeId.UserRolePermissions);
 
     StatusCode statusCode = value.statusCode();

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/nodes/UaVariableNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/nodes/UaVariableNode.java
@@ -442,8 +442,7 @@ public class UaVariableNode extends UaNode implements VariableNode {
    * @return the {@link UInteger} array read from the server.
    * @throws UaException if a service- or operation-level error occurs.
    */
-  @Nullable
-  public UInteger[] readArrayDimensions() throws UaException {
+  public UInteger @Nullable [] readArrayDimensions() throws UaException {
     DataValue value = readAttribute(AttributeId.ArrayDimensions);
     StatusCode statusCode = value.statusCode();
 

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/nodes/UaVariableTypeNode.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/nodes/UaVariableTypeNode.java
@@ -307,8 +307,7 @@ public class UaVariableTypeNode extends UaNode implements VariableTypeNode {
    * @return the {@link UInteger} array read from the server.
    * @throws UaException if a service- or operation-level error occurs.
    */
-  @Nullable
-  public UInteger[] readArrayDimensions() throws UaException {
+  public UInteger @Nullable [] readArrayDimensions() throws UaException {
     DataValue value = readAttribute(AttributeId.ArrayDimensions);
     StatusCode statusCode = value.statusCode();
 

--- a/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/typetree/VariableTypeTreeBuilder.java
+++ b/opc-ua-sdk/sdk-client/src/main/java/org/eclipse/milo/opcua/sdk/client/typetree/VariableTypeTreeBuilder.java
@@ -269,5 +269,5 @@ public class VariableTypeTreeBuilder {
       DataValue value,
       NodeId dataType,
       Integer valueRank,
-      @Nullable UInteger[] arrayDimensions) {}
+      UInteger @Nullable [] arrayDimensions) {}
 }

--- a/opc-ua-sdk/sdk-core/src/main/java/org/eclipse/milo/opcua/sdk/core/QualifiedProperty.java
+++ b/opc-ua-sdk/sdk-core/src/main/java/org/eclipse/milo/opcua/sdk/core/QualifiedProperty.java
@@ -64,8 +64,7 @@ public class QualifiedProperty<T> {
     return javaType;
   }
 
-  @Nullable
-  public UInteger[] getArrayDimensions() {
+  public UInteger @Nullable [] getArrayDimensions() {
     int valueRank = getValueRank();
 
     if (valueRank <= 0) {

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/ManagedAddressSpace.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/ManagedAddressSpace.java
@@ -10,9 +10,6 @@
 
 package org.eclipse.milo.opcua.sdk.server;
 
-import static org.eclipse.milo.opcua.sdk.core.Reference.COMPONENT_OF_PREDICATE;
-import static org.eclipse.milo.opcua.sdk.core.Reference.ORDERED_COMPONENT_OF_PREDICATE;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Semaphore;
@@ -308,7 +305,7 @@ public abstract class ManagedAddressSpace implements AddressSpace {
     }
 
     if (methodNode != null) {
-      return methodNode.getInvocationHandler();
+      return methodNode.getInvocationHandler(objectId);
     } else {
       throw new UaException(StatusCodes.Bad_MethodInvalid);
     }
@@ -345,7 +342,13 @@ public abstract class ManagedAddressSpace implements AddressSpace {
    */
   private boolean isConditionInstanceMethod(UaMethodNode methodNode) {
     return methodNode.getReferences().stream()
-        .filter(COMPONENT_OF_PREDICATE.or(ORDERED_COMPONENT_OF_PREDICATE))
+        .filter(
+            reference ->
+                reference.isInverse()
+                    && (reference.getReferenceTypeId().equals(NodeIds.HasComponent)
+                        || server
+                            .getReferenceTypeTree()
+                            .isSubtypeOf(reference.getReferenceTypeId(), NodeIds.HasComponent)))
         .flatMap(
             reference ->
                 server

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/Session.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/Session.java
@@ -433,12 +433,11 @@ public class Session {
     return sessionName;
   }
 
-  @Nullable
-  public String[] getLocaleIds() {
+  public String @Nullable [] getLocaleIds() {
     return localeIds;
   }
 
-  public void setLocaleIds(@Nullable String[] localeIds) {
+  public void setLocaleIds(String @Nullable [] localeIds) {
     this.localeIds = localeIds;
   }
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/SessionManager.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/SessionManager.java
@@ -1189,7 +1189,7 @@ public class SessionManager {
    */
   @NonNull
   private UserIdentityToken decodeIdentityToken(
-      @Nullable ExtensionObject identityTokenXo, @Nullable UserTokenPolicy[] tokenPolicies) {
+      @Nullable ExtensionObject identityTokenXo, UserTokenPolicy @Nullable [] tokenPolicies) {
 
     if (identityTokenXo != null && !identityTokenXo.isNull()) {
       Object identityToken;

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/methods/MethodBinding.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/methods/MethodBinding.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.methods;
+
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Owns one ObjectId-specific Method registration.
+ *
+ * <p>Close the token when removing its owner node. Closing is idempotent and removes only this
+ * registration, so an old token cannot unregister its replacement. A callback selected before close
+ * may finish afterward.
+ */
+@NullMarked
+public interface MethodBinding extends AutoCloseable {
+  /**
+   * @return the invocation owner's NodeId.
+   */
+  NodeId objectId();
+
+  /**
+   * @return the shared Method's NodeId.
+   */
+  NodeId methodId();
+
+  /** Release this registration without waiting for selected invocations to finish. */
+  @Override
+  void close();
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/methods/MethodBindings.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/methods/MethodBindings.java
@@ -176,9 +176,9 @@ public final class MethodBindings implements AutoCloseable {
   }
 
   private static boolean argumentsDiffer(
-      @Nullable Argument @Nullable [] actual, @Nullable Argument @Nullable [] expected) {
-    @Nullable Argument[] left = actual == null ? new Argument[0] : actual;
-    @Nullable Argument[] right = expected == null ? new Argument[0] : expected;
+      Argument @Nullable [] actual, Argument @Nullable [] expected) {
+    Argument[] left = actual == null ? new Argument[0] : actual;
+    Argument[] right = expected == null ? new Argument[0] : expected;
     if (left.length != right.length) return true;
     for (int i = 0; i < left.length; i++) {
       if (!sameArgument(left[i], right[i])) return true;

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/methods/MethodBindings.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/methods/MethodBindings.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.methods;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import org.eclipse.milo.opcua.sdk.server.OpcUaServer;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaMethodNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectNode;
+import org.eclipse.milo.opcua.sdk.server.nodes.UaObjectTypeNode;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.structured.Argument;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * An application-owned lifetime for ObjectId-specific handlers on shared Method nodes.
+ *
+ * <p>Bind validates the owner's relationship to the Method and the handler's argument metadata,
+ * then installs the handler on the Method for that ObjectId with {@link
+ * UaMethodNode#setInvocationHandler(NodeId, MethodInvocationHandler)}. Bind replaces only the
+ * selected object's registration. Objects without a registration use the Method's default handler,
+ * which this registry never changes.
+ *
+ * <p>Close tokens or call {@link #removeObject(NodeId)} before removing owner nodes. Close the
+ * registry during namespace shutdown. Cleanup is idempotent, releases only registrations this
+ * registry still owns, and does not drain callbacks already selected.
+ *
+ * <pre>{@code
+ * try (MethodBindings bindings = new MethodBindings()) {
+ *   MethodBinding token = bindings.bind(owner, method, handler);
+ *   // Close token before removing owner, or close bindings for the whole application lifetime.
+ * }
+ * }</pre>
+ */
+@NullMarked
+public final class MethodBindings implements AutoCloseable {
+  private final Map<Key, Registration> registrations = new HashMap<>();
+  private boolean closed;
+
+  /**
+   * Bind a validated handler to this owner on a shared Method without changing argument Properties.
+   *
+   * <p>The owner and Method must be live nodes on the same server and have a callable component
+   * relationship. Modelled instance Methods cannot be bound on an ObjectType. ConditionManager
+   * handlers keep their precedence and cannot be bound through this registry. For an
+   * AbstractMethodInvocationHandler, the node and argument data types, ranks, dimensions and names
+   * must match the Method metadata. Raw handlers remain responsible for their own input validation.
+   * Actual calls still pass through normal ownership and service access checks.
+   *
+   * @param invocationOwner the Object or ObjectType used as invocation ObjectId.
+   * @param method the shared Method to dispatch.
+   * @param validatedHandler the synchronous handler; no application callback runs during bind.
+   * @return an identity-bearing lifetime token for this registration.
+   * @throws UaException with Bad_NodeIdUnknown for removed nodes, Bad_MethodInvalid for invalid
+   *     ownership, Bad_TypeMismatch for incompatible metadata, or Bad_NotSupported for a preempting
+   *     ConditionManager handler.
+   * @throws IllegalArgumentException if nodes belong to different servers.
+   * @throws IllegalStateException if the registry is closed.
+   */
+  public MethodBinding bind(
+      UaNode invocationOwner, UaMethodNode method, MethodInvocationHandler validatedHandler)
+      throws UaException {
+    requireNonNull(invocationOwner);
+    requireNonNull(method);
+    requireNonNull(validatedHandler);
+    OpcUaServer server = invocationOwner.getNodeContext().getServer();
+    if (method.getNodeContext().getServer() != server) {
+      throw new IllegalArgumentException("Owner and Method belong to different servers");
+    }
+    validateOwnership(server, invocationOwner, method);
+    validateMetadata(method, validatedHandler);
+
+    synchronized (this) {
+      if (closed) throw new IllegalStateException("Method bindings are closed");
+      Registration registration =
+          new Registration(this, invocationOwner.getNodeId(), method, validatedHandler);
+      method.setInvocationHandler(registration.objectId, validatedHandler);
+      registrations.put(registration.key(), registration);
+      return registration;
+    }
+  }
+
+  /**
+   * Remove all registrations for this ObjectId, without removing its nodes or draining callbacks.
+   *
+   * @param objectId the owner whose registrations to release.
+   */
+  public synchronized void removeObject(NodeId objectId) {
+    requireNonNull(objectId);
+    registrations
+        .values()
+        .removeIf(
+            registration -> {
+              if (registration.objectId.equals(objectId)) {
+                registration.release();
+                return true;
+              }
+              return false;
+            });
+  }
+
+  /** Release every registration this registry still owns. */
+  @Override
+  public synchronized void close() {
+    if (closed) return;
+    closed = true;
+    registrations.values().forEach(Registration::release);
+    registrations.clear();
+  }
+
+  private static void validateOwnership(OpcUaServer server, UaNode owner, UaMethodNode method)
+      throws UaException {
+    // Identity, not just NodeId presence: a node removed and recreated under the same NodeId is a
+    // different instance and must be bound again through the new instance.
+    if (isStale(server, owner) || isStale(server, method)) {
+      throw new UaException(StatusCodes.Bad_NodeIdUnknown);
+    }
+    UaMethodNode owned;
+    if (owner instanceof UaObjectNode object) {
+      owned = object.findMethodNode(method.getNodeId());
+    } else if (owner instanceof UaObjectTypeNode type) {
+      if (method.getModellingRuleNode().isPresent()) {
+        throw new UaException(
+            StatusCodes.Bad_MethodInvalid,
+            "An ObjectType cannot own an invocation of an instance declaration");
+      }
+      owned = type.findMethodNode(method.getNodeId());
+    } else {
+      throw new UaException(
+          StatusCodes.Bad_MethodInvalid, "Method owner must be an Object or ObjectType");
+    }
+    if (server
+        .getConditionManager()
+        .findMethodInvocationHandler(owner.getNodeId(), method.getNodeId())
+        .isPresent()) {
+      throw new UaException(
+          StatusCodes.Bad_NotSupported, "ConditionManager handles this Method relationship");
+    }
+    if (owned != method) {
+      throw new UaException(StatusCodes.Bad_MethodInvalid);
+    }
+  }
+
+  /** A node is stale once the address space no longer manages this exact instance. */
+  private static boolean isStale(OpcUaServer server, UaNode node) {
+    return server.getAddressSpaceManager().getManagedNode(node.getNodeId()).orElse(null) != node;
+  }
+
+  private static void validateMetadata(UaMethodNode method, MethodInvocationHandler handler)
+      throws UaException {
+    if (handler instanceof AbstractMethodInvocationHandler typed) {
+      if (typed.getNode() != method
+          || argumentsDiffer(method.getInputArguments(), typed.getInputArguments())
+          || argumentsDiffer(method.getOutputArguments(), typed.getOutputArguments())) {
+        throw new UaException(
+            StatusCodes.Bad_TypeMismatch, "Handler argument metadata does not match Method");
+      }
+    }
+  }
+
+  private static boolean argumentsDiffer(
+      @Nullable Argument @Nullable [] actual, @Nullable Argument @Nullable [] expected) {
+    @Nullable Argument[] left = actual == null ? new Argument[0] : actual;
+    @Nullable Argument[] right = expected == null ? new Argument[0] : expected;
+    if (left.length != right.length) return true;
+    for (int i = 0; i < left.length; i++) {
+      if (!sameArgument(left[i], right[i])) return true;
+    }
+    return false;
+  }
+
+  /** Compare everything but Description; a null DataType or ValueRank never matches. */
+  private static boolean sameArgument(@Nullable Argument left, @Nullable Argument right) {
+    if (left == null || right == null) return false;
+    if (left.getDataType() == null || left.getValueRank() == null) return false;
+    return Objects.equals(left.getName(), right.getName())
+        && left.getDataType().equals(right.getDataType())
+        && left.getValueRank().equals(right.getValueRank())
+        && sameDimensions(left.getArrayDimensions(), right.getArrayDimensions());
+  }
+
+  /** Null and empty both mean unspecified dimensions. */
+  private static boolean sameDimensions(UInteger @Nullable [] left, UInteger @Nullable [] right) {
+    return Arrays.equals(
+        left == null ? new UInteger[0] : left, right == null ? new UInteger[0] : right);
+  }
+
+  private record Key(NodeId objectId, NodeId methodId) {}
+
+  /**
+   * Deliberately a class, not a record: tokens are compared by identity so that closing a stale
+   * token never releases an equal-valued registration that replaced it.
+   */
+  @SuppressWarnings("ClassCanBeRecord")
+  private static final class Registration implements MethodBinding {
+    final MethodBindings registry;
+    final NodeId objectId;
+    final UaMethodNode method;
+    final MethodInvocationHandler handler;
+
+    Registration(
+        MethodBindings registry,
+        NodeId objectId,
+        UaMethodNode method,
+        MethodInvocationHandler handler) {
+      this.registry = registry;
+      this.objectId = objectId;
+      this.method = method;
+      this.handler = handler;
+    }
+
+    Key key() {
+      return new Key(objectId, method.getNodeId());
+    }
+
+    /** Remove this handler from the Method unless a later registration already replaced it. */
+    void release() {
+      method.removeInvocationHandler(objectId, handler);
+    }
+
+    @Override
+    public NodeId objectId() {
+      return objectId;
+    }
+
+    @Override
+    public NodeId methodId() {
+      return method.getNodeId();
+    }
+
+    @Override
+    public void close() {
+      synchronized (registry) {
+        if (registry.registrations.remove(key(), this)) {
+          release();
+        }
+      }
+    }
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/methods/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/methods/package-info.java
@@ -47,5 +47,18 @@
  * and returns argument diagnostics that index them, one per supplied input. After every
  * address-space group has finished, the service keeps only the fields the ReturnDiagnostics mask
  * requests and builds the response StringTable from the strings those fields reference.
+ *
+ * <p>{@link org.eclipse.milo.opcua.sdk.server.methods.MethodBindings} is an application-owned
+ * lifetime for ObjectId-specific handlers on Methods shared by several Objects. Bind validates the
+ * ownership relationship and typed argument metadata, then installs the handler on the Method node
+ * for that ObjectId. Each {@link org.eclipse.milo.opcua.sdk.server.methods.MethodBinding} token
+ * owns only its registration; closing a replaced token cannot remove the replacement. The Method's
+ * default handler is never touched, so raw handler replacement and ObjectId registrations do not
+ * interfere.
+ *
+ * <p>Applications close tokens or remove ObjectId registrations before deleting owner nodes, and
+ * close the registry on namespace shutdown. Cleanup does not delete nodes, cancel callbacks or wait
+ * for selected invocations. A callback selected before cleanup can complete afterward. Actual Call
+ * dispatch continues to enforce Method ownership, ConditionManager precedence and session access.
  */
 package org.eclipse.milo.opcua.sdk.server.methods;

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/MethodReferences.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/MethodReferences.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.sdk.server.nodes;
+
+import org.eclipse.milo.opcua.sdk.core.Reference;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.types.builtin.NodeId;
+
+/** Shared reference matching for Method ownership and declaration lookup. */
+final class MethodReferences {
+  private MethodReferences() {}
+
+  /**
+   * Whether {@code reference} is a forward HasComponent reference or a forward reference of a
+   * HasComponent subtype, as recorded in the server's ReferenceTypeTree.
+   */
+  static boolean isForwardComponent(UaNodeContext context, Reference reference) {
+    if (!reference.isForward()) return false;
+    NodeId referenceTypeId = reference.getReferenceTypeId();
+    // TypeTree.isSubtypeOf() does not consider a type to be a subtype of itself.
+    return referenceTypeId.equals(NodeIds.HasComponent)
+        || context
+            .getServer()
+            .getReferenceTypeTree()
+            .isSubtypeOf(referenceTypeId, NodeIds.HasComponent);
+  }
+}

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/UaDataTypeNode.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/UaDataTypeNode.java
@@ -149,8 +149,7 @@ public class UaDataTypeNode extends UaNode implements DataTypeNode {
    * @return the value of the EnumStrings Property, if it exists.
    * @see DataTypeNodeProperties#EnumStrings
    */
-  @Nullable
-  public LocalizedText[] getEnumStrings() {
+  public LocalizedText @Nullable [] getEnumStrings() {
     return getProperty(DataTypeNodeProperties.EnumStrings).orElse(null);
   }
 
@@ -160,8 +159,7 @@ public class UaDataTypeNode extends UaNode implements DataTypeNode {
    * @return the value of the EnumValues Property, if it exists.
    * @see DataTypeNodeProperties#EnumValues
    */
-  @Nullable
-  public EnumValueType[] getEnumValues() {
+  public EnumValueType @Nullable [] getEnumValues() {
     return getProperty(DataTypeNodeProperties.EnumValues).orElse(null);
   }
 
@@ -171,8 +169,7 @@ public class UaDataTypeNode extends UaNode implements DataTypeNode {
    * @return the value of the OptionSetValues Property, if it exists.
    * @see DataTypeNodeProperties#OptionSetValues
    */
-  @Nullable
-  public LocalizedText[] getOptionSetValues() {
+  public LocalizedText @Nullable [] getOptionSetValues() {
     return getProperty(DataTypeNodeProperties.OptionSetValues).orElse(null);
   }
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/UaMethodNode.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/UaMethodNode.java
@@ -300,8 +300,7 @@ public class UaMethodNode extends UaNode implements MethodNode {
    * @return the value of the InputArguments Property, if it exists.
    * @see MethodNodeProperties#InputArguments
    */
-  @Nullable
-  public Argument[] getInputArguments() {
+  public Argument @Nullable [] getInputArguments() {
     return getProperty(MethodNodeProperties.InputArguments).orElse(null);
   }
 
@@ -311,8 +310,7 @@ public class UaMethodNode extends UaNode implements MethodNode {
    * @return the value of the OutputArguments Property, if it exists.
    * @see MethodNodeProperties#OutputArguments
    */
-  @Nullable
-  public Argument[] getOutputArguments() {
+  public Argument @Nullable [] getOutputArguments() {
     return getProperty(MethodNodeProperties.OutputArguments).orElse(null);
   }
 

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/UaMethodNode.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/UaMethodNode.java
@@ -17,7 +17,9 @@ import static org.eclipse.milo.opcua.sdk.core.Reference.HAS_PROPERTY_PREDICATE;
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -47,6 +49,8 @@ public class UaMethodNode extends UaNode implements MethodNode {
 
   private final AtomicReference<MethodInvocationHandler> handler =
       new AtomicReference<>(MethodInvocationHandler.NOT_IMPLEMENTED);
+
+  private final Map<NodeId, MethodInvocationHandler> objectHandlers = new ConcurrentHashMap<>();
 
   private Boolean executable;
   private Boolean userExecutable;
@@ -186,12 +190,59 @@ public class UaMethodNode extends UaNode implements MethodNode {
         .collect(Collectors.toList());
   }
 
+  /**
+   * Get the default invocation handler, which serves every ObjectId without a handler of its own.
+   *
+   * @return the default invocation handler.
+   */
   public MethodInvocationHandler getInvocationHandler() {
     return handler.get();
   }
 
+  /**
+   * Get the handler that serves an invocation of this Method with {@code objectId} as ObjectId.
+   *
+   * <p>A Method shared by several Objects can carry one handler per ObjectId. This returns that
+   * handler when one is installed and the default handler otherwise.
+   *
+   * @param objectId the ObjectId of the invocation.
+   * @return the handler serving that ObjectId.
+   */
+  public MethodInvocationHandler getInvocationHandler(NodeId objectId) {
+    MethodInvocationHandler objectHandler = objectHandlers.get(objectId);
+    return objectHandler != null ? objectHandler : handler.get();
+  }
+
+  /**
+   * Set the default invocation handler. ObjectId-specific handlers are unaffected.
+   *
+   * @param handler the default invocation handler.
+   */
   public void setInvocationHandler(MethodInvocationHandler handler) {
     this.handler.set(handler);
+  }
+
+  /**
+   * Install a handler that serves invocations with {@code objectId} as ObjectId, replacing any
+   * handler previously installed for that ObjectId. The default handler is unchanged.
+   *
+   * @param objectId the ObjectId the handler serves.
+   * @param handler the handler for that ObjectId.
+   */
+  public void setInvocationHandler(NodeId objectId, MethodInvocationHandler handler) {
+    objectHandlers.put(objectId, handler);
+  }
+
+  /**
+   * Remove the handler installed for {@code objectId} only while it is still {@code expected}, so
+   * an owner releasing its handler cannot remove one installed later for the same ObjectId.
+   *
+   * @param objectId the ObjectId whose handler to remove.
+   * @param expected the handler owned by the caller.
+   * @return whether a handler was removed.
+   */
+  public boolean removeInvocationHandler(NodeId objectId, MethodInvocationHandler expected) {
+    return objectHandlers.remove(objectId, expected);
   }
 
   /**

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/UaObjectNode.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/UaObjectNode.java
@@ -13,7 +13,6 @@ package org.eclipse.milo.opcua.sdk.server.nodes;
 import static org.eclipse.milo.opcua.sdk.core.Reference.HAS_COMPONENT_PREDICATE;
 import static org.eclipse.milo.opcua.sdk.core.Reference.HAS_EVENT_SOURCE_PREDICATE;
 import static org.eclipse.milo.opcua.sdk.core.Reference.HAS_NOTIFIER_PREDICATE;
-import static org.eclipse.milo.opcua.sdk.core.Reference.HAS_ORDERED_COMPONENT_PREDICATE;
 import static org.eclipse.milo.opcua.sdk.core.Reference.HAS_PROPERTY_PREDICATE;
 import static org.eclipse.milo.opcua.sdk.core.Reference.HAS_TYPE_DEFINITION_PREDICATE;
 import static org.eclipse.milo.opcua.sdk.core.Reference.ORGANIZES_PREDICATE;
@@ -207,11 +206,17 @@ public class UaObjectNode extends UaNode implements ObjectNode {
       if (methodId.equals(methodNode.getNodeId())) {
         return methodNode;
       }
+    }
 
-      NodeId typeDefinitionId = getTypeDefinitionNode().getNodeId();
+    // methodId may name the declaration on the type definition rather than this instance's Method.
+    ObjectTypeNode typeDefinitionNode = getTypeDefinitionNode();
+    if (typeDefinitionNode == null) {
+      return null;
+    }
 
+    for (UaMethodNode methodNode : methodNodes) {
       NodeId methodDeclarationId =
-          findMethodDeclarationId(typeDefinitionId, methodNode.getBrowseName());
+          findMethodDeclarationId(typeDefinitionNode.getNodeId(), methodNode.getBrowseName());
 
       if (methodId.equals(methodDeclarationId)) {
         return methodNode;
@@ -236,7 +241,7 @@ public class UaObjectNode extends UaNode implements ObjectNode {
 
     NodeId nodeId =
         asm.getManagedReferences(typeDefinitionId).stream()
-            .filter(HAS_COMPONENT_PREDICATE.or(HAS_ORDERED_COMPONENT_PREDICATE))
+            .filter(reference -> MethodReferences.isForwardComponent(getNodeContext(), reference))
             .flatMap(r -> getManagedNode(r.getTargetNodeId()).stream())
             .filter(
                 n -> (n instanceof UaMethodNode) && Objects.equals(n.getBrowseName(), methodName))
@@ -278,7 +283,7 @@ public class UaObjectNode extends UaNode implements ObjectNode {
 
   public List<UaMethodNode> getMethodNodes() {
     return getReferences().stream()
-        .filter(HAS_COMPONENT_PREDICATE.or(HAS_ORDERED_COMPONENT_PREDICATE))
+        .filter(reference -> MethodReferences.isForwardComponent(getNodeContext(), reference))
         .flatMap(r -> getManagedNode(r.getTargetNodeId()).stream())
         .filter(n -> (n instanceof UaMethodNode))
         .map(UaMethodNode.class::cast)

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/UaObjectTypeNode.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/UaObjectTypeNode.java
@@ -10,9 +10,6 @@
 
 package org.eclipse.milo.opcua.sdk.server.nodes;
 
-import static org.eclipse.milo.opcua.sdk.core.Reference.HAS_COMPONENT_PREDICATE;
-import static org.eclipse.milo.opcua.sdk.core.Reference.HAS_ORDERED_COMPONENT_PREDICATE;
-
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.List;
@@ -131,7 +128,7 @@ public class UaObjectTypeNode extends UaNode implements ObjectTypeNode {
   @Nullable
   public UaMethodNode findMethodNode(NodeId methodId) {
     return getReferences().stream()
-        .filter(HAS_COMPONENT_PREDICATE.or(HAS_ORDERED_COMPONENT_PREDICATE))
+        .filter(reference -> MethodReferences.isForwardComponent(getNodeContext(), reference))
         .flatMap(r -> getManagedNode(r.getTargetNodeId()).stream())
         .filter(n -> (n instanceof UaMethodNode) && Objects.equals(n.getNodeId(), methodId))
         .map(UaMethodNode.class::cast)
@@ -141,7 +138,7 @@ public class UaObjectTypeNode extends UaNode implements ObjectTypeNode {
 
   public List<UaMethodNode> getMethodNodes() {
     return getReferences().stream()
-        .filter(HAS_COMPONENT_PREDICATE.or(HAS_ORDERED_COMPONENT_PREDICATE))
+        .filter(reference -> MethodReferences.isForwardComponent(getNodeContext(), reference))
         .flatMap(r -> getManagedNode(r.getTargetNodeId()).stream())
         .filter(n -> (n instanceof UaMethodNode))
         .map(UaMethodNode.class::cast)

--- a/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/package-info.java
+++ b/opc-ua-sdk/sdk-server/src/main/java/org/eclipse/milo/opcua/sdk/server/nodes/package-info.java
@@ -20,5 +20,21 @@
  * org.eclipse.milo.opcua.sdk.server.nodes.UaMethodNode#compareAndSetInvocationHandler} so cleanup
  * cannot remove a handler installed later. A call that already obtained the old handler may finish
  * after replacement; changing the handler controls subsequent dispatch.
+ *
+ * <p>A Method shared by several Objects can also carry one handler per invocation ObjectId, set
+ * with {@link org.eclipse.milo.opcua.sdk.server.nodes.UaMethodNode#setInvocationHandler(NodeId,
+ * MethodInvocationHandler)}. Call dispatch resolves the Method through the ObjectId's ownership
+ * rules first, then selects that ObjectId's handler and falls back to the default handler. The two
+ * are independent: replacing the default never touches ObjectId handlers, and owners release an
+ * ObjectId handler with {@link
+ * org.eclipse.milo.opcua.sdk.server.nodes.UaMethodNode#removeInvocationHandler} so a stale owner
+ * cannot remove a replacement.
+ *
+ * <p>Object and ObjectType Method lookup follows forward HasComponent references and their
+ * subtypes, including HasOrderedComponent, as recorded in the server's ReferenceTypeTree. A
+ * namespace that adds ReferenceTypes after that tree was first built must call {@link
+ * org.eclipse.milo.opcua.sdk.server.OpcUaServer#updateReferenceTypeTree()}, the same rule Browse
+ * already imposes. The same lookup resolves Method declarations on an object's type hierarchy.
+ * Organizes references provide navigation and do not establish invocation ownership.
  */
 package org.eclipse.milo.opcua.sdk.server.nodes;

--- a/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/methods/MethodBindingsTest.java
+++ b/opc-ua-sdk/sdk-server/src/test/java/org/eclipse/milo/opcua/sdk/server/methods/MethodBindingsTest.java
@@ -1,0 +1,544 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.eclipse.milo.opcua.sdk.server.methods;
+
+import static org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.Unsigned.uint;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.stream.Stream;
+import org.eclipse.milo.opcua.sdk.core.Reference;
+import org.eclipse.milo.opcua.sdk.server.*;
+import org.eclipse.milo.opcua.sdk.server.items.DataItem;
+import org.eclipse.milo.opcua.sdk.server.items.MonitoredItem;
+import org.eclipse.milo.opcua.sdk.server.nodes.*;
+import org.eclipse.milo.opcua.stack.core.NodeIds;
+import org.eclipse.milo.opcua.stack.core.StatusCodes;
+import org.eclipse.milo.opcua.stack.core.UaException;
+import org.eclipse.milo.opcua.stack.core.security.DefaultCertificateManager;
+import org.eclipse.milo.opcua.stack.core.types.builtin.*;
+import org.eclipse.milo.opcua.stack.core.types.builtin.unsigned.UInteger;
+import org.eclipse.milo.opcua.stack.core.types.structured.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class MethodBindingsTest {
+  private static MethodInvocationHandler reply(String value) {
+    return (context, request) ->
+        new CallMethodResult(StatusCode.GOOD, null, null, new Variant[] {new Variant(value)});
+  }
+
+  private static String value(CallMethodResult result) {
+    assertEquals(StatusCode.GOOD, result.getStatusCode());
+    return (String) result.getOutputArguments()[0].value();
+  }
+
+  @Test
+  void sharedMethodDispatchesByObjectAndStaleTokensCannotRemoveReplacement() throws Exception {
+    try (Fixture f = new Fixture();
+        MethodBindings bindings = new MethodBindings()) {
+      MethodInvocationHandler fallback = reply("fallback");
+      f.method.setInvocationHandler(fallback);
+      MethodBinding old = bindings.bind(f.first, f.method, reply("old"));
+      MethodBinding other = bindings.bind(f.second, f.method, reply("other"));
+      MethodBinding replacement = bindings.bind(f.first, f.method, reply("new"));
+      assertSame(fallback, f.method.getInvocationHandler());
+      old.close();
+      old.close();
+      assertEquals("new", value(f.call(f.first)));
+      assertEquals("other", value(f.call(f.second)));
+      replacement.close();
+      assertEquals("fallback", value(f.call(f.first)));
+      other.close();
+      assertSame(fallback, f.method.getInvocationHandler());
+    }
+  }
+
+  // Selection happens before invocation and cleanup must never wait on application code.
+  @Test
+  void replacementAndCloseDoNotDrainAlreadySelectedCallback() throws Exception {
+    try (Fixture f = new Fixture();
+        MethodBindings bindings = new MethodBindings()) {
+      CountDownLatch entered = new CountDownLatch(1);
+      CountDownLatch release = new CountDownLatch(1);
+      ExecutorService executor = Executors.newSingleThreadExecutor();
+      f.method.setInvocationHandler(reply("fallback"));
+      MethodBinding old =
+          bindings.bind(
+              f.first,
+              f.method,
+              (context, request) -> {
+                entered.countDown();
+                try {
+                  assertTrue(release.await(5, TimeUnit.SECONDS));
+                } catch (InterruptedException e) {
+                  throw new AssertionError(e);
+                }
+                return reply("old").invoke(context, request);
+              });
+      try {
+        Future<CallMethodResult> inFlight = executor.submit(() -> f.call(f.first));
+        assertTrue(entered.await(5, TimeUnit.SECONDS));
+        bindings.bind(f.first, f.method, reply("new"));
+        old.close();
+        assertEquals("new", value(f.call(f.first)));
+        bindings.close();
+        assertEquals("fallback", value(f.call(f.first)));
+        release.countDown();
+        assertEquals("old", value(inFlight.get(5, TimeUnit.SECONDS)));
+      } finally {
+        release.countDown();
+        executor.shutdownNow();
+      }
+    }
+  }
+
+  // The default handler and ObjectId registrations are independent.
+  @Test
+  void rawReplacementChangesOnlyTheDefaultHandler() throws Exception {
+    try (Fixture f = new Fixture();
+        MethodBindings bindings = new MethodBindings()) {
+      MethodBinding token = bindings.bind(f.first, f.method, reply("bound"));
+      MethodInvocationHandler raw = reply("raw");
+      f.method.setInvocationHandler(raw);
+      assertEquals("bound", value(f.call(f.first)));
+      assertEquals("raw", value(f.call(f.second)));
+      bindings.bind(f.second, f.method, reply("late"));
+      assertEquals("late", value(f.call(f.second)));
+      token.close();
+      assertEquals("raw", value(f.call(f.first)));
+      bindings.close();
+      assertSame(raw, f.method.getInvocationHandler());
+      assertEquals("raw", value(f.call(f.second)));
+    }
+  }
+
+  @Test
+  void lastTokenRestoresFallbackAndSameLifetimeCanBindAgain() throws Exception {
+    try (Fixture f = new Fixture();
+        MethodBindings bindings = new MethodBindings()) {
+      MethodInvocationHandler fallback = reply("fallback");
+      f.method.setInvocationHandler(fallback);
+      bindings.bind(f.first, f.method, reply("first")).close();
+      assertSame(fallback, f.method.getInvocationHandler());
+      bindings.bind(f.first, f.method, reply("second"));
+      assertEquals("second", value(f.call(f.first)));
+      bindings.removeObject(f.first.getNodeId());
+      assertSame(fallback, f.method.getInvocationHandler());
+      bindings.close();
+      assertThrows(
+          IllegalStateException.class, () -> bindings.bind(f.first, f.method, reply("closed")));
+    }
+  }
+
+  @Test
+  void registriesShareMethodsAndTheLatestBindWinsPerObject() throws Exception {
+    try (Fixture f = new Fixture();
+        MethodBindings first = new MethodBindings();
+        MethodBindings second = new MethodBindings()) {
+      MethodBinding token = first.bind(f.first, f.method, reply("first"));
+      second.bind(f.second, f.method, reply("second"));
+      assertEquals("first", value(f.call(f.first)));
+      assertEquals("second", value(f.call(f.second)));
+      second.bind(f.first, f.method, reply("override"));
+      assertEquals("override", value(f.call(f.first)));
+      token.close();
+      first.close();
+      assertEquals("override", value(f.call(f.first)));
+      second.close();
+      assertEquals(new StatusCode(StatusCodes.Bad_NotImplemented), f.call(f.first).getStatusCode());
+    }
+  }
+
+  @Test
+  void removeObjectLeavesOtherRegistrationsAndSupportsExplicitNodeRecreation() throws Exception {
+    try (Fixture f = new Fixture();
+        MethodBindings bindings = new MethodBindings()) {
+      MethodBinding old = bindings.bind(f.first, f.method, reply("old"));
+      bindings.bind(f.second, f.method, reply("other"));
+      bindings.removeObject(f.first.getNodeId());
+      f.space.getNodeManager().removeNode(f.first);
+      UaObjectNode recreated = f.object("first");
+      recreated.addComponent(f.method);
+      bindings.bind(recreated, f.method, reply("recreated"));
+      old.close();
+      assertEquals("recreated", value(f.call(recreated)));
+      assertEquals("other", value(f.call(f.second)));
+      assertEquals(
+          new StatusCode(StatusCodes.Bad_NodeIdUnknown),
+          assertThrows(UaException.class, () -> bindings.bind(f.first, f.method, reply("removed")))
+              .getStatusCode());
+    }
+  }
+
+  @Test
+  void invalidOwnershipIsRejectedBeforeHandlerInstallation() throws Exception {
+    try (Fixture f = new Fixture();
+        MethodBindings bindings = new MethodBindings()) {
+      MethodInvocationHandler fallback = f.method.getInvocationHandler();
+      UaObjectNode unrelated = f.object("unrelated");
+      assertEquals(
+          new StatusCode(StatusCodes.Bad_MethodInvalid),
+          assertThrows(UaException.class, () -> bindings.bind(unrelated, f.method, reply("wrong")))
+              .getStatusCode());
+      assertSame(fallback, f.method.getInvocationHandler());
+      assertEquals(
+          new StatusCode(StatusCodes.Bad_MethodInvalid), f.call(unrelated).getStatusCode());
+    }
+  }
+
+  @Test
+  void crossServerOwnerAndMethodAreRejected() throws Exception {
+    try (Fixture f = new Fixture();
+        Fixture other = new Fixture();
+        MethodBindings bindings = new MethodBindings()) {
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> bindings.bind(f.first, other.method, reply("wrong")));
+      assertSame(MethodInvocationHandler.NOT_IMPLEMENTED, other.method.getInvocationHandler());
+    }
+  }
+
+  // Declaration lookup must tolerate an owner whose type definition does not resolve.
+  @Test
+  void ownerWithUnresolvableTypeDefinitionCanBindItsSecondMethod() throws Exception {
+    try (Fixture f = new Fixture();
+        MethodBindings bindings = new MethodBindings()) {
+      UaObjectNode untyped =
+          UaObjectNode.builder(f.space.getNodeContext())
+              .setNodeId(new NodeId(f.namespace, "untyped"))
+              .setBrowseName(new QualifiedName(f.namespace, "untyped"))
+              .setDisplayName(LocalizedText.english("untyped"))
+              .setTypeDefinition(new NodeId(f.namespace, "NoSuchType"))
+              .buildAndAdd();
+      assertNull(untyped.getTypeDefinitionNode());
+      UaMethodNode other = f.method("other");
+      untyped.addComponent(other);
+      untyped.addComponent(f.method);
+      assertNull(untyped.findMethodNode(new NodeId(f.namespace, "missing")));
+      bindings.bind(untyped, f.method, reply("untyped"));
+      assertEquals("untyped", value(f.call(untyped)));
+    }
+  }
+
+  @Test
+  void incompatibleTypedMetadataIsRejectedWithoutRewritingProperties() throws Exception {
+    try (Fixture f = new Fixture();
+        MethodBindings bindings = new MethodBindings()) {
+      Argument[] declared = {
+        new Argument("Value", NodeIds.String, -1, null, LocalizedText.NULL_VALUE)
+      };
+      f.method.setInputArguments(declared);
+      AbstractMethodInvocationHandler handler =
+          new AbstractMethodInvocationHandler(f.method) {
+            public Argument[] getInputArguments() {
+              return new Argument[] {
+                new Argument("Value", NodeIds.Int32, -1, null, LocalizedText.NULL_VALUE)
+              };
+            }
+
+            public Argument[] getOutputArguments() {
+              return f.method.getOutputArguments();
+            }
+
+            protected Variant[] invoke(InvocationContext context, Variant[] values) {
+              return values;
+            }
+          };
+      assertEquals(
+          new StatusCode(StatusCodes.Bad_TypeMismatch),
+          assertThrows(UaException.class, () -> bindings.bind(f.first, f.method, handler))
+              .getStatusCode());
+      assertArrayEquals(declared, f.method.getInputArguments());
+    }
+  }
+
+  @Test
+  void closeDuringMetadataValidationPreventsInstallationWithoutWaitingForTheBinder()
+      throws Exception {
+    try (Fixture f = new Fixture();
+        MethodBindings bindings = new MethodBindings()) {
+      CountDownLatch entered = new CountDownLatch(1);
+      CountDownLatch release = new CountDownLatch(1);
+      ExecutorService executor = Executors.newSingleThreadExecutor();
+      MethodInvocationHandler fallback = f.method.getInvocationHandler();
+      AbstractMethodInvocationHandler handler =
+          new AbstractMethodInvocationHandler(f.method) {
+            public Argument[] getInputArguments() {
+              entered.countDown();
+              try {
+                assertTrue(release.await(5, TimeUnit.SECONDS));
+              } catch (InterruptedException e) {
+                throw new AssertionError(e);
+              }
+              return new Argument[0];
+            }
+
+            public Argument[] getOutputArguments() {
+              return f.method.getOutputArguments();
+            }
+
+            protected Variant[] invoke(InvocationContext context, Variant[] values) {
+              return values;
+            }
+          };
+      try {
+        Future<MethodBinding> pending =
+            executor.submit(() -> bindings.bind(f.first, f.method, handler));
+        assertTrue(entered.await(5, TimeUnit.SECONDS));
+        bindings.close();
+        release.countDown();
+        assertInstanceOf(
+            IllegalStateException.class,
+            assertThrows(ExecutionException.class, () -> pending.get(5, TimeUnit.SECONDS))
+                .getCause());
+        assertSame(fallback, f.method.getInvocationHandler());
+      } finally {
+        release.countDown();
+        executor.shutdownNow();
+      }
+    }
+  }
+
+  static Stream<Arguments> incompatibleInputMetadata() {
+    return Stream.of(
+        Arguments.of("null argument", (Argument) null),
+        Arguments.of(
+            "null data type",
+            new Argument("Value", null, 1, new UInteger[] {uint(2)}, LocalizedText.NULL_VALUE)),
+        Arguments.of(
+            "null rank",
+            new Argument(
+                "Value", NodeIds.String, null, new UInteger[] {uint(2)}, LocalizedText.NULL_VALUE)),
+        Arguments.of(
+            "name",
+            new Argument(
+                "Other", NodeIds.String, 1, new UInteger[] {uint(2)}, LocalizedText.NULL_VALUE)),
+        Arguments.of(
+            "rank", new Argument("Value", NodeIds.String, -1, null, LocalizedText.NULL_VALUE)),
+        Arguments.of(
+            "dimensions",
+            new Argument(
+                "Value", NodeIds.String, 1, new UInteger[] {uint(3)}, LocalizedText.NULL_VALUE)),
+        Arguments.of(
+            "malformed dimensions",
+            new Argument(
+                "Value", NodeIds.String, 1, new UInteger[] {null}, LocalizedText.NULL_VALUE)));
+  }
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("incompatibleInputMetadata")
+  void incompatibleMetadataReturnsTypeMismatchWithoutChangingProperties(
+      String scenario, Argument argument) throws Exception {
+    try (Fixture f = new Fixture();
+        MethodBindings bindings = new MethodBindings()) {
+      Argument[] declared = {
+        new Argument("Value", NodeIds.String, 1, new UInteger[] {uint(2)}, LocalizedText.NULL_VALUE)
+      };
+      f.method.setInputArguments(declared);
+      MethodInvocationHandler fallback = f.method.getInvocationHandler();
+      AbstractMethodInvocationHandler handler =
+          typed(f.method, new Argument[] {argument}, f.method.getOutputArguments());
+      assertEquals(
+          new StatusCode(StatusCodes.Bad_TypeMismatch),
+          assertThrows(UaException.class, () -> bindings.bind(f.first, f.method, handler))
+              .getStatusCode());
+      assertArrayEquals(declared, f.method.getInputArguments());
+      assertSame(fallback, f.method.getInvocationHandler());
+    }
+  }
+
+  @Test
+  void outputMetadataAndTypedNodeMustMatchTheSharedMethod() throws Exception {
+    try (Fixture f = new Fixture();
+        MethodBindings bindings = new MethodBindings()) {
+      MethodInvocationHandler fallback = f.method.getInvocationHandler();
+      assertEquals(
+          new StatusCode(StatusCodes.Bad_TypeMismatch),
+          assertThrows(
+                  UaException.class,
+                  () ->
+                      bindings.bind(
+                          f.first, f.method, typed(f.method, new Argument[0], new Argument[0])))
+              .getStatusCode());
+      UaMethodNode other = f.method("other");
+      assertEquals(
+          new StatusCode(StatusCodes.Bad_TypeMismatch),
+          assertThrows(
+                  UaException.class,
+                  () ->
+                      bindings.bind(
+                          f.first,
+                          f.method,
+                          typed(other, new Argument[0], f.method.getOutputArguments())))
+              .getStatusCode());
+      assertSame(fallback, f.method.getInvocationHandler());
+    }
+  }
+
+  @Test
+  void nullAndEmptyDimensionsDescribeTheSameUnspecifiedShape() throws Exception {
+    try (Fixture f = new Fixture();
+        MethodBindings bindings = new MethodBindings()) {
+      Argument[] declared = {
+        new Argument("Value", NodeIds.String, -1, null, LocalizedText.NULL_VALUE)
+      };
+      Argument[] expected = {
+        new Argument("Value", NodeIds.String, -1, new UInteger[0], LocalizedText.NULL_VALUE)
+      };
+      f.method.setInputArguments(declared);
+      MethodBinding token =
+          bindings.bind(
+              f.first, f.method, typed(f.method, expected, f.method.getOutputArguments()));
+      assertEquals(f.first.getNodeId(), token.objectId());
+      assertArrayEquals(declared, f.method.getInputArguments());
+    }
+  }
+
+  private static AbstractMethodInvocationHandler typed(
+      UaMethodNode method, Argument[] inputs, Argument[] outputs) {
+    return new AbstractMethodInvocationHandler(method) {
+      public Argument[] getInputArguments() {
+        return inputs;
+      }
+
+      public Argument[] getOutputArguments() {
+        return outputs;
+      }
+
+      protected Variant[] invoke(InvocationContext context, Variant[] values) {
+        return new Variant[] {new Variant("typed")};
+      }
+    };
+  }
+
+  @Test
+  void componentReferenceSubtypesSupportBindingAndActualOwnershipDispatch() throws Exception {
+    try (Fixture f = new Fixture();
+        MethodBindings bindings = new MethodBindings()) {
+      NodeId referenceId = new NodeId(f.namespace, "CustomComponent");
+      UaReferenceTypeNode referenceType =
+          new UaReferenceTypeNode(
+              f.space.getNodeContext(),
+              referenceId,
+              new QualifiedName(f.namespace, "CustomComponent"),
+              LocalizedText.english("CustomComponent"),
+              LocalizedText.NULL_VALUE,
+              UInteger.MIN,
+              UInteger.MIN,
+              false,
+              false,
+              LocalizedText.english("CustomComponentOf"));
+      f.space.getNodeManager().addNode(referenceType);
+      referenceType.addReference(
+          new Reference(
+              referenceId,
+              NodeIds.HasSubtype,
+              NodeIds.HasComponent.expanded(),
+              Reference.Direction.INVERSE));
+      f.server.updateReferenceTypeTree();
+      UaObjectNode owner = f.object("customOwner");
+      owner.addReference(
+          new Reference(
+              owner.getNodeId(),
+              referenceId,
+              f.method.getNodeId().expanded(),
+              Reference.Direction.FORWARD));
+      f.method.setInvocationHandler(reply("raw"));
+      assertEquals(StatusCode.GOOD, f.call(owner).getStatusCode());
+      bindings.bind(owner, f.method, reply("custom"));
+      assertEquals("custom", value(f.call(owner)));
+    }
+  }
+
+  private static final class Fixture implements AutoCloseable {
+    final ExecutorService executor = Executors.newSingleThreadExecutor();
+    final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+    final OpcUaServer server;
+    final ManagedAddressSpace space;
+    final int namespace;
+    final UaObjectNode first;
+    final UaObjectNode second;
+    final UaMethodNode method;
+
+    Fixture() {
+      server =
+          new OpcUaServer(
+              OpcUaServerConfig.builder()
+                  .setApplicationUri("urn:milo:test:method-bindings")
+                  .setCertificateManager(new DefaultCertificateManager())
+                  .setExecutor(executor)
+                  .setScheduledExecutor(scheduler)
+                  .build(),
+              profile -> {
+                throw new AssertionError("No transport should start");
+              });
+      server.getEventFactory().startup();
+      namespace = server.getNamespaceTable().add("urn:milo:test:method-bindings").intValue();
+      space =
+          new ManagedAddressSpace(server) {
+            public void onDataItemsCreated(List<DataItem> items) {}
+
+            public void onDataItemsModified(List<DataItem> items) {}
+
+            public void onDataItemsDeleted(List<DataItem> items) {}
+
+            public void onMonitoringModeChanged(List<MonitoredItem> items) {}
+          };
+      server.getAddressSpaceManager().register(space.getNodeManager());
+      first = object("first");
+      second = object("second");
+      method = method("shared");
+      first.addComponent(method);
+      second.addComponent(method);
+    }
+
+    UaMethodNode method(String name) {
+      UaMethodNode result =
+          UaMethodNode.builder(space.getNodeContext())
+              .setNodeId(new NodeId(namespace, name))
+              .setBrowseName(new QualifiedName(namespace, name))
+              .setDisplayName(LocalizedText.english(name))
+              .buildAndAdd();
+      result.setOutputArguments(
+          new Argument[] {
+            new Argument("Message", NodeIds.String, -1, null, LocalizedText.NULL_VALUE)
+          });
+      return result;
+    }
+
+    UaObjectNode object(String name) {
+      return UaObjectNode.builder(space.getNodeContext())
+          .setNodeId(new NodeId(namespace, name))
+          .setBrowseName(new QualifiedName(namespace, name))
+          .setDisplayName(LocalizedText.english(name))
+          .setTypeDefinition(NodeIds.BaseObjectType)
+          .buildAndAdd();
+    }
+
+    CallMethodResult call(UaObjectNode owner) {
+      return space
+          .call(
+              new AddressSpace.CallContext(server, null),
+              List.of(new CallMethodRequest(owner.getNodeId(), method.getNodeId(), new Variant[0])))
+          .get(0);
+    }
+
+    public void close() {
+      server.getAddressSpaceManager().unregister(space.getNodeManager());
+      server.shutdown().join();
+      executor.shutdownNow();
+      scheduler.shutdownNow();
+    }
+  }
+}

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/CertificateValidator.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/CertificateValidator.java
@@ -35,7 +35,7 @@ public interface CertificateValidator {
   void validateCertificateChain(
       List<X509Certificate> certificateChain,
       @Nullable String applicationUri,
-      @Nullable String[] validHostnames)
+      String @Nullable [] validHostnames)
       throws UaException;
 
   /**
@@ -59,7 +59,7 @@ public interface CertificateValidator {
   default void validateCertificateChain(
       List<X509Certificate> certificateChain,
       @Nullable String applicationUri,
-      @Nullable String[] validHostnames,
+      String @Nullable [] validHostnames,
       @Nullable SecurityPolicyProfile securityPolicyProfile)
       throws UaException {
 
@@ -89,7 +89,7 @@ public interface CertificateValidator {
     public void validateCertificateChain(
         List<X509Certificate> certificateChain,
         @Nullable String applicationUri,
-        @Nullable String[] validHostnames,
+        String @Nullable [] validHostnames,
         @Nullable SecurityPolicyProfile securityPolicyProfile) {
 
       // Skip validation entirely, including certificate/profile compatibility checks. The default

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/DefaultClientCertificateValidator.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/DefaultClientCertificateValidator.java
@@ -65,7 +65,7 @@ public class DefaultClientCertificateValidator implements CertificateValidator {
   public void validateCertificateChain(
       List<X509Certificate> certificateChain,
       @Nullable String applicationUri,
-      @Nullable String[] validHostNames)
+      String @Nullable [] validHostNames)
       throws UaException {
 
     validateCertificateChain(certificateChain, applicationUri, validHostNames, null);
@@ -75,7 +75,7 @@ public class DefaultClientCertificateValidator implements CertificateValidator {
   public void validateCertificateChain(
       List<X509Certificate> certificateChain,
       @Nullable String applicationUri,
-      @Nullable String[] validHostNames,
+      String @Nullable [] validHostNames,
       @Nullable SecurityPolicyProfile securityPolicyProfile)
       throws UaException {
 

--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/DefaultServerCertificateValidator.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/security/DefaultServerCertificateValidator.java
@@ -70,7 +70,7 @@ public class DefaultServerCertificateValidator implements CertificateValidator {
   public void validateCertificateChain(
       List<X509Certificate> certificateChain,
       @Nullable String applicationUri,
-      @Nullable String[] validHostnames)
+      String @Nullable [] validHostnames)
       throws UaException {
 
     validateCertificateChain(certificateChain, applicationUri, validHostnames, null);
@@ -80,7 +80,7 @@ public class DefaultServerCertificateValidator implements CertificateValidator {
   public void validateCertificateChain(
       List<X509Certificate> certificateChain,
       @Nullable String applicationUri,
-      @Nullable String[] validHostnames,
+      String @Nullable [] validHostnames,
       @Nullable SecurityPolicyProfile securityPolicyProfile)
       throws UaException {
 


### PR DESCRIPTION
When several Objects share one Method node, the node has a single invocation handler, so installing behavior for the second Object silently changes the first. This adds per-ObjectId handlers on `UaMethodNode`, makes the Call path select by ObjectId, and adds an application-owned `MethodBindings` registry with identity-bearing tokens for replacement and cleanup. It also widens Method ownership lookup to HasComponent subtypes so a custom component reference type can own a callable Method.

Targets `integration/1.2`. The registry accepts existing raw `MethodInvocationHandler` implementations and `AbstractMethodInvocationHandler` subclasses. It does not require the synchronous outcome hooks in #1974.

## Dispatch by ObjectId

`UaMethodNode` keeps its default handler and gains a map of ObjectId-specific handlers:

```java
method.setInvocationHandler(objectId, handler);      // serves Calls with this ObjectId
method.getInvocationHandler(objectId);               // that handler, or the default
method.removeInvocationHandler(objectId, handler);   // only while still installed
```

`ManagedAddressSpace.getInvocationHandler` resolves the Method through the ObjectId's ownership rules as before, then returns `methodNode.getInvocationHandler(objectId)` instead of the default. ConditionManager precedence and session access checks are unchanged and run first.

Because the default handler is never touched, the two mechanisms do not interfere. Replacing the default with `setInvocationHandler` changes only Objects without a registration. A Condition that installs its shared-Method handler when the default is still `NOT_IMPLEMENTED` keeps working regardless of whether bindings were installed first.

## MethodBindings

`MethodBindings` is a lifetime scope an application closes on namespace shutdown. `bind(owner, method, handler)` validates that the owner and Method are live nodes on the same server and that the owner reaches the Method through a component reference (using the same `findMethodNode` the Call path uses), rejects modelled instance declarations on ObjectTypes, rejects relationships the ConditionManager already handles, and for a typed handler checks that its node and argument names, data types, ranks and dimensions match the Method's Properties. Null and empty dimension arrays both mean unspecified. It then installs the handler for that ObjectId and returns a token.

```java
try (MethodBindings bindings = new MethodBindings()) {
  MethodBinding first = bindings.bind(firstObject, sharedMethod, firstHandler);
  MethodBinding second = bindings.bind(secondObject, sharedMethod, secondHandler);
  // Calls with firstObject's ObjectId use firstHandler; secondObject's use secondHandler.
  first.close();   // firstObject falls back to the Method's default handler
}
```

Binding the same owner again replaces its registration; the older token's `close` is then a no-op, both in the registry and on the node, so a stale token cannot remove its replacement. `removeObject` releases every registration for an ObjectId before the owner node is deleted. `close` releases every registration the registry still owns. Cleanup never waits for, cancels or drains callbacks; a handler selected before cleanup can finish afterward, which the tests verify with latches.

Two registries can bind different Objects on the same Method. If they bind the same Object, the later bind wins and the earlier token cannot remove it. Registrations are stored on the Method node instance that was validated; a node removed and recreated under the same NodeId is a different instance and fails bind with `Bad_NodeIdUnknown` until rebound through the new node.

## Component reference subtypes

`UaObjectNode` and `UaObjectTypeNode` Method lookup previously matched only the exact `HasComponent` and `HasOrderedComponent` ids, so a Method reached through a custom subtype of HasComponent returned `Bad_MethodInvalid` on Call. Lookup now accepts any reference type that is `HasComponent` or a subtype in the server's `ReferenceTypeTree`, the same rule Browse, TranslateBrowsePaths and `isConditionInstanceMethod` already use. A namespace that adds ReferenceTypes after that tree was first built must call `OpcUaServer.updateReferenceTypeTree()`, as Browse already requires; the integration test does this in its namespace setup.

`UaObjectNode.findMethodNode` also no longer dereferences a missing type definition when it falls back to checking declaration ids, so an owner whose HasTypeDefinition target does not resolve returns `null` for an unknown Method instead of throwing.

## Verification

Local checks: `spotless:apply`, a clean reactor compile, and a full test run of `opc-ua-sdk/sdk-server` and `opc-ua-sdk/integration-tests` with no failures, errors or skips. The bindings-specific coverage is `MethodBindingsTest` (unit, direct `ManagedAddressSpace` Calls) and `MethodBindingsServiceTest` (username-authenticated client Calls through a namespace using a custom HasComponent subtype, including ObjectType owners, Condition-type failures and ConditionManager precedence).

```sh
mise exec -- mvn -q -nsu -pl opc-ua-sdk/sdk-server,opc-ua-sdk/integration-tests -am test
```

Asynchronous execution, automatic node-removal listeners and draining shutdown are outside this change.
