### PR TITLE
Fix ULong subtraction for values at or above 2^63

### DIFF
--- a/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/unsigned/ULong.java
+++ b/opc-ua-stack/stack-core/src/main/java/org/eclipse/milo/opcua/stack/core/types/builtin/unsigned/ULong.java
@@ -220,7 +220,8 @@ public final class ULong extends UNumber implements Comparable<ULong> {
 
   public ULong add(long val) throws NumberFormatException {
     if (val < 0) {
-      return subtract(Math.abs(val));
+      // valueOf masks, so -Long.MIN_VALUE is 2^63 here rather than an overflow
+      return subtract(valueOf(-val));
     }
     final long result = value + val;
     if (value < 0 && result >= 0) {
@@ -233,11 +234,7 @@ public final class ULong extends UNumber implements Comparable<ULong> {
     if (this.compareTo(val) < 0) {
       throw new NumberFormatException();
     }
-    final long result = value - val.value;
-    if (value < 0 && result >= 0) {
-      throw new NumberFormatException();
-    }
-    return valueOf(result);
+    return valueOf(value - val.value);
   }
 
   public ULong subtract(final int val) {
@@ -246,15 +243,12 @@ public final class ULong extends UNumber implements Comparable<ULong> {
 
   public ULong subtract(final long val) {
     if (val < 0) {
-      return add(-val);
+      // valueOf masks, so -Long.MIN_VALUE is 2^63 here rather than an overflow
+      return add(valueOf(-val));
     }
     if (compare(value, val) < 0) {
       throw new NumberFormatException();
     }
-    final long result = value - val;
-    if (value < 0 && result >= 0) {
-      throw new NumberFormatException();
-    }
-    return valueOf(result);
+    return valueOf(value - val);
   }
 }

--- a/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/types/builtin/unsigned/ULongTest.java
+++ b/opc-ua-stack/stack-core/src/test/java/org/eclipse/milo/opcua/stack/core/types/builtin/unsigned/ULongTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2026 the Eclipse Milo Authors
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+package org.eclipse.milo.opcua.stack.core.types.builtin.unsigned;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.math.BigInteger;
+import java.util.Random;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class ULongTest {
+
+  private static final BigInteger TWO_POW_64 = BigInteger.ONE.shiftLeft(64);
+
+  // Values at or above 2^63 have the sign bit set in the backing long. Subtracting from one of them
+  // used to throw whenever the result dropped below 2^63, which is a valid result.
+  @ParameterizedTest
+  @CsvSource({
+    "18446744073709551615, 18446744073709551615, 0",
+    "9223372036854775808, 9223372036854775808, 0",
+    "9223372036854775808, 1, 9223372036854775807",
+    "18446744073709551615, 9223372036854775808, 9223372036854775807",
+  })
+  void subtractReturnsResultsBelowTheSignedBoundary(
+      String minuend, String subtrahend, String expected) {
+    assertEquals(u(expected), u(minuend).subtract(u(subtrahend)));
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "9223372036854775808, 1, 9223372036854775807",
+    "18446744073709551615, 9223372036854775807, 9223372036854775808",
+  })
+  void subtractLongReturnsResultsBelowTheSignedBoundary(
+      String minuend, long subtrahend, String expected) {
+    assertEquals(u(expected), u(minuend).subtract(subtrahend));
+  }
+
+  // add(long) with a negative argument is a subtraction, so it hit the same bug.
+  @Test
+  void addNegativeLongSubtracts() {
+    assertEquals(u("9223372036854775807"), u("9223372036854775808").add(-1L));
+    assertEquals(u("0"), u("9223372036854775807").add(Long.MIN_VALUE + 1));
+  }
+
+  // Math.abs(Long.MIN_VALUE) is still negative, so add(long) and subtract(long) used to hand
+  // Long.MIN_VALUE back and forth until the stack overflowed.
+  @Test
+  void addAndSubtractAcceptLongMinValue() {
+    assertEquals(u("9223372036854775807"), ULong.MAX.add(Long.MIN_VALUE));
+    assertEquals(u("9223372036854775808"), ULong.MIN.subtract(Long.MIN_VALUE));
+    assertEquals(u("18446744073709551615"), u("9223372036854775807").subtract(Long.MIN_VALUE));
+  }
+
+  @Test
+  void addRejectsOverflow() {
+    assertThrows(NumberFormatException.class, () -> ULong.MAX.add(1));
+    assertThrows(NumberFormatException.class, () -> ULong.MAX.add(u("1")));
+    assertThrows(
+        NumberFormatException.class, () -> u("9223372036854775808").add(u("9223372036854775808")));
+    assertThrows(NumberFormatException.class, () -> ULong.MAX.subtract(Long.MIN_VALUE));
+  }
+
+  @Test
+  void subtractRejectsUnderflow() {
+    assertThrows(NumberFormatException.class, () -> ULong.MIN.subtract(1));
+    assertThrows(NumberFormatException.class, () -> u("1").subtract(u("2")));
+    assertThrows(NumberFormatException.class, () -> ULong.MIN.add(Long.MIN_VALUE));
+    assertThrows(NumberFormatException.class, () -> u("1").add(-2L));
+  }
+
+  // The named cases above pin the boundary; this checks the whole value space against BigInteger
+  // so the sign-bit handling cannot regress somewhere the named cases do not reach.
+  @Test
+  void arithmeticMatchesBigInteger() {
+    var random = new Random(1);
+
+    for (int i = 0; i < 10_000; i++) {
+      long a = random.nextLong();
+      long b = random.nextLong();
+      ULong ua = ULong.valueOf(a);
+      ULong ub = ULong.valueOf(b);
+
+      assertMatches(ua.toBigInteger().add(ub.toBigInteger()), () -> ua.add(ub));
+      assertMatches(ua.toBigInteger().subtract(ub.toBigInteger()), () -> ua.subtract(ub));
+      assertMatches(ua.toBigInteger().add(BigInteger.valueOf(b)), () -> ua.add(b));
+      assertMatches(ua.toBigInteger().subtract(BigInteger.valueOf(b)), () -> ua.subtract(b));
+    }
+  }
+
+  private static void assertMatches(BigInteger expected, Supplier<ULong> operation) {
+    if (expected.signum() >= 0 && expected.compareTo(TWO_POW_64) < 0) {
+      assertEquals(expected, operation.get().toBigInteger());
+    } else {
+      assertThrows(NumberFormatException.class, operation::get, "expected " + expected);
+    }
+  }
+
+  private static ULong u(String value) {
+    return ULong.valueOf(value);
+  }
+}


### PR DESCRIPTION
`ULong.subtract(ULong)` and `subtract(long)` end with an overflow check copied from `add()`: `if (value < 0 && result >= 0) throw`. For subtraction that condition is wrong - the unsigned compare above it already rules out underflow - so any subtraction whose minuend is >= 2^63 and whose result is < 2^63 throws `NumberFormatException`. `MAX - MAX`, `2^63 - 1` and `add(-1)` on 2^63 all fail.

`add(long)` also goes through `Math.abs()`, and `Math.abs(Long.MIN_VALUE)` is still negative, so `add(Long.MIN_VALUE)` and `subtract(Long.MIN_VALUE)` bounce between the two overloads until `StackOverflowError`.

The fix drops the two post-checks and negates through `valueOf()`, which masks the bit pattern so `-Long.MIN_VALUE` comes out as 2^63.

Checked against `BigInteger` over 1.2M random operand pairs with no mismatches. Nothing in the repo calls these methods, so no other behaviour changes. The upstream jOOU `ULong` this class came from has the same two checks, so it is not a copying error - it is wrong there as well.

`ULongTest` is new; there was no test for this class. On the unpatched code 10 of its 11 cases fail.